### PR TITLE
fix(clusters): show each cluster's real member headlines & sentiment

### DIFF
--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -26,13 +26,13 @@ export const mockArticles: Article[] = [
   { title: "Pharma giant’s Alzheimer’s drug clears late-stage trial endpoint", source: "STAT", time: "1h", category: "Health", sent: 0.49, summary: "The therapy slowed cognitive decline by 27% versus placebo, sending shares sharply higher in pre-market.", entities: ["Eli Lilly", "FDA", "Alzheimer’s"] },
 ];
 
-export const mockClusters: Omit<Cluster, "headlines">[] = [
-  { title: "Global central banks converge on rate-pause signaling", count: 47, sources: 23, time: "12m", sent: 0.31, vel: "▲ 340%/h" },
-  { title: "AI chip supply chain tightens ahead of Q3 demand surge", count: 38, sources: 19, time: "24m", sent: 0.18, vel: "▲ 210%/h" },
-  { title: "Cloud antitrust scrutiny widens across EU and US", count: 31, sources: 17, time: "38m", sent: -0.39, vel: "▲ 155%/h" },
-  { title: "Energy markets react to OPEC+ output uncertainty", count: 29, sources: 21, time: "51m", sent: -0.22, vel: "▼ 40%/h" },
-  { title: "Fusion milestone reignites clean-energy investment thesis", count: 22, sources: 14, time: "1h", sent: 0.66, vel: "▲ 480%/h" },
-  { title: "Commercial real-estate stress spreads to regional lenders", count: 26, sources: 16, time: "1h", sent: -0.51, vel: "▲ 90%/h" },
+export const mockClusters: Cluster[] = [
+  { title: "Global central banks converge on rate-pause signaling", count: 47, sources: 23, time: "12m", sent: 0.31, vel: "▲ 340%/h", headlines: ["Fed officials hint at extended pause", "ECB holds as inflation cools"] },
+  { title: "AI chip supply chain tightens ahead of Q3 demand surge", count: 38, sources: 19, time: "24m", sent: 0.18, vel: "▲ 210%/h", headlines: ["Foundry capacity booked through Q4", "Memory prices climb on AI demand"] },
+  { title: "Cloud antitrust scrutiny widens across EU and US", count: 31, sources: 17, time: "38m", sent: -0.39, vel: "▲ 155%/h", headlines: ["Regulators open new cloud probe", "Lawmakers press on lock-in practices"] },
+  { title: "Energy markets react to OPEC+ output uncertainty", count: 29, sources: 21, time: "51m", sent: -0.22, vel: "▼ 40%/h", headlines: ["Crude swings on supply doubts", "Traders weigh demand outlook"] },
+  { title: "Fusion milestone reignites clean-energy investment thesis", count: 22, sources: 14, time: "1h", sent: 0.66, vel: "▲ 480%/h", headlines: ["Net-energy result drives funding", "Startups race to commercialize"] },
+  { title: "Commercial real-estate stress spreads to regional lenders", count: 26, sources: 16, time: "1h", sent: -0.51, vel: "▲ 90%/h", headlines: ["Office vacancies pressure balance sheets", "Refinancing wall looms in 2025"] },
 ];
 
 export const mockTrending: TrendingTopic[] = [

--- a/apps/web/src/lib/adapters.ts
+++ b/apps/web/src/lib/adapters.ts
@@ -70,7 +70,7 @@ export function adaptArticles(raw: RawArticle[]): Article[] {
   }));
 }
 
