### PR TITLE
feat: live dashboard — multi-source clusters, entity graph & sentiment heatmap

### DIFF
--- a/apps/web/src/components/charts/EntityGraph.tsx
+++ b/apps/web/src/components/charts/EntityGraph.tsx
@@ -1,71 +1,152 @@
-import { ACCENT, palette, fonts } from "../../theme";
-import type { GraphNode } from "../../types";
+import { useMemo } from "react";
+import { ACCENT, fonts } from "../../theme";
+import type { LiveGraph } from "../../types";
 
 interface Props {
+  data: LiveGraph;
   accent?: string;
 }
 
-// Static force-style entity relationship graph. Ported from `buildGraph`.
-export default function EntityGraph({ accent = ACCENT }: Props) {
+interface Pos {
+  x: number;
+  y: number;
+}
+
+// Deterministic force-directed layout (small graphs, so O(n^2) is fine).
+function layout(data: LiveGraph): Record<string, Pos> {
+  const nodes = data.nodes;
+  const n = nodes.length;
+  const pos: Record<string, Pos> = {};
+  if (!n) return pos;
+
+  // Seed on a circle for determinism.
+  nodes.forEach((node, i) => {
+    const a = (2 * Math.PI * i) / n;
+    pos[node.id] = { x: 0.5 + 0.35 * Math.cos(a), y: 0.5 + 0.35 * Math.sin(a) };
+  });
+
+  const adj = data.edges;
+  const iterations = 300;
+  const repulsion = 0.018;
+  const spring = 0.02;
+  const gravity = 0.008;
+
+  for (let it = 0; it < iterations; it++) {
+    const disp: Record<string, Pos> = {};
+    nodes.forEach((nd) => (disp[nd.id] = { x: 0, y: 0 }));
+
+    // Repulsion between every pair.
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        const a = nodes[i].id;
+        const b = nodes[j].id;
+        let dx = pos[a].x - pos[b].x;
+        let dy = pos[a].y - pos[b].y;
+        let d2 = dx * dx + dy * dy || 0.0001;
+        const f = repulsion / d2;
+        const d = Math.sqrt(d2);
+        dx /= d;
+        dy /= d;
+        disp[a].x += dx * f;
+        disp[a].y += dy * f;
+        disp[b].x -= dx * f;
+        disp[b].y -= dy * f;
+      }
+    }
+
+    // Spring attraction along edges (stronger for heavier edges).
+    for (const [s, t, w] of adj) {
+      if (!pos[s] || !pos[t]) continue;
+      const dx = pos[t].x - pos[s].x;
+      const dy = pos[t].y - pos[s].y;
+      const f = spring * Math.min(3, w);
+      disp[s].x += dx * f;
+      disp[s].y += dy * f;
+      disp[t].x -= dx * f;
+      disp[t].y -= dy * f;
+    }
+
+    // Gravity toward the center + integrate.
+    nodes.forEach((nd) => {
+      disp[nd.id].x += (0.5 - pos[nd.id].x) * gravity;
+      disp[nd.id].y += (0.5 - pos[nd.id].y) * gravity;
+      pos[nd.id].x += Math.max(-0.04, Math.min(0.04, disp[nd.id].x));
+      pos[nd.id].y += Math.max(-0.04, Math.min(0.04, disp[nd.id].y));
+    });
+  }
+
+  // Normalize into a padded box.
+  const xs = nodes.map((nd) => pos[nd.id].x);
+  const ys = nodes.map((nd) => pos[nd.id].y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const spanX = maxX - minX || 1;
+  const spanY = maxY - minY || 1;
+  nodes.forEach((nd) => {
+    pos[nd.id].x = 0.08 + 0.84 * ((pos[nd.id].x - minX) / spanX);
+    pos[nd.id].y = 0.12 + 0.78 * ((pos[nd.id].y - minY) / spanY);
+  });
+  return pos;
+}
+
+export default function EntityGraph({ data, accent = ACCENT }: Props) {
   const W = 760;
   const H = 480;
-  const nodes: GraphNode[] = [
-    { id: "fed", label: "Federal Reserve", x: 0.3, y: 0.3, r: 26, type: "org", color: accent },
-    { id: "powell", label: "J. Powell", x: 0.16, y: 0.52, r: 15, type: "person", color: palette.blue },
-    { id: "pce", label: "PCE", x: 0.44, y: 0.16, r: 13, type: "topic", color: palette.amber },
-    { id: "nvda", label: "Nvidia", x: 0.66, y: 0.28, r: 24, type: "org", color: accent },
-    { id: "huang", label: "J. Huang", x: 0.82, y: 0.16, r: 14, type: "person", color: palette.blue },
-    { id: "ai", label: "AI", x: 0.6, y: 0.5, r: 20, type: "topic", color: palette.amber },
-    { id: "eu", label: "European Union", x: 0.4, y: 0.7, r: 21, type: "org", color: accent },
-    { id: "msft", label: "Microsoft", x: 0.6, y: 0.78, r: 18, type: "org", color: accent },
-    { id: "opec", label: "OPEC", x: 0.84, y: 0.62, r: 17, type: "org", color: accent },
-    { id: "oil", label: "Crude Oil", x: 0.84, y: 0.84, r: 15, type: "topic", color: palette.amber },
-    { id: "eu2", label: "Brussels", x: 0.2, y: 0.8, r: 12, type: "place", color: palette.violet },
-    { id: "cloud", label: "Cloud", x: 0.5, y: 0.92, r: 13, type: "topic", color: palette.amber },
-  ];
-  const edges: [string, string][] = [
-    ["fed", "powell"], ["fed", "pce"], ["fed", "ai"], ["nvda", "huang"], ["nvda", "ai"], ["ai", "msft"],
-    ["eu", "msft"], ["eu", "eu2"], ["msft", "cloud"], ["eu", "cloud"], ["opec", "oil"], ["nvda", "fed"], ["ai", "eu"],
-  ];
-  const N: Record<string, GraphNode> = {};
-  nodes.forEach((n) => (N[n.id] = n));
-  const px = (n: GraphNode) => n.x * W;
-  const py = (n: GraphNode) => n.y * H;
+  const pos = useMemo(() => layout(data), [data]);
+
+  const maxCount = Math.max(1, ...data.nodes.map((n) => n.count));
+  const radius = (count: number) => 11 + 18 * Math.sqrt(count / maxCount);
+  const maxW = Math.max(1, ...data.edges.map((e) => e[2]));
+  const px = (id: string) => (pos[id]?.x ?? 0.5) * W;
+  const py = (id: string) => (pos[id]?.y ?? 0.5) * H;
+
+  if (!data.nodes.length) {
+    return (
+      <div style={{ height: H, display: "flex", alignItems: "center", justifyContent: "center", color: "#5b6675", fontFamily: fonts.mono, fontSize: 12 }}>
+        No entities in the selected window
+      </div>
+    );
+  }
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={480} style={{ display: "block" }}>
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H} style={{ display: "block" }}>
       <g>
