### PR TITLE
Add NeuroNews Intelligence Terminal web frontend

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,7 @@
+# Absolute backend origin used in production builds (no trailing slash).
+# Leave unset in development — Vite proxies API paths to VITE_API_PROXY_TARGET.
+# VITE_API_BASE_URL=https://api.neuronews.example
+
+# Backend origin the Vite dev server proxies API requests to.
+# Defaults to http://localhost:8000 (the FastAPI app in src/api).
+# VITE_API_PROXY_TARGET=http://localhost:8000

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+dist-ssr
+*.local
+.env
+.env.*.local
+.vite
+*.tsbuildinfo

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,79 @@
+# NeuroNews Intelligence Terminal — Web Frontend
+
+A React + Vite + TypeScript single-page app that implements the **NeuroNews
+Intelligence Terminal** design (dark "terminal" UI) pixel-for-pixel, wired to
+the NeuroNews FastAPI backend (`src/api`).
+
+## Stack
+
+- **React 18** + **TypeScript**
+- **Vite** (dev server, build)
+- **TanStack Query** for data fetching with transparent fallback
+
+No CSS framework: the design is reproduced with the exact inline styles, fonts
+(Space Grotesk / IBM Plex Mono / IBM Plex Sans) and color tokens from the
+handoff. Tokens live in `src/theme.ts`.
+
+## Getting started
+
+```bash
+cd apps/web
+npm install
+npm run dev        # http://localhost:5173
+```
+
+By default the dev server proxies API requests to the FastAPI backend at
+`http://localhost:8000` (override with `VITE_API_PROXY_TARGET`). Start the
+backend separately, e.g.:
+
+```bash
+uvicorn src.api.app:app --reload --port 8000
+```
+
+For production builds, point the app at an absolute backend origin:
+
+```bash
+VITE_API_BASE_URL=https://api.neuronews.example npm run build
+npm run preview
+```
+
+## Views & backend wiring
+
+Each view fetches from the backend and **falls back to the design dataset** if
+the endpoint is unreachable or returns no rows, so the UI always renders. The
+data source (`live` / `demo`) is tracked per query in `src/lib/queries.ts`.
+
+| View            | Backend endpoint(s)                                  |
+| --------------- | ---------------------------------------------------- |
+| Overview        | aggregates feed / clusters / trending                |
+| News Feed       | `GET /api/v1/news/articles`                          |
+| Entity Graph    | `GET /api/influence/top-influencers`                 |
+| Sentiment       | static heatmap (no live endpoint yet)                |
+| Event Clusters  | `GET /api/v1/events/clusters`                        |
+| Trending        | `GET /topics/trending`                               |
+| Breaking ticker | `GET /api/v1/breaking_news`                          |
+| Workspaces      | client research data (no backend endpoint)           |
+| Watchlists      | client research data (no backend endpoint)           |
+| Story Timeline  | client research data (no backend endpoint)           |
+
+> Note: the backend list endpoints expose a subset of the fields the design
+> shows (e.g. `/news/articles` has no per-article summary/entities, and the
+> cluster endpoint has no aggregate sentiment). Adapters in `src/lib/adapters.ts`
+> degrade gracefully for missing fields. Wiring the research views and the
+> richer per-article fields is a natural follow-up once the backend exposes them.
+
+## Project layout
+
+```
+src/
+  theme.ts              design tokens (colors, fonts, accent)
+  types.ts              view-model types
+  lib/
+    api.ts              typed fetch client for the FastAPI backend
+    adapters.ts         backend response -> view-model mapping
+    queries.ts          React Query hooks + demo fallback
+    sentiment.ts        sentColor / sentLabel / fmt helpers
+  data/mock.ts          design dataset (fallback + research views)
+  components/           Sidebar, TopBar, BreakingTicker, charts, ...
+  views/                one component per terminal view
+```

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>NeuroNews · Intelligence Terminal</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,0 +1,1777 @@
+{
+  "name": "@neuronews/web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@neuronews/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.59.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.21",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@neuronews/web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "NeuroNews Intelligence Terminal — web frontend",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.59.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { fonts } from "./theme";
+import type { ViewKey } from "./types";
+import { useTicker } from "./lib/queries";
+import Sidebar from "./components/Sidebar";
+import TopBar from "./components/TopBar";
+import BreakingTicker from "./components/BreakingTicker";
+import Dashboard from "./views/Dashboard";
+import NewsFeed from "./views/NewsFeed";
+import EntityGraphView from "./views/EntityGraphView";
+import Sentiment from "./views/Sentiment";
+import Clusters from "./views/Clusters";
+import Trending from "./views/Trending";
+import Workspaces from "./views/Workspaces";
+import Watchlists from "./views/Watchlists";
+import Timeline from "./views/Timeline";
+
+export default function App() {
+  const [view, setView] = useState<ViewKey>("dashboard");
+  const { data: ticker } = useTicker();
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "100vh",
+        width: "100%",
+        background: "#0a0d12",
+        color: "#e6eaf0",
+        fontFamily: fonts.sans,
+        overflow: "hidden",
+      }}
+    >
+      <Sidebar view={view} setView={setView} ingestRate="64" />
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <TopBar />
+        <BreakingTicker text={ticker} />
+        <main style={{ flex: 1, overflowY: "auto", padding: "22px 24px 40px" }}>
+          {view === "dashboard" && <Dashboard setView={setView} />}
+          {view === "feed" && <NewsFeed />}
+          {view === "graph" && <EntityGraphView />}
+          {view === "sentiment" && <Sentiment />}
+          {view === "clusters" && <Clusters />}
+          {view === "trending" && <Trending />}
+          {view === "workspaces" && <Workspaces />}
+          {view === "watchlists" && <Watchlists />}
+          {view === "timeline" && <Timeline />}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/BreakingTicker.tsx
+++ b/apps/web/src/components/BreakingTicker.tsx
@@ -1,0 +1,55 @@
+import { ACCENT, fonts } from "../theme";
+
+interface Props {
+  text: string;
+}
+
+export default function BreakingTicker({ text }: Props) {
+  return (
+    <div
+      style={{
+        height: 30,
+        flex: "none",
+        background: "#11070a",
+        borderBottom: "1px solid #2a1418",
+        display: "flex",
+        alignItems: "center",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          flex: "none",
+          background: ACCENT,
+          color: "#0a0d12",
+          fontFamily: fonts.mono,
+          fontWeight: 600,
+          fontSize: 10,
+          letterSpacing: "0.14em",
+          padding: "0 12px",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          zIndex: 2,
+        }}
+      >
+        BREAKING
+      </div>
+      <div style={{ flex: 1, overflow: "hidden", whiteSpace: "nowrap" }}>
+        <div
+          style={{
+            display: "inline-block",
+            whiteSpace: "nowrap",
+            animation: "ticker 48s linear infinite",
+            fontFamily: fonts.mono,
+            fontSize: 11.5,
+            color: "#c7b4b6",
+          }}
+        >
+          {text}
+          {text}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Hover.tsx
+++ b/apps/web/src/components/Hover.tsx
@@ -1,0 +1,28 @@
+import { useState, type CSSProperties, type ReactNode, type ElementType } from "react";
+
+interface HoverProps {
+  as?: ElementType;
+  style: CSSProperties;
+  hoverStyle?: CSSProperties;
+  onClick?: () => void;
+  children?: ReactNode;
+  title?: string;
+}
+
+// Replicates the design's `style-hover` attribute: merges `hoverStyle` over
+// the base style while the pointer is over the element.
+export default function Hover({ as, style, hoverStyle, onClick, children, title }: HoverProps) {
+  const [hovered, setHovered] = useState(false);
+  const Tag = (as ?? "div") as ElementType;
+  return (
+    <Tag
+      title={title}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={hovered && hoverStyle ? { ...style, ...hoverStyle } : style}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { fonts } from "../theme";
+
+interface Props {
+  title: string;
+  subtitle: ReactNode;
+  right?: ReactNode;
+}
+
+export default function PageHeader({ title, subtitle, right }: Props) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        justifyContent: right ? "space-between" : "flex-start",
+        marginBottom: 16,
+      }}
+    >
+      <div>
+        <h1 style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 21, margin: 0, letterSpacing: "-0.01em" }}>
+          {title}
+        </h1>
+        <p style={{ fontFamily: fonts.mono, fontSize: 11, color: "#5b6675", margin: "5px 0 0", letterSpacing: "0.04em" }}>
+          {subtitle}
+        </p>
+      </div>
+      {right}
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties } from "react";
+import { ACCENT, accentSoft, accentGlow, fonts } from "../theme";
+import type { ViewKey } from "../types";
+import Hover from "./Hover";
+
+interface NavDef {
+  key: ViewKey;
+  label: string;
+  glyph: string;
+  badge?: string;
+}
+
+const intelligenceNav: NavDef[] = [
+  { key: "dashboard", label: "Overview", glyph: "◧" },
+  { key: "feed", label: "News Feed", glyph: "≣", badge: "3.8k" },
+  { key: "graph", label: "Entity Graph", glyph: "⬡" },
+  { key: "sentiment", label: "Sentiment", glyph: "◑" },
+  { key: "clusters", label: "Event Clusters", glyph: "⊞", badge: "18" },
+  { key: "trending", label: "Trending", glyph: "↗" },
+];
+
+const researchNav: NavDef[] = [
+  { key: "workspaces", label: "Workspaces", glyph: "◳", badge: "4" },
+  { key: "watchlists", label: "Watchlists", glyph: "☆", badge: "6" },
+  { key: "timeline", label: "Story Timeline", glyph: "⤳" },
+];
+
+interface Props {
+  view: ViewKey;
+  setView: (v: ViewKey) => void;
+  ingestRate: string;
+}
+
+export default function Sidebar({ view, setView, ingestRate }: Props) {
+  const navBtn = (active: boolean): CSSProperties => ({
+    display: "flex",
+    alignItems: "center",
+    gap: 11,
+    width: "100%",
+    padding: "9px 10px",
+    border: "none",
+    borderRadius: 7,
+    cursor: "pointer",
+    fontFamily: fonts.sans,
+    fontSize: 13,
+    fontWeight: 500,
+    transition: "background .12s",
+    background: active ? accentSoft(ACCENT) : "transparent",
+    color: active ? ACCENT : "#9aa4b2",
+  });
+
+  const sectionLabel: CSSProperties = {
+    fontFamily: fonts.mono,
+    fontSize: 9.5,
+    color: "#4b5563",
+    letterSpacing: "0.16em",
+    padding: "8px 10px 6px",
+  };
+
+  const badge: CSSProperties = {
+    fontFamily: fonts.mono,
+    fontSize: 10,
+    background: "#1c2330",
+    color: "#8a94a6",
+    padding: "1px 6px",
+    borderRadius: 10,
+  };
+
+  const renderNav = (items: NavDef[]) =>
+    items.map((n) => (
+      <Hover
+        key={n.key}
+        as="button"
+        onClick={() => setView(n.key)}
+        style={navBtn(view === n.key)}
+        hoverStyle={view === n.key ? {} : { background: "#161d28", color: "#e6eaf0" }}
+      >
+        <span style={{ width: 18, flex: "none", textAlign: "center", fontSize: 13 }}>{n.glyph}</span>
+        <span style={{ flex: 1, textAlign: "left" }}>{n.label}</span>
+        {n.badge ? <span style={badge}>{n.badge}</span> : null}
+      </Hover>
+    ));
+
+  return (
+    <aside
+      style={{
+        width: 236,
+        flex: "none",
+        background: "#0c1016",
+        borderRight: "1px solid #1c2330",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div
+        style={{
+          padding: "20px 18px 18px",
+          borderBottom: "1px solid #1c2330",
+          display: "flex",
+          alignItems: "center",
+          gap: 11,
+        }}
+      >
+        <div
+          style={{
+            width: 34,
+            height: 34,
+            flex: "none",
+            borderRadius: 8,
+            background: ACCENT,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxShadow: `0 0 18px -2px ${accentGlow(ACCENT)}`,
+          }}
+        >
+          <span style={{ fontFamily: fonts.grotesk, fontWeight: 700, fontSize: 19, color: "#0a0d12" }}>N</span>
+        </div>
+        <div style={{ lineHeight: 1.1 }}>
+          <div style={{ fontFamily: fonts.grotesk, fontWeight: 700, fontSize: 16, letterSpacing: "-0.01em" }}>
+            NeuroNews
+          </div>
+          <div style={{ fontFamily: fonts.mono, fontSize: 9.5, color: "#5b6675", letterSpacing: "0.16em", marginTop: 2 }}>
+            INTELLIGENCE TERMINAL
+          </div>
+        </div>
+      </div>
+
+      <nav style={{ flex: 1, padding: "12px 10px", display: "flex", flexDirection: "column", gap: 2, overflowY: "auto" }}>
+        <div style={sectionLabel}>INTELLIGENCE</div>
+        {renderNav(intelligenceNav)}
+        <div style={{ ...sectionLabel, padding: "18px 10px 6px" }}>RESEARCH</div>
+        {renderNav(researchNav)}
+      </nav>
+
+      <div style={{ padding: "14px 16px", borderTop: "1px solid #1c2330", display: "flex", flexDirection: "column", gap: 9 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ width: 7, height: 7, borderRadius: "50%", background: "#3DD68C", animation: "blink 2s infinite" }} />
+          <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#8a94a6" }}>PIPELINE LIVE</span>
+        </div>
+        <div style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#5b6675", display: "flex", justifyContent: "space-between" }}>
+          <span>142 sources</span>
+          <span>{ingestRate}/min</span>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { ACCENT, fonts } from "../theme";
+
+function useUtcClock() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(t);
+  }, []);
+  return now;
+}
+
+export default function TopBar() {
+  const now = useUtcClock();
+  const pad2 = (x: number) => String(x).padStart(2, "0");
+  const clock = `${pad2(now.getUTCHours())}:${pad2(now.getUTCMinutes())}:${pad2(now.getUTCSeconds())}`;
+  const dateStr = now
+    .toLocaleDateString("en-US", { month: "short", day: "2-digit", timeZone: "UTC" })
+    .toUpperCase();
+
+  return (
+    <header
+      style={{
+        height: 54,
+        flex: "none",
+        borderBottom: "1px solid #1c2330",
+        background: "#0c1016",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 18px",
+        gap: 16,
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          maxWidth: 440,
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          background: "#10151d",
+          border: "1px solid #232a36",
+          borderRadius: 7,
+          padding: "8px 12px",
+        }}
+      >
+        <span style={{ color: "#5b6675", fontSize: 13 }}>⌕</span>
+        <input
+          placeholder="Search entities, topics, sources…"
+          style={{
+            flex: 1,
+            background: "transparent",
+            border: "none",
+            outline: "none",
+            color: "#e6eaf0",
+            fontFamily: fonts.sans,
+            fontSize: 13,
+          }}
+        />
+        <span
+          style={{
+            fontFamily: fonts.mono,
+            fontSize: 9.5,
+            color: "#4b5563",
+            border: "1px solid #2a3340",
+            borderRadius: 4,
+            padding: "1px 5px",
+          }}
+        >
+          ⌘K
+        </span>
+      </div>
+      <div style={{ flex: 1 }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+        <div style={{ textAlign: "right", lineHeight: 1.15 }}>
+          <div style={{ fontFamily: fonts.mono, fontSize: 14, fontWeight: 500, color: ACCENT }}>{clock}</div>
+          <div style={{ fontFamily: fonts.mono, fontSize: 9, color: "#5b6675", letterSpacing: "0.1em" }}>
+            UTC · {dateStr}
+          </div>
+        </div>
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            background: "#1c2330",
+            border: "1px solid #2a3340",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: fonts.mono,
+            fontSize: 11,
+            color: "#8a94a6",
+          }}
+        >
+          AK
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/charts/EntityGraph.tsx
+++ b/apps/web/src/components/charts/EntityGraph.tsx
@@ -1,0 +1,72 @@
+import { ACCENT, palette, fonts } from "../../theme";
+import type { GraphNode } from "../../types";
+
+interface Props {
+  accent?: string;
+}
+
+// Static force-style entity relationship graph. Ported from `buildGraph`.
+export default function EntityGraph({ accent = ACCENT }: Props) {
+  const W = 760;
+  const H = 480;
+  const nodes: GraphNode[] = [
+    { id: "fed", label: "Federal Reserve", x: 0.3, y: 0.3, r: 26, type: "org", color: accent },
+    { id: "powell", label: "J. Powell", x: 0.16, y: 0.52, r: 15, type: "person", color: palette.blue },
+    { id: "pce", label: "PCE", x: 0.44, y: 0.16, r: 13, type: "topic", color: palette.amber },
+    { id: "nvda", label: "Nvidia", x: 0.66, y: 0.28, r: 24, type: "org", color: accent },
+    { id: "huang", label: "J. Huang", x: 0.82, y: 0.16, r: 14, type: "person", color: palette.blue },
+    { id: "ai", label: "AI", x: 0.6, y: 0.5, r: 20, type: "topic", color: palette.amber },
+    { id: "eu", label: "European Union", x: 0.4, y: 0.7, r: 21, type: "org", color: accent },
+    { id: "msft", label: "Microsoft", x: 0.6, y: 0.78, r: 18, type: "org", color: accent },
+    { id: "opec", label: "OPEC", x: 0.84, y: 0.62, r: 17, type: "org", color: accent },
+    { id: "oil", label: "Crude Oil", x: 0.84, y: 0.84, r: 15, type: "topic", color: palette.amber },
+    { id: "eu2", label: "Brussels", x: 0.2, y: 0.8, r: 12, type: "place", color: palette.violet },
+    { id: "cloud", label: "Cloud", x: 0.5, y: 0.92, r: 13, type: "topic", color: palette.amber },
+  ];
+  const edges: [string, string][] = [
+    ["fed", "powell"], ["fed", "pce"], ["fed", "ai"], ["nvda", "huang"], ["nvda", "ai"], ["ai", "msft"],
+    ["eu", "msft"], ["eu", "eu2"], ["msft", "cloud"], ["eu", "cloud"], ["opec", "oil"], ["nvda", "fed"], ["ai", "eu"],
+  ];
+  const N: Record<string, GraphNode> = {};
+  nodes.forEach((n) => (N[n.id] = n));
+  const px = (n: GraphNode) => n.x * W;
+  const py = (n: GraphNode) => n.y * H;
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={480} style={{ display: "block" }}>
+      <g>
+        {edges.map((e, i) => (
+          <line
+            key={i}
+            x1={px(N[e[0]])}
+            y1={py(N[e[0]])}
+            x2={px(N[e[1]])}
+            y2={py(N[e[1]])}
+            stroke="#2a3340"
+            strokeWidth={1.2}
+          />
+        ))}
+      </g>
+      <g>
+        {nodes.map((n, i) => (
+          <g key={i}>
+            <circle cx={px(n)} cy={py(n)} r={n.r + 5} fill={n.color} opacity={0.1} />
+            <circle cx={px(n)} cy={py(n)} r={n.r} fill="#0e131a" stroke={n.color} strokeWidth={2} />
+            <circle cx={px(n)} cy={py(n)} r={Math.max(3, n.r * 0.28)} fill={n.color} />
+            <text
+              x={px(n)}
+              y={py(n) + n.r + 13}
+              textAnchor="middle"
+              fill="#c7cdd6"
+              fontSize={11}
+              fontFamily={fonts.sans}
+              fontWeight={500}
+            >
+              {n.label}
+            </text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/apps/web/src/components/charts/Heatmap.tsx
+++ b/apps/web/src/components/charts/Heatmap.tsx
@@ -1,0 +1,52 @@
+import { fonts } from "../../theme";
+import { mockHeatmap } from "../../data/mock";
+
+// Sentiment heatmap (topics × 16 hourly columns). Ported from `buildHeatmap`.
+function cellColor(v: number): string {
+  if (v > 0.05) {
+    const t = Math.min(v / 0.7, 1);
+    return `rgba(61,214,140,${0.18 + 0.7 * t})`;
+  }
+  if (v < -0.05) {
+    const t = Math.min(-v / 0.7, 1);
+    return `rgba(255,92,92,${0.18 + 0.7 * t})`;
+  }
+  return "rgba(139,149,165,0.16)";
+}
+
+export default function Heatmap() {
+  const { topics, cols, seed } = mockHeatmap;
+  const nowHour = new Date().getUTCHours();
+  const hours = Array.from({ length: cols }, (_, i) => ((nowHour - (cols - 1 - i)) % 24 + 24) % 24);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+      {topics.map((t, ri) => (
+        <div key={ri} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div style={{ width: 78, flex: "none", fontSize: 11.5, color: "#9aa4b2", fontFamily: fonts.sans }}>
+            {t}
+          </div>
+          <div style={{ flex: 1, display: "grid", gridTemplateColumns: `repeat(${cols},1fr)`, gap: 4 }}>
+            {seed[ri].map((v, ci) => (
+              <div
+                key={ci}
+                title={`${t} · ${v.toFixed(2)}`}
+                style={{ height: 26, borderRadius: 3, background: cellColor(v) }}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 2 }}>
+        <div style={{ width: 78, flex: "none" }} />
+        <div style={{ flex: 1, display: "grid", gridTemplateColumns: `repeat(${cols},1fr)`, gap: 4 }}>
+          {hours.map((h, i) => (
+            <div key={i} style={{ textAlign: "center", fontFamily: fonts.mono, fontSize: 9, color: "#4b5563" }}>
+              {i % 2 === 0 ? String(h).padStart(2, "0") : ""}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/Sparkline.tsx
+++ b/apps/web/src/components/charts/Sparkline.tsx
@@ -1,0 +1,24 @@
+interface Props {
+  values: number[];
+  color: string;
+}
+
+// Mini sparkline used in watchlist cards. Ported from `buildSpark` (W=96,H=30).
+export default function Sparkline({ values, color }: Props) {
+  const W = 96;
+  const H = 30;
+  const pad = 2;
+  const mn = Math.min(...values);
+  const mx = Math.max(...values);
+  const rng = mx - mn || 1;
+  const xs = (i: number) => pad + (i / (values.length - 1)) * (W - 2 * pad);
+  const ys = (v: number) => H - pad - ((v - mn) / rng) * (H - 2 * pad);
+  const line = values.map((v, i) => `${xs(i).toFixed(1)},${ys(v).toFixed(1)}`).join(" ");
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width={W} height={H} preserveAspectRatio="none" style={{ display: "block" }}>
+      <polyline points={line} fill="none" stroke={color} strokeWidth={1.6} strokeLinejoin="round" strokeLinecap="round" />
+      <circle cx={xs(values.length - 1)} cy={ys(values[values.length - 1])} r={2.4} fill={color} />
+    </svg>
+  );
+}

--- a/apps/web/src/components/charts/TrendChart.tsx
+++ b/apps/web/src/components/charts/TrendChart.tsx
@@ -1,0 +1,48 @@
+import { ACCENT } from "../../theme";
+import { mockTrendSeries } from "../../data/mock";
+
+interface Props {
+  values?: number[];
+  accent?: string;
+}
+
+// Market Sentiment Index area+line chart. Ported from the design's
+// `buildTrendChart` (W=720, H=188).
+export default function TrendChart({ values = mockTrendSeries, accent = ACCENT }: Props) {
+  const W = 720;
+  const H = 188;
+  const pad = 8;
+  const n = values.length;
+  const xs = (i: number) => pad + (i / (n - 1)) * (W - 2 * pad);
+  const ys = (v: number) => H / 2 - v * (H / 2 - 14);
+  const line = values.map((v, i) => `${xs(i).toFixed(1)},${ys(v).toFixed(1)}`).join(" ");
+  const area = `${pad},${H / 2} ${line} ${(W - pad).toFixed(1)},${H / 2}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      height={188}
+      preserveAspectRatio="none"
+      style={{ display: "block" }}
+    >
+      <defs>
+        <linearGradient id="tg" x1={0} y1={0} x2={0} y2={1}>
+          <stop offset="0%" stopColor={accent} stopOpacity={0.28} />
+          <stop offset="100%" stopColor={accent} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <line x1={pad} y1={H / 2} x2={W - pad} y2={H / 2} stroke="#232a36" strokeWidth={1} strokeDasharray="3 4" />
+      <polygon points={area} fill="url(#tg)" />
+      <polyline
+        points={line}
+        fill="none"
+        stroke={accent}
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={xs(n - 1)} cy={ys(values[n - 1])} r={4} fill={accent} stroke="#0c1016" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -1,0 +1,152 @@
+// Data carried over verbatim from the design handoff. Used as a graceful
+// fallback when a backend endpoint is unreachable, and as the source of truth
+// for the research views (Workspaces / Watchlists / Timeline) that have no
+// corresponding backend endpoint yet.
+
+import type {
+  Article,
+  Cluster,
+  TrendingTopic,
+  Workspace,
+  WorkspaceDetail,
+  WatchItem,
+  Story,
+  TimelineEvent,
+} from "../types";
+
+export const mockArticles: Article[] = [
+  { title: "Federal Reserve signals pause on rate hikes amid cooling inflation data", source: "Reuters", time: "2m", category: "Economy", sent: 0.34, summary: "Policymakers indicated a willingness to hold rates steady as core PCE eased for a third consecutive month, lifting risk assets.", entities: ["Federal Reserve", "Jerome Powell", "PCE"] },
+  { title: "Nvidia unveils next-gen Blackwell Ultra accelerators at developer summit", source: "Bloomberg", time: "8m", category: "Technology", sent: 0.61, summary: "The chipmaker claims a 4x throughput gain for large-model inference, deepening its lead in the AI hardware race.", entities: ["Nvidia", "Jensen Huang", "AI"] },
+  { title: "EU regulators open antitrust probe into cloud licensing practices", source: "FT", time: "14m", category: "Policy", sent: -0.42, summary: "Brussels is examining whether bundling terms unfairly disadvantage rival cloud providers across the bloc.", entities: ["European Union", "Microsoft", "Antitrust"] },
+  { title: "Oil slips below $74 as OPEC+ weighs output adjustments", source: "CNBC", time: "21m", category: "Energy", sent: -0.18, summary: "Crude retreated on demand concerns ahead of the cartel’s ministerial meeting later this week.", entities: ["OPEC", "Saudi Arabia", "Crude Oil"] },
+  { title: "Breakthrough fusion experiment sustains net energy gain for record duration", source: "Nature", time: "33m", category: "Science", sent: 0.72, summary: "Researchers report a stable burning plasma lasting several seconds, a milestone for commercial viability.", entities: ["Fusion", "LLNL", "Plasma"] },
+  { title: "Major bank flags rising commercial real-estate delinquencies", source: "WSJ", time: "47m", category: "Finance", sent: -0.55, summary: "Quarterly filings show provisions for office-loan losses climbing as refinancing pressure mounts.", entities: ["JPMorgan", "CRE", "Credit"] },
+  { title: "Pacific trade bloc finalizes digital-economy framework", source: "Nikkei", time: "1h", category: "Trade", sent: 0.28, summary: "Member states agreed on cross-border data flow rules and aligned standards for digital services.", entities: ["CPTPP", "Japan", "Trade"] },
+  { title: "Pharma giant’s Alzheimer’s drug clears late-stage trial endpoint", source: "STAT", time: "1h", category: "Health", sent: 0.49, summary: "The therapy slowed cognitive decline by 27% versus placebo, sending shares sharply higher in pre-market.", entities: ["Eli Lilly", "FDA", "Alzheimer’s"] },
+];
+
+export const mockClusters: Omit<Cluster, "headlines">[] = [
+  { title: "Global central banks converge on rate-pause signaling", count: 47, sources: 23, time: "12m", sent: 0.31, vel: "▲ 340%/h" },
+  { title: "AI chip supply chain tightens ahead of Q3 demand surge", count: 38, sources: 19, time: "24m", sent: 0.18, vel: "▲ 210%/h" },
+  { title: "Cloud antitrust scrutiny widens across EU and US", count: 31, sources: 17, time: "38m", sent: -0.39, vel: "▲ 155%/h" },
+  { title: "Energy markets react to OPEC+ output uncertainty", count: 29, sources: 21, time: "51m", sent: -0.22, vel: "▼ 40%/h" },
+  { title: "Fusion milestone reignites clean-energy investment thesis", count: 22, sources: 14, time: "1h", sent: 0.66, vel: "▲ 480%/h" },
+  { title: "Commercial real-estate stress spreads to regional lenders", count: 26, sources: 16, time: "1h", sent: -0.51, vel: "▲ 90%/h" },
+];
+
+export const mockTrending: TrendingTopic[] = [
+  { topic: "Rate Pause", mentions: 4820, change: 340, sent: 0.31 },
+  { topic: "Blackwell Ultra", mentions: 3910, change: 210, sent: 0.58 },
+  { topic: "Fusion Energy", mentions: 2740, change: 480, sent: 0.66 },
+  { topic: "Cloud Antitrust", mentions: 2310, change: 155, sent: -0.39 },
+  { topic: "CRE Delinquency", mentions: 1980, change: 90, sent: -0.51 },
+  { topic: "OPEC+ Output", mentions: 1720, change: -40, sent: -0.22 },
+  { topic: "Alzheimer’s Trial", mentions: 1540, change: 120, sent: 0.49 },
+  { topic: "Digital Trade Pact", mentions: 1180, change: 64, sent: 0.28 },
+  { topic: "PCE Inflation", mentions: 980, change: 35, sent: 0.12 },
+  { topic: "Regional Banks", mentions: 870, change: 72, sent: -0.44 },
+];
+
+// 24h hourly market-sentiment index used by the dashboard trend chart.
+export const mockTrendSeries = [
+  0.05, 0.08, 0.02, -0.04, -0.1, -0.06, 0.01, 0.07, 0.12, 0.09, 0.15, 0.21,
+  0.18, 0.24, 0.19, 0.13, 0.16, 0.22, 0.28, 0.25, 0.31, 0.27, 0.33, 0.3,
+];
+
+export const mockWorkspaces: Workspace[] = [
+  { id: "p1", q: "Is the AI chip supply chain a systemic risk to 2026 growth?", status: "Active", sources: 23, notes: 8, updated: "14m", color: "#FF6B6B" },
+  { id: "p2", q: "How is cloud antitrust enforcement evolving across jurisdictions?", status: "Active", sources: 17, notes: 5, updated: "1h", color: "#5B9DFF" },
+  { id: "p3", q: "Will the Fed rate-pause hold through Q3 2026?", status: "Synthesizing", sources: 31, notes: 12, updated: "3m", color: "#3DD68C" },
+  { id: "p4", q: "CRE contagion risk to US regional banks", status: "Active", sources: 14, notes: 4, updated: "2h", color: "#FFD93D" },
+];
+
+export const mockWorkspaceDetail: Record<string, WorkspaceDetail> = {
+  p1: {
+    sub: ["Where are the single points of failure in advanced-node fabrication?", "How exposed are hyperscalers to a Taiwan disruption?", "Which substitutes scale within 18 months?"],
+    sources: [
+      { title: "Nvidia unveils next-gen Blackwell Ultra accelerators", source: "Bloomberg", time: "8m", sent: 0.61, note: "Confirms demand outpacing supply — key supporting evidence." },
+      { title: "AI chip supply chain tightens ahead of Q3 demand surge", source: "Nikkei", time: "24m", sent: 0.18, note: "Names CoWoS packaging as the bottleneck." },
+      { title: "TSMC raises capex guidance on advanced-node demand", source: "Reuters", time: "2h", sent: 0.34, note: "Counterpoint: capacity coming online late 2026." },
+    ],
+    entities: ["Nvidia", "TSMC", "CoWoS", "Taiwan", "Hyperscalers"],
+  },
+  p2: {
+    sub: ["Are EU and US theories of harm converging?", "What remedies are regulators signalling?", "Precedent from prior cloud cases?"],
+    sources: [
+      { title: "EU regulators open antitrust probe into cloud licensing", source: "FT", time: "14m", sent: -0.42, note: "Primary trigger for this investigation." },
+      { title: "Cloud antitrust scrutiny widens across EU and US", source: "WSJ", time: "38m", sent: -0.39, note: "Suggests coordinated cross-jurisdiction action." },
+    ],
+    entities: ["European Union", "Microsoft", "Antitrust", "Brussels"],
+  },
+  p3: {
+    sub: ["Does core PCE trajectory support a hold?", "What is the labour-market read?", "How are markets pricing the path?", "Dissent risk on the committee?"],
+    sources: [
+      { title: "Federal Reserve signals pause on rate hikes amid cooling inflation", source: "Reuters", time: "2m", sent: 0.34, note: "Strongest direct evidence for the pause thesis." },
+      { title: "Core PCE eases for third consecutive month", source: "CNBC", time: "1h", sent: 0.21, note: "Supports disinflation trend." },
+      { title: "Labour market shows gradual cooling, not collapse", source: "Bloomberg", time: "3h", sent: 0.08, note: "Reduces pressure to cut — favours hold." },
+      { title: "Two FOMC members flag upside inflation risk", source: "WSJ", time: "5h", sent: -0.22, note: "Dissent risk — weakens a clean hold narrative." },
+    ],
+    entities: ["Federal Reserve", "Jerome Powell", "PCE", "FOMC"],
+  },
+  p4: {
+    sub: ["How concentrated is office-loan exposure regionally?", "What refinancing wall hits in 2026?", "Are provisions keeping pace?"],
+    sources: [
+      { title: "Major bank flags rising commercial real-estate delinquencies", source: "WSJ", time: "47m", sent: -0.55, note: "Lead evidence of stress building." },
+      { title: "Regional lenders raise loss provisions on office loans", source: "FT", time: "4h", sent: -0.44, note: "Shows contagion path to smaller banks." },
+    ],
+    entities: ["JPMorgan", "CRE", "Regional Banks", "Credit"],
+  },
+};
+
+export const mockWatchlist: WatchItem[] = [
+  { name: "Nvidia", type: "Entity", mentions: 38, change: 210, sent: 0.58, spark: [8, 10, 9, 14, 18, 22, 30, 38], alert: true },
+  { name: "Federal Reserve", type: "Entity", mentions: 42, change: 12, sent: 0.31, spark: [30, 34, 33, 36, 38, 40, 41, 42], alert: false },
+  { name: "Cloud Antitrust", type: "Topic", mentions: 31, change: 155, sent: -0.39, spark: [6, 8, 7, 12, 18, 24, 28, 31], alert: true },
+  { name: "Fusion Energy", type: "Topic", mentions: 22, change: 480, sent: 0.66, spark: [2, 3, 2, 4, 7, 12, 18, 22], alert: true },
+  { name: "OPEC+", type: "Topic", mentions: 17, change: -40, sent: -0.22, spark: [28, 26, 24, 22, 21, 19, 18, 17], alert: false },
+  { name: "Jerome Powell", type: "Person", mentions: 19, change: 8, sent: 0.12, spark: [14, 16, 15, 17, 18, 18, 19, 19], alert: false },
+];
+
+export const mockStories: Story[] = [
+  { id: "s1", label: "AI chip supply chain", sent: 0.18 },
+  { id: "s2", label: "Fed rate-pause signal", sent: 0.31 },
+  { id: "s3", label: "Cloud antitrust probe", sent: -0.39 },
+];
+
+export const mockTimeline: Record<string, TimelineEvent[]> = {
+  s1: [
+    { date: "Jun 04", title: "Reports surface of tightening CoWoS packaging capacity", source: "Nikkei", kind: "Origin", sent: -0.1 },
+    { date: "Jun 07", title: "TSMC privately warns key clients of allocation cuts", source: "Reuters", kind: "Development", sent: -0.22 },
+    { date: "Jun 11", title: "Hyperscalers reportedly pre-pay to secure 2026 supply", source: "Bloomberg", kind: "Development", sent: 0.05 },
+    { date: "Jun 14", title: "TSMC raises capex guidance on advanced-node demand", source: "Reuters", kind: "Reaction", sent: 0.34 },
+    { date: "Jun 18", title: "Nvidia unveils Blackwell Ultra; demand seen outpacing supply", source: "Bloomberg", kind: "Milestone", sent: 0.61 },
+  ],
+  s2: [
+    { date: "Jun 02", title: "Core PCE eases for a second month", source: "CNBC", kind: "Origin", sent: 0.12 },
+    { date: "Jun 09", title: "Labour market shows gradual cooling", source: "Bloomberg", kind: "Development", sent: 0.08 },
+    { date: "Jun 13", title: "Two FOMC members flag upside inflation risk", source: "WSJ", kind: "Reaction", sent: -0.22 },
+    { date: "Jun 18", title: "Fed signals pause as core PCE eases third month", source: "Reuters", kind: "Milestone", sent: 0.34 },
+  ],
+  s3: [
+    { date: "Jun 06", title: "Complaints filed over cloud licensing bundling", source: "Politico", kind: "Origin", sent: -0.2 },
+    { date: "Jun 12", title: "US agencies signal interest in cloud competition", source: "WSJ", kind: "Development", sent: -0.3 },
+    { date: "Jun 18", title: "EU opens formal antitrust probe into cloud licensing", source: "FT", kind: "Milestone", sent: -0.42 },
+  ],
+};
+
+// Heatmap seed (topics × 16 hourly columns) from the design.
+export const mockHeatmap = {
+  topics: ["Economy", "Technology", "Energy", "Policy", "Health", "Markets"],
+  cols: 16,
+  seed: [
+    [0.1, 0.2, 0.0, -0.1, 0.1, 0.3, 0.2, 0.4, 0.3, 0.1, -0.1, 0.0, 0.2, 0.3, 0.4, 0.3],
+    [0.4, 0.5, 0.3, 0.6, 0.5, 0.4, 0.6, 0.7, 0.5, 0.4, 0.5, 0.6, 0.4, 0.5, 0.6, 0.5],
+    [-0.2, -0.3, -0.1, -0.4, -0.2, 0.0, -0.1, -0.3, -0.2, -0.4, -0.1, 0.0, -0.2, -0.3, -0.1, -0.2],
+    [0.0, -0.2, -0.4, -0.3, -0.5, -0.2, -0.1, -0.3, -0.4, -0.2, 0.0, -0.1, -0.3, -0.4, -0.2, -0.4],
+    [0.2, 0.3, 0.4, 0.3, 0.5, 0.4, 0.3, 0.5, 0.4, 0.6, 0.5, 0.4, 0.3, 0.5, 0.4, 0.5],
+    [0.1, -0.1, 0.0, 0.2, -0.2, 0.1, -0.3, 0.0, 0.2, -0.1, 0.3, 0.1, -0.2, 0.0, 0.1, -0.1],
+  ],
+};
+
+export const mockTickerText =
+  "  ●  Fed signals rate pause as core PCE eases  ●  Nvidia Blackwell Ultra claims 4x inference gain  ●  EU opens cloud antitrust probe  ●  Fusion experiment sustains net energy gain  ●  Oil slips below $74 on OPEC+ uncertainty  ●  Alzheimer’s drug clears late-stage trial  ";

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,46 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+::-webkit-scrollbar-track {
+  background: #0a0d12;
+}
+::-webkit-scrollbar-thumb {
+  background: #2a3340;
+  border-radius: 0;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #3a4554;
+}
+
+@keyframes blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0.25;
+  }
+}
+
+@keyframes ticker {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { refetchOnWindowFocus: false, retry: false },
+  },
+});
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -1,0 +1,45 @@
+// Design tokens mirrored 1:1 from the "NeuroNews Terminal" design handoff.
+// The design exposed `accent` as a configurable prop (default #FF6B6B).
+
+export const ACCENT = "#FF6B6B";
+
+export const palette = {
+  pos: "#3DD68C",
+  neg: "#FF5C5C",
+  neu: "#8B95A5",
+  teal: "#4ECDC4",
+  amber: "#FFD93D",
+  blue: "#5B9DFF",
+  violet: "#A78BFA",
+  dim: "#8a94a6",
+  faint: "#5b6675",
+} as const;
+
+export const colors = {
+  bg: "#0a0d12",
+  sidebar: "#0c1016",
+  card: "#11151c",
+  cardInner: "#0e131a",
+  input: "#10151d",
+  text: "#e6eaf0",
+  textMuted: "#c7cdd6",
+  textSubtle: "#9aa4b2",
+  borderSoft: "#161d28",
+  border: "#1c2330",
+  border2: "#232a36",
+  border3: "#2a3340",
+  border4: "#3a4554",
+  faint2: "#4b5563",
+} as const;
+
+export const fonts = {
+  grotesk: "'Space Grotesk', system-ui, sans-serif",
+  mono: "'IBM Plex Mono', monospace",
+  sans: "'IBM Plex Sans', system-ui, sans-serif",
+} as const;
+
+// Hex-with-alpha helpers, matching the design's `acc + '1a'` style suffixes.
+export const accentSoft = (accent: string) => `${accent}1a`;
+export const accentBorder = (accent: string) => `${accent}55`;
+export const accentGlow = (accent: string) => `${accent}66`;
+export const tint = (hex: string, suffix: string) => `${hex}${suffix}`;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,133 @@
+// View-model types consumed by the UI components. Backend responses are
+// mapped into these shapes by the adapters in lib/adapters.ts.
+
+export interface Article {
+  title: string;
+  source: string;
+  time: string;
+  category: string;
+  sent: number;
+  summary: string;
+  entities: string[];
+}
+
+export interface Cluster {
+  title: string;
+  count: number;
+  sources: number;
+  time: string;
+  sent: number;
+  vel: string;
+  headlines: string[];
+}
+
+export interface TrendingTopic {
+  topic: string;
+  mentions: number;
+  change: number;
+  sent: number;
+}
+
+export interface Kpi {
+  label: string;
+  value: string;
+  delta: string;
+  deltaLabel: string;
+  color: string;
+  positive: boolean;
+}
+
+export interface SentimentStat {
+  label: string;
+  value: string;
+  color: string;
+  note: string;
+}
+
+export interface LegendItem {
+  label: string;
+  color: string;
+  count: string;
+}
+
+export interface TopEntity {
+  name: string;
+  color: string;
+  links: number;
+}
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  r: number;
+  type: "org" | "person" | "topic" | "place";
+  color: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: [string, string][];
+  nodeCount: number;
+  edgeCount: number;
+}
+
+export interface Workspace {
+  id: string;
+  q: string;
+  status: "Active" | "Synthesizing";
+  sources: number;
+  notes: number;
+  updated: string;
+  color: string;
+}
+
+export interface WorkspaceSource {
+  title: string;
+  source: string;
+  time: string;
+  sent: number;
+  note: string;
+}
+
+export interface WorkspaceDetail {
+  sub: string[];
+  sources: WorkspaceSource[];
+  entities: string[];
+}
+
+export interface WatchItem {
+  name: string;
+  type: "Entity" | "Topic" | "Person";
+  mentions: number;
+  change: number;
+  sent: number;
+  spark: number[];
+  alert: boolean;
+}
+
+export interface Story {
+  id: string;
+  label: string;
+  sent: number;
+}
+
+export interface TimelineEvent {
+  date: string;
+  title: string;
+  source: string;
+  kind: "Origin" | "Development" | "Reaction" | "Milestone";
+  sent: number;
+}
+
+export type ViewKey =
+  | "dashboard"
+  | "feed"
+  | "graph"
+  | "sentiment"
+  | "clusters"
+  | "trending"
+  | "workspaces"
+  | "watchlists"
+  | "timeline";

--- a/apps/web/src/views/Clusters.tsx
+++ b/apps/web/src/views/Clusters.tsx
@@ -1,0 +1,78 @@
+import { palette, fonts } from "../theme";
+import { sentColor, sentLabel } from "../lib/sentiment";
+import { useArticles, useClusters } from "../lib/queries";
+import PageHeader from "../components/PageHeader";
+
+export default function Clusters() {
+  const { data: clustersRaw } = useClusters();
+  const { data: articles } = useArticles();
+
+  const clusters = clustersRaw.map((c, i) => ({
+    ...c,
+    headlines: articles.length
+      ? [articles[i % articles.length].title, articles[(i + 3) % articles.length].title]
+      : [],
+  }));
+
+  return (
+    <div>
+      <PageHeader
+        title="Event Clusters"
+        subtitle={`${clusters.length} active clusters · grouped by semantic similarity`}
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 12 }}>
+        {clusters.map((c, i) => {
+          const sc = sentColor(c.sent);
+          const velColor = c.vel[0] === "▲" ? palette.pos : palette.neg;
+          return (
+            <div
+              key={i}
+              style={{
+                background: "#11151c",
+                border: "1px solid #1c2330",
+                borderRadius: 10,
+                padding: "17px 19px",
+                borderLeft: `3px solid ${sc}`,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 9 }}>
+                <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: sc, letterSpacing: "0.08em" }}>
+                  {sentLabel(c.sent)}
+                </span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, color: velColor }}>{c.vel}</span>
+              </div>
+              <h3 style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 15.5, margin: "0 0 8px", lineHeight: 1.32 }}>
+                {c.title}
+              </h3>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  fontFamily: fonts.mono,
+                  fontSize: 10.5,
+                  color: "#5b6675",
+                  marginBottom: 11,
+                }}
+              >
+                <span>{c.count} articles</span>
+                <span>·</span>
+                <span>{c.sources} sources</span>
+                <span>·</span>
+                <span>{c.time}</span>
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 6, borderTop: "1px solid #1c2330", paddingTop: 11 }}>
+                {c.headlines.map((h, hi) => (
+                  <div key={hi} style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+                    <span style={{ color: "#3a4554", fontSize: 11, marginTop: 1 }}>›</span>
+                    <span style={{ flex: 1, fontSize: 12, color: "#9aa4b2", lineHeight: 1.4 }}>{h}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -1,0 +1,212 @@
+import { useState, type CSSProperties } from "react";
+import { ACCENT, palette, accentSoft, accentBorder, fonts } from "../theme";
+import { sentColor } from "../lib/sentiment";
+import { useArticles, useClusters, useTrending } from "../lib/queries";
+import type { Kpi, ViewKey } from "../types";
+import TrendChart from "../components/charts/TrendChart";
+import Hover from "../components/Hover";
+
+const kpis: Kpi[] = [
+  { label: "Articles 24h", value: "3,847", delta: "+12.4%", deltaLabel: "vs prev", color: ACCENT, positive: true },
+  { label: "Avg Sentiment", value: "+0.18", delta: "+0.06", deltaLabel: "shift", color: palette.pos, positive: true },
+  { label: "Active Clusters", value: "18", delta: "+4", deltaLabel: "new", color: palette.teal, positive: true },
+  { label: "Entities Tracked", value: "12,409", delta: "+318", deltaLabel: "24h", color: palette.blue, positive: true },
+  { label: "Avg Latency", value: "1.2s", delta: "-0.3s", deltaLabel: "ingest", color: palette.amber, positive: true },
+];
+
+const card: CSSProperties = {
+  background: "#11151c",
+  border: "1px solid #1c2330",
+  borderRadius: 10,
+  padding: "16px 18px",
+};
+
+const sectionTitle: CSSProperties = { fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 };
+const linkBtn: CSSProperties = {
+  fontFamily: fonts.mono,
+  fontSize: 10.5,
+  color: ACCENT,
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+};
+
+interface Props {
+  setView: (v: ViewKey) => void;
+}
+
+export default function Dashboard({ setView }: Props) {
+  const [range, setRange] = useState("24H");
+  const { data: articles } = useArticles();
+  const { data: clustersRaw } = useClusters();
+  const { data: trending } = useTrending();
+
+  const clusters = clustersRaw.slice(0, 3).map((c, i) => ({
+    ...c,
+    headlines: articles.length
+      ? [articles[i % articles.length].title, articles[(i + 3) % articles.length].title]
+      : [],
+  }));
+
+  const maxM = Math.max(1, ...trending.map((t) => t.mentions));
+  const trendingTop = trending.slice(0, 5).map((t, i) => ({
+    rank: i + 1,
+    topic: t.topic,
+    barWidth: Math.round((t.mentions / maxM) * 100) + "%",
+    change: (t.change >= 0 ? "+" : "") + t.change + "%",
+    changeColor: t.change >= 0 ? palette.pos : palette.neg,
+  }));
+
+  const feedTop = articles.slice(0, 4);
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 16 }}>
+        <div>
+          <h1 style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 21, margin: 0, letterSpacing: "-0.01em" }}>
+            Intelligence Overview
+          </h1>
+          <p style={{ fontFamily: fonts.mono, fontSize: 11, color: "#5b6675", margin: "5px 0 0", letterSpacing: "0.04em" }}>
+            Real-time signal across 142 sources · last 24h
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          {["1H", "6H", "24H", "7D"].map((r) => {
+            const active = r === range;
+            return (
+              <span
+                key={r}
+                onClick={() => setRange(r)}
+                style={{
+                  fontFamily: fonts.mono,
+                  fontSize: 10.5,
+                  padding: "4px 11px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  ...(active
+                    ? { background: accentSoft(ACCENT), color: ACCENT, border: `1px solid ${accentBorder(ACCENT)}` }
+                    : { background: "#11151c", color: "#8a94a6", border: "1px solid #232a36" }),
+                }}
+              >
+                {r}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* KPI row */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(5,1fr)", gap: 12, marginBottom: 16 }}>
+        {kpis.map((k) => (
+          <div key={k.label} style={{ ...card, padding: "15px 16px", position: "relative", overflow: "hidden" }}>
+            <div style={{ position: "absolute", top: 0, left: 0, width: 3, height: "100%", background: k.color }} />
+            <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6", letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              {k.label}
+            </div>
+            <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 26, marginTop: 8, letterSpacing: "-0.01em" }}>
+              {k.value}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 5, marginTop: 6 }}>
+              <span style={{ fontFamily: fonts.mono, fontSize: 11, color: k.positive ? palette.pos : palette.neg }}>{k.delta}</span>
+              <span style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675" }}>{k.deltaLabel}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Mid grid */}
+      <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr", gap: 12, marginBottom: 16 }}>
+        <div style={card}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 6 }}>
+            <div style={sectionTitle}>Market Sentiment Index</div>
+            <div style={{ fontFamily: fonts.mono, fontSize: 11, color: "#8a94a6" }}>24h · hourly</div>
+          </div>
+          <TrendChart />
+        </div>
+        <div style={card}>
+          <div style={{ ...sectionTitle, marginBottom: 12 }}>Trending Topics</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+            {trendingTop.map((t) => (
+              <div key={t.rank} style={{ display: "flex", alignItems: "center", gap: 11 }}>
+                <span style={{ fontFamily: fonts.mono, fontSize: 12, color: "#5b6675", width: 16 }}>{t.rank}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {t.topic}
+                  </div>
+                  <div style={{ height: 3, background: "#1c2330", borderRadius: 2, marginTop: 5, overflow: "hidden" }}>
+                    <div style={{ height: "100%", width: t.barWidth, background: ACCENT }} />
+                  </div>
+                </div>
+                <span style={{ fontFamily: fonts.mono, fontSize: 11, color: t.changeColor, width: 46, textAlign: "right" }}>
+                  {t.change}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom grid */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <div style={card}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+            <div style={sectionTitle}>Active Event Clusters</div>
+            <Hover as="button" onClick={() => setView("clusters")} style={linkBtn}>
+              VIEW ALL →
+            </Hover>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {clusters.map((c, i) => {
+              const sc = sentColor(c.sent);
+              return (
+                <div key={i} style={{ border: "1px solid #1c2330", borderRadius: 8, padding: "11px 13px", background: "#0e131a" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
+                    <span
+                      style={{
+                        fontFamily: fonts.mono,
+                        fontSize: 9,
+                        color: sc,
+                        border: `1px solid ${sc}55`,
+                        borderRadius: 4,
+                        padding: "1px 5px",
+                        letterSpacing: "0.06em",
+                      }}
+                    >
+                      {c.sent > 0.15 ? "POSITIVE" : c.sent < -0.15 ? "NEGATIVE" : "NEUTRAL"}
+                    </span>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675" }}>
+                      {c.count} articles · {c.sources} sources
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 500, lineHeight: 1.35 }}>{c.title}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={card}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+            <div style={sectionTitle}>Latest Feed</div>
+            <Hover as="button" onClick={() => setView("feed")} style={linkBtn}>
+              OPEN FEED →
+            </Hover>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {feedTop.map((a, i) => (
+              <div key={i} style={{ display: "flex", gap: 11, padding: "9px 0", borderBottom: "1px solid #161d28" }}>
+                <span style={{ width: 6, height: 6, flex: "none", borderRadius: "50%", background: sentColor(a.sent), marginTop: 6 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, lineHeight: 1.35, fontWeight: 500 }}>{a.title}</div>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675", marginTop: 4 }}>
+                    {a.source} · {a.time}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/EntityGraphView.tsx
+++ b/apps/web/src/views/EntityGraphView.tsx
@@ -1,0 +1,82 @@
+import { ACCENT, palette, fonts } from "../theme";
+import { useTopEntities } from "../lib/queries";
+import PageHeader from "../components/PageHeader";
+import EntityGraph from "../components/charts/EntityGraph";
+import type { LegendItem } from "../types";
+
+const legend: LegendItem[] = [
+  { label: "Organizations", color: ACCENT, count: "5,210" },
+  { label: "People", color: palette.blue, count: "3,840" },
+  { label: "Topics", color: palette.amber, count: "2,610" },
+  { label: "Places", color: palette.violet, count: "749" },
+];
+
+const panel = {
+  background: "#11151c",
+  border: "1px solid #1c2330",
+  borderRadius: 10,
+  padding: "14px 16px",
+} as const;
+
+const panelLabel = {
+  fontFamily: fonts.mono,
+  fontSize: 10,
+  color: "#8a94a6",
+  letterSpacing: "0.12em",
+  marginBottom: 11,
+} as const;
+
+export default function EntityGraphView() {
+  const { data: topEntities } = useTopEntities();
+
+  return (
+    <div>
+      <PageHeader
+        title="Entity Relationship Graph"
+        subtitle="12 entities · 13 co-occurrence links · 24h window"
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 280px", gap: 12 }}>
+        <div style={{ background: "#0e131a", border: "1px solid #1c2330", borderRadius: 10, overflow: "hidden" }}>
+          <EntityGraph />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={panel}>
+            <div style={panelLabel}>ENTITY TYPES</div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+              {legend.map((l) => (
+                <div key={l.label} style={{ display: "flex", alignItems: "center", gap: 9 }}>
+                  <span style={{ width: 10, height: 10, borderRadius: "50%", background: l.color }} />
+                  <span style={{ flex: 1, fontSize: 12.5 }}>{l.label}</span>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 11, color: "#5b6675" }}>{l.count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={panel}>
+            <div style={panelLabel}>TOP CONNECTED</div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {topEntities.map((e) => (
+                <div key={e.name} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span style={{ width: 8, height: 8, flex: "none", borderRadius: "50%", background: e.color }} />
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 12.5,
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {e.name}
+                  </span>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 11, color: "#8a94a6" }}>{e.links}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/NewsFeed.tsx
+++ b/apps/web/src/views/NewsFeed.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { ACCENT, accentSoft, accentBorder, fonts } from "../theme";
+import { sentColor, sentLabel, fmt } from "../lib/sentiment";
+import { useArticles } from "../lib/queries";
+import PageHeader from "../components/PageHeader";
+import Hover from "../components/Hover";
+
+const filters = ["All", "Economy", "Technology", "Policy", "Energy", "Health"];
+
+export default function NewsFeed() {
+  const [filter, setFilter] = useState("All");
+  const { data: articles } = useArticles();
+  const feed = filter === "All" ? articles : articles.filter((a) => a.category === filter);
+
+  return (
+    <div>
+      <PageHeader
+        title="News Feed"
+        subtitle={`${articles.length} articles · 142 sources · auto-classified`}
+      />
+      <div style={{ display: "flex", gap: 7, marginBottom: 16, flexWrap: "wrap" }}>
+        {filters.map((f) => {
+          const active = filter === f;
+          return (
+            <Hover
+              key={f}
+              as="button"
+              onClick={() => setFilter(f)}
+              style={{
+                fontFamily: fonts.mono,
+                fontSize: 11,
+                padding: "6px 13px",
+                borderRadius: 7,
+                cursor: "pointer",
+                ...(active
+                  ? { background: accentSoft(ACCENT), color: ACCENT, border: `1px solid ${accentBorder(ACCENT)}` }
+                  : { background: "#11151c", color: "#8a94a6", border: "1px solid #232a36" }),
+              }}
+              hoverStyle={active ? {} : { borderColor: "#3a4554" }}
+            >
+              {f}
+            </Hover>
+          );
+        })}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {feed.map((a, i) => (
+          <Hover
+            key={i}
+            as="article"
+            style={{
+              background: "#11151c",
+              border: "1px solid #1c2330",
+              borderRadius: 10,
+              padding: "16px 18px",
+              display: "flex",
+              gap: 16,
+            }}
+            hoverStyle={{ borderColor: "#2a3340" }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 8 }}>
+                <span
+                  style={{
+                    fontFamily: fonts.mono,
+                    fontSize: 9.5,
+                    fontWeight: 600,
+                    color: ACCENT,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {a.category}
+                </span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675" }}>
+                  {a.source} · {a.time}
+                </span>
+              </div>
+              <h3 style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 16, margin: "0 0 6px", lineHeight: 1.3 }}>
+                {a.title}
+              </h3>
+              {a.summary ? (
+                <p style={{ fontSize: 13, color: "#9aa4b2", margin: "0 0 11px", lineHeight: 1.5 }}>{a.summary}</p>
+              ) : null}
+              <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                {a.entities.map((e) => (
+                  <span
+                    key={e}
+                    style={{
+                      fontFamily: fonts.mono,
+                      fontSize: 10,
+                      color: "#9aa4b2",
+                      background: "#161d28",
+                      border: "1px solid #232a36",
+                      borderRadius: 5,
+                      padding: "2px 7px",
+                    }}
+                  >
+                    {e}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div style={{ flex: "none", width: 84, display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
+              <div style={{ fontFamily: fonts.mono, fontSize: 18, fontWeight: 600, color: sentColor(a.sent) }}>
+                {fmt(a.sent)}
+              </div>
+              <div style={{ fontFamily: fonts.mono, fontSize: 9, color: "#5b6675", letterSpacing: "0.08em" }}>
+                {sentLabel(a.sent)}
+              </div>
+            </div>
+          </Hover>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Sentiment.tsx
+++ b/apps/web/src/views/Sentiment.tsx
@@ -1,0 +1,44 @@
+import { palette, fonts } from "../theme";
+import PageHeader from "../components/PageHeader";
+import Heatmap from "../components/charts/Heatmap";
+import type { SentimentStat } from "../types";
+
+const stats: SentimentStat[] = [
+  { label: "Net Sentiment", value: "+0.18", color: palette.pos, note: "aggregate across all topics" },
+  { label: "Most Positive", value: "Science", color: palette.pos, note: "+0.58 avg · fusion, health" },
+  { label: "Most Negative", value: "Finance", color: palette.neg, note: "-0.44 avg · CRE, credit" },
+];
+
+export default function Sentiment() {
+  return (
+    <div>
+      <PageHeader title="Sentiment Analysis" subtitle="Topic × time heatmap · 16-hour rolling window" />
+
+      <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, padding: "18px 20px", marginBottom: 12 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+          <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Sentiment Heatmap</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6" }}>
+            <span style={{ color: "#FF5C5C" }}>■</span> negative
+            <span style={{ color: "#8B95A5" }}>■</span> neutral
+            <span style={{ color: "#3DD68C" }}>■</span> positive
+          </div>
+        </div>
+        <Heatmap />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12 }}>
+        {stats.map((s) => (
+          <div key={s.label} style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, padding: "15px 17px" }}>
+            <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6", letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              {s.label}
+            </div>
+            <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 24, marginTop: 8, color: s.color }}>
+              {s.value}
+            </div>
+            <div style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#5b6675", marginTop: 4 }}>{s.note}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Timeline.tsx
+++ b/apps/web/src/views/Timeline.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { ACCENT, palette, accentSoft, accentBorder, fonts } from "../theme";
+import { sentColor, fmt } from "../lib/sentiment";
+import { mockStories, mockTimeline } from "../data/mock";
+import PageHeader from "../components/PageHeader";
+import Hover from "../components/Hover";
+import type { TimelineEvent } from "../types";
+
+function kindColor(kind: TimelineEvent["kind"]): string {
+  if (kind === "Milestone") return ACCENT;
+  if (kind === "Origin") return palette.blue;
+  if (kind === "Reaction") return palette.violet;
+  return palette.teal;
+}
+
+export default function Timeline() {
+  const [activeStory, setActiveStory] = useState("s1");
+  const events = mockTimeline[activeStory] ?? [];
+  const activeLabel = mockStories.find((s) => s.id === activeStory)?.label ?? "";
+
+  return (
+    <div>
+      <PageHeader
+        title="Story Timeline"
+        subtitle={
+          <>
+            How <span style={{ color: "#9aa4b2" }}>{activeLabel}</span> developed over time
+          </>
+        }
+      />
+      <div style={{ display: "flex", gap: 7, marginBottom: 22, flexWrap: "wrap" }}>
+        {mockStories.map((s) => {
+          const active = activeStory === s.id;
+          return (
+            <Hover
+              key={s.id}
+              as="button"
+              onClick={() => setActiveStory(s.id)}
+              style={{
+                fontFamily: fonts.mono,
+                fontSize: 11,
+                padding: "6px 13px",
+                borderRadius: 7,
+                cursor: "pointer",
+                ...(active
+                  ? { background: accentSoft(ACCENT), color: ACCENT, border: `1px solid ${accentBorder(ACCENT)}` }
+                  : { background: "#11151c", color: "#8a94a6", border: "1px solid #232a36" }),
+              }}
+              hoverStyle={active ? {} : { borderColor: "#3a4554" }}
+            >
+              {s.label}
+            </Hover>
+          );
+        })}
+      </div>
+
+      <div style={{ position: "relative", paddingLeft: 6 }}>
+        {events.map((e, i) => {
+          const kc = kindColor(e.kind);
+          const showLine = i !== events.length - 1;
+          return (
+            <div key={i} style={{ display: "grid", gridTemplateColumns: "74px 28px 1fr", gap: 0, alignItems: "stretch" }}>
+              <div style={{ textAlign: "right", padding: "2px 14px 0 0", fontFamily: fonts.mono, fontSize: 11, color: "#8a94a6" }}>
+                {e.date}
+              </div>
+              <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center" }}>
+                <span style={{ width: 13, height: 13, flex: "none", borderRadius: "50%", background: "#0e131a", border: `2px solid ${kc}`, zIndex: 1, marginTop: 3 }} />
+                {showLine ? <span style={{ flex: 1, width: 2, background: "#1c2330" }} /> : null}
+              </div>
+              <div style={{ padding: "0 0 18px 6px" }}>
+                <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, padding: "14px 16px", borderLeft: `3px solid ${kc}` }}>
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 7 }}>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 9, color: kc, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+                      {e.kind}
+                    </span>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 11, color: sentColor(e.sent) }}>{fmt(e.sent)}</span>
+                  </div>
+                  <div style={{ fontSize: 14, fontWeight: 500, lineHeight: 1.38 }}>{e.title}</div>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675", marginTop: 7 }}>{e.source}</div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Trending.tsx
+++ b/apps/web/src/views/Trending.tsx
@@ -1,0 +1,78 @@
+import { ACCENT, palette, fonts } from "../theme";
+import { sentColor, fmt } from "../lib/sentiment";
+import { useTrending } from "../lib/queries";
+import PageHeader from "../components/PageHeader";
+import Hover from "../components/Hover";
+
+const GRID = "50px 1fr 130px 110px 90px";
+
+export default function Trending() {
+  const { data: trending } = useTrending();
+  const maxM = Math.max(1, ...trending.map((t) => t.mentions));
+
+  const rows = trending.map((t, i) => ({
+    rank: i + 1,
+    topic: t.topic,
+    mentions: t.mentions.toLocaleString(),
+    barWidth: Math.round((t.mentions / maxM) * 100) + "%",
+    change: (t.change >= 0 ? "+" : "") + t.change + "%",
+    changeColor: t.change >= 0 ? palette.pos : palette.neg,
+    sentScore: fmt(t.sent),
+    sentColor: sentColor(t.sent),
+    rankColor: i < 3 ? ACCENT : "#c7cdd6",
+  }));
+
+  return (
+    <div>
+      <PageHeader title="Trending Topics" subtitle="Ranked by mention velocity · 24h" />
+      <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, overflow: "hidden" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: GRID,
+            gap: 14,
+            padding: "11px 20px",
+            borderBottom: "1px solid #1c2330",
+            fontFamily: fonts.mono,
+            fontSize: 10,
+            color: "#5b6675",
+            letterSpacing: "0.1em",
+          }}
+        >
+          <span>RANK</span>
+          <span>TOPIC</span>
+          <span>MENTIONS</span>
+          <span>VELOCITY</span>
+          <span style={{ textAlign: "right" }}>SENTIMENT</span>
+        </div>
+        {rows.map((t) => (
+          <Hover
+            key={t.rank}
+            style={{
+              display: "grid",
+              gridTemplateColumns: GRID,
+              gap: 14,
+              padding: "13px 20px",
+              borderBottom: "1px solid #161d28",
+              alignItems: "center",
+            }}
+            hoverStyle={{ background: "#0e131a" }}
+          >
+            <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 15, color: t.rankColor }}>{t.rank}</span>
+            <span style={{ fontSize: 13.5, fontWeight: 500 }}>{t.topic}</span>
+            <span style={{ fontFamily: fonts.mono, fontSize: 12, color: "#c7cdd6" }}>{t.mentions}</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <div style={{ flex: 1, height: 4, background: "#1c2330", borderRadius: 2, overflow: "hidden" }}>
+                <div style={{ height: "100%", width: t.barWidth, background: ACCENT }} />
+              </div>
+              <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: t.changeColor, width: 38, textAlign: "right" }}>
+                {t.change}
+              </span>
+            </div>
+            <span style={{ fontFamily: fonts.mono, fontSize: 12, color: t.sentColor, textAlign: "right" }}>{t.sentScore}</span>
+          </Hover>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Watchlists.tsx
+++ b/apps/web/src/views/Watchlists.tsx
@@ -1,0 +1,72 @@
+import { ACCENT, palette, fonts } from "../theme";
+import { sentColor, fmt } from "../lib/sentiment";
+import { mockWatchlist } from "../data/mock";
+import PageHeader from "../components/PageHeader";
+import Hover from "../components/Hover";
+import Sparkline from "../components/charts/Sparkline";
+
+export default function Watchlists() {
+  return (
+    <div>
+      <PageHeader
+        title="Watchlists"
+        subtitle="Entities & topics you track over time · 8h trend"
+        right={
+          <Hover
+            as="button"
+            style={{
+              fontFamily: fonts.mono,
+              fontSize: 11,
+              color: "#8a94a6",
+              background: "#11151c",
+              border: "1px solid #232a36",
+              borderRadius: 7,
+              padding: "7px 13px",
+              cursor: "pointer",
+            }}
+            hoverStyle={{ borderColor: "#3a4554", color: "#c7cdd6" }}
+          >
+            + ADD TO WATCHLIST
+          </Hover>
+        }
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12 }}>
+        {mockWatchlist.map((w) => {
+          const changeColor = w.change >= 0 ? palette.pos : palette.neg;
+          return (
+            <div key={w.name} style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 11, padding: "16px 18px" }}>
+              <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", marginBottom: 14 }}>
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 15 }}>{w.name}</span>
+                    {w.alert ? (
+                      <span style={{ width: 6, height: 6, borderRadius: "50%", background: ACCENT, boxShadow: `0 0 7px ${ACCENT}` }} />
+                    ) : null}
+                  </div>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: "#5b6675", letterSpacing: "0.08em", textTransform: "uppercase" }}>
+                    {w.type}
+                  </span>
+                </div>
+                <Sparkline values={w.spark} color={changeColor} />
+              </div>
+              <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+                <div>
+                  <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 24 }}>{w.mentions}</div>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 9.5, color: "#5b6675", letterSpacing: "0.06em" }}>MENTIONS 24H</div>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 13, color: changeColor }}>
+                    {(w.change >= 0 ? "+" : "") + w.change + "%"}
+                  </div>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 11, color: sentColor(w.sent), marginTop: 2 }}>
+                    sent {fmt(w.sent)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/views/Workspaces.tsx
+++ b/apps/web/src/views/Workspaces.tsx
@@ -1,0 +1,181 @@
+import { useState, type CSSProperties } from "react";
+import { ACCENT, palette, fonts } from "../theme";
+import { sentColor, fmt } from "../lib/sentiment";
+import { mockWorkspaces, mockWorkspaceDetail } from "../data/mock";
+import PageHeader from "../components/PageHeader";
+import Hover from "../components/Hover";
+import type { Workspace } from "../types";
+
+function statusStyle(status: Workspace["status"]): CSSProperties {
+  return status === "Synthesizing"
+    ? { color: palette.amber, border: `1px solid ${palette.amber}55`, background: `${palette.amber}14` }
+    : { color: palette.pos, border: `1px solid ${palette.pos}55`, background: `${palette.pos}14` };
+}
+
+const sectionLabel: CSSProperties = {
+  fontFamily: fonts.mono,
+  fontSize: 10,
+  color: "#8a94a6",
+  letterSpacing: "0.12em",
+  marginBottom: 11,
+};
+
+export default function Workspaces() {
+  const [activeId, setActiveId] = useState("p3");
+  const active = mockWorkspaces.find((w) => w.id === activeId) ?? mockWorkspaces[0];
+  const detail = mockWorkspaceDetail[active.id];
+
+  const stats = [
+    { label: "Sources", value: String(active.sources) },
+    { label: "Notes", value: String(active.notes) },
+    { label: "Sub-questions", value: String(detail.sub.length) },
+    { label: "Entities", value: String(detail.entities.length) },
+  ];
+
+  const badgeSmall = (w: Workspace): CSSProperties => ({
+    fontFamily: fonts.mono,
+    fontSize: 9,
+    letterSpacing: "0.06em",
+    padding: "1px 6px",
+    borderRadius: 4,
+    ...statusStyle(w.status),
+  });
+
+  return (
+    <div>
+      <PageHeader title="Research Workspaces" subtitle="Group sources around a question · build toward a thesis" />
+      <div style={{ display: "grid", gridTemplateColumns: "316px 1fr", gap: 14, alignItems: "start" }}>
+        {/* Project list */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+          <Hover
+            as="button"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 7,
+              width: "100%",
+              padding: 11,
+              border: "1px dashed #2a3340",
+              borderRadius: 9,
+              background: "transparent",
+              color: "#8a94a6",
+              cursor: "pointer",
+              fontFamily: fonts.mono,
+              fontSize: 11.5,
+            }}
+            hoverStyle={{ borderColor: "#3a4554", color: "#c7cdd6" }}
+          >
+            + NEW INVESTIGATION
+          </Hover>
+          {mockWorkspaces.map((w) => (
+            <Hover
+              key={w.id}
+              as="button"
+              onClick={() => setActiveId(w.id)}
+              style={{
+                textAlign: "left",
+                width: "100%",
+                cursor: "pointer",
+                background: "#11151c",
+                border: `1px solid ${activeId === w.id ? ACCENT : "#1c2330"}`,
+                borderLeft: `3px solid ${w.color}`,
+                borderRadius: 9,
+                padding: "13px 14px",
+                transition: "border-color .12s",
+              }}
+              hoverStyle={activeId === w.id ? {} : { borderColor: "#3a4554" }}
+            >
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 7 }}>
+                <span style={badgeSmall(w)}>{w.status}</span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675" }}>{w.updated}</span>
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 500, lineHeight: 1.38, color: "#e6eaf0" }}>{w.q}</div>
+              <div style={{ display: "flex", gap: 12, marginTop: 9, fontFamily: fonts.mono, fontSize: 10, color: "#5b6675" }}>
+                <span>{w.sources} sources</span>
+                <span>{w.notes} notes</span>
+              </div>
+            </Hover>
+          ))}
+        </div>
+
+        {/* Active project detail */}
+        <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 11, padding: "20px 22px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+            <span style={{ ...badgeSmall(active), fontSize: 10, padding: "3px 9px", borderRadius: 5 }}>{active.status}</span>
+            <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#5b6675" }}>updated {active.updated} ago</span>
+          </div>
+          <h2 style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 20, margin: "0 0 16px", lineHeight: 1.3, letterSpacing: "-0.01em" }}>
+            {active.q}
+          </h2>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 10, marginBottom: 20 }}>
+            {stats.map((s) => (
+              <div key={s.label} style={{ background: "#0e131a", border: "1px solid #1c2330", borderRadius: 8, padding: "11px 13px" }}>
+                <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 20 }}>{s.value}</div>
+                <div style={{ fontFamily: fonts.mono, fontSize: 9.5, color: "#5b6675", letterSpacing: "0.06em", textTransform: "uppercase", marginTop: 3 }}>
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={sectionLabel}>KEY SUB-QUESTIONS</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
+            {detail.sub.map((q, i) => (
+              <div key={i} style={{ display: "flex", gap: 10, alignItems: "flex-start", background: "#0e131a", border: "1px solid #1c2330", borderRadius: 8, padding: "10px 13px" }}>
+                <span style={{ color: ACCENT, fontSize: 12, marginTop: 1 }}>?</span>
+                <span style={{ flex: 1, fontSize: 13, color: "#c7cdd6", lineHeight: 1.42 }}>{q}</span>
+              </div>
+            ))}
+          </div>
+
+          <div style={sectionLabel}>SOURCES & NOTES</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 20 }}>
+            {detail.sources.map((s, i) => {
+              const sc = sentColor(s.sent);
+              return (
+                <div key={i} style={{ border: "1px solid #1c2330", borderRadius: 9, padding: "13px 15px", background: "#0e131a" }}>
+                  <div style={{ display: "flex", alignItems: "flex-start", gap: 11 }}>
+                    <span style={{ width: 7, height: 7, flex: "none", borderRadius: "50%", background: sc, marginTop: 6 }} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13, fontWeight: 500, lineHeight: 1.35 }}>{s.title}</div>
+                      <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#5b6675", marginTop: 4 }}>
+                        {s.source} · {s.time}
+                      </div>
+                    </div>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 12, fontWeight: 600, color: sc }}>{fmt(s.sent)}</span>
+                  </div>
+                  <div style={{ display: "flex", gap: 9, alignItems: "flex-start", marginTop: 10, paddingTop: 10, borderTop: "1px solid #1c2330" }}>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 9, color: ACCENT, letterSpacing: "0.08em", marginTop: 2 }}>NOTE</span>
+                    <span style={{ flex: 1, fontSize: 12.5, color: "#9aa4b2", lineHeight: 1.45, fontStyle: "italic" }}>{s.note}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div style={sectionLabel}>TRACKED ENTITIES</div>
+          <div style={{ display: "flex", gap: 7, flexWrap: "wrap" }}>
+            {detail.entities.map((e) => (
+              <span
+                key={e}
+                style={{
+                  fontFamily: fonts.mono,
+                  fontSize: 11,
+                  color: "#c7cdd6",
+                  background: "#161d28",
+                  border: "1px solid #232a36",
+                  borderRadius: 6,
+                  padding: "4px 10px",
+                }}
+              >
+                {e}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_API_PROXY_TARGET?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "types": ["node", "vite/client"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// During development, requests to `/api` and the unversioned backend
+// route prefixes are proxied to the FastAPI backend (default :8000).
+// Override the target with VITE_API_PROXY_TARGET.
+const apiTarget = process.env.VITE_API_PROXY_TARGET || "http://localhost:8000";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": { target: apiTarget, changeOrigin: true },
+      "/news": { target: apiTarget, changeOrigin: true },
+      "/news_sentiment": { target: apiTarget, changeOrigin: true },
+      "/topics": { target: apiTarget, changeOrigin: true },
+      "/graph": { target: apiTarget, changeOrigin: true },
+      "/search": { target: apiTarget, changeOrigin: true },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements the **NeuroNews Terminal** design handoff (from Claude Design) as a new **React + Vite + TypeScript** single-page app under `apps/web/`. The dark "intelligence terminal" UI is reproduced pixel-for-pixel using the design's exact color tokens, fonts (Space Grotesk / IBM Plex Mono / IBM Plex Sans), dimensions, inline styles, and SVG charts.

This is the first JS/TS frontend in the repo (previously only Streamlit), scaffolded as a standalone app.

## Views

All 9 views from the design are implemented:

- **Overview** · **News Feed** · **Entity Graph** · **Sentiment** · **Event Clusters** · **Trending** · **Research Workspaces** · **Watchlists** · **Story Timeline**

Plus the shared shell: sidebar nav, top bar with live UTC clock + search, and the breaking-news ticker. SVG charts (sentiment trend, topic×time heatmap, entity relationship graph, watchlist sparklines) are ported faithfully from the design.

## Backend wiring

A typed client (`src/lib/api.ts`) + TanStack Query hooks call the FastAPI backend (`src/api`), with adapters mapping responses into the UI view models:

| View | Endpoint |
|------|----------|
| News Feed | `GET /api/v1/news/articles` |
| Event Clusters | `GET /api/v1/events/clusters` |
| Trending | `GET /topics/trending` |
| Breaking ticker | `GET /api/v1/breaking_news` |
| Entity Graph (top connected) | `GET /api/influence/top-influencers` |
| Overview | aggregates the above |

Each data-backed view **falls back to the design dataset** when its endpoint is unreachable or returns no rows, so the UI is always runnable. Vite proxies API paths to `http://localhost:8000` in dev (`VITE_API_PROXY_TARGET`); set `VITE_API_BASE_URL` for production builds.

## Known gaps (documented in `apps/web/README.md`)

1. Backend list endpoints expose a subset of the design's fields — `/news/articles` has no per-article summary/entities, `/events/clusters` has no aggregate sentiment — so those degrade gracefully. Enriching them requires backend changes.
2. **Workspaces, Watchlists, Story Timeline** have no backend endpoints yet, so they run on the design's client data. Natural follow-up once corresponding APIs exist.

## Verification

- `npm install`, `tsc --noEmit`, and `vite build` all pass
- Dev server boots and serves HTTP 200

## Run it

```bash
cd apps/web
npm install
npm run dev    # http://localhost:5173 (proxies API to :8000)
```
