### PR TITLE
Knowledge engine pivot: plan plus generalized Document data model (#513)

### DIFF
--- a/contracts/examples/document-ingest-v1/README.md
+++ b/contracts/examples/document-ingest-v1/README.md
@@ -1,0 +1,34 @@
+# document-ingest-v1 examples
+
+Golden fixtures for the generalized `document-ingest-v1` contract (M0 keystone of
+the knowledge-engine pivot — see `docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`).
+
+`Document` generalizes the news-specific `ArticleIngest`; `news` is now one
+`source_type` among `news | blog | book | paper | transcript | web | note`.
+Enrichments (sentiment, topics, ...) are produced downstream and are **not** part
+of this core record.
+
+Timestamps (`created_at`, `ingested_at`) are milliseconds since epoch, matching the
+Avro schema (`contracts/schemas/avro/document-ingest-v1.avsc`) used for runtime
+validation by `services/ingest/common/document_contracts.py`.
+
+## valid/
+| Fixture | source_type | Highlights |
+| --- | --- | --- |
+| `valid-paper.json` | paper | arXiv id, DOI, `content_ref` to object storage, reference DOIs |
+| `valid-book.json` | book | ISBN, multiple authors, no `url`/`source_id` |
+| `valid-news.json` | news | country/section in `metadata` (article specialization) |
+| `valid-blog-minimal.json` | blog | only the four required fields |
+| `valid-transcript.json` | transcript | media metadata, speakers, timestamped body |
+
+## invalid/
+| Fixture | Why it fails |
+| --- | --- |
+| `invalid-missing-document-id.json` | missing required `document_id` |
+| `invalid-bad-source-type.json` | `source_type` not in the allowed enum |
+| `invalid-missing-language.json` | missing required `language` |
+| `invalid-missing-ingested-at.json` | missing required `ingested_at` |
+
+Required fields: `document_id`, `source_type`, `language`, `ingested_at`.
+
+Tested by `contracts/tests/test_document_contract.py`.

--- a/contracts/examples/document-ingest-v1/invalid/invalid-bad-source-type.json
+++ b/contracts/examples/document-ingest-v1/invalid/invalid-bad-source-type.json
@@ -1,0 +1,6 @@
+{
+  "document_id": "doc-123",
+  "source_type": "tweet",
+  "language": "en",
+  "ingested_at": 1735371342000
+}

--- a/contracts/examples/document-ingest-v1/invalid/invalid-missing-document-id.json
+++ b/contracts/examples/document-ingest-v1/invalid/invalid-missing-document-id.json
@@ -1,0 +1,5 @@
+{
+  "source_type": "paper",
+  "language": "en",
+  "ingested_at": 1735371342000
+}

--- a/contracts/examples/document-ingest-v1/invalid/invalid-missing-ingested-at.json
+++ b/contracts/examples/document-ingest-v1/invalid/invalid-missing-ingested-at.json
@@ -1,0 +1,5 @@
+{
+  "document_id": "doc-123",
+  "source_type": "news",
+  "language": "en"
+}

--- a/contracts/examples/document-ingest-v1/invalid/invalid-missing-language.json
+++ b/contracts/examples/document-ingest-v1/invalid/invalid-missing-language.json
@@ -1,0 +1,5 @@
+{
+  "document_id": "doc-123",
+  "source_type": "blog",
+  "ingested_at": 1735371342000
+}

--- a/contracts/examples/document-ingest-v1/valid/valid-blog-minimal.json
+++ b/contracts/examples/document-ingest-v1/valid/valid-blog-minimal.json
@@ -1,0 +1,6 @@
+{
+  "document_id": "blog:simonwillison:weeknotes-2026-06",
+  "source_type": "blog",
+  "language": "en",
+  "ingested_at": 1735371342000
+}

--- a/contracts/examples/document-ingest-v1/valid/valid-book.json
+++ b/contracts/examples/document-ingest-v1/valid/valid-book.json
@@ -1,0 +1,19 @@
+{
+  "document_id": "isbn:9780262033848",
+  "source_type": "book",
+  "source_id": null,
+  "url": null,
+  "title": "Introduction to Algorithms",
+  "content": null,
+  "content_ref": "s3://neuronews-docs/books/9780262033848.epub",
+  "language": "en",
+  "authors": ["Thomas H. Cormen", "Charles E. Leiserson", "Ronald L. Rivest", "Clifford Stein"],
+  "created_at": 1247529600000,
+  "ingested_at": 1735371342000,
+  "metadata": {
+    "isbn": "9780262033848",
+    "publisher": "MIT Press",
+    "edition": "3rd",
+    "chapter_count": 35
+  }
+}

--- a/contracts/examples/document-ingest-v1/valid/valid-news.json
+++ b/contracts/examples/document-ingest-v1/valid/valid-news.json
@@ -1,0 +1,17 @@
+{
+  "document_id": "550e8400-e29b-41d4-a716-446655440000",
+  "source_type": "news",
+  "source_id": "bbc-news",
+  "url": "https://www.bbc.com/news/technology-12345678",
+  "title": "Breakthrough in AI Technology Announced",
+  "content": "Scientists have announced a major breakthrough in artificial intelligence technology that could revolutionize how we interact with computers.",
+  "content_ref": null,
+  "language": "en",
+  "authors": [],
+  "created_at": 1735371000000,
+  "ingested_at": 1735371342000,
+  "metadata": {
+    "country": "UK",
+    "section": "technology"
+  }
+}

--- a/contracts/examples/document-ingest-v1/valid/valid-paper.json
+++ b/contracts/examples/document-ingest-v1/valid/valid-paper.json
@@ -1,0 +1,19 @@
+{
+  "document_id": "arxiv:2303.08774",
+  "source_type": "paper",
+  "source_id": "arxiv",
+  "url": "https://arxiv.org/abs/2303.08774",
+  "title": "GPT-4 Technical Report",
+  "content": null,
+  "content_ref": "s3://neuronews-docs/papers/arxiv/2303.08774.pdf",
+  "language": "en",
+  "authors": ["OpenAI"],
+  "created_at": 1678838400000,
+  "ingested_at": 1735371342000,
+  "metadata": {
+    "arxiv_id": "2303.08774",
+    "doi": "10.48550/arXiv.2303.08774",
+    "primary_category": "cs.CL",
+    "reference_dois": ["10.5555/3295222.3295349", "10.18653/v1/N19-1423"]
+  }
+}

--- a/contracts/examples/document-ingest-v1/valid/valid-transcript.json
+++ b/contracts/examples/document-ingest-v1/valid/valid-transcript.json
@@ -1,0 +1,18 @@
+{
+  "document_id": "podcast:lexfridman:ep420",
+  "source_type": "transcript",
+  "source_id": "lex-fridman-podcast",
+  "url": "https://www.youtube.com/watch?v=example",
+  "title": "Episode 420: On Knowledge Graphs",
+  "content": "[00:00:00] Welcome to the podcast. Today we discuss knowledge graphs...",
+  "content_ref": null,
+  "language": "en",
+  "authors": ["Lex Fridman", "Guest Speaker"],
+  "created_at": 1735300000000,
+  "ingested_at": 1735371342000,
+  "metadata": {
+    "media_url": "https://example.com/audio.mp3",
+    "duration_s": 7200,
+    "speakers": ["host", "guest"]
+  }
+}

--- a/contracts/schemas/avro/document-ingest-v1.avsc
+++ b/contracts/schemas/avro/document-ingest-v1.avsc
@@ -1,0 +1,95 @@
+{
+  "type": "record",
+  "name": "DocumentIngest",
+  "namespace": "neuronews.events",
+  "doc": "Generalized raw document as captured from any source. Supersedes ArticleIngest (the news specialization). Enrichments (sentiment, topics) are produced downstream and are not part of this core record.",
+  "fields": [
+    {
+      "name": "document_id",
+      "type": "string",
+      "doc": "Unique identifier for the document"
+    },
+    {
+      "name": "source_type",
+      "type": {
+        "type": "enum",
+        "name": "SourceType",
+        "symbols": ["news", "blog", "book", "paper", "transcript", "web", "note"]
+      },
+      "doc": "Kind of source the document came from"
+    },
+    {
+      "name": "source_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Identifier of the originating source (publisher, repository, feed, channel)"
+    },
+    {
+      "name": "url",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Origin URL, if the document was published on the web"
+    },
+    {
+      "name": "title",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Document title/headline"
+    },
+    {
+      "name": "content",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Inline document body text"
+    },
+    {
+      "name": "content_ref",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Pointer to the document body in object storage, used for large documents"
+    },
+    {
+      "name": "language",
+      "type": "string",
+      "doc": "Document language using ISO 639-1 code (e.g., 'en', 'es', 'fr')"
+    },
+    {
+      "name": "authors",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": [],
+      "doc": "Authors/creators of the document"
+    },
+    {
+      "name": "created_at",
+      "type": ["null", {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }],
+      "default": null,
+      "doc": "When the document was originally created/published (milliseconds since epoch). Generalizes ArticleIngest.published_at."
+    },
+    {
+      "name": "ingested_at",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "When the document was ingested by our system (milliseconds since epoch)"
+    },
+    {
+      "name": "metadata",
+      "type": {
+        "type": "map",
+        "values": ["null", "boolean", "long", "double", "string", {
+          "type": "array",
+          "items": "string"
+        }]
+      },
+      "default": {},
+      "doc": "Flexible bag of source-type-specific fields (scalars and string arrays). Deeper nested structures arrive with their connectors."
+    }
+  ]
+}

--- a/contracts/schemas/jsonschema/document-ingest-v1.json
+++ b/contracts/schemas/jsonschema/document-ingest-v1.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://contracts.neuronews.com/schemas/document-ingest-v1.json",
+  "title": "DocumentIngest v1",
+  "description": "Generalized raw document as captured from any source (news, blog, book, paper, transcript, web, note). Supersedes ArticleIngest v1, which is the news specialization of this contract. Enrichments such as sentiment and topics are intentionally not part of this core record; they are produced downstream and stored separately.",
+  "type": "object",
+  "properties": {
+    "document_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the document"
+    },
+    "source_type": {
+      "type": "string",
+      "enum": ["news", "blog", "book", "paper", "transcript", "web", "note"],
+      "description": "Kind of source the document came from"
+    },
+    "source_id": {
+      "type": ["string", "null"],
+      "description": "Identifier of the originating source (publisher, repository, feed, channel). Optional: books and uploads may have none."
+    },
+    "url": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "description": "Origin URL, if the document was published on the web. Optional: books, papers, and uploads may have none."
+    },
+    "title": {
+      "type": ["string", "null"],
+      "description": "Document title/headline"
+    },
+    "content": {
+      "type": ["string", "null"],
+      "description": "Inline document body text. Use content_ref instead for large documents (books, PDFs)."
+    },
+    "content_ref": {
+      "type": ["string", "null"],
+      "description": "Pointer to the document body in object storage (e.g. s3://...), used when content is too large to inline"
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z]{2}$",
+      "description": "Document language using ISO 639-1 code (e.g., 'en', 'es', 'fr')",
+      "examples": ["en", "es", "fr", "de", "it", "pt", "ru", "zh", "ja", "ar"]
+    },
+    "authors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": [],
+      "description": "Authors/creators of the document (article byline, paper authors, book authors, speakers)"
+    },
+    "created_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "When the document was originally created/published (ISO 8601). Generalizes ArticleIngest.published_at. Optional: some documents have no known date."
+    },
+    "ingested_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the document was ingested by our system (ISO 8601)"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Flexible bag of source-type-specific fields, e.g. paper: doi/arxiv_id/journal/references; book: isbn/publisher/chapter/page_range; transcript: media_url/duration_s/speakers; news: country/section/byline.",
+      "additionalProperties": true,
+      "default": {}
+    }
+  },
+  "required": [
+    "document_id",
+    "source_type",
+    "language",
+    "ingested_at"
+  ],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "document_id": "arxiv:2303.08774",
+      "source_type": "paper",
+      "source_id": "arxiv",
+      "url": "https://arxiv.org/abs/2303.08774",
+      "title": "GPT-4 Technical Report",
+      "content": null,
+      "content_ref": "s3://neuronews-docs/papers/arxiv/2303.08774.pdf",
+      "language": "en",
+      "authors": ["OpenAI"],
+      "created_at": "2023-03-15T00:00:00Z",
+      "ingested_at": "2026-06-21T10:35:42Z",
+      "metadata": {
+        "arxiv_id": "2303.08774",
+        "doi": "10.48550/arXiv.2303.08774",
+        "primary_category": "cs.CL"
+      }
+    },
+    {
+      "document_id": "550e8400-e29b-41d4-a716-446655440000",
+      "source_type": "news",
+      "source_id": "bbc-news",
+      "url": "https://www.bbc.com/news/technology-12345678",
+      "title": "Breakthrough in AI Technology Announced",
+      "content": "Scientists have announced a major breakthrough...",
+      "content_ref": null,
+      "language": "en",
+      "authors": [],
+      "created_at": "2025-08-28T10:30:00Z",
+      "ingested_at": "2025-08-28T10:35:42Z",
+      "metadata": {
+        "country": "UK",
+        "section": "technology"
+      }
+    }
+  ]
+}

