### PR TITLE
docs: fix scraper run command in README (use module form)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,12 @@ What gets logged automatically:
 
 ### 8. Run the scraper
 
+Run it as a module from the repository root (it uses package-relative imports):
+
 ```bash
-python src/scraper/run.py
+python -m src.scraper.run --help          # list all options
+python -m src.scraper.run --spider bbc    # scrape a single source
+python -m src.scraper.run --multi-source  # scrape all sources
 ```
 
 ### 9. Access dashboards and reports


### PR DESCRIPTION
## Summary

- Replace `python src/scraper/run.py` with `python -m src.scraper.run` in the README.
- `run.py` uses package-relative imports (`from .data_validator import …`), so it must be invoked as a module from the repo root — running it as a plain script raises `ImportError: attempted relative import with no known parent package`.
- Added `--spider` and `--multi-source` usage examples so readers know the common flags without having to run `--help` first.

## Test plan

- [ ] From repo root, run `python -m src.scraper.run --help` and confirm the help text prints without error.
- [ ] Confirm `python src/scraper/run.py` still raises `ImportError` (expected; the README now documents the correct form).

https://claude.ai/code/session_01Y242QQX4yW7mhV94uKsm7w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y242QQX4yW7mhV94uKsm7w)_