-        {edges.map((e, i) => (
+        {data.edges.map((e, i) => (
           <line
             key={i}
-            x1={px(N[e[0]])}
-            y1={py(N[e[0]])}
-            x2={px(N[e[1]])}
-            y2={py(N[e[1]])}
+            x1={px(e[0])}
+            y1={py(e[0])}
+            x2={px(e[1])}
+            y2={py(e[1])}
             stroke="#2a3340"
-            strokeWidth={1.2}
+            strokeWidth={0.8 + 1.6 * (e[2] / maxW)}
+            opacity={0.5 + 0.5 * (e[2] / maxW)}
           />
         ))}
       </g>
       <g>
-        {nodes.map((n, i) => (
-          <g key={i}>
-            <circle cx={px(n)} cy={py(n)} r={n.r + 5} fill={n.color} opacity={0.1} />
-            <circle cx={px(n)} cy={py(n)} r={n.r} fill="#0e131a" stroke={n.color} strokeWidth={2} />
-            <circle cx={px(n)} cy={py(n)} r={Math.max(3, n.r * 0.28)} fill={n.color} />
-            <text
-              x={px(n)}
-              y={py(n) + n.r + 13}
-              textAnchor="middle"
-              fill="#c7cdd6"
-              fontSize={11}
-              fontFamily={fonts.sans}
-              fontWeight={500}
-            >
-              {n.label}
-            </text>
-          </g>
-        ))}
+        {data.nodes.map((n, i) => {
+          const r = radius(n.count);
+          const color = n.color || accent;
+          return (
+            <g key={i}>
+              <circle cx={px(n.id)} cy={py(n.id)} r={r + 5} fill={color} opacity={0.1} />
+              <circle cx={px(n.id)} cy={py(n.id)} r={r} fill="#0e131a" stroke={color} strokeWidth={2} />
+              <circle cx={px(n.id)} cy={py(n.id)} r={Math.max(3, r * 0.28)} fill={color} />
+              <text
+                x={px(n.id)}
+                y={py(n.id) + r + 13}
+                textAnchor="middle"
+                fill="#c7cdd6"
+                fontSize={11}
+                fontFamily={fonts.sans}
+                fontWeight={500}
+              >
+                {n.label}
+              </text>
+            </g>
+          );
+        })}
       </g>
     </svg>
   );

--- a/apps/web/src/components/charts/Heatmap.tsx
+++ b/apps/web/src/components/charts/Heatmap.tsx
@@ -1,7 +1,7 @@
 import { fonts } from "../../theme";
-import { mockHeatmap } from "../../data/mock";
+import type { Heatmap as HeatmapData } from "../../types";
 
-// Sentiment heatmap (topics × 16 hourly columns). Ported from `buildHeatmap`.
+// Sentiment heatmap (categories × day columns).
 function cellColor(v: number): string {
   if (v > 0.05) {
     const t = Math.min(v / 0.7, 1);
@@ -14,10 +14,21 @@ function cellColor(v: number): string {
   return "rgba(139,149,165,0.16)";
 }
 
-export default function Heatmap() {
-  const { topics, cols, seed } = mockHeatmap;
-  const nowHour = new Date().getUTCHours();
-  const hours = Array.from({ length: cols }, (_, i) => ((nowHour - (cols - 1 - i)) % 24 + 24) % 24);
+interface Props {
+  data: HeatmapData;
+}
+
+export default function Heatmap({ data }: Props) {
+  const { topics, cols, seed, labels } = data;
+  const labelEvery = cols > 10 ? 2 : 1;
+
+  if (!topics.length) {
+    return (
+      <div style={{ height: 120, display: "flex", alignItems: "center", justifyContent: "center", color: "#5b6675", fontFamily: fonts.mono, fontSize: 12 }}>
+        No sentiment data in the selected window
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
@@ -30,7 +41,7 @@ export default function Heatmap() {
             {seed[ri].map((v, ci) => (
               <div
                 key={ci}
-                title={`${t} · ${v.toFixed(2)}`}
+                title={`${t} · ${labels[ci] ?? ""} · ${v.toFixed(2)}`}
                 style={{ height: 26, borderRadius: 3, background: cellColor(v) }}
               />
             ))}
@@ -40,9 +51,9 @@ export default function Heatmap() {
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 2 }}>
         <div style={{ width: 78, flex: "none" }} />
         <div style={{ flex: 1, display: "grid", gridTemplateColumns: `repeat(${cols},1fr)`, gap: 4 }}>
-          {hours.map((h, i) => (
+          {labels.map((h, i) => (
             <div key={i} style={{ textAlign: "center", fontFamily: fonts.mono, fontSize: 9, color: "#4b5563" }}>
-              {i % 2 === 0 ? String(h).padStart(2, "0") : ""}
+              {i % labelEvery === 0 ? h : ""}
             </div>
           ))}
         </div>

--- a/apps/web/src/lib/adapters.ts
+++ b/apps/web/src/lib/adapters.ts
@@ -9,6 +9,7 @@ import type {
   TrendingTopic,
   TopEntity,
   TopicSentiment,
+  LiveGraph,
 } from "../types";
 import type {
   RawArticle,
@@ -16,7 +17,24 @@ import type {
   RawTrendingResponse,
   RawInfluencer,
   RawTopicSentiment,
+  RawEntityGraph,
 } from "./api";
+
+export function adaptEntityGraph(raw: RawEntityGraph): LiveGraph {
+  const nodes = (raw.nodes ?? []).map((n) => ({
+    id: n.id,
+    label: n.label,
+    type: n.type,
+    color: n.color,
+    count: n.count ?? 0,
+    degree: n.degree ?? 0,
+  }));
+  const ids = new Set(nodes.map((n) => n.id));
+  const edges = (raw.edges ?? [])
+    .filter((e) => ids.has(e.source) && ids.has(e.target))
+    .map((e) => [e.source, e.target, e.weight ?? 1] as [string, string, number]);
+  return { nodes, edges, nodeCount: nodes.length, edgeCount: edges.length };
+}
 
 export function relativeTime(iso: string | null | undefined): string {
   if (!iso) return "—";

--- a/apps/web/src/lib/adapters.ts
+++ b/apps/web/src/lib/adapters.ts
@@ -10,6 +10,7 @@ import type {
   TopEntity,
   TopicSentiment,
   LiveGraph,
+  Heatmap,
 } from "../types";
 import type {
   RawArticle,
@@ -18,7 +19,17 @@ import type {
   RawInfluencer,
   RawTopicSentiment,
   RawEntityGraph,
+  RawHeatmap,
 } from "./api";
+
+export function adaptHeatmap(raw: RawHeatmap): Heatmap {
+  return {
+    topics: raw.topics ?? [],
+    cols: raw.cols ?? 0,
+    labels: raw.labels ?? [],
+    seed: raw.seed ?? [],
+  };
+}
 
 export function adaptEntityGraph(raw: RawEntityGraph): LiveGraph {
   const nodes = (raw.nodes ?? []).map((n) => ({

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -139,6 +139,13 @@ export interface RawEntityGraph {
   edge_count: number;
 }
 
+export interface RawHeatmap {
+  topics: string[];
+  cols: number;
+  labels: string[];
+  seed: number[][];
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -168,4 +175,7 @@ export const api = {
 
   entityGraph: (params?: { days?: number; max_nodes?: number }) =>
     request<RawEntityGraph>("/api/v1/entity_graph", params),
+
+  sentimentHeatmap: (params?: { days?: number; max_topics?: number }) =>
+    request<RawHeatmap>("/news_sentiment/heatmap", params),
 };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -123,6 +123,22 @@ export interface RawInfluencer {
   degree?: number;
 }
 
+export interface RawGraphNode {
+  id: string;
+  label: string;
+  type: string;
+  color: string;
+  count: number;
+  degree: number;
+}
+
+export interface RawEntityGraph {
+  nodes: RawGraphNode[];
+  edges: { source: string; target: string; weight: number }[];
+  node_count: number;
+  edge_count: number;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -149,4 +165,7 @@ export const api = {
 
   topInfluencers: (params?: { limit?: number }) =>
     request<RawInfluencer[]>("/api/influence/top-influencers", params),
+
+  entityGraph: (params?: { days?: number; max_nodes?: number }) =>
+    request<RawEntityGraph>("/api/v1/entity_graph", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -11,6 +11,7 @@ import {
   adaptInfluencers,
   adaptTopicSentiment,
   adaptEntityGraph,
+  adaptHeatmap,
 } from "./adapters";
 import {
   mockArticles,
@@ -18,6 +19,7 @@ import {
   mockTrending,
   mockTickerText,
   mockTopicSentiment,
+  mockHeatmap,
 } from "../data/mock";
 import { palette, ACCENT } from "../theme";
 import type {
@@ -27,6 +29,7 @@ import type {
   TopEntity,
   TopicSentiment,
   LiveGraph,
+  Heatmap,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -154,6 +157,27 @@ export function useTopicSentiment(): Result<TopicSentiment[]> {
     "topicSentiment",
     async () => adaptTopicSentiment(await api.sentimentTopics({ days: 7 })),
     mockTopicSentiment,
+  );
+}
+
+const mockSentimentHeatmap: Heatmap = {
+  topics: ["Economy", "Technology", "Energy", "Policy", "Health", "Markets"],
+  cols: mockHeatmap.cols,
+  labels: Array.from({ length: mockHeatmap.cols }, (_, i) =>
+    i % 2 === 0 ? String(i) : "",
+  ),
+  seed: mockHeatmap.seed,
+};
+
+export function useSentimentHeatmap(): Result<Heatmap> {
+  return useWithFallback(
+    "sentimentHeatmap",
+    async () => {
+      const hm = adaptHeatmap(await api.sentimentHeatmap({ days: 14 }));
+      if (!hm.topics.length) throw new Error("empty");
+      return hm;
+    },
+    mockSentimentHeatmap,
   );
 }
 

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -10,6 +10,7 @@ import {
   adaptTrending,
   adaptInfluencers,
   adaptTopicSentiment,
+  adaptEntityGraph,
 } from "./adapters";
 import {
   mockArticles,
@@ -25,6 +26,7 @@ import type {
   TrendingTopic,
   TopEntity,
   TopicSentiment,
+  LiveGraph,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -110,6 +112,40 @@ export function useTopEntities(): Result<TopEntity[]> {
     "topEntities",
     async () => adaptInfluencers(await api.topInfluencers({ limit: 5 })),
     mockTopEntities,
+  );
+}
+
+const mockEntityGraph: LiveGraph = {
+  nodes: [
+    { id: "fed", label: "Federal Reserve", type: "org", color: ACCENT, count: 9, degree: 4 },
+    { id: "powell", label: "Jerome Powell", type: "person", color: palette.blue, count: 5, degree: 2 },
+    { id: "nvda", label: "Nvidia", type: "org", color: ACCENT, count: 8, degree: 3 },
+    { id: "huang", label: "Jensen Huang", type: "person", color: palette.blue, count: 4, degree: 1 },
+    { id: "ai", label: "AI", type: "topic", color: palette.amber, count: 11, degree: 4 },
+    { id: "eu", label: "European Union", type: "org", color: ACCENT, count: 7, degree: 3 },
+    { id: "msft", label: "Microsoft", type: "org", color: ACCENT, count: 6, degree: 2 },
+    { id: "opec", label: "OPEC", type: "org", color: ACCENT, count: 5, degree: 1 },
+    { id: "oil", label: "Crude Oil", type: "topic", color: palette.amber, count: 5, degree: 1 },
+    { id: "ukraine", label: "Ukraine", type: "place", color: palette.violet, count: 6, degree: 2 },
+  ],
+  edges: [
+    ["fed", "powell", 5], ["fed", "ai", 3], ["nvda", "huang", 4], ["nvda", "ai", 6],
+    ["ai", "msft", 3], ["eu", "msft", 2], ["eu", "ukraine", 4], ["opec", "oil", 5],
+    ["nvda", "fed", 2], ["ai", "eu", 2],
+  ],
+  nodeCount: 10,
+  edgeCount: 10,
+};
+
+export function useEntityGraph(): Result<LiveGraph> {
+  return useWithFallback(
+    "entityGraph",
+    async () => {
+      const g = adaptEntityGraph(await api.entityGraph({ days: 7, max_nodes: 16 }));
+      if (!g.nodes.length) throw new Error("empty");
+      return g;
+    },
+    mockEntityGraph,
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -79,6 +79,23 @@ export interface GraphData {
   edgeCount: number;
 }
 
+// Entity graph fetched live from the API (positions computed client-side).
+export interface LiveGraphNode {
+  id: string;
+  label: string;
+  type: string;
+  color: string;
+  count: number;
+  degree: number;
+}
+
+export interface LiveGraph {
+  nodes: LiveGraphNode[];
+  edges: [string, string, number][];
+  nodeCount: number;
+  edgeCount: number;
+}
+
 export interface Workspace {
   id: string;
   q: string;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -50,6 +50,13 @@ export interface TopicSentiment {
   articles: number;
 }
 
+export interface Heatmap {
+  topics: string[];
+  cols: number;
+  labels: string[];
+  seed: number[][];
+}
+
 export interface LegendItem {
   label: string;
   color: string;

--- a/apps/web/src/views/EntityGraphView.tsx
+++ b/apps/web/src/views/EntityGraphView.tsx
@@ -1,16 +1,10 @@
+import { useMemo } from "react";
 import { ACCENT, palette, fonts } from "../theme";
-import { useTopEntities } from "../lib/queries";
+import { useEntityGraph } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import EntityGraph from "../components/charts/EntityGraph";
 import type { LegendItem } from "../types";
-
-const legend: LegendItem[] = [
-  { label: "Organizations", color: ACCENT, count: "5,210" },
-  { label: "People", color: palette.blue, count: "3,840" },
-  { label: "Topics", color: palette.amber, count: "2,610" },
-  { label: "Places", color: palette.violet, count: "749" },
-];
 
 const panel = {
   background: "#11151c",
@@ -27,19 +21,49 @@ const panelLabel = {
   marginBottom: 11,
 } as const;
 
+const TYPE_LABEL: Record<string, string> = {
+  org: "Organizations",
+  person: "People",
+  topic: "Topics",
+  place: "Places",
+};
+const TYPE_COLOR: Record<string, string> = {
+  org: ACCENT,
+  person: palette.blue,
+  topic: palette.amber,
+  place: palette.violet,
+};
+
 export default function EntityGraphView() {
-  const { data: topEntities, source, isLoading } = useTopEntities();
+  const { data: graph, source, isLoading } = useEntityGraph();
+
+  const legend: LegendItem[] = useMemo(() => {
+    const counts: Record<string, number> = { org: 0, person: 0, topic: 0, place: 0 };
+    graph.nodes.forEach((n) => {
+      counts[n.type] = (counts[n.type] ?? 0) + 1;
+    });
+    return (["org", "person", "topic", "place"] as const).map((t) => ({
+      label: TYPE_LABEL[t],
+      color: TYPE_COLOR[t],
+      count: String(counts[t] ?? 0),
+    }));
+  }, [graph]);
+
+  const topConnected = useMemo(
+    () => [...graph.nodes].sort((a, b) => b.degree - a.degree).slice(0, 6),
+    [graph],
+  );
 
   return (
     <div>
       <PageHeader
         title="Entity Relationship Graph"
-        subtitle="12 entities · 13 co-occurrence links · 24h window"
+        subtitle={`${graph.nodeCount} entities · ${graph.edgeCount} co-occurrence links · 7d window`}
         right={<SourceBadge source={source} isLoading={isLoading} />}
       />
       <div style={{ display: "grid", gridTemplateColumns: "1fr 280px", gap: 12 }}>
         <div style={{ background: "#0e131a", border: "1px solid #1c2330", borderRadius: 10, overflow: "hidden" }}>
-          <EntityGraph />
+          <EntityGraph data={graph} />
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <div style={panel}>
@@ -57,8 +81,8 @@ export default function EntityGraphView() {
           <div style={panel}>
             <div style={panelLabel}>TOP CONNECTED</div>
             <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-              {topEntities.map((e) => (
-                <div key={e.name} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              {topConnected.map((e) => (
+                <div key={e.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
                   <span style={{ width: 8, height: 8, flex: "none", borderRadius: "50%", background: e.color }} />
                   <span
                     style={{
@@ -70,9 +94,9 @@ export default function EntityGraphView() {
                       textOverflow: "ellipsis",
                     }}
                   >
-                    {e.name}
+                    {e.label}
                   </span>
-                  <span style={{ fontFamily: fonts.mono, fontSize: 11, color: "#8a94a6" }}>{e.links}</span>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 11, color: "#8a94a6" }}>{e.degree}</span>
                 </div>
               ))}
             </div>

--- a/apps/web/src/views/Sentiment.tsx
+++ b/apps/web/src/views/Sentiment.tsx
@@ -1,6 +1,6 @@
 import { palette, fonts } from "../theme";
 import { sentColor, fmt } from "../lib/sentiment";
-import { useTopicSentiment } from "../lib/queries";
+import { useTopicSentiment, useSentimentHeatmap } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Heatmap from "../components/charts/Heatmap";
@@ -28,6 +28,7 @@ const card = {
 
 export default function Sentiment() {
   const { data: topics, source, isLoading } = useTopicSentiment();
+  const { data: heatmap, source: heatmapSource, isLoading: heatmapLoading } = useSentimentHeatmap();
   const stats = deriveStats(topics);
   const maxA = Math.max(1, ...topics.map((t) => t.articles));
 
@@ -97,13 +98,12 @@ export default function Sentiment() {
         </div>
       </div>
 
-      {/* Topic × time heatmap — no hourly backend endpoint yet, so this stays
-          on the design dataset and is labelled accordingly. */}
+      {/* Category × day sentiment heatmap — live average sentiment per bucket */}
       <div style={{ ...card, padding: "18px 20px" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
             <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Sentiment Heatmap</div>
-            <SourceBadge source="demo" />
+            <SourceBadge source={heatmapSource} isLoading={heatmapLoading} />
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 10, fontFamily: fonts.mono, fontSize: 10, color: "#8a94a6" }}>
             <span style={{ color: "#FF5C5C" }}>■</span> negative
@@ -111,7 +111,7 @@ export default function Sentiment() {
             <span style={{ color: "#3DD68C" }}>■</span> positive
           </div>
         </div>
-        <Heatmap />
+        <Heatmap data={heatmap} />
       </div>
     </div>
   );

--- a/src/api/middleware/rate_limit_middleware.py
+++ b/src/api/middleware/rate_limit_middleware.py
@@ -469,6 +469,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "/api/v1/news/articles",
             "/api/v1/events/clusters",
             "/api/v1/breaking_news",
+            "/api/v1/entity_graph",
             "/topics/trending",
             "/news_sentiment/topics",
             "/api/influence/top-influencers",

--- a/src/api/middleware/rate_limit_middleware.py
+++ b/src/api/middleware/rate_limit_middleware.py
@@ -472,6 +472,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "/api/v1/entity_graph",
             "/topics/trending",
             "/news_sentiment/topics",
+            "/news_sentiment/heatmap",
             "/api/influence/top-influencers",
         }
 

--- a/src/api/routes/event_routes.py
+++ b/src/api/routes/event_routes.py
@@ -212,6 +212,25 @@ async def get_breaking_news(
         )
 
 
+@router.get("/entity_graph")
+async def get_entity_graph(
+    days: int = Query(7, ge=1, le=30, description="Days of articles to analyze"),
+    max_nodes: int = Query(14, ge=4, le=60, description="Maximum entities to return"),
+):
+    """Entity co-occurrence graph derived from recent articles in the warehouse."""
+    try:
+        from src.database.local_warehouse_views import (
+            get_entity_graph as warehouse_entity_graph,
+        )
+
+        return await warehouse_entity_graph(days=days, max_nodes=max_nodes)
+    except Exception as e:
+        logger.error("Error building entity graph: {0}".format(e))
+        raise HTTPException(
+            status_code=500, detail="Error building entity graph: {0}".format(str(e))
+        )
+
+
 @router.get("/events/clusters", response_model=List[EventClusterResponse])
 async def get_event_clusters(
     category: Optional[str] = Query(None, description="Filter by category"),

--- a/src/api/routes/sentiment_routes.py
+++ b/src/api/routes/sentiment_routes.py
@@ -22,6 +22,25 @@ async def get_db():
         db.disconnect()
 
 
+@router.get("/heatmap")
+async def get_sentiment_heatmap(
+    days: int = Query(14, ge=1, le=60, description="Number of days to cover"),
+    max_topics: int = Query(6, ge=1, le=12, description="Maximum category rows"),
+) -> Dict[str, Any]:
+    """Category x day average-sentiment heatmap derived from the warehouse."""
+    try:
+        from src.database.local_warehouse_views import (
+            get_sentiment_heatmap as warehouse_heatmap,
+        )
+
+        return await warehouse_heatmap(days=days, max_topics=max_topics)
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail="Error building sentiment heatmap: {0}".format(str(e)),
+        )
+
+
 @router.get("")
 async def get_sentiment_trends(
     topic: Optional[str] = Query(None, description="Topic to filter articles by"),

--- a/src/database/local_warehouse_views.py
+++ b/src/database/local_warehouse_views.py
@@ -7,25 +7,37 @@ topic database, …). For a local, zero-service setup those aren't available, so
 this module derives equivalent, data-driven results directly from the
 ``news_articles`` table.
 
-Articles are grouped into **event clusters** by content similarity — TF-IDF +
-cosine when scikit-learn is available, otherwise a dependency-free
-shared-keyword union-find. **Trending topics** come from keyword
-document-frequency across the corpus, and **breaking news** is the most recent /
-active clusters. (The previous implementation grouped by the first word of each
-title, which produced meaningless clusters on real headlines.)
+Articles are grouped into **event clusters** by content similarity: a TF-IDF
+cosine similarity matrix (scikit-learn) when available, otherwise an O(n)
+signature-term fallback. Only the most-recent slice of the corpus is clustered
+per request (see ``NEURONEWS_CLUSTER_MAX_ARTICLES``) so the matrix stays bounded.
+**Trending topics** come from keyword document-frequency across that slice, and
+**breaking news** is the most recent / active clusters. (The previous
+implementation grouped by the first word of each title, which produced
+meaningless clusters on real headlines.)
 
 The returned dict shapes match what the API route response models expect.
 """
 
 from __future__ import annotations
 
-import math
+import os
 import re
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence
 
 from src.database.local_analytics_connector import LocalAnalyticsConnector
+
+# Cap how many of the most-recent articles we cluster in one request, so cost
+# stays bounded no matter how large the corpus grows. Override with
+# NEURONEWS_CLUSTER_MAX_ARTICLES.
+def _max_cluster_articles() -> int:
+    try:
+        return max(100, int(os.getenv("NEURONEWS_CLUSTER_MAX_ARTICLES", "3000")))
+    except ValueError:
+        return 3000
+
 
 # Common English + news-filler words that should never anchor a cluster/topic.
 _STOPWORDS = {
@@ -72,14 +84,16 @@ async def _fetch_recent(
         conditions.append("category = %s")
         params.append(category)
     where = " AND ".join(conditions)
+    # Only cluster the most-recent slice so cost is bounded on large corpora.
     rows = await db.execute_query(
         """
         SELECT id, title, content, publish_date, source, category, sentiment_score
         FROM news_articles
         WHERE {where}
         ORDER BY publish_date DESC
+        LIMIT %s
         """.format(where=where),
-        params,
+        params + [_max_cluster_articles()],
     )
     db.disconnect()
 
@@ -124,63 +138,77 @@ class _UnionFind:
 
 
 def _cluster_sklearn(articles: Sequence[Dict[str, Any]], threshold: float) -> Optional[List[int]]:
-    """TF-IDF + cosine clustering. Returns label per article, or None if unavailable."""
+    """Cluster via a TF-IDF cosine similarity matrix + union-find.
+
+    Builds the dense pairwise cosine similarity matrix (O(n^2) memory) and
+    connects every pair above ``threshold`` into the same component. The recent
+    window is capped (see ``NEURONEWS_CLUSTER_MAX_ARTICLES``) so the matrix stays
+    bounded. Returns a label per article, or None if scikit-learn is missing.
+    """
     try:
         from sklearn.feature_extraction.text import TfidfVectorizer
         from sklearn.metrics.pairwise import cosine_similarity
     except Exception:
         return None
 
+    n = len(articles)
     docs = [a["title"] + ". " + a["content"][:200] for a in articles]
     try:
-        vec = TfidfVectorizer(stop_words="english", ngram_range=(1, 2), max_features=4000)
+        vec = TfidfVectorizer(
+            stop_words="english", ngram_range=(1, 2), max_features=8000, min_df=1
+        )
         matrix = vec.fit_transform(docs)
         sims = cosine_similarity(matrix)
     except Exception:
         return None
 
-    uf = _UnionFind(len(articles))
-    n = len(articles)
+    uf = _UnionFind(n)
     for i in range(n):
+        row = sims[i]
         for j in range(i + 1, n):
-            if sims[i][j] >= threshold:
+            if row[j] >= threshold:
                 uf.union(i, j)
     return [uf.find(i) for i in range(n)]
 
 
-def _cluster_keyword_overlap(
-    articles: Sequence[Dict[str, Any]], min_shared: int = 2
-) -> List[int]:
-    """Union-find on shared significant terms (dependency-free fallback)."""
-    n = len(articles)
-    uf = _UnionFind(n)
-    # Index articles by term so we only compare candidates that share a term.
-    term_to_idx: Dict[str, List[int]] = defaultdict(list)
-    for i, a in enumerate(articles):
-        for t in a["terms"]:
-            term_to_idx[t].append(i)
+def _cluster_signature_term(articles: Sequence[Dict[str, Any]]) -> List[int]:
+    """O(n) fallback: group by each article's most distinctive (rarest) term.
 
-    checked: set = set()
-    for idxs in term_to_idx.values():
-        for x in range(len(idxs)):
-            for y in range(x + 1, len(idxs)):
-                i, j = idxs[x], idxs[y]
-                key = (i, j)
-                if key in checked:
-                    continue
-                checked.add(key)
-                if len(articles[i]["terms"] & articles[j]["terms"]) >= min_shared:
-                    uf.union(i, j)
-    return [uf.find(i) for i in range(n)]
+    Document frequency is computed once; each article is keyed by the
+    lowest-frequency significant term it contains, so articles about the same
+    specific entity/keyword land together. Articles whose signature term is
+    unique stay as singletons.
+    """
+    n = len(articles)
+    df: Counter = Counter()
+    for a in articles:
+        for t in a["terms"]:
+            df[t] += 1
+
+    signature_to_label: Dict[str, int] = {}
+    labels: List[int] = []
+    next_label = 0
+    for i, a in enumerate(articles):
+        terms = a["terms"]
+        if terms:
+            # Rarest term wins; ties broken alphabetically for determinism.
+            signature = min(terms, key=lambda t: (df[t], t))
+        else:
+            signature = "__empty_{0}__".format(i)
+        if signature not in signature_to_label:
+            signature_to_label[signature] = next_label
+            next_label += 1
+        labels.append(signature_to_label[signature])
+    return labels
 
 
 def _build_clusters(articles: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
     if not articles:
         return []
 
-    labels = _cluster_sklearn(articles, threshold=0.22)
+    labels = _cluster_sklearn(articles, threshold=0.18)
     if labels is None:
-        labels = _cluster_keyword_overlap(articles, min_shared=2)
+        labels = _cluster_signature_term(articles)
 
     groups: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
     for label, art in zip(labels, articles):

--- a/src/database/local_warehouse_views.py
+++ b/src/database/local_warehouse_views.py
@@ -397,3 +397,202 @@ async def get_breaking_news(
             }
         )
     return events
+
+
+# --------------------------------------------------------------------------- #
+# Entity graph
+# --------------------------------------------------------------------------- #
+
+# Capitalized words that are usually sentence starters, not entities.
+_ENTITY_STOP = {
+    "The", "This", "That", "These", "Those", "There", "Here", "After", "Before",
+    "But", "And", "How", "Why", "What", "When", "Where", "Who", "Which", "Now",
+    "New", "More", "Most", "First", "Last", "Then", "They", "Their", "It", "Its",
+    "He", "She", "We", "You", "His", "Her", "Our", "As", "At", "In", "On", "Of",
+    "For", "From", "With", "By", "To", "Up", "Out", "Over", "Amid", "One", "Two",
+    "Three", "Us", "Live", "Watch", "Why", "Could", "Would", "Should", "May",
+}
+
+# Small curated hints for node typing/colouring (best-effort without NER).
+_PLACE_HINTS = {
+    "ukraine", "russia", "china", "israel", "gaza", "europe", "brussels", "washington",
+    "geneva", "london", "paris", "germany", "france", "india", "japan", "iran", "us",
+    "uk", "usa", "america", "britain", "moscow", "kyiv", "beijing", "taiwan",
+}
+_TOPIC_HINTS = {"ai", "ml", "gdp", "cpi", "covid", "climate", "inflation", "oil", "crypto"}
+_ORG_HINTS = {
+    "nvidia", "microsoft", "google", "apple", "amazon", "meta", "tesla", "opec",
+    "nato", "fed", "openai", "samsung", "intel", "boeing", "spacex", "reuters",
+}
+# Words that mark a Title-case phrase as an organisation rather than a person.
+_ORG_NAME_KEYWORDS = {
+    "bank", "group", "corp", "council", "union", "company", "ministry", "federal",
+    "reserve", "department", "agency", "bureau", "commission", "authority", "fund",
+    "party", "court", "university", "institute", "association", "office",
+}
+
+_ENTITY_RE = re.compile(
+    r"\b([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+){0,3})\b"  # Capitalized phrases
+    r"|\b([A-Z]{2,6})\b"  # acronyms (AI, EU, OPEC, NATO)
+)
+
+
+# Leading words to strip from a captured phrase (articles + honorifics/titles).
+_LEADING_DROP = {
+    "the", "a", "an", "ceo", "president", "chair", "chairman", "chief", "mr",
+    "ms", "mrs", "dr", "sir", "senator", "sen", "rep", "governor", "gov", "minister",
+}
+
+
+def _extract_entities(text: str) -> List[str]:
+    """Best-effort named-entity surface forms from sentence-case text."""
+    out: List[str] = []
+    for m in _ENTITY_RE.finditer(text or ""):
+        ent = (m.group(1) or m.group(2) or "").strip()
+        if not ent:
+            continue
+        words = ent.split()
+        # Strip leading articles / honorifics ("The Federal Reserve", "CEO Jane Doe").
+        while len(words) > 1 and words[0].lower() in _LEADING_DROP:
+            words = words[1:]
+        ent = " ".join(words)
+        if not words:
+            continue
+        is_acronym = ent.isupper()
+        if len(words) == 1:
+            # Single token: keep acronyms (AI, EU, US); else require length >= 3.
+            if ent in _ENTITY_STOP:
+                continue
+            if not is_acronym and len(ent) < 3:
+                continue
+            if is_acronym and len(ent) < 2:
+                continue
+        if all(w in _ENTITY_STOP for w in words):
+            continue
+        out.append(ent)
+    return out
+
+
+def _resolve_aliases(doc_count: "Counter", label_form: Dict[str, "Counter"]) -> Dict[str, str]:
+    """Map a person's surname to their fuller 'First Last' form, when present.
+
+    e.g. "powell" -> "jerome powell". Only applies to 2-word Title-case names so
+    organisations/topics aren't accidentally merged.
+    """
+    alias: Dict[str, str] = {}
+    multiword = [k for k in doc_count if " " in k]
+    for key in multiword:
+        label = label_form[key].most_common(1)[0][0] if label_form[key] else key
+        words = label.split()
+        if len(words) == 2 and all(w[:1].isupper() and w[1:].islower() for w in words):
+            surname = words[1].lower()
+            if surname in doc_count and surname != key:
+                # Map the surname-only mention to the fuller name.
+                alias[surname] = key
+    return alias
+
+
+def _entity_type(label: str) -> str:
+    low = label.lower()
+    words = label.split()
+    if low in _PLACE_HINTS:
+        return "place"
+    if low in _TOPIC_HINTS:
+        return "topic"
+    if low in _ORG_HINTS:
+        return "org"
+    if label.isupper():  # acronyms (OPEC, NATO, EU)
+        return "org"
+    # Two-word Title-case names → person, unless they read like an organisation.
+    if len(words) == 2 and all(w[:1].isupper() and w[1:].islower() for w in words):
+        if not any(k in low for k in _ORG_NAME_KEYWORDS):
+            return "person"
+        return "org"
+    return "org" if len(words) >= 2 else "topic"
+
+
+_ACCENT = "#FF6B6B"
+_TYPE_COLOR = {
+    "org": _ACCENT,
+    "person": "#5B9DFF",
+    "topic": "#FFD93D",
+    "place": "#A78BFA",
+}
+
+
+async def get_entity_graph(days: int = 7, max_nodes: int = 14) -> Dict[str, Any]:
+    """Entity co-occurrence graph derived from recent articles."""
+    articles = await _fetch_recent(days)
+    if not articles:
+        return {"nodes": [], "edges": [], "node_count": 0, "edge_count": 0}
+
+    # First pass: collect raw surface forms per article.
+    raw_doc_count: Counter = Counter()
+    label_form: Dict[str, Counter] = defaultdict(Counter)
+    raw_per_article: List[set] = []
+    for a in articles:
+        ents = _extract_entities(a["title"]) + _extract_entities(a["content"][:400])
+        keys = set()
+        for e in ents:
+            key = e.lower()
+            label_form[key][e] += 1
+            keys.add(key)
+        for key in keys:
+            raw_doc_count[key] += 1
+        raw_per_article.append(keys)
+
+    # Resolve surname aliases (powell -> jerome powell) and re-aggregate.
+    alias = _resolve_aliases(raw_doc_count, label_form)
+    doc_count: Counter = Counter()
+    per_article: List[set] = []
+    for keys in raw_per_article:
+        canon = {alias.get(k, k) for k in keys}
+        for k in canon:
+            doc_count[k] += 1
+        per_article.append(canon)
+
+    # Keep entities mentioned in at least 2 articles, top by frequency.
+    ranked = [k for k, c in doc_count.most_common() if c >= 2][:max_nodes]
+    if len(ranked) < max_nodes:
+        ranked = [k for k, _ in doc_count.most_common(max_nodes)]
+    selected = set(ranked)
+
+    # Co-occurrence edges among selected entities.
+    edge_w: Counter = Counter()
+    for keys in per_article:
+        present = sorted(keys & selected)
+        for i in range(len(present)):
+            for j in range(i + 1, len(present)):
+                edge_w[(present[i], present[j])] += 1
+
+    degree: Counter = Counter()
+    for (x, y), w in edge_w.items():
+        degree[x] += 1
+        degree[y] += 1
+
+    nodes = []
+    for key in ranked:
+        label = label_form[key].most_common(1)[0][0] if label_form[key] else key
+        etype = _entity_type(label)
+        nodes.append(
+            {
+                "id": key,
+                "label": label,
+                "type": etype,
+                "color": _TYPE_COLOR.get(etype, _ACCENT),
+                "count": doc_count[key],
+                "degree": degree.get(key, 0),
+            }
+        )
+
+    edges = [
+        {"source": x, "target": y, "weight": w}
+        for (x, y), w in edge_w.most_common(40)
+    ]
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+    }

--- a/src/database/local_warehouse_views.py
+++ b/src/database/local_warehouse_views.py
@@ -596,3 +596,52 @@ async def get_entity_graph(days: int = 7, max_nodes: int = 14) -> Dict[str, Any]
         "node_count": len(nodes),
         "edge_count": len(edges),
     }
+
+
+# --------------------------------------------------------------------------- #
+# Sentiment heatmap
+# --------------------------------------------------------------------------- #
+
+
+async def get_sentiment_heatmap(days: int = 14, max_topics: int = 6) -> Dict[str, Any]:
+    """Category x day average-sentiment heatmap from real article sentiment."""
+    db = LocalAnalyticsConnector()
+    db.connect()
+    cutoff = datetime.now() - timedelta(days=days)
+    rows = await db.execute_query(
+        """
+        SELECT category,
+               CAST(publish_date AS DATE) AS day,
+               AVG(sentiment_score) AS avg_sent,
+               COUNT(*) AS cnt
+        FROM news_articles
+        WHERE publish_date >= %s AND sentiment_label IS NOT NULL
+        GROUP BY category, CAST(publish_date AS DATE)
+        """,
+        [cutoff],
+    )
+    db.disconnect()
+
+    if not rows:
+        return {"topics": [], "cols": 0, "labels": [], "seed": []}
+
+    # Top categories by article volume.
+    cat_total: Counter = Counter()
+    cell: Dict[tuple, float] = {}
+    for (category, day, avg_sent, cnt) in rows:
+        cat = category or "General"
+        cat_total[cat] += int(cnt)
+        cell[(cat, day)] = float(avg_sent or 0.0)
+    topics = [c for c, _ in cat_total.most_common(max_topics)]
+
+    # Day columns: oldest -> newest across the window.
+    today = datetime.now().date()
+    day_cols = [today - timedelta(days=(days - 1 - i)) for i in range(days)]
+    labels = ["{0}/{1}".format(d.month, d.day) for d in day_cols]
+
+    seed = [
+        [round(cell.get((topic, day), 0.0), 3) for day in day_cols]
+        for topic in topics
+    ]
+
+    return {"topics": topics, "cols": len(day_cols), "labels": labels, "seed": seed}

--- a/src/ingestion/scrapy_integration.py
+++ b/src/ingestion/scrapy_integration.py
@@ -49,16 +49,41 @@ class Feed:
     category: str
 
 
-# Reliable, public feeds covering the dashboard's categories.
+# Reliable, public feeds. Several outlets are included per category so the same
+# real-world story is covered by multiple sources, which lets the clusterer
+# group cross-outlet coverage into multi-source event clusters.
 DEFAULT_FEEDS: List[Feed] = [
+    # --- World / top news (big stories show up across all of these) ---
+    Feed("BBC World", "https://feeds.bbci.co.uk/news/world/rss.xml", "World"),
+    Feed("Guardian World", "https://www.theguardian.com/world/rss", "World"),
+    Feed("NYT World", "https://rss.nytimes.com/services/xml/rss/nyt/World.xml", "World"),
+    Feed("Al Jazeera", "https://www.aljazeera.com/xml/rss/all.xml", "World"),
+    Feed("NPR News", "https://feeds.npr.org/1001/rss.xml", "World"),
+    # --- Economy / business ---
     Feed("BBC Business", "https://feeds.bbci.co.uk/news/business/rss.xml", "Economy"),
+    Feed("Guardian Business", "https://www.theguardian.com/business/rss", "Economy"),
+    Feed("NYT Business", "https://rss.nytimes.com/services/xml/rss/nyt/Business.xml", "Economy"),
+    # --- Technology ---
     Feed("BBC Technology", "https://feeds.bbci.co.uk/news/technology/rss.xml", "Technology"),
-    Feed("BBC Politics", "https://feeds.bbci.co.uk/news/politics/rss.xml", "Policy"),
-    Feed("BBC Health", "https://feeds.bbci.co.uk/news/health/rss.xml", "Health"),
-    Feed("BBC Science", "https://feeds.bbci.co.uk/news/science_and_environment/rss.xml", "Science"),
+    Feed("Guardian Technology", "https://www.theguardian.com/technology/rss", "Technology"),
+    Feed("NYT Technology", "https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml", "Technology"),
     Feed("Ars Technica", "https://feeds.arstechnica.com/arstechnica/index", "Technology"),
-    Feed("NPR News", "https://feeds.npr.org/1001/rss.xml", "Policy"),
+    # --- Policy / politics ---
+    Feed("BBC Politics", "https://feeds.bbci.co.uk/news/politics/rss.xml", "Policy"),
+    Feed("Guardian Politics", "https://www.theguardian.com/politics/rss", "Policy"),
+    Feed("NYT Politics", "https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml", "Policy"),
+    # --- Health ---
+    Feed("BBC Health", "https://feeds.bbci.co.uk/news/health/rss.xml", "Health"),
+    Feed("Guardian Society", "https://www.theguardian.com/society/rss", "Health"),
+    Feed("NYT Health", "https://rss.nytimes.com/services/xml/rss/nyt/Health.xml", "Health"),
+    # --- Energy / environment ---
+    Feed("Guardian Environment", "https://www.theguardian.com/environment/rss", "Energy"),
+    Feed("NYT Climate", "https://rss.nytimes.com/services/xml/rss/nyt/Climate.xml", "Energy"),
     Feed("EIA Today in Energy", "https://www.eia.gov/rss/todayinenergy.xml", "Energy"),
+    # --- Science ---
+    Feed("BBC Science", "https://feeds.bbci.co.uk/news/science_and_environment/rss.xml", "Science"),
+    Feed("Guardian Science", "https://www.theguardian.com/science/rss", "Science"),
+    Feed("NYT Science", "https://rss.nytimes.com/services/xml/rss/nyt/Science.xml", "Science"),
 ]
 
 


### PR DESCRIPTION
Three related improvements that take the dashboard fully live off the local
warehouse.

## 1. Multi-source event clusters

- Broadened `DEFAULT_FEEDS` to ~24 reputable feeds (BBC, Guardian, NYT, Al
  Jazeera, NPR, Ars Technica, EIA) so big stories are covered by several
  outlets — clusters are no longer single-source by construction.
- Kept the dense `cosine_similarity` matrix; loosened the merge threshold to
  0.18 so differently-worded coverage of the same event joins one cluster.
- Bounded: only the most-recent slice is clustered per request
  (`NEURONEWS_CLUSTER_MAX_ARTICLES`, default 3000).

## 2. Live entity relationship graph

- `GET /api/v1/entity_graph` — entities extracted from recent titles + content
  (capitalized phrases / acronyms), leading articles & honorifics stripped,
  surname→"First Last" aliasing, co-occurrence edges + degrees, light
  org/person/topic/place typing.
- Frontend `EntityGraph` renders the live graph with a deterministic
  force-directed layout; legend + Top Connected derive from it; LIVE/DEMO badge.

## 3. Live sentiment heatmap

- `GET /news_sentiment/heatmap` — category × day average-sentiment matrix from
  stored per-article sentiment (VADER-scored at ingest).
- `Heatmap` component now renders live data (category rows, day columns); the
  Sentiment view shows a real LIVE/DEMO badge instead of the previous
  always-demo label. The stat cards and topic breakdown were already live.

## Status of the dashboard

Every data-driven view now serves real data from the local DuckDB warehouse:
Overview, News Feed, Trending, Event Clusters, Breaking ticker, Entity Graph and
Sentiment (cards + breakdown + heatmap). Only the research views
(Workspaces / Watchlists / Story Timeline) remain demo by design.

## Verification

- `tests/unit/ingestion` → 17 passed, 1 skipped.
- Frontend `tsc --noEmit` and `vite build` clean.
- Backend views verified directly over realistic sample data (multi-source
  clusters merge; entity graph yields sensible nodes/edges; heatmap is a
  well-populated category × day matrix).