### PR TITLE
fix(api): stop WAF blocking the frontend; add NEURONEWS_DEV_MODE

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,8 +28,13 @@ backend separately, e.g.:
 
 ```bash
 pip install -r requirements.txt
-uvicorn src.api.app:app --reload --port 8000
+NEURONEWS_DEV_MODE=true uvicorn src.api.app:app --reload --port 8000
 ```
+
+`NEURONEWS_DEV_MODE=true` disables the WAF, rate limiting, API-key and RBAC
+middlewares for local development. Without it the API protects itself with an
+aggressive WAF and a low anonymous rate limit (10 req/min), which blocks the
+dashboard's burst of requests on load. Leave it unset in production.
 
 The backend serves real data from a **local DuckDB warehouse** (no Snowflake or
 external services needed). On first request it creates and seeds

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -281,8 +281,27 @@ def configure_error_handlers_if_available(app):
     return False
 
 
+def _dev_mode_enabled() -> bool:
+    """Whether to skip heavy security middleware for local development.
+
+    Set NEURONEWS_DEV_MODE=true to disable the WAF, rate limiting, API-key and
+    RBAC middlewares so the local frontend can talk to the API without
+    authentication or throttling. Defaults to off (production-safe).
+    """
+    import os
+
+    return os.getenv("NEURONEWS_DEV_MODE", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def add_waf_middleware_if_available(app):
     """Add WAF security middleware first for maximum protection (Issue #65)."""
+    if _dev_mode_enabled():
+        return False
     if WAF_SECURITY_AVAILABLE:
         waf_security_middleware = _imported_modules.get('WAFSecurityMiddleware')
         waf_metrics_middleware = _imported_modules.get('WAFMetricsMiddleware')
@@ -295,6 +314,8 @@ def add_waf_middleware_if_available(app):
 
 def add_rate_limiting_middleware_if_available(app):
     """Add rate limiting middleware (Issue #59)."""
+    if _dev_mode_enabled():
+        return False
     if RATE_LIMITING_AVAILABLE:
         rate_limit_middleware = _imported_modules.get('RateLimitMiddleware')
         rate_limit_config = _imported_modules.get('RateLimitConfig')
@@ -306,6 +327,8 @@ def add_rate_limiting_middleware_if_available(app):
 
 def add_api_key_middleware_if_available(app):
     """Add API key authentication middleware (Issue #61)."""
+    if _dev_mode_enabled():
+        return False
     if API_KEY_MANAGEMENT_AVAILABLE:
         api_key_auth_middleware = _imported_modules.get('APIKeyAuthMiddleware')
         api_key_metrics_middleware = _imported_modules.get('APIKeyMetricsMiddleware')
@@ -318,6 +341,8 @@ def add_api_key_middleware_if_available(app):
 
 def add_rbac_middleware_if_available(app):
     """Add RBAC middleware (Issue #60)."""
+    if _dev_mode_enabled():
+        return False
     if RBAC_AVAILABLE:
         enhanced_rbac_middleware = _imported_modules.get('EnhancedRBACMiddleware')
         rbac_metrics_middleware = _imported_modules.get('RBACMetricsMiddleware')

--- a/src/api/security/waf_middleware.py
+++ b/src/api/security/waf_middleware.py
@@ -327,15 +327,17 @@ class WAFSecurityMiddleware(BaseHTTPMiddleware):
             return {"detected": False, "error": str(e)}
 
     async def _check_xss_attacks(self, request: Request) -> Dict[str, Any]:
-        """Check for XSS attack attempts."""
+        """Check for XSS attack attempts in user-controllable, reflectable input.
+
+        Only the query string and request body are inspected. Standard request
+        headers (user-agent, sec-ch-ua, accept, …) are not reflected by the API
+        and routinely contain substrings that match XSS heuristics (e.g.
+        ``on\\w+=``), so scanning them produces false positives that block
+        legitimate browser traffic without adding protection.
+        """
         try:
             # Check query parameters
             query_string = str(request.url.query)
-
-            # Check request headers
-            headers_content = " ".join(
-                "{0}:{1}".format(k, v) for k, v in request.headers.items()
-            )
 
             # Check request body if present
             body_content = ""
@@ -346,10 +348,8 @@ class WAFSecurityMiddleware(BaseHTTPMiddleware):
                 except Exception:
                     body_content = ""
 
-            # Combine all content to check
-            content_to_check = "{0} {1} {2}".format(
-                query_string, headers_content, body_content
-            )
+            # Combine user-controllable content to check
+            content_to_check = "{0} {1}".format(query_string, body_content)
 
             # Check against XSS patterns
             for pattern in self.xss_patterns:


### PR DESCRIPTION
## Summary

With the local DuckDB warehouse merged (#503), starting the backend and loading
the frontend still showed **demo data** — because every data endpoint returned
**403 (WAF)** or **429 (rate limit)**. This PR makes the API actually reachable
from a browser locally.

Observed in the backend log on a normal page load:

```
WARNING SECURITY EVENT: xss_attack ... Path: /api/v1/news/articles - Action: BLOCK
INFO    "GET /api/v1/news/articles HTTP/1.1" 403 Forbidden
INFO    "GET /api/v1/breaking_news?limit=6 HTTP/1.1" 429 Too Many Requests
```

## Root causes & fixes

**1. WAF false positive on request headers (403).**
`_check_xss_attacks` concatenated *all* request headers and scanned them with
XSS heuristics (e.g. `on\w+\s*=`). Ordinary browser headers (`sec-ch-ua`,
`user-agent`, …) match these patterns, so every request was blocked — with no
security benefit, since request headers aren't reflected by the JSON endpoints.
Now only the **query string and request body** (the user-controllable,
reflectable input) are scanned. Verified: a request whose *headers* contain
`onload=` is allowed, while a malicious *query string* (`?q=<img onerror=…>`) is
still detected.

**2. Anonymous rate limit too low for a dashboard (429).**
The FREE tier is 10 req/min; the dashboard fires ~8 requests per load plus a
periodic health poll, so reloads hit 429. Added a **`NEURONEWS_DEV_MODE`** env
flag that skips the WAF, rate limiting, API-key and RBAC middlewares for local
development. Defaults to off, so **production behavior is unchanged**.

## How to run locally

```bash
NEURONEWS_DEV_MODE=true uvicorn src.api.app:app --reload --port 8000
```

Documented in the web README. With this, News Feed, Overview and Sentiment serve
live data from the local warehouse and the badges read `LIVE`.

## Notes

- The WAF header-scanning fix applies in all environments (it's a real bug);
  dev mode is what relaxes throttling/auth for local use.
- Existing WAF security tests are placeholder-style and exercise query-param
  payloads, which are still scanned — no behavior they assert changes.