--- a/contracts/tests/test_document_contract.py
+++ b/contracts/tests/test_document_contract.py
@@ -1,0 +1,125 @@
+"""
+Contract tests for document-ingest-v1 (M0 keystone of the knowledge-engine pivot).
+
+Validates that:
+1. Valid document fixtures pass schema validation.
+2. Invalid document fixtures fail with DataContractViolation.
+3. The Article <-> Document adapter round-trips news fields losslessly, so the
+   legacy news pipeline stays green.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.ingest.common.contracts import DataContractViolation
+from services.ingest.common.document_contracts import DocumentIngestValidator
+from services.ingest.common.document_model import (
+    Document,
+    article_to_document,
+    article_enrichments,
+    document_to_article,
+)
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+EXAMPLES = REPO_ROOT / "contracts" / "examples" / "document-ingest-v1"
+ARTICLE_EXAMPLES = REPO_ROOT / "contracts" / "examples"
+
+
+def _load(path: Path) -> dict:
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def _fixtures(subdir: str):
+    return sorted((EXAMPLES / subdir).glob("*.json"))
+
+
+@pytest.fixture(scope="module")
+def validator():
+    return DocumentIngestValidator()
+
+
+@pytest.mark.parametrize("fixture_path", _fixtures("valid"), ids=lambda p: p.name)
+def test_valid_documents_pass(validator, fixture_path):
+    """Every valid fixture validates cleanly against document-ingest-v1."""
+    validator.validate_document(_load(fixture_path))
+
+
+@pytest.mark.parametrize("fixture_path", _fixtures("invalid"), ids=lambda p: p.name)
+def test_invalid_documents_rejected(validator, fixture_path):
+    """Every invalid fixture is rejected with DataContractViolation."""
+    with pytest.raises(DataContractViolation):
+        validator.validate_document(_load(fixture_path))
+
+
+def test_source_type_enum_enforced():
+    """A bad source_type is rejected by the Document model."""
+    with pytest.raises(ValueError):
+        Document(
+            document_id="x",
+            source_type="tweet",
+            language="en",
+            ingested_at=1735371342000,
+        )
+
+
+def test_document_model_roundtrip():
+    """Document.to_dict/from_dict is stable."""
+    doc = Document(
+        document_id="doc-1",
+        source_type="paper",
+        language="en",
+        ingested_at=1735371342000,
+        metadata={"doi": "10.1/x"},
+    )
+    assert Document.from_dict(doc.to_dict()) == doc
+
+
+def test_article_to_document_produces_valid_document(validator):
+    """An adapted article passes document-ingest-v1 validation as source_type=news."""
+    article = _load(ARTICLE_EXAMPLES / "valid" / "valid-full-article.json")
+    document = article_to_document(article)
+
+    validator.validate_document(document)
+    assert document["source_type"] == "news"
+    assert document["document_id"] == article["article_id"]
+    assert document["content"] == article["body"]
+    assert document["created_at"] == article["published_at"]
+    assert document["metadata"].get("country") == article.get("country")
+    # Enrichments must not leak into the core record.
+    assert "sentiment_score" not in document
+    assert "topics" not in document
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "valid-full-article.json",
+        "valid-minimal-fields.json",
+        "valid-french-article.json",
+        "valid-empty-content.json",
+    ],
+)
+def test_article_document_roundtrip_lossless(fixture_name):
+    """article -> (document + enrichments) -> article preserves all news fields."""
+    original = _load(ARTICLE_EXAMPLES / "valid" / fixture_name)
+
+    document = article_to_document(original)
+    enrichments = article_enrichments(original)
+    restored = document_to_article(document, enrichments)
+
+    # Normalize optional fields that default rather than being absent.
+    expected = dict(original)
+    expected.setdefault("title", None)
+    expected.setdefault("body", None)
+    expected.setdefault("country", None)
+    expected.setdefault("sentiment_score", None)
+    expected.setdefault("topics", [])
+
+    assert restored == expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/db/migrations/pg/0005_document_model.sql
+++ b/db/migrations/pg/0005_document_model.sql
@@ -1,0 +1,76 @@
+-- Migration: 0005_document_model.sql
+-- Description: Generalized document ingest model (M0 keystone of the knowledge-engine pivot)
+-- Author: NeuroNews Team
+-- Date: 2026-06-21
+--
+-- Introduces the generalized `document_ingest` landing table that supersedes the
+-- news-specific article-ingest record, plus a separate `document_enrichments`
+-- table (sentiment, topics, ... are now one analyzer among many, not intrinsic
+-- to a document) and a backward-compatible view that reproduces the
+-- article-ingest contract shape so the legacy news pipeline stays green.
+--
+-- This is purely additive. It does NOT touch the existing `documents` table from
+-- 0002_schema_chunks.sql (the RAG chunk store), nor the dbt `articles` source.
+
+-- Generalized raw document captured from any source (document-ingest-v1).
+CREATE TABLE IF NOT EXISTS document_ingest (
+    document_id    TEXT PRIMARY KEY,
+    source_type    TEXT NOT NULL CHECK (
+        source_type IN ('news', 'blog', 'book', 'paper', 'transcript', 'web', 'note')
+    ),
+    source_id      TEXT,
+    url            TEXT,
+    title          TEXT,
+    content        TEXT,
+    content_ref    TEXT,
+    language       VARCHAR(8) NOT NULL,
+    authors        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at     TIMESTAMP WITH TIME ZONE,                  -- generalizes published_at; nullable
+    ingested_at    TIMESTAMP WITH TIME ZONE NOT NULL,
+    metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,        -- source-type-specific bag
+    row_created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_ingest_source_type ON document_ingest (source_type);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_ingested_at ON document_ingest (ingested_at);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_created_at ON document_ingest (created_at);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_metadata ON document_ingest USING GIN (metadata);
+
+-- Enrichment layer: downstream analyzer outputs, kept separate from the core record.
+-- One row per (document, enrichment_type), e.g. ('sentiment', {"score": 0.75}),
+-- ('topics', ["technology", "ai"]).
+CREATE TABLE IF NOT EXISTS document_enrichments (
+    document_id     TEXT NOT NULL REFERENCES document_ingest (document_id) ON DELETE CASCADE,
+    enrichment_type TEXT NOT NULL,
+    value           JSONB NOT NULL,
+    model           TEXT,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (document_id, enrichment_type)
+);
+
+-- Backward-compatible view reproducing the article-ingest-v1 record shape from the
+-- generalized store (news documents only). Sentiment/topics are re-joined from the
+-- enrichment layer so existing consumers of the article shape keep working.
+CREATE OR REPLACE VIEW v_article_ingest AS
+SELECT
+    d.document_id                                   AS article_id,
+    d.source_id,
+    d.url,
+    d.title,
+    d.content                                       AS body,
+    d.language,
+    d.metadata ->> 'country'                        AS country,
+    d.created_at                                    AS published_at,
+    d.ingested_at,
+    (se.value ->> 'score')::double precision        AS sentiment_score,
+    COALESCE(te.value, '[]'::jsonb)                 AS topics
+FROM document_ingest d
+LEFT JOIN document_enrichments se
+    ON se.document_id = d.document_id AND se.enrichment_type = 'sentiment'
+LEFT JOIN document_enrichments te
+    ON te.document_id = d.document_id AND te.enrichment_type = 'topics'
+WHERE d.source_type = 'news';
+
+COMMENT ON TABLE document_ingest IS 'Generalized raw document landing table (document-ingest-v1); supersedes the news-only article-ingest record.';
+COMMENT ON TABLE document_enrichments IS 'Downstream analyzer outputs (sentiment, topics, ...) kept separate from the core document record.';
+COMMENT ON VIEW v_article_ingest IS 'Backward-compatible article-ingest-v1 shape over the generalized document store (news only).';

--- a/docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md
+++ b/docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md
@@ -220,19 +220,96 @@ This satisfies "keep news as an optional pack" with minimal disruption.
 
 ---
 
-## 11. Phased rollout
+## 11. Milestones
 
-| Phase | Scope | Exit criteria |
-| --- | --- | --- |
-| **0. Foundations** | `document-ingest-v1` contract + Avro; `Document` model; Article→Document adapter; `documents` table + legacy `articles` view | Existing news pipeline green via adapter; contract tests pass |
-| **1. Connector framework** | `connectors/base.py` + `registry.py`; refactor existing HTML ingest behind it | News ingest runs through the new framework unchanged |
-| **2. Papers E2E** | arXiv/PubMed connector, PDF parsing, citation graph, structured chunking, RAG over papers | Ingest a paper by id → ask a question → get cited answer; citation graph queryable |
-| **3. Knowledge layer** | claim extractor + cross-document claim graph | Claims with provenance queryable in KG |
-| **4. Domain packs** | extract news modules into `src/domains/news/`; feature flags; `document_routes` | News features run only when pack enabled; generic API works pack-off |
-| **5. Web reframing** | Library view, document reader, citation graph UI, gate news views | Papers usable end-to-end in the UI |
-| **6. Rebrand** | naming, docs, README | Identity reflects general knowledge engine |
+The current `src/knowledge_graph/` is an **entity-relationship (ER) graph**, not a knowledge
+graph: nodes are `Article` vertices, relations are inferred by co-occurrence/patterns, and there
+is no ontology, no provenance, no entity resolution, and no claim representation. The pivot
+therefore promotes the **knowledge-graph redesign to a foundational milestone (M2)**, not a
+late-stage add-on.
 
-Phases 0–2 deliver a working general engine with papers; 3–6 deepen and polish.
+Milestones are ordered by dependency. M0–M6 deliver a working general knowledge engine with
+papers end-to-end; M7–M12 broaden coverage and polish.
+
+### M0 — Document data model (keystone)
+- New core contract `document-ingest-v1` (JSON Schema + Avro) alongside `article-ingest-v1`.
+- `Document` model with `source_type`, optional `url`/`created_at`/`country`, flexible `metadata`.
+- `Article → Document` adapter (`source_type = news`, news fields → `metadata`).
+- DB: `documents` table (or `source_type` + JSON `metadata` column) + legacy `articles` view.
+- Move `sentiment_score`/`topics` out of the core record into an enrichment layer.
+- **Exit:** existing news pipeline green via adapter; contract tests pass.
+
+### M1 — Connector framework
+- `src/ingestion/connectors/{base.py,registry.py}` with `discover→fetch→parse→Document`.
+- Refactor existing Scrapy/Playwright HTML ingest behind the framework as the `news`/`web` connector.
+- **Exit:** current news ingest runs unchanged through the new framework.
+
+### M2 — Knowledge graph foundation (was "ER graph")
+- **Ontology**: typed entity classes (`Entity`, `Person`, `Organization`, `Concept`, `Document`,
+  `Claim`, `Method`, `Dataset`) and relation types (`AUTHORED_BY`, `CITES`, `INSTANCE_OF`,
+  `PART_OF`, `DEFINES`, `SUPPORTS`, `CONTRADICTS`, `MENTIONS`) with constraints.
+- **Node re-centering**: graph center of gravity moves from `Article` vertices to
+  `Concept`/`Claim` nodes; documents become anchors, not the primary node.
+- **Provenance on every triple**: `(subject, predicate, object, source_doc, chunk_id, confidence)`.
+- **Reified relations**: edges carry properties (e.g., `CITES.year`, `CITES.context`).
+- **Exit:** facts are stored as cited triples; ontology validates entity/relation types.
+
+### M3 — Entity resolution
+- Canonicalization stage before graph insertion: dedup the same person/org/concept across
+  documents into one canonical node (alias table, embedding + string similarity).
+- Backfill existing nodes to canonical IDs.
+- **Exit:** "Geoffrey Hinton" / "Hinton" / "G. Hinton" resolve to one node across the corpus.
+
+### M4 — Papers connector + citation graph
+- arXiv/PubMed/Crossref/Semantic Scholar discovery; PDF fetch to object storage (`content_ref`).
+- PDF parsing (GROBID preferred, `pymupdf`/`pdfplumber` fallback): sections, figures/captions,
+  reference list.
+- References become first-class `CITES` edges → queryable citation graph.
+- **Exit:** ingest a paper by id → its references appear as `CITES` edges in the KG.
+
+### M5 — Structure-aware chunking
+- `SplitStrategy.STRUCTURED` in `services/rag/chunking.py` consuming the section/chapter tree.
+- Each chunk carries a `path` (e.g., `["§4","4.2 Methods"]`) for location-cited retrieval.
+- **Exit:** RAG over a paper returns answers cited to specific sections.
+
+### M6 — Claim extraction + knowledge layer
+- `src/knowledge_graph/claim_extractor.py`: atomic subject–predicate–object claims with provenance.
+- Claims stored as KG nodes/edges; `SUPPORTS`/`CONTRADICTS` links across documents.
+- RAG surfaces corroborating/contradicting evidence per claim.
+- **Exit:** "what does the literature say about X" returns synthesized, cited claims; papers E2E done.
+
+### M7 — Domain packs (news kept, optional)
+- `src/domains/{base.py,news/}`; move `fake_news_detector`, news sentiment, `event_clusterer`,
+  `influence_network_analyzer`, news timeline UI into the `news` pack.
+- Feature-flag pack registration; add generic `document_routes.py`; gate news-only routes.
+- **Exit:** news features run only when pack enabled; generic API/KG works with pack off.
+
+### M8 — Books connector
+- EPUB/PDF ingestion with hierarchical structure (parts → chapters → sections); OCR fallback.
+- Reuses M5 structured chunking and M2 KG.
+- **Exit:** "chat with this book" answers cited to chapter/section.
+
+### M9 — Blogs / RSS / Atom connector
+- Feed subscription + readability extraction (reuses existing scraper).
+- Generic watchlists/digests over feeds.
+- **Exit:** subscribe to a feed → new posts auto-ingested, entities/claims extracted.
+
+### M10 — Media (audio/video) connector
+- Whisper transcription → `Document` with `source_type = transcript`, timestamped chunks.
+- **Exit:** semantic search over a podcast returns timestamp-linked answers.
+
+### M11 — Generic upload connector
+- PDF/Markdown/docx/text/email upload + paste path → personal/team knowledge base.
+- **Exit:** drop in mixed docs → cross-corpus, cross-source-type cited Q&A.
+
+### M12 — Web reframing & rebrand
+- `NewsFeed` → generic **Library / Sources**; `EntityGraphView` → knowledge/citation graph UI;
+  new **Document reader** view; gate news views behind the pack.
+- Rename/rebrand from "NeuroNews" last, after the engine is generalized.
+- **Exit:** all source types usable in the UI under a non-news identity.
+
+**Critical path to a working general engine with papers:** M0 → M1 → M2 → M3 → M4 → M5 → M6.
+M7 unlocks the optional-news architecture; M8–M11 add coverage; M12 finishes the product identity.
 
 ---
 
@@ -251,13 +328,13 @@ Phases 0–2 deliver a working general engine with papers; 3–6 deepen and poli
   (`pymupdf`/`pdfplumber`, simpler deploy). Recommend GROBID with a Python fallback.
 - **Storage of large docs:** books/PDFs use `content_ref` to S3-compatible storage rather than
   inlining `content` — keep the metadata store lean.
-- **Entity resolution at scale:** cross-source dedup of the same person/concept becomes more
-  important than in news-only; may warrant a dedicated entity-resolution pass in Phase 3.
-- **Naming:** "NeuroNews" implies news; rebrand deferred to Phase 6 to avoid churn mid-pivot.
+- **Entity resolution at scale:** cross-source dedup of the same person/concept is foundational,
+  not optional — promoted to its own milestone (M3).
+- **Naming:** "NeuroNews" implies news; rebrand deferred to M12 to avoid churn mid-pivot.
 
 ---
 
 ## 14. Recommended immediate next step
 
-Begin **Phase 0** (the `Document` contract + Article adapter). It is purely additive, unblocks
-every later phase, and carries zero risk to the existing news pipeline.
+Begin **M0** (the `Document` contract + Article adapter). It is purely additive, unblocks every
+later milestone, and carries zero risk to the existing news pipeline.

--- a/docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md
+++ b/docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md
@@ -1,0 +1,263 @@
+# Pivot Plan: From News Analytics to a General Knowledge Extraction Engine
+
+**Status:** Proposed
+**Owner:** TBD
+**Date:** 2026-06-21
+**Decisions locked in:**
+
+- First new source type built end-to-end: **Academic papers** (arXiv / PubMed / PDF).
+- Existing news features are **kept as an optional "domain pack"**, not deleted.
+- Migration is **incremental and additive** — the existing news pipeline stays green throughout.
+
+---
+
+## 1. Vision
+
+NeuroNews becomes a **knowledge extraction engine for arbitrary text media** — news sites,
+blogs, books, papers, transcripts, and uploaded documents. The product output shifts from
+"news dashboards" to a **queryable, cited, cross-source knowledge base**: entities, relations,
+and claims extracted from any document, retrievable via RAG and explorable as a knowledge graph.
+
+News analytics (sentiment, fake-news, events, influence networks) is preserved as one
+**pluggable domain pack** that runs only for `source_type = news`.
+
+---
+
+## 2. What already transfers (no change required)
+
+These components are already domain-agnostic and form the core of the new engine:
+
+| Capability | Location | Role in new engine |
+| --- | --- | --- |
+| RAG (chunk/retrieve/rerank/diversify/answer) | `services/rag/` | Core Q&A over any corpus |
+| Vector search | Qdrant + pgvector, `services/vector_service.py` | Core semantic retrieval |
+| Embeddings | `src/nlp/article_embedder.py`, `services/embeddings/` | Core indexing |
+| Entity **and relation** extraction | `src/knowledge_graph/enhanced_entity_extractor.py` (`extract_entities_from_article`, `extract_relationships`) | Core KG construction |
+| Knowledge graph build/query/search | `src/knowledge_graph/{graph_builder,graph_query_engine,graph_search_service,semantic_analyzer}.py` | Core knowledge base |
+| NER / keywords / topics / summarization / multilingual | `src/nlp/` | Generic enrichers |
+| Orchestration / MLOps / contracts / FinOps | `airflow/`, `src/ml/mlops/`, `contracts/`, `deploy/kubernetes/finops/` | Reusable as-is |
+
+**Implication:** the pivot is mostly a *data-model generalization* plus *new ingestion connectors*,
+not a rewrite of the analytical core.
+
+---
+
+## 3. Keystone: `Article` → `Document`
+
+All news-specificity traces back to the ingest contract
+(`contracts/schemas/jsonschema/article-ingest-v1.json`), which assumes a published news article:
+`url`, `source_id` (publisher), `published_at`, and `country` are effectively required and
+`sentiment_score`/`topics` are inlined.
+
+### 3.1 New core contract: `document-ingest-v1`
+
+Introduce `contracts/schemas/jsonschema/document-ingest-v1.json` (and matching Avro
+`contracts/schemas/avro/document-ingest-v1.avsc`) alongside the existing article contract.
+
+Core fields:
+
+```jsonc
+{
+  "document_id": "string (required)",
+  "source_type": "enum: news | blog | book | paper | transcript | web | note (required)",
+  "title": "string|null",
+  "content": "string|null",            // inline body, OR
+  "content_ref": "string|null",        // pointer to object storage for large docs (books/PDFs)
+  "language": "string (ISO 639-1)",
+  "ingested_at": "date-time (required)",
+  "created_at": "date-time|null",      // generalizes published_at; optional
+  "authors": ["string"],               // optional
+  "source_id": "string|null",          // publisher/repository; optional
+  "url": "string|null",                // optional (books/uploads have none)
+  "metadata": { }                      // type-specific bag (see below)
+}
+```
+
+`metadata` examples by `source_type`:
+
+- **paper**: `doi`, `arxiv_id`, `pubmed_id`, `journal`, `venue`, `references[]`, `sections[]`, `cited_by_count`
+- **book**: `isbn`, `publisher`, `edition`, `toc[]`, `chapter`, `page_range`
+- **transcript**: `media_url`, `duration_s`, `speakers[]`, `timestamps[]`
+- **news**: `country`, `section`, `byline` (the old fields move here)
+
+### 3.2 Enrichments move out of the core record
+
+`sentiment_score` and `topics` leave the ingest record and become rows in an **enrichment
+layer** (one analyzer among many), keyed by `document_id`. This is what makes news analytics
+"just a domain pack."
+
+### 3.3 Backward compatibility
+
+- Keep `article-ingest-v1` valid. Add an **adapter** that maps an `ArticleIngest` to a
+  `Document` (`source_type = news`, news fields → `metadata`).
+- Existing DAGs/tables continue to work via the adapter; no big-bang migration.
+- DB: add a `documents` table (or generalize the existing articles table with a
+  `source_type` column + JSON `metadata`). Provide a view `articles` for legacy queries.
+
+---
+
+## 4. Ingestion connector framework
+
+Today ingestion is HTML/Scrapy-centric (`src/ingestion/`, `src/scraper/`). Introduce a
+**connector framework** so each media type plugs in behind a common interface.
+
+```
+src/ingestion/connectors/
+  base.py            # Connector protocol: discover() -> fetch() -> parse() -> Document
+  registry.py        # source_type -> connector
+  paper/             # FIRST (this milestone)
+    arxiv.py         # arXiv API: metadata, PDF, references
+    pubmed.py        # PubMed/Crossref metadata
+    pdf_parser.py    # PDF -> sections, figures/captions, references (GROBID or pdfplumber)
+  book/              # later: EPUB/PDF, hierarchical TOC, OCR fallback
+  blog/              # later: RSS/Atom + readability (reuse scraper)
+  transcript/        # later: audio/video -> Whisper -> Document
+  upload/            # later: generic PDF/md/docx/text upload
+```
+
+Common interface:
+
+```python
+class Connector(Protocol):
+    source_type: str
+    async def discover(self, query) -> list[Ref]: ...
+    async def fetch(self, ref) -> RawDoc: ...
+    async def parse(self, raw) -> Document: ...   # normalized Document contract
+```
+
+---
+
+## 5. First milestone end-to-end: Academic papers
+
+Chosen as the proof of the pivot — cleanest metadata, highest knowledge-engine value, and it
+exercises the citation graph (a genuinely new capability).
+
+Pipeline:
+
+1. **Discover** via arXiv/PubMed/Crossref API by query, author, or ID.
+2. **Fetch** PDF + structured metadata; store PDF in object storage, reference via `content_ref`.
+3. **Parse** with GROBID (preferred) or `pdfplumber`/`pymupdf` fallback into:
+   - section tree (abstract, intro, methods, …)
+   - figure/table captions
+   - **reference list** (parsed citations with DOIs where resolvable)
+4. **Chunk** section-aware + hierarchical (see §6).
+5. **Extract** entities + relations (reuse `enhanced_entity_extractor`) and **claims** (§7).
+6. **Build KG**: paper node, author nodes, and **`CITES` edges** between papers → a citation
+   graph. Concepts/entities link papers across the corpus.
+7. **Index** chunks into the vector store for RAG.
+8. **Expose** via API (§8) and a new web view (§9).
+
+New API surface for this milestone: `POST /documents/ingest` (paper by id/url),
+`GET /documents/{id}`, `GET /documents/{id}/citations`, RAG `ask` already works over the new chunks.
+
+---
+
+## 6. Structure-aware chunking
+
+`services/rag/chunking.py` is currently flat (sentence/paragraph/word/char). Add a
+**hierarchical, structure-aware** strategy:
+
+- New `SplitStrategy.STRUCTURED` that consumes the parsed section/chapter tree.
+- Each `TextChunk` carries `path` metadata (e.g., `["§4", "4.2 Methods"]` or
+  `["Part II", "Chapter 5"]`) so retrieval can cite location.
+- Keep existing strategies for flat sources (news/blogs) — fully backward compatible.
+
+This materially improves long-document RAG for papers and books.
+
+---
+
+## 7. Relation + claim extraction (the differentiator)
+
+Entities and relations already exist. Add a **claim extraction** pass:
+
+- New module `src/knowledge_graph/claim_extractor.py`: extract atomic
+  subject–predicate–object claims with **provenance** (`document_id` + chunk `path`).
+- Store claims as KG nodes/edges so the graph answers cross-document questions
+  ("what does the literature say about X") with citations.
+- Reuse RAG to surface corroborating/contradicting evidence per claim (this also powers the
+  existing news fact-checking idea as a special case).
+
+---
+
+## 8. API generalization
+
+`src/api/routes/` is article/news-centric. Plan:
+
+- Add `document_routes.py` (ingest, get, list by `source_type`, citations, enrichments).
+- Keep `article_routes.py`, `news_routes.py`, `sentiment_*`, `veracity_*`, `event_*`,
+  `influence_*` registered **only when the news domain pack is enabled** (feature flag).
+- RAG/search/graph routes stay; they already operate on generic chunks/KG.
+
+---
+
+## 9. Domain-pack architecture (news kept, not deleted)
+
+Introduce a lightweight pack registry:
+
+```
+src/domains/
+  base.py        # DomainPack: enrichers, routes, UI feature flags
+  news/          # wraps fake_news_detector, news sentiment, event_clusterer,
+                 #   influence_network_analyzer, news timeline UI
+```
+
+- A pack registers **enrichers** (run per matching `source_type`), **routes**, and **UI flags**.
+- Config (`config/`) selects active packs. Default ships `news` enabled so nothing regresses.
+- Future packs: `research` (papers), `legal`, `finance`, etc.
+
+This satisfies "keep news as an optional pack" with minimal disruption.
+
+---
+
+## 10. Web app reframing (`apps/web/`)
+
+- `NewsFeed.tsx` → generic **Library / Sources** view with a `source_type` filter.
+- `EntityGraphView.tsx` extended to render the **citation graph** for papers.
+- Add a **Document reader** view (section tree + inline entity/claim highlights + "ask this doc").
+- News-only views (`Sentiment`, `Timeline`, `Clusters`, `Trending`, `Watchlists`) gated behind
+  the news domain-pack flag.
+- Rebrand/rename is the **last** step, after the engine is generalized.
+
+---
+
+## 11. Phased rollout
+
+| Phase | Scope | Exit criteria |
+| --- | --- | --- |
+| **0. Foundations** | `document-ingest-v1` contract + Avro; `Document` model; Article→Document adapter; `documents` table + legacy `articles` view | Existing news pipeline green via adapter; contract tests pass |
+| **1. Connector framework** | `connectors/base.py` + `registry.py`; refactor existing HTML ingest behind it | News ingest runs through the new framework unchanged |
+| **2. Papers E2E** | arXiv/PubMed connector, PDF parsing, citation graph, structured chunking, RAG over papers | Ingest a paper by id → ask a question → get cited answer; citation graph queryable |
+| **3. Knowledge layer** | claim extractor + cross-document claim graph | Claims with provenance queryable in KG |
+| **4. Domain packs** | extract news modules into `src/domains/news/`; feature flags; `document_routes` | News features run only when pack enabled; generic API works pack-off |
+| **5. Web reframing** | Library view, document reader, citation graph UI, gate news views | Papers usable end-to-end in the UI |
+| **6. Rebrand** | naming, docs, README | Identity reflects general knowledge engine |
+
+Phases 0–2 deliver a working general engine with papers; 3–6 deepen and polish.
+
+---
+
+## 12. Testing & data quality
+
+- Contract tests for `document-ingest-v1` mirroring existing `contracts/tests/` + valid/invalid examples.
+- Connector unit tests with recorded fixtures (one real arXiv paper, one PubMed record).
+- Golden-set RAG eval (`evals/`) extended with paper Q&A pairs.
+- Adapter round-trip test: `ArticleIngest` ⇄ `Document` lossless for news fields.
+
+---
+
+## 13. Open questions / risks
+
+- **PDF parsing dependency:** GROBID (Docker service, best quality) vs. pure-Python
+  (`pymupdf`/`pdfplumber`, simpler deploy). Recommend GROBID with a Python fallback.
+- **Storage of large docs:** books/PDFs use `content_ref` to S3-compatible storage rather than
+  inlining `content` — keep the metadata store lean.
+- **Entity resolution at scale:** cross-source dedup of the same person/concept becomes more
+  important than in news-only; may warrant a dedicated entity-resolution pass in Phase 3.
+- **Naming:** "NeuroNews" implies news; rebrand deferred to Phase 6 to avoid churn mid-pivot.
+
+---
+
+## 14. Recommended immediate next step
+
+Begin **Phase 0** (the `Document` contract + Article adapter). It is purely additive, unblocks
+every later phase, and carries zero risk to the existing news pipeline.

--- a/migrations/pg/0005_document_model.sql
+++ b/migrations/pg/0005_document_model.sql
@@ -1,0 +1,76 @@
+-- Migration: 0005_document_model.sql
+-- Description: Generalized document ingest model (M0 keystone of the knowledge-engine pivot)
+-- Author: NeuroNews Team
+-- Date: 2026-06-21
+--
+-- Introduces the generalized `document_ingest` landing table that supersedes the
+-- news-specific article-ingest record, plus a separate `document_enrichments`
+-- table (sentiment, topics, ... are now one analyzer among many, not intrinsic
+-- to a document) and a backward-compatible view that reproduces the
+-- article-ingest contract shape so the legacy news pipeline stays green.
+--
+-- This is purely additive. It does NOT touch the existing `documents` table from
+-- 0002_schema_chunks.sql (the RAG chunk store), nor the dbt `articles` source.
+
+-- Generalized raw document captured from any source (document-ingest-v1).
+CREATE TABLE IF NOT EXISTS document_ingest (
+    document_id    TEXT PRIMARY KEY,
+    source_type    TEXT NOT NULL CHECK (
+        source_type IN ('news', 'blog', 'book', 'paper', 'transcript', 'web', 'note')
+    ),
+    source_id      TEXT,
+    url            TEXT,
+    title          TEXT,
+    content        TEXT,
+    content_ref    TEXT,
+    language       VARCHAR(8) NOT NULL,
+    authors        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at     TIMESTAMP WITH TIME ZONE,                  -- generalizes published_at; nullable
+    ingested_at    TIMESTAMP WITH TIME ZONE NOT NULL,
+    metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,        -- source-type-specific bag
+    row_created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_ingest_source_type ON document_ingest (source_type);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_ingested_at ON document_ingest (ingested_at);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_created_at ON document_ingest (created_at);
+CREATE INDEX IF NOT EXISTS idx_document_ingest_metadata ON document_ingest USING GIN (metadata);
+
+-- Enrichment layer: downstream analyzer outputs, kept separate from the core record.
+-- One row per (document, enrichment_type), e.g. ('sentiment', {"score": 0.75}),
+-- ('topics', ["technology", "ai"]).
+CREATE TABLE IF NOT EXISTS document_enrichments (
+    document_id     TEXT NOT NULL REFERENCES document_ingest (document_id) ON DELETE CASCADE,
+    enrichment_type TEXT NOT NULL,
+    value           JSONB NOT NULL,
+    model           TEXT,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (document_id, enrichment_type)
+);
+
+-- Backward-compatible view reproducing the article-ingest-v1 record shape from the
+-- generalized store (news documents only). Sentiment/topics are re-joined from the
+-- enrichment layer so existing consumers of the article shape keep working.
+CREATE OR REPLACE VIEW v_article_ingest AS
+SELECT
+    d.document_id                                   AS article_id,
+    d.source_id,
+    d.url,
+    d.title,
+    d.content                                       AS body,
+    d.language,
+    d.metadata ->> 'country'                        AS country,
+    d.created_at                                    AS published_at,
+    d.ingested_at,
+    (se.value ->> 'score')::double precision        AS sentiment_score,
+    COALESCE(te.value, '[]'::jsonb)                 AS topics
+FROM document_ingest d
+LEFT JOIN document_enrichments se
+    ON se.document_id = d.document_id AND se.enrichment_type = 'sentiment'
+LEFT JOIN document_enrichments te
+    ON te.document_id = d.document_id AND te.enrichment_type = 'topics'
+WHERE d.source_type = 'news';
+
+COMMENT ON TABLE document_ingest IS 'Generalized raw document landing table (document-ingest-v1); supersedes the news-only article-ingest record.';
+COMMENT ON TABLE document_enrichments IS 'Downstream analyzer outputs (sentiment, topics, ...) kept separate from the core document record.';
+COMMENT ON VIEW v_article_ingest IS 'Backward-compatible article-ingest-v1 shape over the generalized document store (news only).';

--- a/services/ingest/common/document_contracts.py
+++ b/services/ingest/common/document_contracts.py
@@ -1,0 +1,95 @@
+"""
+Producer-side validation middleware for the generalized document contract.
+
+Mirrors :mod:`services.ingest.common.contracts` (which validates the news-only
+``article-ingest-v1``) but validates against ``document-ingest-v1``. Part of M0
+of the knowledge-engine pivot.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastavro import parse_schema, validate
+
+from services.ingest.common.contracts import DataContractViolation, metrics
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentIngestValidator:
+    """Validates document payloads against the document-ingest-v1 schema."""
+
+    def __init__(self, schema_path: Optional[str] = None, fail_on_error: bool = True):
+        self.fail_on_error = fail_on_error
+        self.schema = self._load_schema(schema_path)
+        logger.info(f"DocumentIngestValidator initialized with fail_on_error={fail_on_error}")
+
+    def _load_schema(self, schema_path: Optional[str] = None) -> Dict[str, Any]:
+        if schema_path is None:
+            schema_path = self._get_default_schema_path()
+        try:
+            with open(schema_path, "r") as f:
+                schema_dict = json.load(f)
+            parsed_schema = parse_schema(schema_dict)
+            logger.info(f"Successfully loaded schema from {schema_path}")
+            return parsed_schema
+        except FileNotFoundError:
+            logger.error(f"Schema file not found: {schema_path}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in schema file {schema_path}: {e}")
+            raise
+
+    def _get_default_schema_path(self) -> str:
+        current_dir = Path(__file__).parent
+        repo_root = current_dir.parent.parent.parent  # services/ingest/common -> repo root
+        schema_path = repo_root / "contracts" / "schemas" / "avro" / "document-ingest-v1.avsc"
+        if not schema_path.exists():
+            raise FileNotFoundError(f"Default schema not found at {schema_path}")
+        return str(schema_path)
+
+    def validate_document(self, payload: Dict[str, Any]) -> None:
+        """Validate a document payload; raise DataContractViolation on failure."""
+        doc_id = payload.get("document_id", "unknown")
+        try:
+            is_valid = validate(payload, self.schema, raise_errors=False)
+            if is_valid:
+                metrics.increment_success()
+                logger.debug(f"Document validation successful for document_id: {doc_id}")
+                return
+
+            error_msg = f"Data contract validation failed for document: {doc_id}"
+            metrics.increment_failure()
+            if self.fail_on_error:
+                logger.error(error_msg)
+                raise DataContractViolation(error_msg)
+            logger.warning(f"{error_msg} - sending to DLQ")
+            metrics.increment_dlq()
+        except DataContractViolation:
+            raise
+        except Exception as e:
+            error_msg = f"Validation error for document {doc_id}: {str(e)}"
+            metrics.increment_failure()
+            if self.fail_on_error:
+                logger.error(error_msg)
+                raise DataContractViolation(error_msg) from e
+            logger.warning(f"{error_msg} - sending to DLQ")
+            metrics.increment_dlq()
+
+
+_default_validator: Optional[DocumentIngestValidator] = None
+
+
+def get_default_validator() -> DocumentIngestValidator:
+    """Get the default document validator (singleton)."""
+    global _default_validator
+    if _default_validator is None:
+        _default_validator = DocumentIngestValidator()
+    return _default_validator
+
+
+def validate_document(payload: Dict[str, Any]) -> None:
+    """Convenience function for validating a single document payload."""
+    get_default_validator().validate_document(payload)

