### PR TITLE
Replace AWS CloudWatch/SNS with local file-based logging and alerting

### DIFF
--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -14,8 +14,7 @@ openlineage-python==1.9.0
 apache-airflow-providers-postgres==5.8.0
 apache-airflow-providers-mysql==5.4.0
 
-# Cloud providers for AWS integration
-apache-airflow-providers-amazon==8.15.0
+# HTTP provider (local integrations)
 apache-airflow-providers-http==4.7.0
 
 # Data processing and analysis libraries (for DAGs)
@@ -80,4 +79,3 @@ xlrd==2.0.1
 
 # Network and connectivity
 psycopg2-binary==2.9.9
-boto3==1.34.0

--- a/requirements/requirements-test-minimal.txt
+++ b/requirements/requirements-test-minimal.txt
@@ -2,5 +2,4 @@
 pytest>=7.0.0
 psycopg2-binary>=2.9.9
 redis>=4.5.0
-boto3>=1.26.0
 python-dotenv>=0.19.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,15 +3,12 @@ pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0,<1.0.0
 httpx>=0.24.0
-moto>=4.2.0
 pytest-mock>=3.10.0 # Added for mocking
 
 # Graph Database
 gremlinpython>=3.6.0
 
-# Storage
-boto3>=1.26.0
-botocore>=1.29.0
+# Storage (local filesystem + SQLite via stdlib; no cloud SDK required)
 
 # Web Framework
 fastapi>=0.68.0

--- a/src/api/logging_config.py
+++ b/src/api/logging_config.py
@@ -1,44 +1,75 @@
 """
 Logging configuration for the API.
+
+Replaces the deprecated AWS CloudWatch request logging middleware with a
+rotating local log file written under NEURONEWS_LOG_DIR (default ./logs).
 """
 
+import json
 import logging
+import os
+import re
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
 from typing import Optional
 
-import boto3
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
-class CloudWatchLogger(BaseHTTPMiddleware):
-    """Middleware for logging API requests to CloudWatch."""
+def _get_log_dir() -> str:
+    """Return the local log directory (env NEURONEWS_LOG_DIR, default ./logs)."""
+    log_dir = os.environ.get("NEURONEWS_LOG_DIR", "./logs")
+    os.makedirs(log_dir, exist_ok=True)
+    return log_dir
+
+
+def _sanitize_name(name: str) -> str:
+    """Sanitize a log group style name for use as a filename."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-") or "default"
+
+
+class LocalRequestLogger(BaseHTTPMiddleware):
+    """Middleware for logging API requests to a rotating local log file."""
 
     def __init__(self, app, log_group: str, aws_region: Optional[str] = None):
         """Initialize the logger.
 
         Args:
             app: FastAPI application
-            log_group: CloudWatch log group name
-            aws_region: AWS region (defaults to environment variable)
+            log_group: Logical log group name (maps to a local log file)
+            aws_region: Deprecated, kept for backward compatibility (ignored)
         """
         super().__init__(app)
         self.log_group = log_group
-        self.logs_client = boto3.client("logs", region_name=aws_region)
+        self.aws_region = aws_region  # Deprecated, unused
         self.log_stream = f"api-{datetime.now().strftime('%Y%m%d')}"
 
-        # Create log stream if needed
-        try:
-            self.logs_client.create_log_stream(
-                logGroupName=self.log_group, logStreamName=self.log_stream
-            )
-        except self.logs_client.exceptions.ResourceAlreadyExistsException:
-            pass
+        # Build the local log file path from the log group name
+        log_dir = _get_log_dir()
+        self.log_file = os.path.join(
+            log_dir, "{0}.log".format(_sanitize_name(log_group))
+        )
 
-        self.sequence_token = None
+        # Dedicated rotating file logger for API request entries
+        self._file_logger = logging.getLogger(
+            "neuronews.api.{0}".format(_sanitize_name(log_group))
+        )
+        self._file_logger.setLevel(logging.INFO)
+        self._file_logger.propagate = False
+        if not any(
+            isinstance(h, RotatingFileHandler)
+            and getattr(h, "baseFilename", None) == os.path.abspath(self.log_file)
+            for h in self._file_logger.handlers
+        ):
+            handler = RotatingFileHandler(
+                self.log_file, maxBytes=10 * 1024 * 1024, backupCount=5
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            self._file_logger.addHandler(handler)
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        """Log request and response details to CloudWatch."""
+        """Log request and response details to the local log file."""
         start_time = datetime.now()
 
         # Process the request
@@ -57,6 +88,7 @@ class CloudWatchLogger(BaseHTTPMiddleware):
             # Prepare log entry
             log_entry = {
                 "timestamp": start_time.strftime("%Y-%m-%d %H:%M:%S"),
+                "log_stream": self.log_stream,
                 "request_id": request.headers.get("X-Request-ID", ""),
                 "method": request.method,
                 "path": request.url.path,
@@ -67,27 +99,11 @@ class CloudWatchLogger(BaseHTTPMiddleware):
             if error:
                 log_entry["error"] = error
 
-            # Send to CloudWatch
+            # Write to the local log file
             try:
-                kwargs = {
-                    "logGroupName": self.log_group,
-                    "logStreamName": self.log_stream,
-                    "logEvents": [
-                        {
-                            "timestamp": int(start_time.timestamp() * 1000),
-                            "message": str(log_entry),
-                        }
-                    ],
-                }
-
-                if self.sequence_token:
-                    kwargs["sequenceToken"] = self.sequence_token
-
-                response = self.logs_client.put_log_events(**kwargs)
-                self.sequence_token = response.get("nextSequenceToken")
-
-            except Exception as e:
-                logging.error("Failed to send logs to CloudWatch: {0}".format(e))
+                self._file_logger.info(json.dumps(log_entry))
+            except (OSError, ValueError) as e:
+                logging.error("Failed to write logs to local file: {0}".format(e))
 
         if error:
             raise
@@ -100,7 +116,11 @@ def configure_logging(app, log_group: str, aws_region: Optional[str] = None):
 
     Args:
         app: FastAPI application
-        log_group: CloudWatch log group name
-        aws_region: AWS region (optional)
+        log_group: Logical log group name (maps to a local log file)
+        aws_region: Deprecated, kept for backward compatibility (ignored)
     """