-export function adaptClusters(raw: RawEventCluster[]): Omit<Cluster, "headlines">[] {
+export function adaptClusters(raw: RawEventCluster[]): Cluster[] {
   return raw.map((c) => {
     const dir = c.velocity_score >= 0 ? "▲" : "▼";
     return {
@@ -78,10 +78,9 @@ export function adaptClusters(raw: RawEventCluster[]): Omit<Cluster, "headlines"
       count: c.cluster_size,
       sources: c.primary_sources?.length ?? 0,
       time: relativeTime(c.last_article_date),
-      // The cluster endpoint has no aggregate sentiment; approximate from
-      // impact direction so the accent bar still reads meaningfully.
-      sent: 0,
+      sent: c.avg_sentiment ?? 0,
       vel: `${dir} ${Math.abs(Math.round(c.velocity_score * 100))}%/h`,
+      headlines: c.sample_headlines ?? [],
     };
   });
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -70,6 +70,8 @@ export interface RawEventCluster {
   primary_sources: string[];
   key_entities: string[];
   status: string;
+  avg_sentiment?: number | null;
+  sample_headlines?: string[];
 }
 
 export interface RawBreakingNews {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -90,7 +90,7 @@ export function useArticles(): Result<Article[]> {
   return useWithFallback("articles", async () => adaptArticles(await api.articles()), mockArticles);
 }
 
-export function useClusters(): Result<Omit<Cluster, "headlines">[]> {
+export function useClusters(): Result<Cluster[]> {
   return useWithFallback("clusters", async () => adaptClusters(await api.eventClusters()), mockClusters);
 }
 

--- a/apps/web/src/views/Clusters.tsx
+++ b/apps/web/src/views/Clusters.tsx
@@ -1,19 +1,11 @@
 import { palette, fonts } from "../theme";
 import { sentColor, sentLabel } from "../lib/sentiment";
-import { useArticles, useClusters } from "../lib/queries";
+import { useClusters } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 
 export default function Clusters() {
-  const { data: clustersRaw, source, isLoading } = useClusters();
-  const { data: articles } = useArticles();
-
-  const clusters = clustersRaw.map((c, i) => ({
-    ...c,
-    headlines: articles.length
-      ? [articles[i % articles.length].title, articles[(i + 3) % articles.length].title]
-      : [],
-  }));
+  const { data: clusters, source, isLoading } = useClusters();
 
   return (
     <div>

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -39,15 +39,10 @@ interface Props {
 export default function Dashboard({ setView }: Props) {
   const [range, setRange] = useState("24H");
   const { data: articles, source, isLoading } = useArticles();
-  const { data: clustersRaw } = useClusters();
+  const { data: clusters } = useClusters();
   const { data: trending } = useTrending();
 
-  const clusters = clustersRaw.slice(0, 3).map((c, i) => ({
-    ...c,
-    headlines: articles.length
-      ? [articles[i % articles.length].title, articles[(i + 3) % articles.length].title]
-      : [],
-  }));
+  const topClusters = clusters.slice(0, 3);
 
   const maxM = Math.max(1, ...trending.map((t) => t.mentions));
   const trendingTop = trending.slice(0, 5).map((t, i) => ({
@@ -160,7 +155,7 @@ export default function Dashboard({ setView }: Props) {
             </Hover>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {clusters.map((c, i) => {
+            {topClusters.map((c, i) => {
               const sc = sentColor(c.sent);
               return (
                 <div key={i} style={{ border: "1px solid #1c2330", borderRadius: 8, padding: "11px 13px", background: "#0e131a" }}>

--- a/src/api/routes/event_routes.py
+++ b/src/api/routes/event_routes.py
@@ -85,6 +85,8 @@ class EventClusterResponse(BaseModel):
     key_entities: List[str]
     status: str
     created_at: str
+    avg_sentiment: Optional[float] = None
+    sample_headlines: List[str] = []
 
 
 class ArticleInClusterResponse(BaseModel):
@@ -302,6 +304,8 @@ async def get_event_clusters(
                     key_entities=row["key_entities"],
                     status=row["status"],
                     created_at=row["created_at"],
+                    avg_sentiment=row.get("avg_sentiment"),
+                    sample_headlines=row.get("sample_headlines", []),
                 )
             )
 

--- a/src/database/local_warehouse_views.py
+++ b/src/database/local_warehouse_views.py
@@ -287,9 +287,16 @@ def _build_clusters(articles: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "trending_score": trending_score,
                 "impact_score": impact_score,
                 "velocity_score": round(recent_fraction, 3),
-                "sample_titles": [m["title"] for m in sorted(
-                    members, key=lambda m: m["publish_date"] or datetime.min, reverse=True
-                )][:3],
+                # Other member headlines (excluding the representative), newest first.
+                "sample_titles": [
+                    m["title"]
+                    for m in sorted(
+                        members,
+                        key=lambda m: m["publish_date"] or datetime.min,
+                        reverse=True,
+                    )
+                    if m["title"] != rep["title"]
+                ][:3],
             }
         )
 
@@ -389,6 +396,8 @@ async def get_event_clusters(
                 "key_entities": c["key_entities"],
                 "status": "active",
                 "created_at": now_iso,
+                "avg_sentiment": c["avg_sentiment"],
+                "sample_headlines": c["sample_titles"],
             }
         )
     return out[:limit]


### PR DESCRIPTION
## Summary

In the Event Clusters view, the headlines listed under each cluster were
**fabricated** — the frontend built them with `articles[i % articles.length]`,
so every card showed unrelated, repeated stories (e.g. "Mines, Logistics and
Deep Uncertainty…" and "A Humble 3-Wheel Electric Vehicle…" appeared under many
clusters). Every cluster also showed **NEUTRAL** because cluster sentiment was
hardcoded to 0.

## Fix

- **Backend** — the clusters endpoint now returns each cluster's **real member
  headlines** (`sample_headlines`, excluding the representative title) and its
  **`avg_sentiment`**. Added both fields to `EventClusterResponse` and to
  `get_event_clusters` (computed from the actual cluster members).
- **Frontend** — `adaptClusters` maps the real headlines and sentiment into the
  `Cluster` model; the **Clusters** and **Dashboard** views render the actual
  member headlines instead of indexing random articles, and the sentiment label
  now reflects the cluster's real sentiment. Demo-fallback clusters were given
  representative headlines so the fallback looks right too.

## Verification

Over realistic multi-source data, clusters now list their own members:

```
[3] sent=+0.50 sources=[Ars, BBC, NYT]
    TITLE: Nvidia launches AI chip to power data centers
      - Nvidia unveils new AI chip for data centers
      - Nvidia AI chip demand sends shares higher
[2] sent=-0.15 sources=[AlJazeera, BBC]
    TITLE: Ukraine and Russia hold peace talks in Geneva
      - Peace talks between Ukraine and Russia resume
```

Frontend `tsc --noEmit` + `vite build` clean.
