### PR TITLE
fix(api): better topic & entity extraction (stopwords, possessives, keyword sentiment)

### DIFF
--- a/src/api/routes/sentiment_routes.py
+++ b/src/api/routes/sentiment_routes.py
@@ -301,56 +301,21 @@ async def get_topic_sentiment_analysis(
         List of topics with their sentiment statistics
     """
     try:
-        start_date = datetime.now() - timedelta(days=days)
+        # Keyword-based topic sentiment from the local warehouse (significant
+        # terms, not the first word of each title).
+        from src.database.local_warehouse_views import get_topic_sentiment
 
-        # This is a simplified topic extraction - in production you might want
-        # to use more sophisticated NLP techniques or pre-computed topic tags
-        query = """
-            SELECT
-                UPPER(SPLIT_PART(title, ' ', 1)) as topic_word,
-                sentiment_label,
-                COUNT(*) as article_count,
-                AVG(sentiment_score) as avg_sentiment
-            FROM news_articles
-            WHERE publish_date >= %s
-                AND sentiment_label IS NOT NULL
-                AND LENGTH(SPLIT_PART(title, ' ', 1)) > 3
-            GROUP BY UPPER(SPLIT_PART(title, ' ', 1)), sentiment_label
-            HAVING COUNT(*) >= %s
-            ORDER BY article_count DESC
-        """
+        topic_list = await get_topic_sentiment(
+            days=days, min_articles=min_articles, max_topics=12
+        )
 
-        results = await db.execute_query(query, [start_date, min_articles])
-
-        # Group results by topic
-        topics = {}
-        for row in results:
-            topic = row[0]
-            sentiment = row[1].lower()
-            count = int(row[2])
-            avg_score = float(row[3]) if row[3] else 0.0
-
-            if topic not in topics:
-                topics[topic] = {"topic": topic, "total_articles": 0, "sentiments": {}}
-
-            topics[topic]["total_articles"] += count
-            topics[topic]["sentiments"][sentiment] = {
-                "count": count,
-                "avg_score": round(avg_score, 3),
-            }
-
-        # Convert to list and calculate percentages
-        topic_list = []
-        for topic_data in topics.values():
-            total = topic_data["total_articles"]
+        # Add percentage breakdown per sentiment label.
+        for topic_data in topic_list:
+            total = topic_data["total_articles"] or 1
             for sentiment_data in topic_data["sentiments"].values():
                 sentiment_data["percentage"] = round(
                     sentiment_data["count"] / total * 100, 2
                 )
-            topic_list.append(topic_data)
-
-        # Sort by total articles descending
-        topic_list.sort(key=lambda x: x["total_articles"], reverse=True)
 
         return topic_list
 

--- a/src/database/local_warehouse_views.py
+++ b/src/database/local_warehouse_views.py
@@ -41,30 +41,60 @@ def _max_cluster_articles() -> int:
 
 # Common English + news-filler words that should never anchor a cluster/topic.
 _STOPWORDS = {
-    "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with",
-    "at", "by", "from", "as", "is", "are", "was", "were", "be", "been", "being",
-    "it", "its", "this", "that", "these", "those", "their", "they", "them", "he",
-    "she", "his", "her", "you", "your", "we", "our", "us", "i", "my",
-    "will", "would", "could", "should", "can", "may", "might", "must", "has",
-    "have", "had", "do", "does", "did", "not", "no", "new", "says", "say", "said",
-    "after", "over", "amid", "into", "out", "up", "down", "off", "more", "most",
-    "than", "then", "now", "how", "why", "what", "who", "when", "where", "which",
-    "about", "against", "before", "between", "during", "without", "under", "first",
-    "two", "three", "year", "years", "day", "days", "week", "month", "set", "get",
-    "make", "made", "back", "calls", "call", "warns", "warn", "amphtml", "live",
+    # articles / conjunctions / prepositions
+    "the", "a", "an", "and", "or", "but", "nor", "of", "to", "in", "on", "for",
+    "with", "at", "by", "from", "as", "into", "onto", "upon", "about", "against",
+    "before", "after", "between", "during", "without", "within", "under", "over",
+    "above", "below", "amid", "amongst", "among", "across", "behind", "beyond",
+    "near", "off", "out", "up", "down", "through", "per", "via", "than", "then",
+    # pronouns / determiners
+    "it", "its", "this", "that", "these", "those", "there", "here", "their",
+    "they", "them", "he", "she", "him", "his", "her", "you", "your", "yours",
+    "we", "our", "ours", "us", "i", "my", "mine", "me", "who", "whom", "whose",
+    "which", "what", "whatever", "some", "any", "all", "both", "each", "few",
+    "more", "most", "other", "others", "such", "no", "nor", "not", "only", "own",
+    "same", "so", "too", "very", "one", "ones", "two", "three", "four", "five",
+    # verbs / auxiliaries
+    "is", "are", "was", "were", "be", "been", "being", "am", "will", "would",
+    "could", "should", "shall", "can", "may", "might", "must", "has", "have",
+    "had", "having", "do", "does", "did", "done", "doing", "get", "gets", "got",
+    "make", "makes", "made", "say", "says", "said", "tell", "told", "see", "seen",
+    "go", "goes", "went", "set", "put", "take", "took", "give", "gave", "use",
+    "used", "call", "calls", "called", "warn", "warns", "warned", "join", "joins",
+    "show", "shows", "showed", "face", "faces", "faced", "back", "backs",
+    # adverbs / time
+    "now", "when", "where", "while", "why", "how", "again", "ever", "never",
+    "once", "always", "often", "still", "just", "also", "even", "yet", "soon",
+    "today", "year", "years", "day", "days", "week", "weeks", "month", "months",
+    "time", "times", "ago", "first", "last", "next", "new", "old", "end", "live",
+    # generic news nouns (not useful as standalone topics)
+    "news", "report", "reports", "update", "updates", "people", "man", "woman",
+    "men", "women", "way", "ways", "thing", "things", "part", "case", "cases",
+    "plan", "plans", "deal", "deals", "data", "media", "company", "companies",
+    "group", "groups", "department", "official", "officials", "leader", "leaders",
+    "minister", "government", "president", "according", "amphtml", "video", "watch",
 }
 
 _TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z'&-]+")
+
+
+def _normalize_token(tok: str) -> str:
+    """Lowercase, strip surrounding punctuation and a trailing possessive."""
+    t = tok.lower().strip("'-&")
+    if t.endswith("'s"):
+        t = t[:-2]
+    return t
 
 
 def _terms(text: str) -> List[str]:
     """Lowercased significant terms (length > 2, not stopwords)."""
     out = []
     for tok in _TOKEN_RE.findall(text or ""):
-        t = tok.lower().strip("'-&")
+        t = _normalize_token(tok)
         if len(t) > 2 and t not in _STOPWORDS:
             out.append(t)
     return out
+
 
 
 # --------------------------------------------------------------------------- #
@@ -437,11 +467,13 @@ _ENTITY_RE = re.compile(
 )
 
 
-# Leading words to strip from a captured phrase (articles + honorifics/titles).
+# Leading/trailing words to strip from a captured phrase (articles, honorifics,
+# titles, and any generic stopword that leaked into a Title-case run).
 _LEADING_DROP = {
     "the", "a", "an", "ceo", "president", "chair", "chairman", "chief", "mr",
     "ms", "mrs", "dr", "sir", "senator", "sen", "rep", "governor", "gov", "minister",
 }
+_LEAD_TRAIL_STOP = _STOPWORDS | _LEADING_DROP
 
 
 def _extract_entities(text: str) -> List[str]:
@@ -452,22 +484,25 @@ def _extract_entities(text: str) -> List[str]:
         if not ent:
             continue
         words = ent.split()
-        # Strip leading articles / honorifics ("The Federal Reserve", "CEO Jane Doe").
-        while len(words) > 1 and words[0].lower() in _LEADING_DROP:
+        # Strip leading/trailing filler ("As Israel", "Join Trump", "But Burnham",
+        # "The Federal Reserve", "CEO Jane Doe", "Trump Says").
+        while len(words) > 1 and words[0].lower() in _LEAD_TRAIL_STOP:
             words = words[1:]
-        ent = " ".join(words)
+        while len(words) > 1 and words[-1].lower() in _LEAD_TRAIL_STOP:
+            words = words[:-1]
         if not words:
             continue
+        ent = " ".join(words)
         is_acronym = ent.isupper()
         if len(words) == 1:
-            # Single token: keep acronyms (AI, EU, US); else require length >= 3.
-            if ent in _ENTITY_STOP:
+            low = ent.lower()
+            if low in _STOPWORDS or ent in _ENTITY_STOP:
                 continue
             if not is_acronym and len(ent) < 3:
                 continue
             if is_acronym and len(ent) < 2:
                 continue
-        if all(w in _ENTITY_STOP for w in words):
+        if all(w.lower() in _LEAD_TRAIL_STOP or w in _ENTITY_STOP for w in words):
             continue
         out.append(ent)
     return out
@@ -645,3 +680,48 @@ async def get_sentiment_heatmap(days: int = 14, max_topics: int = 6) -> Dict[str
     ]
 
     return {"topics": topics, "cols": len(day_cols), "labels": labels, "seed": seed}
+
+
+# --------------------------------------------------------------------------- #
+# Topic sentiment (keyword-based, replaces first-word grouping)
+# --------------------------------------------------------------------------- #
+
+
+def _label_for(score: float) -> str:
+    return "positive" if score > 0.05 else "negative" if score < -0.05 else "neutral"
+
+
+async def get_topic_sentiment(
+    days: int = 7, min_articles: int = 5, max_topics: int = 12
+) -> List[Dict[str, Any]]:
+    """Per-keyword sentiment breakdown (shape matches /news_sentiment/topics)."""
+    articles = await _fetch_recent(days)
+    if not articles:
+        return []
+
+    term_docs: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for a in articles:
+        for t in set(a["terms"]):
+            term_docs[t].append(a)
+
+    topics: List[Dict[str, Any]] = []
+    for term, docs in term_docs.items():
+        if len(docs) < min_articles:
+            continue
+        buckets: Dict[str, List[float]] = defaultdict(list)
+        for d in docs:
+            buckets[_label_for(d["sentiment"])].append(d["sentiment"])
+        sentiments = {
+            lbl: {"count": len(vals), "avg_score": round(sum(vals) / len(vals), 3)}
+            for lbl, vals in buckets.items()
+        }
+        topics.append(
+            {
+                "topic": term.title(),
+                "total_articles": len(docs),
+                "sentiments": sentiments,
+            }
+        )
+
+    topics.sort(key=lambda x: x["total_articles"], reverse=True)
+    return topics[:max_topics]


### PR DESCRIPTION
## Summary

Once real news was loaded, the derived views were noisy (per the screenshots):

- **Trending** surfaced function words — *Some, One, While, There, What, End*.
- **Sentiment** still grouped by the **first word of each title** → topics like
  *WHAT* and *TRUMP'S*.
- **Entities** captured leading filler (*As Israel*, *Join Trump*, *But Burnham*)
  and split possessives (*Trump* vs *Trump's*); **0 organizations** were typed.

This PR overhauls the extraction quality.

## Changes (`local_warehouse_views.py`, `sentiment_routes.py`)

- **Bigger stopword list** (function words + generic news nouns) and **trailing
  possessive stripping** (`Trump's → trump`), shared by trending, clustering and
  entity extraction.
- **Entity extraction** strips leading/trailing stopwords from captured phrases
  and drops bare stopword tokens — killing *As Israel* / *Join Trump* /
  *But Burnham* style noise; surname → "First Last" aliasing already merges
  *Burnham* into *Andy Burnham*.
- **Sentiment topics** — replace the `SPLIT_PART(title,' ',1)` first-word SQL
  grouping with **keyword-based** `get_topic_sentiment()` over significant
  terms, so topics are real keywords with proper positive/negative/neutral
  breakdowns.
- **Entity typing** detects organisations (acronyms + org hints + org-name
  keywords) instead of defaulting everything to person/topic.

## Before / after (realistic noisy headlines)

```
Trending:  Burnham, Iran, Trump, Andy, Labour, England, Musk, Israel, Economy …
           (was: Some, One, While, There, What, End, …)
Topic sentiment:  Burnham, Iran, Trump, Labour, England — each with
                  positive/negative/neutral counts   (was: WHAT, TRUMP'S)
Entity types:  {place: 3, person: 4, topic: 5, org: 2}   (was: org: 0)
               As Israel → Israel · But Burnham → Andy Burnham
```

## Limits / follow-up

Regex extraction over Title-case headlines is inherently imperfect — some
single-word people (e.g. *Trump*) still type as *topic*, and multi-word events
(*World Cup*) can fragment. Wiring in **spaCy NER** (already in `requirements`,
needs `python -m spacy download en_core_web_sm`) would give accurate
PERSON/ORG/GPE types and cleaner entity boundaries; happy to add that as an
opt-in next.

## Test plan

- `tests/unit/ingestion` → 17 passed, 1 skipped.
- Backend views verified directly over realistic noisy headlines (output above).