-    app.add_middleware(CloudWatchLogger, log_group=log_group, aws_region=aws_region)
+    app.add_middleware(LocalRequestLogger, log_group=log_group, aws_region=aws_region)
+
+
+# Backward-compatibility alias (deprecated name from the old CloudWatch integration)
+CloudWatchLogger = LocalRequestLogger

--- a/src/scraper/cloudwatch_logger.py
+++ b/src/scraper/cloudwatch_logger.py
@@ -1,16 +1,34 @@
 """
-CloudWatch monitoring integration for NeuroNews scraper.
-Tracks execution success/failure rates, performance metrics, and sends alerts.
+Local monitoring integration for NeuroNews scraper.
+Tracks execution success/failure rates and performance metrics using local
+log and metrics files (replaces the deprecated AWS CloudWatch integration).
 """
 
 import json
 import logging
+import os
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
+from logging.handlers import RotatingFileHandler
 from typing import List, Optional
 
-import boto3
+
+def _get_log_dir() -> str:
+    """Return the local log directory (env NEURONEWS_LOG_DIR, default ./logs)."""
+    log_dir = os.environ.get("NEURONEWS_LOG_DIR", "./logs")
+    os.makedirs(log_dir, exist_ok=True)
+    return log_dir
+
+
+def _sanitize_name(name: str) -> str:
+    """Sanitize a log group/stream style name for use as a filename."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-") or "default"
+
+
+class MetricsStorageError(Exception):
+    """Raised when local metric/log storage fails (replaces botocore ClientError)."""
 
 
 class ScrapingStatus(Enum):
@@ -42,50 +60,73 @@ class ScrapingMetrics:
     ip_blocked: bool = False
 
 
-class CloudWatchLogger:
-    """CloudWatch integration for scraper monitoring and alerting."""
+class LocalMetricsLogger:
+    """Local file-based integration for scraper monitoring and alerting."""
 
     def __init__(
         self,
-        region_name: str = "us-east-1",
+        region_name: str = "local",
         namespace: str = "NeuroNews/Scraper",
-        log_group: str = "/aws/lambda/neuronews-scraper",
+        log_group: str = "neuronews-scraper",
     ):
         """
-        Initialize CloudWatch logger.
+        Initialize local metrics logger.
 
         Args:
-            region_name: AWS region for CloudWatch
-            namespace: CloudWatch namespace for metrics
-            log_group: CloudWatch log group name
+            region_name: Deprecated, kept for backward compatibility (ignored)
+            namespace: Namespace recorded in metric records
+            log_group: Logical log group name (maps to a local log file)
         """
-        self.region_name = region_name
+        self.region_name = region_name  # Deprecated, unused
         self.namespace = namespace
         self.log_group = log_group
 
-        # Initialize AWS clients
-        self.cloudwatch = boto3.client("cloudwatch", region_name=region_name)
-        self.logs_client = boto3.client("logs", region_name=region_name)
+        # Local storage paths
+        self.log_dir = _get_log_dir()
+        self.log_file = os.path.join(
+            self.log_dir, "{0}.log".format(_sanitize_name(log_group))
+        )
+        self.metrics_file = os.path.join(self.log_dir, "scraper_metrics.jsonl")
+        self.alarms_file = os.path.join(self.log_dir, "scraper_alarms.jsonl")
 
         # Setup logging
         self.logger = logging.getLogger(__name__)
+
+        # Dedicated rotating file logger for log entries (one file per log group)
+        self._file_logger = logging.getLogger(
+            "neuronews.scraper.{0}".format(_sanitize_name(log_group))
+        )
+        self._file_logger.setLevel(logging.INFO)
+        self._file_logger.propagate = False
+        if not any(
+            isinstance(h, RotatingFileHandler)
+            and getattr(h, "baseFilename", None) == os.path.abspath(self.log_file)
+            for h in self._file_logger.handlers
+        ):
+            handler = RotatingFileHandler(
+                self.log_file, maxBytes=10 * 1024 * 1024, backupCount=5
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            self._file_logger.addHandler(handler)
 
         # Metrics buffer for batch sending
         self.metrics_buffer: List[ScrapingMetrics] = []
         self.buffer_size = 10
 
-        # Ensure log group exists
+        # Ensure log group (local directory/file) exists
         self._ensure_log_group_exists()
 
     def _ensure_log_group_exists(self):
-        """Create CloudWatch log group if it doesn't exist."""
+        """Create the local log directory/file if it doesn't exist."""
         try:
