### PR TITLE
feat(web): NeuroNews Intelligence Terminal frontend with live backend data

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -37,24 +37,41 @@ VITE_API_BASE_URL=https://api.neuronews.example npm run build
 npm run preview
 ```
 
+## Live data
+
+The app talks to the FastAPI backend on every view. To make it obvious what
+you're looking at:
+
+- The **top bar** shows a global connection pill driven by a `/health` probe:
+  `CONNECTING` → `BACKEND LIVE` (green) → `DEMO MODE`. The probe re-runs every
+  30s, so it flips automatically when the backend comes up or goes down.
+- Each data-backed view carries a small **`LIVE` / `DEMO` / `SYNC`** badge so
+  you can tell, per panel, whether the rows came from the API or the bundled
+  design dataset.
+
+To see live data: start the backend (below), then run `npm run dev`. With no
+backend reachable every badge reads `DEMO`.
+
 ## Views & backend wiring
 
 Each view fetches from the backend and **falls back to the design dataset** if
 the endpoint is unreachable or returns no rows, so the UI always renders. The
-data source (`live` / `demo`) is tracked per query in `src/lib/queries.ts`.
+data source (`live` / `demo`) is tracked per query in `src/lib/queries.ts` and
+surfaced through `src/components/SourceBadge.tsx`.
 
-| View            | Backend endpoint(s)                                  |
-| --------------- | ---------------------------------------------------- |
-| Overview        | aggregates feed / clusters / trending                |
-| News Feed       | `GET /api/v1/news/articles`                          |
-| Entity Graph    | `GET /api/influence/top-influencers`                 |
-| Sentiment       | static heatmap (no live endpoint yet)                |
-| Event Clusters  | `GET /api/v1/events/clusters`                        |
-| Trending        | `GET /topics/trending`                               |
-| Breaking ticker | `GET /api/v1/breaking_news`                          |
-| Workspaces      | client research data (no backend endpoint)           |
-| Watchlists      | client research data (no backend endpoint)           |
-| Story Timeline  | client research data (no backend endpoint)           |
+| View            | Backend endpoint(s)                                  | Badge     |
+| --------------- | ---------------------------------------------------- | --------- |
+| Overview        | aggregates feed / clusters / trending                | live/demo |
+| News Feed       | `GET /api/v1/news/articles`                          | live/demo |
+| Entity Graph    | `GET /api/influence/top-influencers`                 | live/demo |
+| Sentiment       | `GET /news_sentiment/topics` (stats + breakdown)     | live/demo |
+| Sentiment       | topic×time heatmap — no hourly endpoint yet          | demo      |
+| Event Clusters  | `GET /api/v1/events/clusters`                        | live/demo |
+| Trending        | `GET /topics/trending`                               | live/demo |
+| Breaking ticker | `GET /api/v1/breaking_news`                          | live/demo |
+| Workspaces      | client research data (no backend endpoint)           | demo      |
+| Watchlists      | client research data (no backend endpoint)           | demo      |
+| Story Timeline  | client research data (no backend endpoint)           | demo      |
 
 > Note: the backend list endpoints expose a subset of the fields the design
 > shows (e.g. `/news/articles` has no per-article summary/entities, and the

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -1,0 +1,53 @@
+import { palette, fonts } from "../theme";
+import type { Source } from "../lib/queries";
+
+// Small pill that tells the operator whether the panel is rendering data
+// pulled live from the backend or the bundled demo dataset (used as a
+// fallback when the API is unreachable or returns nothing).
+interface Props {
+  source: Source;
+  isLoading?: boolean;
+}
+
+export default function SourceBadge({ source, isLoading }: Props) {
+  const live = source === "live";
+  const color = isLoading ? palette.amber : live ? palette.pos : palette.faint;
+  const label = isLoading ? "SYNC" : live ? "LIVE" : "DEMO";
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontFamily: fonts.mono,
+        fontSize: 9.5,
+        letterSpacing: "0.12em",
+        color,
+        border: `1px solid ${color}44`,
+        background: `${color}14`,
+        borderRadius: 5,
+        padding: "3px 8px",
+      }}
+      title={
+        isLoading
+          ? "Fetching from backend…"
+          : live
+            ? "Live data from the NeuroNews API"
+            : "Backend unreachable or empty — showing demo dataset"
+      }
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: color,
+          boxShadow: live && !isLoading ? `0 0 6px ${color}` : "none",
+          animation: isLoading ? "pulse 1s ease-in-out infinite" : undefined,
+        }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -1,5 +1,53 @@
 import { useEffect, useState } from "react";
-import { ACCENT, fonts } from "../theme";
+import { ACCENT, palette, fonts } from "../theme";
+import { useBackendStatus, type BackendStatus } from "../lib/queries";
+
+const STATUS_META: Record<BackendStatus, { color: string; label: string }> = {
+  checking: { color: palette.amber, label: "CONNECTING" },
+  online: { color: palette.pos, label: "BACKEND LIVE" },
+  offline: { color: palette.faint, label: "DEMO MODE" },
+};
+
+function ConnectionPill() {
+  const status = useBackendStatus();
+  const { color, label } = STATUS_META[status];
+  return (
+    <div
+      title={
+        status === "online"
+          ? "Connected to the NeuroNews API"
+          : status === "checking"
+            ? "Probing the backend…"
+            : "Backend unreachable — views fall back to the demo dataset"
+      }
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 7,
+        fontFamily: fonts.mono,
+        fontSize: 10,
+        letterSpacing: "0.1em",
+        color,
+        border: `1px solid ${color}44`,
+        background: `${color}14`,
+        borderRadius: 6,
+        padding: "5px 10px",
+      }}
+    >
+      <span
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: "50%",
+          background: color,
+          boxShadow: status === "online" ? `0 0 6px ${color}` : "none",
+          animation: status === "checking" ? "pulse 1s ease-in-out infinite" : undefined,
+        }}
+      />
+      {label}
+    </div>
+  );
+}
 
 function useUtcClock() {
   const [now, setNow] = useState(() => new Date());
@@ -72,6 +120,7 @@ export default function TopBar() {
       </div>
       <div style={{ flex: 1 }} />
       <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+        <ConnectionPill />
         <div style={{ textAlign: "right", lineHeight: 1.15 }}>
           <div style={{ fontFamily: fonts.mono, fontSize: 14, fontWeight: 500, color: ACCENT }}>{clock}</div>
           <div style={{ fontFamily: fonts.mono, fontSize: 9, color: "#5b6675", letterSpacing: "0.1em" }}>

--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -7,6 +7,7 @@ import type {
   Article,
   Cluster,
   TrendingTopic,
+  TopicSentiment,
   Workspace,
   WorkspaceDetail,
   WatchItem,
@@ -147,6 +148,18 @@ export const mockHeatmap = {
     [0.1, -0.1, 0.0, 0.2, -0.2, 0.1, -0.3, 0.0, 0.2, -0.1, 0.3, 0.1, -0.2, 0.0, 0.1, -0.1],
   ],
 };
+
+// Per-topic average sentiment (mirrors /news_sentiment/topics shape) used as a
+// fallback for the Sentiment view's live topic breakdown.
+export const mockTopicSentiment: TopicSentiment[] = [
+  { topic: "Science", avgScore: 0.58, articles: 412 },
+  { topic: "Technology", avgScore: 0.34, articles: 980 },
+  { topic: "Health", avgScore: 0.27, articles: 356 },
+  { topic: "Markets", avgScore: 0.04, articles: 642 },
+  { topic: "Policy", avgScore: -0.19, articles: 528 },
+  { topic: "Energy", avgScore: -0.31, articles: 274 },
+  { topic: "Finance", avgScore: -0.44, articles: 489 },
+];
 
 export const mockTickerText =
   "  ●  Fed signals rate pause as core PCE eases  ●  Nvidia Blackwell Ultra claims 4x inference gain  ●  EU opens cloud antitrust probe  ●  Fusion experiment sustains net energy gain  ●  Oil slips below $74 on OPEC+ uncertainty  ●  Alzheimer’s drug clears late-stage trial  ";

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -44,3 +44,13 @@ body,
     transform: translateX(-50%);
   }
 }
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}

--- a/apps/web/src/lib/adapters.ts
+++ b/apps/web/src/lib/adapters.ts
@@ -8,12 +8,14 @@ import type {
   Cluster,
   TrendingTopic,
   TopEntity,
+  TopicSentiment,
 } from "../types";
 import type {
   RawArticle,
   RawEventCluster,
   RawTrendingResponse,
   RawInfluencer,
+  RawTopicSentiment,
 } from "./api";
 
 export function relativeTime(iso: string | null | undefined): string {
@@ -65,6 +67,22 @@ export function adaptTrending(raw: RawTrendingResponse): TrendingTopic[] {
     change: Math.round((t.growth_rate ?? t.article_count / max) * 100),
     sent: t.avg_sentiment ?? 0,
   }));
+}
+
+export function adaptTopicSentiment(raw: RawTopicSentiment[]): TopicSentiment[] {
+  return raw
+    .map((t) => {
+      // Collapse the per-label breakdown into one article-weighted average.
+      const entries = Object.values(t.sentiments ?? {});
+      const total = entries.reduce((s, e) => s + (e.count ?? 0), 0);
+      const weighted = entries.reduce((s, e) => s + (e.count ?? 0) * (e.avg_score ?? 0), 0);
+      return {
+        topic: t.topic,
+        articles: t.total_articles ?? total,
+        avgScore: total > 0 ? weighted / total : 0,
+      };
+    })
+    .sort((a, b) => b.articles - a.articles);
 }
 
 const ENTITY_TYPE_COLOR: Record<string, string> = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -98,6 +98,17 @@ export interface RawSentimentSummary {
   [key: string]: unknown;
 }
 
+export interface RawHealth {
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface RawTopicSentiment {
+  topic: string;
+  total_articles: number;
+  sentiments: Record<string, { count: number; avg_score: number; percentage?: number }>;
+}
+
 export interface RawKgStats {
   [key: string]: unknown;
 }
@@ -115,6 +126,8 @@ export interface RawInfluencer {
 // ---------- endpoint calls ----------
 
 export const api = {
+  health: () => request<RawHealth>("/health"),
+
   articles: (params?: { category?: string; source?: string }) =>
     request<RawArticle[]>("/api/v1/news/articles", params),
 
@@ -129,7 +142,8 @@ export const api = {
 
   sentimentSummary: () => request<RawSentimentSummary>("/news_sentiment/summary"),
 
-  sentimentTopics: () => request<RawSentimentSummary>("/news_sentiment/topics"),
+  sentimentTopics: (params?: { days?: number; min_articles?: number }) =>
+    request<RawTopicSentiment[]>("/news_sentiment/topics", params),
 
   knowledgeGraphStats: () => request<RawKgStats>("/api/v1/knowledge_graph_stats"),
 

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -9,15 +9,23 @@ import {
   adaptClusters,
   adaptTrending,
   adaptInfluencers,
+  adaptTopicSentiment,
 } from "./adapters";
 import {
   mockArticles,
   mockClusters,
   mockTrending,
   mockTickerText,
+  mockTopicSentiment,
 } from "../data/mock";
 import { palette, ACCENT } from "../theme";
-import type { Article, Cluster, TrendingTopic, TopEntity } from "../types";
+import type {
+  Article,
+  Cluster,
+  TrendingTopic,
+  TopEntity,
+  TopicSentiment,
+} from "../types";
 
 export type Source = "live" | "demo";
 export interface Result<T> {
@@ -26,7 +34,27 @@ export interface Result<T> {
   isLoading: boolean;
 }
 
+export type BackendStatus = "checking" | "online" | "offline";
+
 const STALE = 60_000;
+
+// Lightweight liveness probe against the backend's /health endpoint. Drives
+// the global connection indicator in the top bar and is polled periodically so
+// the UI reflects the backend coming up or going down without a reload.
+export function useBackendStatus(): BackendStatus {
+  const q = useQuery({
+    queryKey: ["health"],
+    queryFn: async () => {
+      const h = await api.health();
+      return h?.status ?? "ok";
+    },
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    retry: false,
+  });
+  if (q.isLoading) return "checking";
+  return q.isSuccess ? "online" : "offline";
+}
 
 function useWithFallback<T>(key: string, fn: () => Promise<T>, fallback: T): Result<T> {
   const q = useQuery({
@@ -82,6 +110,14 @@ export function useTopEntities(): Result<TopEntity[]> {
     "topEntities",
     async () => adaptInfluencers(await api.topInfluencers({ limit: 5 })),
     mockTopEntities,
+  );
+}
+
+export function useTopicSentiment(): Result<TopicSentiment[]> {
+  return useWithFallback(
+    "topicSentiment",
+    async () => adaptTopicSentiment(await api.sentimentTopics({ days: 7 })),
+    mockTopicSentiment,
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -44,6 +44,12 @@ export interface SentimentStat {
   note: string;
 }
 
+export interface TopicSentiment {
+  topic: string;
+  avgScore: number;
+  articles: number;
+}
+
 export interface LegendItem {
   label: string;
   color: string;

--- a/apps/web/src/views/Clusters.tsx
+++ b/apps/web/src/views/Clusters.tsx
@@ -2,9 +2,10 @@ import { palette, fonts } from "../theme";
 import { sentColor, sentLabel } from "../lib/sentiment";
 import { useArticles, useClusters } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 
 export default function Clusters() {
-  const { data: clustersRaw } = useClusters();
+  const { data: clustersRaw, source, isLoading } = useClusters();
   const { data: articles } = useArticles();
 
   const clusters = clustersRaw.map((c, i) => ({
@@ -19,6 +20,7 @@ export default function Clusters() {
       <PageHeader
         title="Event Clusters"
         subtitle={`${clusters.length} active clusters · grouped by semantic similarity`}
+        right={<SourceBadge source={source} isLoading={isLoading} />}
       />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 12 }}>
         {clusters.map((c, i) => {

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -4,6 +4,7 @@ import { sentColor } from "../lib/sentiment";
 import { useArticles, useClusters, useTrending } from "../lib/queries";
 import type { Kpi, ViewKey } from "../types";
 import TrendChart from "../components/charts/TrendChart";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 
 const kpis: Kpi[] = [
@@ -37,7 +38,7 @@ interface Props {
 
 export default function Dashboard({ setView }: Props) {
   const [range, setRange] = useState("24H");
-  const { data: articles } = useArticles();
+  const { data: articles, source, isLoading } = useArticles();
   const { data: clustersRaw } = useClusters();
   const { data: trending } = useTrending();
 
@@ -70,8 +71,10 @@ export default function Dashboard({ setView }: Props) {
             Real-time signal across 142 sources · last 24h
           </p>
         </div>
-        <div style={{ display: "flex", gap: 6 }}>
-          {["1H", "6H", "24H", "7D"].map((r) => {
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <SourceBadge source={source} isLoading={isLoading} />
+          <div style={{ display: "flex", gap: 6 }}>
+            {["1H", "6H", "24H", "7D"].map((r) => {
             const active = r === range;
             return (
               <span
@@ -91,7 +94,8 @@ export default function Dashboard({ setView }: Props) {
                 {r}
               </span>
             );
-          })}
+            })}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/views/EntityGraphView.tsx
+++ b/apps/web/src/views/EntityGraphView.tsx
@@ -1,6 +1,7 @@
 import { ACCENT, palette, fonts } from "../theme";
 import { useTopEntities } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import EntityGraph from "../components/charts/EntityGraph";
 import type { LegendItem } from "../types";
 
@@ -27,13 +28,14 @@ const panelLabel = {
 } as const;
 
 export default function EntityGraphView() {
-  const { data: topEntities } = useTopEntities();
+  const { data: topEntities, source, isLoading } = useTopEntities();
 
   return (
     <div>
       <PageHeader
         title="Entity Relationship Graph"
         subtitle="12 entities · 13 co-occurrence links · 24h window"
+        right={<SourceBadge source={source} isLoading={isLoading} />}
       />
       <div style={{ display: "grid", gridTemplateColumns: "1fr 280px", gap: 12 }}>
         <div style={{ background: "#0e131a", border: "1px solid #1c2330", borderRadius: 10, overflow: "hidden" }}>

--- a/apps/web/src/views/NewsFeed.tsx
+++ b/apps/web/src/views/NewsFeed.tsx
@@ -3,13 +3,14 @@ import { ACCENT, accentSoft, accentBorder, fonts } from "../theme";
 import { sentColor, sentLabel, fmt } from "../lib/sentiment";
 import { useArticles } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 
 const filters = ["All", "Economy", "Technology", "Policy", "Energy", "Health"];
 
 export default function NewsFeed() {
   const [filter, setFilter] = useState("All");
-  const { data: articles } = useArticles();
+  const { data: articles, source, isLoading } = useArticles();
   const feed = filter === "All" ? articles : articles.filter((a) => a.category === filter);
 
   return (
@@ -17,6 +18,7 @@ export default function NewsFeed() {
       <PageHeader
         title="News Feed"
         subtitle={`${articles.length} articles · 142 sources · auto-classified`}
+        right={<SourceBadge source={source} isLoading={isLoading} />}
       />
       <div style={{ display: "flex", gap: 7, marginBottom: 16, flexWrap: "wrap" }}>
         {filters.map((f) => {

--- a/apps/web/src/views/Sentiment.tsx
+++ b/apps/web/src/views/Sentiment.tsx
@@ -1,34 +1,48 @@
 import { palette, fonts } from "../theme";
+import { sentColor, fmt } from "../lib/sentiment";
+import { useTopicSentiment } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Heatmap from "../components/charts/Heatmap";
-import type { SentimentStat } from "../types";
+import type { SentimentStat, TopicSentiment } from "../types";
 
-const stats: SentimentStat[] = [
-  { label: "Net Sentiment", value: "+0.18", color: palette.pos, note: "aggregate across all topics" },
-  { label: "Most Positive", value: "Science", color: palette.pos, note: "+0.58 avg · fusion, health" },
-  { label: "Most Negative", value: "Finance", color: palette.neg, note: "-0.44 avg · CRE, credit" },
-];
+function deriveStats(topics: TopicSentiment[]): SentimentStat[] {
+  if (!topics.length) return [];
+  const totalArticles = topics.reduce((s, t) => s + t.articles, 0) || 1;
+  const net = topics.reduce((s, t) => s + t.avgScore * t.articles, 0) / totalArticles;
+  const sorted = [...topics].sort((a, b) => b.avgScore - a.avgScore);
+  const top = sorted[0];
+  const bottom = sorted[sorted.length - 1];
+  return [
+    { label: "Net Sentiment", value: fmt(net), color: sentColor(net), note: `weighted across ${topics.length} topics` },
+    { label: "Most Positive", value: top.topic, color: palette.pos, note: `${fmt(top.avgScore)} avg · ${top.articles} articles` },
+    { label: "Most Negative", value: bottom.topic, color: palette.neg, note: `${fmt(bottom.avgScore)} avg · ${bottom.articles} articles` },
+  ];
+}
+
+const card = {
+  background: "#11151c",
+  border: "1px solid #1c2330",
+  borderRadius: 10,
+} as const;
 
 export default function Sentiment() {
+  const { data: topics, source, isLoading } = useTopicSentiment();
+  const stats = deriveStats(topics);
+  const maxA = Math.max(1, ...topics.map((t) => t.articles));
+
   return (
     <div>
-      <PageHeader title="Sentiment Analysis" subtitle="Topic × time heatmap · 16-hour rolling window" />
+      <PageHeader
+        title="Sentiment Analysis"
+        subtitle="Per-topic sentiment · last 7 days"
+        right={<SourceBadge source={source} isLoading={isLoading} />}
+      />
 
-      <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, padding: "18px 20px", marginBottom: 12 }}>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
-          <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Sentiment Heatmap</div>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6" }}>
-            <span style={{ color: "#FF5C5C" }}>■</span> negative
-            <span style={{ color: "#8B95A5" }}>■</span> neutral
-            <span style={{ color: "#3DD68C" }}>■</span> positive
-          </div>
-        </div>
-        <Heatmap />
-      </div>
-
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12 }}>
+      {/* Stat cards — derived live from /news_sentiment/topics */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 12 }}>
         {stats.map((s) => (
-          <div key={s.label} style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, padding: "15px 17px" }}>
+          <div key={s.label} style={{ ...card, padding: "15px 17px" }}>
             <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6", letterSpacing: "0.1em", textTransform: "uppercase" }}>
               {s.label}
             </div>
@@ -38,6 +52,66 @@ export default function Sentiment() {
             <div style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#5b6675", marginTop: 4 }}>{s.note}</div>
           </div>
         ))}
+      </div>
+
+      {/* Live topic breakdown */}
+      <div style={{ ...card, padding: "18px 20px", marginBottom: 12 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+          <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Topic Sentiment</div>
+          <div style={{ fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6" }}>avg score · article volume</div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+          {topics.slice(0, 10).map((t) => {
+            const c = sentColor(t.avgScore);
+            // Center a diverging bar at 50%: positive grows right, negative left.
+            const pct = Math.min(Math.abs(t.avgScore), 1) * 50;
+            return (
+              <div key={t.topic} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <span style={{ width: 110, flex: "none", fontSize: 12.5, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {t.topic}
+                </span>
+                <div style={{ flex: 1, position: "relative", height: 8, background: "#0e131a", borderRadius: 3 }}>
+                  <div style={{ position: "absolute", left: "50%", top: 0, bottom: 0, width: 1, background: "#2a3340" }} />
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      bottom: 0,
+                      borderRadius: 3,
+                      background: c,
+                      ...(t.avgScore >= 0
+                        ? { left: "50%", width: `${pct}%` }
+                        : { right: "50%", width: `${pct}%` }),
+                    }}
+                  />
+                </div>
+                <span style={{ fontFamily: fonts.mono, fontSize: 11.5, color: c, width: 48, textAlign: "right" }}>
+                  {fmt(t.avgScore)}
+                </span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: "#5b6675", width: 52, textAlign: "right" }}>
+                  {Math.round((t.articles / maxA) * 100)}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Topic × time heatmap — no hourly backend endpoint yet, so this stays
+          on the design dataset and is labelled accordingly. */}
+      <div style={{ ...card, padding: "18px 20px" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Sentiment Heatmap</div>
+            <SourceBadge source="demo" />
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6" }}>
+            <span style={{ color: "#FF5C5C" }}>■</span> negative
+            <span style={{ color: "#8B95A5" }}>■</span> neutral
+            <span style={{ color: "#3DD68C" }}>■</span> positive
+          </div>
+        </div>
+        <Heatmap />
       </div>
     </div>
   );

--- a/apps/web/src/views/Timeline.tsx
+++ b/apps/web/src/views/Timeline.tsx
@@ -3,6 +3,7 @@ import { ACCENT, palette, accentSoft, accentBorder, fonts } from "../theme";
 import { sentColor, fmt } from "../lib/sentiment";
 import { mockStories, mockTimeline } from "../data/mock";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 import type { TimelineEvent } from "../types";
 
@@ -27,6 +28,7 @@ export default function Timeline() {
             How <span style={{ color: "#9aa4b2" }}>{activeLabel}</span> developed over time
           </>
         }
+        right={<SourceBadge source="demo" />}
       />
       <div style={{ display: "flex", gap: 7, marginBottom: 22, flexWrap: "wrap" }}>
         {mockStories.map((s) => {

--- a/apps/web/src/views/Trending.tsx
+++ b/apps/web/src/views/Trending.tsx
@@ -2,12 +2,13 @@ import { ACCENT, palette, fonts } from "../theme";
 import { sentColor, fmt } from "../lib/sentiment";
 import { useTrending } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 
 const GRID = "50px 1fr 130px 110px 90px";
 
 export default function Trending() {
-  const { data: trending } = useTrending();
+  const { data: trending, source, isLoading } = useTrending();
   const maxM = Math.max(1, ...trending.map((t) => t.mentions));
 
   const rows = trending.map((t, i) => ({
@@ -24,7 +25,11 @@ export default function Trending() {
 
   return (
     <div>
-      <PageHeader title="Trending Topics" subtitle="Ranked by mention velocity · 24h" />
+      <PageHeader
+        title="Trending Topics"
+        subtitle="Ranked by mention velocity · 24h"
+        right={<SourceBadge source={source} isLoading={isLoading} />}
+      />
       <div style={{ background: "#11151c", border: "1px solid #1c2330", borderRadius: 10, overflow: "hidden" }}>
         <div
           style={{

--- a/apps/web/src/views/Watchlists.tsx
+++ b/apps/web/src/views/Watchlists.tsx
@@ -2,6 +2,7 @@ import { ACCENT, palette, fonts } from "../theme";
 import { sentColor, fmt } from "../lib/sentiment";
 import { mockWatchlist } from "../data/mock";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 import Sparkline from "../components/charts/Sparkline";
 
@@ -12,22 +13,25 @@ export default function Watchlists() {
         title="Watchlists"
         subtitle="Entities & topics you track over time · 8h trend"
         right={
-          <Hover
-            as="button"
-            style={{
-              fontFamily: fonts.mono,
-              fontSize: 11,
-              color: "#8a94a6",
-              background: "#11151c",
-              border: "1px solid #232a36",
-              borderRadius: 7,
-              padding: "7px 13px",
-              cursor: "pointer",
-            }}
-            hoverStyle={{ borderColor: "#3a4554", color: "#c7cdd6" }}
-          >
-            + ADD TO WATCHLIST
-          </Hover>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <SourceBadge source="demo" />
+            <Hover
+              as="button"
+              style={{
+                fontFamily: fonts.mono,
+                fontSize: 11,
+                color: "#8a94a6",
+                background: "#11151c",
+                border: "1px solid #232a36",
+                borderRadius: 7,
+                padding: "7px 13px",
+                cursor: "pointer",
+              }}
+              hoverStyle={{ borderColor: "#3a4554", color: "#c7cdd6" }}
+            >
+              + ADD TO WATCHLIST
+            </Hover>
+          </div>
         }
       />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12 }}>

--- a/apps/web/src/views/Workspaces.tsx
+++ b/apps/web/src/views/Workspaces.tsx
@@ -3,6 +3,7 @@ import { ACCENT, palette, fonts } from "../theme";
 import { sentColor, fmt } from "../lib/sentiment";
 import { mockWorkspaces, mockWorkspaceDetail } from "../data/mock";
 import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
 import Hover from "../components/Hover";
 import type { Workspace } from "../types";
 
@@ -43,7 +44,11 @@ export default function Workspaces() {
 
   return (
     <div>
-      <PageHeader title="Research Workspaces" subtitle="Group sources around a question · build toward a thesis" />
+      <PageHeader
+        title="Research Workspaces"
+        subtitle="Group sources around a question · build toward a thesis"
+        right={<SourceBadge source="demo" />}
+      />
       <div style={{ display: "grid", gridTemplateColumns: "316px 1fr", gap: 14, alignItems: "start" }}>
         {/* Project list */}
         <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      "/health": { target: apiTarget, changeOrigin: true },
       "/api": { target: apiTarget, changeOrigin: true },
       "/news": { target: apiTarget, changeOrigin: true },
       "/news_sentiment": { target: apiTarget, changeOrigin: true },


### PR DESCRIPTION
## Summary

Adds the **NeuroNews Intelligence Terminal** web frontend (React + Vite +
TypeScript, in `apps/web/`) and wires it to consume **real data** from the
FastAPI backend, with clear indicators for when a panel is showing live API
data vs the bundled demo dataset.

This branch bundles three things:
1. The terminal frontend itself (9 views, dark design, SVG charts)
2. A fix for `src/lib/` files being excluded by the root Python `.gitignore`
3. **Live-data wiring + visibility** (the focus of the latest work)

## Make it use actual data

- **Global connection pill** in the top bar, driven by a `/health` probe:
  `CONNECTING → BACKEND LIVE → DEMO MODE`. Re-polled every 30s so it flips
  automatically as the backend comes up or goes down.
- **Per-view `LIVE` / `DEMO` / `SYNC` badge** (`SourceBadge`) on every
  data-backed view, so it's obvious per panel whether rows came from the API
  or the fallback dataset.
- **Sentiment view wired to live data**: stat cards (net / most positive /
  most negative) and a new topic-sentiment breakdown bar list are derived from
  `GET /news_sentiment/topics` (article-weighted average per topic). The
  topic×time heatmap stays on the demo dataset and is explicitly labelled
  `DEMO` since there's no hourly endpoint yet.
- Research views (Workspaces / Watchlists / Story Timeline) are labelled
  `DEMO` since they have no backend endpoint.

## Backend wiring

| View            | Endpoint                                         |
| --------------- | ------------------------------------------------ |
| Overview        | feed / clusters / trending aggregates            |
| News Feed       | `GET /api/v1/news/articles`                      |
| Entity Graph    | `GET /api/influence/top-influencers`             |
| Sentiment       | `GET /news_sentiment/topics`                     |
| Event Clusters  | `GET /api/v1/events/clusters`                    |
| Trending        | `GET /topics/trending`                           |
| Breaking ticker | `GET /api/v1/breaking_news`                      |
| Health probe    | `GET /health`                                    |

Each query transparently falls back to the design dataset when the endpoint is
unreachable or empty, so the UI always renders.

## Test plan

- `npm run typecheck` — passes
- `npm run build` — passes (103 modules, ~72 kB gzip)
- With the backend running (`uvicorn src.api.app:app --reload --port 8000`),
  badges read `LIVE`; with no backend, the top bar shows `DEMO MODE` and every
  badge reads `DEMO`.