### PR TITLE
Fix dependency install: drop unused gensim, pin plotly&lt;6

### DIFF
--- a/requirements-snowflake.txt
+++ b/requirements-snowflake.txt
@@ -11,7 +11,7 @@ numpy>=1.24.0
 
 # Dashboard and visualization
 streamlit>=1.28.0
-plotly>=5.17.0
+plotly>=5.17.0,<6.0.0
 networkx>=3.2.0
 
 # Database utilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ beautifulsoup4>=4.12.0
 
 # Dashboard & Visualization
 streamlit>=1.28.0
-plotly>=5.17.0
+plotly>=5.17.0,<6.0.0
 networkx>=3.1
 
 # Rate Limiting & Security (Issue #59)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ sentence-transformers>=2.0.0
 
 # Keyword Extraction & Topic Modeling
 scikit-learn>=1.3.0
-gensim>=4.3.0
 nltk>=3.8.1
 spacy>=3.7.0
 wordcloud>=1.9.0


### PR DESCRIPTION
- **Drop unused `gensim` dependency**: gensim is not imported anywhere in the
  codebase (topic modeling uses scikit-learn's LDA). It has no prebuilt wheel for
  Python 3.14, so pip tried to compile it from source and failed on missing
  `Python.h` dev headers. Removing the dead dependency fixes `pip install`.
- **Pin `plotly<6`**: the dashboard chart builders use plotly-5 layout
  properties (e.g. `titlefont`) that were removed in plotly 6; cap the version so
  installs stay compatible with the existing code and tests.