-            self.logs_client.create_log_group(logGroupName=self.log_group)
-            self.logger.info("Created CloudWatch log group: {0}".format(self.log_group))
-        except self.logs_client.exceptions.ResourceAlreadyExistsException:
-            self.logger.debug("Log group already exists: {0}".format(self.log_group))
-        except Exception as e:
-            self.logger.error("Error creating log group: {0}".format(e))
+            os.makedirs(self.log_dir, exist_ok=True)
+            if not os.path.exists(self.log_file):
+                open(self.log_file, "a").close()
+                self.logger.info("Created local log file: {0}".format(self.log_file))
+            else:
+                self.logger.debug("Log file already exists: {0}".format(self.log_file))
+        except OSError as e:
+            self.logger.error("Error creating log file: {0}".format(e))
 
     async def log_scraping_attempt(self, metrics: ScrapingMetrics):
         """
@@ -97,10 +138,10 @@ class CloudWatchLogger:
         # Add to buffer
         self.metrics_buffer.append(metrics)
 
-        # Send to CloudWatch Logs
+        # Send to local log file
         await self._send_log_entry(metrics)
 
-        # Send metrics to CloudWatch
+        # Record metrics locally
         await self._send_cloudwatch_metrics(metrics)
 
         # Check if buffer is full and send batch metrics
@@ -109,12 +150,13 @@ class CloudWatchLogger:
             self.metrics_buffer.clear()
 
     async def _send_log_entry(self, metrics: ScrapingMetrics):
-        """Send detailed log entry to CloudWatch Logs."""
+        """Write a detailed log entry to the local log file."""
         try:
             log_entry = {
                 "timestamp": datetime.fromtimestamp(
                     metrics.timestamp, tz=timezone.utc
                 ).isoformat(),
+                "log_stream": f"scraper-{datetime.now().strftime('%Y-%m-%d')}",
                 "url": metrics.url,
                 "status": metrics.status.value,
                 "duration_ms": metrics.duration_ms,
@@ -127,34 +169,28 @@ class CloudWatchLogger:
                 "error_message": metrics.error_message,
             }
 
-            # Create log stream name with date
-            log_stream = f"scraper-{datetime.now().strftime('%Y-%m-%d')}"
+            self._file_logger.info(json.dumps(log_entry))
 
-            # Ensure log stream exists
-            try:
-                self.logs_client.create_log_stream(
-                    logGroupName=self.log_group, logStreamName=log_stream
-                )
-            except self.logs_client.exceptions.ResourceAlreadyExistsException:
-                pass
+        except (OSError, MetricsStorageError, ValueError) as e:
+            self.logger.error("Error writing log entry to local log: {0}".format(e))
 
-            # Send log event
-            self.logs_client.put_log_events(
-                logGroupName=self.log_group,
-                logStreamName=log_stream,
-                logEvents=[
-                    {
-                        "timestamp": int(metrics.timestamp * 1000),
-                        "message": json.dumps(log_entry),
-                    }
-                ],
-            )
-
-        except Exception as e:
-            self.logger.error("Error sending log entry to CloudWatch: {0}".format(e))
+    def _write_metric_records(self, metric_data: List[dict]):
+        """Append metric records (JSON lines) to the local metrics file."""
+        with open(self.metrics_file, "a") as f:
+            for record in metric_data:
+                record = dict(record)
+                record["Namespace"] = self.namespace
+                # Normalize timestamps to ISO strings for JSON serialization
+                ts = record.get("Timestamp")
+                if isinstance(ts, datetime):
+                    record["Timestamp"] = ts.isoformat()
+                f.write(json.dumps(record) + "\n")
 
     async def _send_cloudwatch_metrics(self, metrics: ScrapingMetrics):
-        """Send metrics to CloudWatch for monitoring and alerting."""
+        """Record metrics locally for monitoring and alerting.
+
+        Deprecated name kept for backward compatibility (was the CloudWatch sender).
+        """
         try:
             metric_data = []
 
@@ -268,13 +304,11 @@ class CloudWatchLogger:
                     }
                 )
 
-            # Send metrics to CloudWatch
-            self.cloudwatch.put_metric_data(
-                Namespace=self.namespace, MetricData=metric_data
-            )
+            # Write metrics to the local metrics file
+            self._write_metric_records(metric_data)
 
-        except Exception as e:
-            self.logger.error("Error sending metrics to CloudWatch: {0}".format(e))
+        except (OSError, MetricsStorageError, ValueError) as e:
+            self.logger.error("Error writing metrics to local file: {0}".format(e))
 
     async def _send_batch_metrics(self):
         """Send aggregated metrics from buffer."""
@@ -287,7 +321,6 @@ class CloudWatchLogger:
             successful_attempts = sum(
                 1 for m in self.metrics_buffer if m.status == ScrapingStatus.SUCCESS
             )
-            total_attempts - successful_attempts
             avg_duration = (
                 sum(m.duration_ms for m in self.metrics_buffer) / total_attempts
             )
@@ -317,12 +350,10 @@ class CloudWatchLogger:
                 },
             ]
 
-            self.cloudwatch.put_metric_data(
-                Namespace=self.namespace, MetricData=metric_data
-            )
+            self._write_metric_records(metric_data)
 
-        except Exception as e:
-            self.logger.error("Error sending batch metrics: {0}".format(e))
+        except (OSError, MetricsStorageError, ValueError) as e:
+            self.logger.error("Error writing batch metrics: {0}".format(e))
 
     def _get_domain_from_url(self, url: str) -> str:
         """Extract domain from URL for grouping metrics."""
@@ -332,6 +363,33 @@ class CloudWatchLogger:
             return urlparse(url).netloc
         except Exception:
             return "unknown"
+
+    def _read_metric_records(self, metric_name: str, hours: int) -> List[dict]:
+        """Read metric records for the last N hours from the local metrics file."""
+        records = []
+        if not os.path.exists(self.metrics_file):
+            return records
+
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - hours * 3600
+        with open(self.metrics_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    continue
+                if record.get("MetricName") != metric_name:
+                    continue
+                ts = record.get("Timestamp")
+                try:
+                    record_time = datetime.fromisoformat(ts).timestamp()
+                except (TypeError, ValueError):
+                    continue
+                if record_time >= cutoff:
+                    records.append(record)
+        return records
 
     async def get_success_rate(self, hours: int = 24) -> float:
         """
@@ -344,28 +402,15 @@ class CloudWatchLogger:
             Success rate as percentage
         """
         try:
-            end_time = datetime.now(tz=timezone.utc)
-            start_time = end_time.replace(hour=end_time.hour - hours)
+            datapoints = self._read_metric_records("SuccessRate", hours)
 
-            # Query CloudWatch for success rate
-            response = self.cloudwatch.get_metric_statistics(
-                Namespace=self.namespace,
-                MetricName="SuccessRate",
-                StartTime=start_time,
-                EndTime=end_time,
-                Period=3600,  # 1 hour periods
-                Statistics=["Average"],
-            )
-
-            if response["Datapoints"]:
+            if datapoints:
                 # Return average success rate
-                return sum(dp["Average"] for dp in response["Datapoints"]) / len(
-                    response["Datapoints"]
-                )
+                return sum(dp["Value"] for dp in datapoints) / len(datapoints)
             else:
                 return 0.0
 
-        except Exception as e:
+        except (OSError, MetricsStorageError, ValueError, KeyError) as e:
             self.logger.error("Error getting success rate: {0}".format(e))
             return 0.0
 
@@ -380,25 +425,23 @@ class CloudWatchLogger:
             Number of failures
         """
         try:
-            end_time = datetime.now(tz=timezone.utc)
-            start_time = end_time.replace(hour=end_time.hour - hours)
+            datapoints = self._read_metric_records("ScrapingAttempts", hours)
 