--- a/services/ingest/common/document_model.py
+++ b/services/ingest/common/document_model.py
@@ -1,0 +1,143 @@
+"""
+Generalized Document data model and Article<->Document adapter.
+
+Part of M0 (keystone) of the knowledge-engine pivot. See
+``docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md``.
+
+The ``Document`` record generalizes the news-specific ``ArticleIngest`` so the
+pipeline can ingest news, blogs, books, papers, transcripts, and arbitrary
+uploads through one contract (``document-ingest-v1``). ``news`` becomes one
+``source_type`` among many.
+
+Enrichments (sentiment, topics, ...) are intentionally *not* part of the core
+record. They are produced downstream and carried separately so they are one
+analyzer among many rather than intrinsic to a document.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+
+# Valid source types, mirrored from the document-ingest-v1 contract.
+SOURCE_TYPES = ("news", "blog", "book", "paper", "transcript", "web", "note")
+
+
+@dataclass
+class DocumentEnrichments:
+    """Downstream-produced enrichments, stored separately from the core record."""
+
+    sentiment_score: Optional[float] = None
+    topics: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"sentiment_score": self.sentiment_score, "topics": list(self.topics)}
+
+
+@dataclass
+class Document:
+    """Generalized raw document captured from any source (document-ingest-v1)."""
+
+    document_id: str
+    source_type: str
+    language: str
+    ingested_at: int  # milliseconds since epoch
+    source_id: Optional[str] = None
+    url: Optional[str] = None
+    title: Optional[str] = None
+    content: Optional[str] = None
+    content_ref: Optional[str] = None
+    authors: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None  # milliseconds since epoch
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.source_type not in SOURCE_TYPES:
+            raise ValueError(
+                f"Invalid source_type {self.source_type!r}; expected one of {SOURCE_TYPES}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a document-ingest-v1 payload dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "Document":
+        """Build a Document from a document-ingest-v1 payload dict."""
+        known = {
+            "document_id",
+            "source_type",
+            "language",
+            "ingested_at",
+            "source_id",
+            "url",
+            "title",
+            "content",
+            "content_ref",
+            "authors",
+            "created_at",
+            "metadata",
+        }
+        return cls(**{k: v for k, v in payload.items() if k in known})
+
+
+def article_to_document(article: Dict[str, Any]) -> Dict[str, Any]:
+    """Map an ArticleIngest payload to a document-ingest-v1 payload (core only).
+
+    News-specific fields with no generic home (``country``) move into
+    ``metadata``. Enrichments (``sentiment_score``, ``topics``) are *not*
+    included here; use :func:`article_enrichments` to extract them.
+    """
+    metadata: Dict[str, Any] = {}
+    if article.get("country") is not None:
+        metadata["country"] = article["country"]
+
+    return Document(
+        document_id=article["article_id"],
+        source_type="news",
+        language=article["language"],
+        ingested_at=article["ingested_at"],
+        source_id=article.get("source_id"),
+        url=article.get("url"),
+        title=article.get("title"),
+        content=article.get("body"),
+        content_ref=None,
+        authors=[],
+        created_at=article.get("published_at"),
+        metadata=metadata,
+    ).to_dict()
+
+
+def article_enrichments(article: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the enrichment fields that left the core record."""
+    return DocumentEnrichments(
+        sentiment_score=article.get("sentiment_score"),
+        topics=list(article.get("topics", [])),
+    ).to_dict()
+
+
+def document_to_article(
+    document: Dict[str, Any],
+    enrichments: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Reverse adapter: reconstruct an ArticleIngest payload from a news Document.
+
+    Together with :func:`article_to_document` / :func:`article_enrichments` this
+    round-trips news fields losslessly, keeping the legacy news pipeline green.
+    """
+    metadata = document.get("metadata") or {}
+    enrichments = enrichments or {}
+    return {
+        "article_id": document["document_id"],
+        "source_id": document.get("source_id"),
+        "url": document.get("url"),
+        "title": document.get("title"),
+        "body": document.get("content"),
+        "language": document["language"],
+        "country": metadata.get("country"),
+        "published_at": document.get("created_at"),
+        "ingested_at": document["ingested_at"],
+        "sentiment_score": enrichments.get("sentiment_score"),
+        "topics": list(enrichments.get("topics", [])),
+    }


### PR DESCRIPTION
## Overview

Kicks off the pivot from a news-analytics pipeline to a general-purpose knowledge extraction engine for any text media (news, blogs, books, papers, transcripts, uploads). This PR contains the planning docs and the first implementation milestone.

## Contents

### Pivot plan (`docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`)
- Documents what already transfers (RAG, vector search, KG, NLP, MLOps) versus the thin news-specific layer.
- Establishes `Article` to `Document` as the keystone generalization.
- 13 dependency-ordered milestones, with the knowledge-graph redesign promoted to a foundational milestone (today's `src/knowledge_graph/` is an entity-relationship graph, not a knowledge graph).
- Tracked as issues #513 through #525.

### Generalized Document data model (#513)
Purely additive; the legacy news pipeline stays green via an Article to Document adapter. `news` becomes one `source_type` among many.

- **Contract** `document-ingest-v1` (JSON Schema plus Avro): `source_type` enum (`news`, `blog`, `book`, `paper`, `transcript`, `web`, `note`), optional `url`/`created_at`/`country`, flexible `metadata` bag, `content_ref` for large docs.
- **Model plus adapter** (`services/ingest/common/document_model.py`): `Document` dataclass, `article_to_document` and `document_to_article` (lossless round-trip), with `sentiment_score`/`topics` moved out of the core record into a separate enrichment layer.
- **Validation**: `DocumentIngestValidator` mirroring the existing `ArticleIngestValidator`.
- **Database** (`migrations/pg/0005_document_model.sql`, mirrored in `db/migrations/pg/`): `document_ingest` plus `document_enrichments` tables and a `v_article_ingest` backward-compat view. Does not touch the existing `documents` (RAG store) or dbt `articles` tables.
- **Examples plus tests**: valid/invalid fixtures per source type plus README; `contracts/tests/test_document_contract.py`.

## Testing
- PASS: `test_document_contract.py`, 16 of 16 passing, including the lossless Article to Document round-trip on existing article fixtures.
- PASS: migration applied against a real Postgres 16 instance; verified the legacy view rejoins enrichments and filters to `news`.
- NOTE: the pre-existing `test_contracts_e2e.py` cannot be collected in the sandbox (its Kafka consumer import chain, `confluent-kafka` then `authlib`, is blocked by a system `cryptography` conflict). This is environmental and unrelated to this change; the article validation path was verified directly.

## Exit criteria (per #513): met
- Contract tests pass.
- Existing news pipeline green via the adapter.

## Next on the critical path
Connector framework (#514).

Generated with Claude Code (https://claude.com/claude-code)