-            response = self.cloudwatch.get_metric_statistics(
-                Namespace=self.namespace,
-                MetricName="ScrapingAttempts",
-                Dimensions=[{"Name": "Status", "Value": "failure"}],
-                StartTime=start_time,
-                EndTime=end_time,
-                Period=3600,
-                Statistics=["Sum"],
-            )
+            failures = [
+                dp
+                for dp in datapoints
+                if any(
+                    d.get("Name") == "Status" and d.get("Value") == "failure"
+                    for d in dp.get("Dimensions", [])
+                )
+            ]
 
-            if response["Datapoints"]:
-                return int(sum(dp["Sum"] for dp in response["Datapoints"]))
+            if failures:
+                return int(sum(dp["Value"] for dp in failures))
             else:
                 return 0
 
-        except Exception as e:
+        except (OSError, MetricsStorageError, ValueError, KeyError) as e:
             self.logger.error("Error getting failure count: {0}".format(e))
             return 0
 
@@ -411,38 +454,39 @@ class CloudWatchLogger:
         sns_topic_arn: Optional[str] = None,
     ):
         """
-        Create CloudWatch alarm for monitoring.
+        Record a local alarm definition for monitoring.
 
         Args:
             alarm_name: Name of the alarm
-            metric_name: CloudWatch metric to monitor
+            metric_name: Metric to monitor
             threshold: Threshold value for alarm
             comparison_operator: Comparison operator for threshold
-            sns_topic_arn: SNS topic ARN for notifications
+            sns_topic_arn: Deprecated, kept for backward compatibility (ignored)
         """
         try:
-            alarm_actions = [sns_topic_arn] if sns_topic_arn else []
-
-            self.cloudwatch.put_metric_alarm(
-                AlarmName=alarm_name,
-                ComparisonOperator=comparison_operator,
-                EvaluationPeriods=2,
-                MetricName=metric_name,
-                Namespace=self.namespace,
-                Period=300,  # 5 minutes
-                Statistic="Average",
-                Threshold=threshold,
-                ActionsEnabled=True,
-                AlarmActions=alarm_actions,
-                AlarmDescription="Alarm for {0} in NeuroNews scraper".format(
+            alarm_record = {
+                "AlarmName": alarm_name,
+                "ComparisonOperator": comparison_operator,
+                "EvaluationPeriods": 2,
+                "MetricName": metric_name,
+                "Namespace": self.namespace,
+                "Period": 300,  # 5 minutes
+                "Statistic": "Average",
+                "Threshold": threshold,
+                "ActionsEnabled": True,
+                "AlarmDescription": "Alarm for {0} in NeuroNews scraper".format(
                     metric_name
                 ),
-                Unit="Count",
-            )
+                "Unit": "Count",
+                "CreatedAt": datetime.now(tz=timezone.utc).isoformat(),
+            }
 
-            self.logger.info("Created CloudWatch alarm: {0}".format(alarm_name))
+            with open(self.alarms_file, "a") as f:
+                f.write(json.dumps(alarm_record) + "\n")
 
-        except Exception as e:
+            self.logger.info("Created local alarm definition: {0}".format(alarm_name))
+
+        except (OSError, ValueError) as e:
             self.logger.error("Error creating alarm: {0}".format(e))
 
     async def flush_metrics(self):
@@ -450,3 +494,7 @@ class CloudWatchLogger:
         if self.metrics_buffer:
             await self._send_batch_metrics()
             self.metrics_buffer.clear()
+
+
+# Backward-compatibility alias (deprecated name from the old CloudWatch integration)
+CloudWatchLogger = LocalMetricsLogger

--- a/src/scraper/extensions/__init__.py
+++ b/src/scraper/extensions/__init__.py
@@ -2,6 +2,6 @@
 Extensions package for NeuroNews scrapers.
 """
 
-from .cloudwatch_logging import CloudWatchLoggingExtension
+from .cloudwatch_logging import CloudWatchLoggingExtension, LocalFileLoggingExtension
 
-__all__ = ["CloudWatchLoggingExtension"]
+__all__ = ["CloudWatchLoggingExtension", "LocalFileLoggingExtension"]

--- a/src/scraper/extensions/cloudwatch_logging.py
+++ b/src/scraper/extensions/cloudwatch_logging.py
@@ -1,5 +1,8 @@
 """
-CloudWatch logging extension for Scrapy.
+Local file logging extension for Scrapy.
+
+Replaces the deprecated AWS CloudWatch Logs extension with rotating local
+log files written under NEURONEWS_LOG_DIR (default ./logs).
 """
 
 import logging
@@ -10,17 +13,20 @@ from scrapy.exceptions import NotConfigured
 from ..log_utils import configure_cloudwatch_logging
 
 
-class CloudWatchLoggingExtension:
+class LocalFileLoggingExtension:
     """
-    Scrapy extension to send logs to AWS CloudWatch Logs.
+    Scrapy extension to send logs to rotating local log files.
     """
 
     @classmethod
     def from_crawler(cls, crawler):
         """Initialize the extension from a crawler."""
-        # Check if CloudWatch logging is enabled
-        if not crawler.settings.getbool("CLOUDWATCH_LOGGING_ENABLED", False):
-            raise NotConfigured("CloudWatch logging is not enabled")
+        # Check if file logging is enabled (CLOUDWATCH_* key is a deprecated alias)
+        if not (
+            crawler.settings.getbool("LOCAL_FILE_LOGGING_ENABLED", False)
+            or crawler.settings.getbool("CLOUDWATCH_LOGGING_ENABLED", False)
+        ):
+            raise NotConfigured("Local file logging is not enabled")
 
         # Create an instance of the extension
         ext = cls()
@@ -43,7 +49,7 @@ class CloudWatchLoggingExtension:
         Args:
             spider: The spider that was opened
         """
-        # Configure CloudWatch logging
+        # Configure local file logging
         handler = configure_cloudwatch_logging(self.crawler.settings, spider.name)
 
         if handler:
@@ -62,9 +68,9 @@ class CloudWatchLoggingExtension:
             spider_logger = logging.getLogger(spider.name)
             spider_logger.addHandler(handler)
 
-            # Log that CloudWatch logging is configured
+            # Log that local file logging is configured
             spider.logger.info(
-                "CloudWatch logging configured: group={0}, stream={1}".format(
+                "Local file logging configured: group={0}, stream={1}".format(
                     handler.log_group_name, handler.log_stream_name
                 )
             )
@@ -78,7 +84,7 @@ class CloudWatchLoggingExtension:
         """
         if hasattr(self, "handler"):
             # Log that the spider is closing
-            spider.logger.info("Spider closing, shutting down CloudWatch logging")
+            spider.logger.info("Spider closing, shutting down local file logging")
 
             # Remove the handler from the root logger
             root_logger = logging.getLogger()
@@ -94,3 +100,7 @@ class CloudWatchLoggingExtension:
 
             # Close the handler
             self.handler.close()
+
+
+# Backward-compatibility alias (deprecated name from the old CloudWatch integration)
+CloudWatchLoggingExtension = LocalFileLoggingExtension

--- a/src/scraper/log_utils/__init__.py
+++ b/src/scraper/log_utils/__init__.py
@@ -2,6 +2,16 @@
 Logging package for NeuroNews scrapers.
 """
 
-from .cloudwatch_handler import CloudWatchLoggingHandler, configure_cloudwatch_logging
+from .cloudwatch_handler import (
+    CloudWatchLoggingHandler,
+    LocalFileLoggingHandler,
+    configure_cloudwatch_logging,
+    configure_local_file_logging,
+)
 
-__all__ = ["CloudWatchLoggingHandler", "configure_cloudwatch_logging"]
+__all__ = [
+    "CloudWatchLoggingHandler",
+    "LocalFileLoggingHandler",
+    "configure_cloudwatch_logging",
+    "configure_local_file_logging",
+]

--- a/src/scraper/log_utils/cloudwatch_handler.py
+++ b/src/scraper/log_utils/cloudwatch_handler.py
@@ -1,17 +1,39 @@
 """
-CloudWatch logging handler for NeuroNews scrapers.
+Local file logging handler for NeuroNews scrapers.
+
+Replaces the deprecated AWS CloudWatch Logs handler with a rotating local
+file handler. Filenames are derived from the old log group/stream concepts.
 """
 
 import logging
+import os
+import re
 from datetime import datetime
-
-import boto3
-from botocore.exceptions import ClientError
+from logging.handlers import RotatingFileHandler
 
 
-class CloudWatchLoggingHandler(logging.Handler):
+def _get_log_dir() -> str:
+    """Return the local log directory (env NEURONEWS_LOG_DIR, default ./logs)."""
+    log_dir = os.environ.get("NEURONEWS_LOG_DIR", "./logs")
+    os.makedirs(log_dir, exist_ok=True)
+    return log_dir
+
+
+def _sanitize_name(name: str) -> str:
+    """Sanitize a log group/stream style name for use as a filename."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-") or "default"
+
+
+class LogStreamError(Exception):
+    """Raised when local log storage fails (replaces botocore ClientError)."""
+
+
+class LocalFileLoggingHandler(logging.Handler):
     """
-    A logging handler that sends logs to AWS CloudWatch Logs.
+    A logging handler that writes logs to a rotating local file.
+
+    One file is created per log group/stream combination under the directory
+    given by the NEURONEWS_LOG_DIR environment variable (default ./logs).
     """
 
     def __init__(
@@ -23,15 +45,15 @@ class CloudWatchLoggingHandler(logging.Handler):
         aws_region=None,
     ):
         """
-        Initialize the CloudWatch logging handler.
+        Initialize the local file logging handler.
 
         Args:
-            log_group_name (str): CloudWatch Logs group name
-            log_stream_name (str, optional): CloudWatch Logs stream name.
+            log_group_name (str): Logical log group name (maps to a file prefix)
+            log_stream_name (str, optional): Logical log stream name.
                                             If not provided, a name will be generated.
-            aws_access_key_id (str, optional): AWS access key ID
-            aws_secret_access_key (str, optional): AWS secret access key
-            aws_region (str, optional): AWS region
+            aws_access_key_id: Deprecated, kept for backward compatibility (ignored)
+            aws_secret_access_key: Deprecated, kept for backward compatibility (ignored)
+            aws_region: Deprecated, kept for backward compatibility (ignored)
         """
         super().__init__()
         self.log_group_name = log_group_name
@@ -39,113 +61,96 @@ class CloudWatchLoggingHandler(logging.Handler):
             log_stream_name or f"scraper-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         )
 
-        # Initialize CloudWatch Logs client
-        self.logs_client = boto3.client(
-            "logs",
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            region_name=aws_region or "us-east-1",
+        # Build the local log file path from group/stream names
+        self.log_dir = _get_log_dir()
+        self.log_file = os.path.join(
+            self.log_dir,
+            "{0}-{1}.log".format(
+                _sanitize_name(self.log_group_name),
+                _sanitize_name(self.log_stream_name),
+            ),
         )
 
-        self.sequence_token = None
+        self._file_handler = None
         self._create_log_group_and_stream()
 
     def _create_log_group_and_stream(self):
-        """Create the log group and stream if they don't exist."""
-        # Create log group if it doesn't exist
+        """Create the local log directory and rotating file handler."""
         try:
-            self.logs_client.create_log_group(logGroupName=self.log_group_name)
-        except ClientError as e:
-            # ResourceAlreadyExistsException is expected if the log group
-            # already exists
-            if e.response["Error"]["Code"] != "ResourceAlreadyExistsException":
-                raise
-
-        # Create log stream if it doesn't exist
-        try:
-            self.logs_client.create_log_stream(
-                logGroupName=self.log_group_name, logStreamName=self.log_stream_name
+            os.makedirs(self.log_dir, exist_ok=True)
+            self._file_handler = RotatingFileHandler(
+                self.log_file, maxBytes=10 * 1024 * 1024, backupCount=5
             )
-        except ClientError as e:
-            # ResourceAlreadyExistsException is expected if the log stream
-            # already exists
-            if e.response["Error"]["Code"] != "ResourceAlreadyExistsException":
-                raise
+        except OSError as e:
+            raise LogStreamError(
+                "Failed to create local log file {0}: {1}".format(self.log_file, e)
+            )
+
+    def setFormatter(self, fmt):
+        """Set the formatter on both this handler and the underlying file handler."""
+        super().setFormatter(fmt)
+        if self._file_handler is not None:
+            self._file_handler.setFormatter(fmt)
 
     def emit(self, record):
         """
-        Send a log record to CloudWatch Logs.
+        Write a log record to the local log file.
 
         Args:
             record: The log record to send
         """
         try:
-            # Format the log message
-            log_message = self.format(record)
-
-            # Prepare the log event
-            log_event = {
-                "timestamp": int(
-                    record.created * 1000
-                ),  # CloudWatch expects milliseconds
-                "message": log_message,
-            }
-
-            # Add the log event to CloudWatch Logs
-            kwargs = {
-                "logGroupName": self.log_group_name,
-                "logStreamName": self.log_stream_name,
-                "logEvents": [log_event],
-            }
-
-            # Include sequence token if we have one
-            if self.sequence_token:
-                kwargs["sequenceToken"] = self.sequence_token
-
-            # Put the log event
-            response = self.logs_client.put_log_events(**kwargs)
-
-            # Update the sequence token for the next call
-            self.sequence_token = response.get("nextSequenceToken")
+            if self._file_handler is not None:
+                self._file_handler.emit(record)
 
         except Exception:
             # Don't raise exceptions from the logging handler
             self.handleError(record)
 
+    def close(self):
+        """Close the underlying file handler."""
+        if self._file_handler is not None:
+            self._file_handler.close()
+        super().close()
+
 
 def configure_cloudwatch_logging(settings, spider_name):
     """
-    Configure CloudWatch logging for a Scrapy spider.
+    Configure local file logging for a Scrapy spider.
+
+    Deprecated name kept for backward compatibility (was the CloudWatch setup).
 
     Args:
         settings: Scrapy settings object
         spider_name: Name of the spider
 
     Returns:
-        CloudWatchLoggingHandler: The configured handler, or None if CloudWatch logging is disabled
+        LocalFileLoggingHandler: The configured handler, or None if file logging is disabled
     """
-    # Check if CloudWatch logging is enabled
-    if not settings.getbool("CLOUDWATCH_LOGGING_ENABLED", False):
+    # Check if file logging is enabled (CLOUDWATCH_* keys are deprecated aliases)
+    if not (
+        settings.getbool("LOCAL_FILE_LOGGING_ENABLED", False)
+        or settings.getbool("CLOUDWATCH_LOGGING_ENABLED", False)
+    ):
         return None
 
-    # Get CloudWatch settings
-    aws_access_key_id = settings.get("AWS_ACCESS_KEY_ID")
-    aws_secret_access_key = settings.get("AWS_SECRET_ACCESS_KEY")
-    aws_region = settings.get("AWS_REGION", "us-east-1")
-    log_group_name = settings.get("CLOUDWATCH_LOG_GROUP", "NeuroNews-Scraper")
-    log_stream_prefix = settings.get("CLOUDWATCH_LOG_STREAM_PREFIX", "scraper")
+    # Get logging settings (CLOUDWATCH_* keys are deprecated aliases)
+    log_group_name = settings.get(
+        "LOCAL_LOG_GROUP", settings.get("CLOUDWATCH_LOG_GROUP", "NeuroNews-Scraper")
+    )
+    log_stream_prefix = settings.get(
+        "LOCAL_LOG_STREAM_PREFIX",
+        settings.get("CLOUDWATCH_LOG_STREAM_PREFIX", "scraper"),
+    )
 
     # Generate a log stream name
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     log_stream_name = "{0}-{1}-{2}".format(log_stream_prefix, spider_name, timestamp)
 
     # Create and configure the handler
-    handler = CloudWatchLoggingHandler(
+    handler = LocalFileLoggingHandler(
         log_group_name=log_group_name,
         log_stream_name=log_stream_name,
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_region=aws_region,
     )
 
     # Set the formatter
@@ -154,8 +159,15 @@ def configure_cloudwatch_logging(settings, spider_name):
     )
     handler.setFormatter(formatter)
 
-    # Set the log level
-    log_level = settings.get("CLOUDWATCH_LOG_LEVEL", "INFO")
+    # Set the log level (CLOUDWATCH_LOG_LEVEL is a deprecated alias)
+    log_level = settings.get(
+        "LOCAL_LOG_LEVEL", settings.get("CLOUDWATCH_LOG_LEVEL", "INFO")
+    )
     handler.setLevel(getattr(logging, log_level))
 
     return handler
+
+
+# Backward-compatibility aliases (deprecated names from the old CloudWatch integration)
+CloudWatchLoggingHandler = LocalFileLoggingHandler
+configure_local_file_logging = configure_cloudwatch_logging

--- a/src/scraper/sns_alert_manager.py
+++ b/src/scraper/sns_alert_manager.py
@@ -1,28 +1,32 @@
 """
-SNS integration for sending alerts when scrapers fail multiple times.
-Provides intelligent alerting with rate limiting and escal             try:
-            # Prepare SNS message  
-            subject = f"[{alert.severity.value}] NeuroNews Scraper Alert: {alert.title}"
-            message = alert.to_sns_message()
+Local alerting integration for sending alerts when scrapers fail multiple times.
+Provides intelligent alerting with rate limiting and escalation.
 
-            # Add message attributes for filtering            # Prepare SNS message
-            subject = "[{0}] NeuroNews Scraper Alert: {1}".format(
-                alert.severity.value, alert.title
-            )
-            message = alert.to_sns_message()      subject = "[{0}] NeuroNews Scraper Alert: {1}".format(
-                alert.severity.value, alert.title
-            )on.
+Replaces the deprecated AWS SNS integration: alerts are appended as JSON
+lines to a local alerts file under NEURONEWS_LOG_DIR (default ./logs) and
+optionally POSTed to a webhook URL from NEURONEWS_ALERT_WEBHOOK_URL.
 """
 
 import json
 import logging
+import os
 import time
+import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import boto3
+
+def _get_log_dir() -> str:
+    """Return the local log directory (env NEURONEWS_LOG_DIR, default ./logs)."""
+    log_dir = os.environ.get("NEURONEWS_LOG_DIR", "./logs")
+    os.makedirs(log_dir, exist_ok=True)
+    return log_dir
+
+
+class AlertDeliveryError(Exception):
+    """Raised when local alert delivery fails (replaces botocore ClientError)."""
 
 
 class AlertSeverity(Enum):
@@ -56,8 +60,8 @@ class Alert:
     timestamp: float
     metadata: Dict[str, Any]
 
-    def to_sns_message(self) -> str:
-        """Convert alert to SNS message format."""
+    def to_message(self) -> str:
+        """Convert alert to JSON message format."""
         alert_data = {
             "timestamp": datetime.fromtimestamp(
                 self.timestamp, tz=timezone.utc
@@ -70,33 +74,38 @@ class Alert:
         }
         return json.dumps(alert_data, indent=2)
 
+    # Backward-compatibility alias (deprecated name from the old SNS integration)
+    to_sns_message = to_message
 
-class SNSAlertManager:
-    """SNS integration for scraper failure alerts and notifications."""
+
+class LocalAlertManager:
+    """Local alerting integration for scraper failure alerts and notifications."""
 
     def __init__(
         self,
-        topic_arn: str,
-        region_name: str = "us-east-1",
+        topic_arn: str = "local-alerts",
+        region_name: str = "local",
         rate_limit_window: int = 3600,
         max_alerts_per_window: int = 10,
     ):
         """
-        Initialize SNS alert manager.
+        Initialize local alert manager.
 
         Args:
-            topic_arn: SNS topic ARN for sending alerts
-            region_name: AWS region for SNS
+            topic_arn: Logical alert channel name (deprecated AWS-style argument,
+                       kept for backward compatibility; only used as a label)
+            region_name: Deprecated, kept for backward compatibility (ignored)
             rate_limit_window: Time window for rate limiting (seconds)
             max_alerts_per_window: Maximum alerts per window
         """
         self.topic_arn = topic_arn
-        self.region_name = region_name
+        self.region_name = region_name  # Deprecated, unused
         self.rate_limit_window = rate_limit_window
         self.max_alerts_per_window = max_alerts_per_window
 
-        # Initialize SNS client
-        self.sns = boto3.client("sns", region_name=region_name)
+        # Local alert storage and optional webhook delivery
+        self.alerts_file = os.path.join(_get_log_dir(), "alerts.jsonl")
+        self.webhook_url = os.environ.get("NEURONEWS_ALERT_WEBHOOK_URL")
 
         # Setup logging
         self.logger = logging.getLogger(__name__)
@@ -110,9 +119,55 @@ class SNSAlertManager:
         self.consecutive_failure_threshold = 5
         self.response_time_threshold = 30000  # 30 seconds
 
+    def _deliver_alert(self, subject: str, alert: Alert) -> str:
+        """
+        Deliver an alert: append it to the local alerts file and optionally
+        POST it to the configured webhook URL (fail soft).
+
+        Returns:
+            A local message id for the delivered alert
+        """
+        message_id = "local-{0}".format(int(alert.timestamp * 1000))
+
+        record = {
+            "message_id": message_id,
+            "channel": self.topic_arn,
+            "subject": subject,
+            "timestamp": datetime.fromtimestamp(
+                alert.timestamp, tz=timezone.utc
+            ).isoformat(),
+            "severity": alert.severity.value,
+            "alert_type": alert.alert_type.value,
+            "title": alert.title,
+            "message": alert.message,
+            "metadata": alert.metadata,
+        }
+
+        # Append to the local alerts file (JSON lines)
+        with open(self.alerts_file, "a") as f:
+            f.write(json.dumps(record) + "\n")
+
+        # Optionally POST to a webhook (fail soft)
+        if self.webhook_url:
+            try:
+                request = urllib.request.Request(
+                    self.webhook_url,
+                    data=json.dumps(record).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(request, timeout=10):
+                    pass
+            except Exception as e:
+                self.logger.warning(
+                    "Failed to POST alert to webhook: {0}".format(str(e))
+                )
+
+        return message_id
+
     async def send_alert(self, alert: Alert, force: bool = False) -> bool:
         """
-        Send an alert via SNS with rate limiting.
+        Send an alert locally with rate limiting.
 
         Args:
             alert: Alert object to send
@@ -123,14 +178,14 @@ class SNSAlertManager:
         """
         current_time = time.time()
 
-        # Check if we're in a mute period'
+        # Check if we're in a mute period
         if current_time < self.muted_until and not force:
             self.logger.debug("Alert muted due to rate limiting")
             return False
 
         # Check rate limiting
         if not force and not self._is_within_rate_limit():
-            # Mute alerts for the next hour if we've exceeded the limit'
+            # Mute alerts for the next hour if we've exceeded the limit
             self.muted_until = current_time + self.rate_limit_window
             self.logger.warning(
                 "Alert rate limit exceeded, muting alerts for 1 hour")
@@ -140,41 +195,22 @@ class SNSAlertManager:
             return False
 
         try:
-            # Prepare SNS message
+            # Prepare alert message
             subject = f"[{alert.severity.value}] NeuroNews Scraper Alert: {alert.title}"
-            message = alert.to_sns_message()
 
-            # Add message attributes for filtering
-            message_attributes = {
-                "severity": {"DataType": "String", "StringValue": alert.severity.value},
-                "alert_type": {
-                    "DataType": "String",
-                    "StringValue": alert.alert_type.value,
-                },
-                "timestamp": {
-                    "DataType": "Number",
-                    "StringValue": str(alert.timestamp),
-                },
-            }
-
-            # Send to SNS
-            response = self.sns.publish(
-                TopicArn=self.topic_arn,
-                Subject=subject,
-                Message=message,
-                MessageAttributes=message_attributes,
-            )
+            # Deliver locally (file + optional webhook)
+            message_id = self._deliver_alert(subject, alert)
 
             # Track alert for rate limiting
             self.alert_history.append(current_time)
             self._cleanup_old_alerts()
 
             self.logger.info(
-                f"Sent alert: {alert.title} (MessageId: {response['MessageId']})"
+                f"Sent alert: {alert.title} (MessageId: {message_id})"
             )
             return True
 
-        except Exception as e:
+        except (OSError, AlertDeliveryError, ValueError) as e:
             self.logger.error(f"Error sending alert: {str(e)}")
             return False
 
@@ -212,11 +248,9 @@ class SNSAlertManager:
             subject = "[{0}] NeuroNews Scraper Alert: {1}".format(
                 alert.severity.value, alert.title
             )
-            message = alert.to_sns_message()
 
-            self.sns.publish(TopicArn=self.topic_arn,
-                             Subject=subject, Message=message)
-        except Exception as e:
+            self._deliver_alert(subject, alert)
+        except (OSError, AlertDeliveryError, ValueError) as e:
             self.logger.error(
                 "Error sending rate limit notification: {0}".format(str(e)))
 
@@ -286,7 +320,7 @@ class SNSAlertManager:
             timestamp=time.time(),
             metadata={
                 "failure_rate": failure_rate,
-            "time_period_hours": time_period,
+                "time_period_hours": time_period,
                 "failed_count": failed_count,
                 "total_count": total_count,
             },
@@ -414,7 +448,7 @@ class SNSAlertManager:
             alert_type=AlertType.SYSTEM_ERROR,
             severity=AlertSeverity.INFO,
             title="Test Alert",
-            message="This is a test alert to verify the SNS alert system is working properly.",
+            message="This is a test alert to verify the local alert system is working properly.",
             timestamp=time.time(),
             metadata={"test": True},
         )
@@ -426,14 +460,16 @@ class SNSAlertManager:
         self.failure_rate_threshold = threshold
         self.logger.info("Set failure rate threshold to {0}%".format(threshold))
 
-
     def set_consecutive_failure_threshold(self, threshold: int):
         """Set the consecutive failure threshold for alerts."""
         self.consecutive_failure_threshold = threshold
         self.logger.info("Set consecutive failure threshold to {0}".format(threshold))
 
-
     def set_response_time_threshold(self, threshold: float):
         """Set the response time threshold for alerts."""
         self.response_time_threshold = threshold
         self.logger.info("Set response time threshold to {0}ms".format(threshold))
+
+
+# Backward-compatibility alias (deprecated name from the old SNS integration)
+SNSAlertManager = LocalAlertManager


### PR DESCRIPTION
# Pull Request: Migrate from AWS CloudWatch/SNS to Local File-Based Monitoring

## 🎯 **Overview**

This PR removes all AWS CloudWatch and SNS dependencies from the NeuroNews scraper and API, replacing them with local file-based logging and alerting. The migration maintains backward compatibility through aliases while providing a simpler, dependency-free monitoring solution.

## 📋 **Changes Summary**

- ✅ **Removed AWS dependencies**: `boto3`, `botocore` from requirements
- ✅ **Replaced CloudWatch Logs** with rotating local log files
- ✅ **Replaced CloudWatch Metrics** with JSON Lines metrics files
- ✅ **Replaced SNS Alerts** with local alerts file + optional webhook delivery
- ✅ **Maintained backward compatibility** through class/function aliases
- ✅ **Added environment variable configuration** for log directory and webhook URL

## 🔧 **Files Modified**

### Core Monitoring Components

- **`src/scraper/cloudwatch_logger.py`** → `LocalMetricsLogger`
  - Replaced `boto3` CloudWatch client with local file I/O
  - Metrics now written to `scraper_metrics.jsonl` (JSON Lines format)
  - Alarms recorded to `scraper_alarms.jsonl`
  - Log entries written to rotating local log files
  - Added `MetricsStorageError` exception (replaces `botocore.ClientError`)
  - Maintained `CloudWatchLogger` alias for backward compatibility

- **`src/scraper/log_utils/cloudwatch_handler.py`** → `LocalFileLoggingHandler`
  - Replaced CloudWatch Logs client with `RotatingFileHandler`
  - Log files created under `NEURONEWS_LOG_DIR` (default: `./logs`)
  - Sanitized log group/stream names for filesystem compatibility
  - Added `LogStreamError` exception
  - Maintained `CloudWatchLoggingHandler` alias for backward compatibility

- **`src/scraper/sns_alert_manager.py`** → `LocalAlertManager`
  - Replaced SNS client with local file-based alert storage
  - Alerts appended to `alerts.jsonl` (JSON Lines format)
  - Optional webhook delivery via `NEURONEWS_ALERT_WEBHOOK_URL` environment variable
  - Fail-soft webhook delivery (errors logged but don't block alert recording)
  - Added `AlertDeliveryError` exception
  - Maintained `SNSAlertManager` alias for backward compatibility

- **`src/api/logging_config.py`** → `LocalRequestLogger`
  - Replaced CloudWatch Logs middleware with local file-based logging
  - API request logs written to rotating local files
  - Maintained `CloudWatchLogger` alias for backward compatibility

- **`src/scraper/extensions/cloudwatch_logging.py`** → `LocalFileLoggingExtension`
  - Updated Scrapy extension to use local file logging
  - Supports both `LOCAL_FILE_LOGGING_ENABLED` and deprecated `CLOUDWATCH_LOGGING_ENABLED` settings
  - Maintained `CloudWatchLoggingExtension` alias for backward compatibility

### Package Exports

- **`src/scraper/log_utils/__init__.py`**
  - Exported new `LocalFileLoggingHandler` class
  - Exported new `configure_local_file_logging` function
  - Maintained backward-compatible exports

- **`src/scraper/extensions/__init__.py`**
  - Exported new `LocalFileLoggingExtension` class
  - Maintained backward-compatible exports

### Dependencies

- **`requirements/requirements.txt`**
  - Removed `boto3>=1.26.0`
  - Removed `botocore>=1.29.0`
  - Removed `moto>=4.2.0` (AWS mocking library)

- **`docker/airflow/requirements.txt`**
  - Removed `apache-airflow-providers-amazon==8.15.0`

## 🚀 **Key Features**

https://claude.ai/code/session_01TqnMCBsUf1JHi2T1jqNR7v