### PR TITLE
Ingestion connector framework (#514)

### DIFF
--- a/src/ingestion/connectors/README.md
+++ b/src/ingestion/connectors/README.md
@@ -1,0 +1,58 @@
+# Ingestion connectors
+
+Connectors normalize arbitrary sources into `document-ingest-v1` `Document`
+records (see `services/ingest/common/document_model.py`) behind one interface, so
+the rest of the pipeline does not care whether a document came from a news feed,
+a paper repository, a book file, or an audio transcript.
+
+Part of the knowledge-engine pivot; see
+`docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`.
+
+## Interface
+
+Every connector implements three steps and inherits `harvest()`:
+
+```
+discover(query) -> Iterable[SourceRef]   # what is there to ingest
+fetch(ref)      -> RawDocument           # pull raw bytes/text
+parse(raw)      -> List[Document]         # normalize to the contract
+harvest(query)  -> Iterator[Document]     # discover -> fetch -> parse (resilient)
+```
+
+`harvest()` skips sources that fail to fetch or parse so one bad source does not
+abort a run.
+
+## Usage
+
+```python
+from src.ingestion.connectors import get_connector
+
+for document in get_connector("news").harvest():
+    ...  # document is a document-ingest-v1 record (source_type="news")
+```
+
+## Registering a connector
+
+Subclass `Connector`, set `source_type`, and register it. Importing the
+`connectors` package registers the built-ins.
+
+```python
+from src.ingestion.connectors.base import Connector
+from src.ingestion.connectors.registry import register_connector
+
+@register_connector
+class MyConnector(Connector):
+    source_type = "paper"
+    def discover(self, query=None): ...
+    def fetch(self, ref): ...
+    def parse(self, raw): ...
+```
+
+## Built-in connectors
+
+| source_type | Module | Notes |
+| --- | --- | --- |
+| `news` | `news.py` | Wraps the existing RSS/Atom ingest (`scrapy_integration`). Sentiment, which the legacy ingester computes inline, is exposed as an enrichment via `NewsConnector.enrichments_for`, not baked into the core `Document`. |
+
+Planned connectors (tracked as issues): papers (#517), books (#521), blogs/RSS
+(#522), media/transcripts (#523), generic upload (#524).

--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -1,0 +1,29 @@
+"""
+Ingestion connector framework.
+
+Connectors normalize arbitrary sources into document-ingest-v1 ``Document``
+records behind a common ``discover -> fetch -> parse`` interface. Importing this
+package registers the built-in connectors so they are resolvable by source type
+via :func:`get_connector`.
+"""
+
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.registry import (
+    available_source_types,
+    get_connector,
+    is_registered,
+    register_connector,
+)
+
+# Importing the module triggers @register_connector for the built-in connectors.
+from src.ingestion.connectors import news  # noqa: E402,F401
+
+__all__ = [
+    "Connector",
+    "RawDocument",
+    "SourceRef",
+    "available_source_types",
+    "get_connector",
+    "is_registered",
+    "register_connector",
+]

--- a/src/ingestion/connectors/base.py
+++ b/src/ingestion/connectors/base.py
@@ -1,0 +1,97 @@
+"""
+Ingestion connector framework.
+
+A connector turns some external source (a news feed, a paper repository, a book
+file, an audio transcript, ...) into normalized ``Document`` records
+(document-ingest-v1). Every connector follows the same three-step contract:
+
+    discover()  ->  iterable of SourceRef   (what is there to ingest)
+    fetch(ref)  ->  RawDocument             (pull the raw bytes/text)
+    parse(raw)  ->  list of Document        (normalize to the contract)
+
+``harvest()`` chains the three so callers can iterate ``Document`` objects
+without caring about the source. New media types (papers, books, transcripts,
+uploads) plug in by subclassing :class:`Connector` and registering a
+``source_type`` in :mod:`src.ingestion.connectors.registry`.
+
+See ``docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import abc
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+
+from services.ingest.common.document_model import Document
+
+
+@dataclass
+class SourceRef:
+    """A discoverable location/handle to fetch (a feed URL, paper id, file path)."""
+
+    locator: str
+    title: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RawDocument:
+    """Raw payload fetched for a :class:`SourceRef`, prior to normalization."""
+
+    ref: SourceRef
+    content: Union[bytes, str]
+    content_type: Optional[str] = None
+    fetched_at: int = field(default_factory=lambda: int(time.time() * 1000))
+
+
+class Connector(abc.ABC):
+    """Base class for all ingestion connectors.
+
+    Subclasses set :attr:`source_type` (one of the document-ingest-v1 source
+    types) and implement :meth:`discover`, :meth:`fetch`, and :meth:`parse`.
+    """
+
+    #: document-ingest-v1 source_type this connector produces.
+    source_type: str = ""
+
+    @abc.abstractmethod
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        """Enumerate the sources to ingest (optionally narrowed by ``query``)."""
+
+    @abc.abstractmethod
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        """Pull the raw payload for a single :class:`SourceRef`."""
+
+    @abc.abstractmethod
+    def parse(self, raw: RawDocument) -> List[Document]:
+        """Normalize a :class:`RawDocument` into one or more ``Document`` records."""
+
+    def harvest(self, query: Optional[Any] = None) -> Iterator[Document]:
+        """Run discover -> fetch -> parse, yielding normalized documents.
+
+        Individual sources that fail to fetch/parse are skipped (logged by the
+        connector) so one bad source does not abort the whole run.
+        """
+        for ref in self.discover(query):
+            try:
+                raw = self.fetch(ref)
+            except Exception:  # noqa: BLE001 - resilience: skip unreachable sources
+                self._on_error("fetch", ref)
+                continue
+            try:
+                documents = self.parse(raw)
+            except Exception:  # noqa: BLE001 - resilience: skip unparseable sources
+                self._on_error("parse", ref)
+                continue
+            for document in documents:
+                yield document
+
+    def _on_error(self, stage: str, ref: SourceRef) -> None:
+        import logging
+
+        logging.getLogger(self.__class__.__module__).warning(
+            "%s: %s stage failed for %s", self.__class__.__name__, stage, ref.locator,
+            exc_info=True,
+        )

--- a/src/ingestion/connectors/news.py
+++ b/src/ingestion/connectors/news.py
@@ -1,0 +1,112 @@
+"""
+News connector: the existing RSS/Atom news ingest, expressed as a connector.
+
+This wraps the pure fetch/parse helpers already in
+``src.ingestion.scrapy_integration`` (the live news ingester) behind the generic
+connector interface, producing ``Document`` records with ``source_type="news"``.
+The legacy warehouse path in ``scrapy_integration`` is left untouched; this is
+the generalized entry point on top of the same fetch/parse logic.
+
+Sentiment, which the legacy ingester computes inline, is an enrichment under the
+document model and is therefore exposed separately via :meth:`enrichments_for`
+rather than baked into the core ``Document``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.registry import register_connector
+
+
+def _to_millis(dt: datetime) -> int:
+    """Convert a (naive, UTC) datetime to milliseconds since epoch."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+@register_connector
+class NewsConnector(Connector):
+    """Ingest news articles from RSS/Atom feeds as document-ingest-v1 records."""
+
+    source_type = "news"
+
+    def __init__(
+        self,
+        feeds: Optional[Sequence[Any]] = None,
+        limit_per_feed: int = 25,
+        http_get=None,
+    ):
+        # Imported lazily so the framework stays importable without the news deps.
+        from src.ingestion import scrapy_integration as si
+
+        self._si = si
+        self._feeds = list(feeds) if feeds is not None else list(si.DEFAULT_FEEDS)
+        self._limit_per_feed = limit_per_feed
+        self._http_get = http_get or si._http_get
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        """Yield one SourceRef per configured feed.
+
+        ``query`` may be a sequence of ``Feed`` objects to override the default
+        feed list for this run.
+        """
+        feeds = list(query) if query else self._feeds
+        for feed in feeds:
+            yield SourceRef(
+                locator=feed.url,
+                title=feed.name,
+                metadata={"feed_name": feed.name, "category": feed.category},
+            )
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        return RawDocument(
+            ref=ref,
+            content=self._http_get(ref.locator),
+            content_type="application/xml",
+        )
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        feed = self._si.Feed(
+            name=raw.ref.metadata.get("feed_name", raw.ref.title or raw.ref.locator),
+            url=raw.ref.locator,
+            category=raw.ref.metadata.get("category", "World"),
+        )
+        content = raw.content
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        ingested_at = raw.fetched_at
+        documents: List[Document] = []
+        for article in self._si.parse_feed(content, feed, limit=self._limit_per_feed):
+            documents.append(self._article_to_document(article, ingested_at))
+        return documents
+
+    @staticmethod
+    def _article_to_document(article: Any, ingested_at: int) -> Document:
+        return Document(
+            document_id=article.id,
+            source_type="news",
+            language="en",
+            ingested_at=ingested_at,
+            source_id=article.source,
+            url=article.url,
+            title=article.title,
+            content=article.content,
+            created_at=_to_millis(article.publish_date),
+            metadata={"category": article.category},
+        )
+
+    @staticmethod
+    def enrichments_for(article: Any) -> Dict[str, Any]:
+        """Enrichments the legacy ingester computes inline (kept out of the core record)."""
+        return {
+            "sentiment": {
+                "score": article.sentiment_score,
+                "label": article.sentiment_label,
+            }
+        }

--- a/src/ingestion/connectors/registry.py
+++ b/src/ingestion/connectors/registry.py
@@ -1,0 +1,67 @@
+"""
+Connector registry: maps a document ``source_type`` to its connector.
+
+Connectors register themselves (typically at import time) so callers can resolve
+the right connector for a source type without importing it directly::
+
+    from src.ingestion.connectors.registry import get_connector
+    connector = get_connector("news")
+    for document in connector.harvest():
+        ...
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Type, Union
+
+from src.ingestion.connectors.base import Connector
+
+# source_type -> connector class (instantiated lazily on first get).
+_REGISTRY: Dict[str, Type[Connector]] = {}
+_INSTANCES: Dict[str, Connector] = {}
+
+
+def register_connector(
+    connector_cls: Type[Connector] = None,
+) -> Union[Type[Connector], Callable[[Type[Connector]], Type[Connector]]]:
+    """Register a connector class under its ``source_type``.
+
+    Usable as a plain call or a class decorator::
+
+        @register_connector
+        class NewsConnector(Connector):
+            source_type = "news"
+    """
+
+    def _do_register(cls: Type[Connector]) -> Type[Connector]:
+        source_type = getattr(cls, "source_type", "")
+        if not source_type:
+            raise ValueError(f"{cls.__name__} must set a non-empty source_type to register")
+        _REGISTRY[source_type] = cls
+        _INSTANCES.pop(source_type, None)  # drop any stale cached instance
+        return cls
+
+    if connector_cls is not None:
+        return _do_register(connector_cls)
+    return _do_register
+
+
+def get_connector(source_type: str) -> Connector:
+    """Return a (cached) connector instance for ``source_type``."""
+    if source_type not in _REGISTRY:
+        raise KeyError(
+            f"No connector registered for source_type {source_type!r}; "
+            f"available: {available_source_types()}"
+        )
+    if source_type not in _INSTANCES:
+        _INSTANCES[source_type] = _REGISTRY[source_type]()
+    return _INSTANCES[source_type]
+
+
+def available_source_types() -> List[str]:
+    """List the source types that currently have a registered connector."""
+    return sorted(_REGISTRY)
+
+
+def is_registered(source_type: str) -> bool:
+    return source_type in _REGISTRY

--- a/src/ingestion/scrapy_integration.py
+++ b/src/ingestion/scrapy_integration.py
@@ -30,8 +30,9 @@ from typing import List, Optional, Sequence, Tuple
 from urllib.request import Request, urlopen
 import xml.etree.ElementTree as ET
 
-from src.database.local_analytics_connector import get_shared_connection
-from src.database.local_warehouse_seed import ensure_schema
+# NOTE: warehouse imports (DuckDB) are intentionally lazy, done inside the
+# storage functions below, so the pure fetch/parse helpers in this module can be
+# reused by the ingestion connector framework without pulling in DuckDB.
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +308,9 @@ def store_articles(articles: Sequence[Article], replace: bool = False) -> int:
     sample seed (ids ``art-*``) is dropped and only previously unseen URLs are
     inserted, so re-running is idempotent.
     """
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.database.local_warehouse_seed import ensure_schema
+
     conn = get_shared_connection()
     ensure_schema(conn)
 
@@ -337,6 +341,8 @@ def ingest(
     replace: bool = False,
 ) -> dict:
     """Fetch real news and store it. Returns summary stats."""
+    from src.database.local_analytics_connector import get_shared_connection
+
     articles = fetch_articles(feeds, limit_per_feed=limit_per_feed)
     inserted = store_articles(articles, replace=replace)
     total = get_shared_connection().execute(

--- a/tests/ingestion/test_connectors.py
+++ b/tests/ingestion/test_connectors.py
@@ -1,0 +1,167 @@
+"""
+Tests for the ingestion connector framework (registry + news connector).
+
+Verifies that:
+1. The registry registers, resolves, and lists connectors.
+2. The news connector wraps the existing RSS ingest, producing valid
+   document-ingest-v1 records with source_type=news.
+3. harvest() chains discover -> fetch -> parse and is resilient to bad sources.
+"""
+
+import pytest
+
+from services.ingest.common.document_contracts import DocumentIngestValidator
+from src.ingestion.connectors import (
+    Connector,
+    RawDocument,
+    SourceRef,
+    available_source_types,
+    get_connector,
+    is_registered,
+    register_connector,
+)
+from src.ingestion.connectors.news import NewsConnector
+from src.ingestion.scrapy_integration import Feed
+
+SAMPLE_RSS = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>Test Feed</title>
+  <item>
+    <title>Markets surge on strong earnings</title>
+    <link>https://example.com/a</link>
+    <description>Some &lt;b&gt;great&lt;/b&gt; news about record gains</description>
+    <pubDate>Wed, 02 Oct 2024 13:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Second headline</title>
+    <link>https://example.com/b</link>
+    <description>More coverage</description>
+    <pubDate>Wed, 02 Oct 2024 14:00:00 GMT</pubDate>
+  </item>
+</channel></rss>"""
+
+
+@pytest.fixture(scope="module")
+def validator():
+    return DocumentIngestValidator()
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+
+def test_news_connector_is_registered():
+    assert is_registered("news")
+    assert "news" in available_source_types()
+    assert isinstance(get_connector("news"), NewsConnector)
+
+
+def test_get_connector_unknown_raises():
+    with pytest.raises(KeyError):
+        get_connector("does-not-exist")
+
+
+def test_register_requires_source_type():
+    with pytest.raises(ValueError):
+
+        @register_connector
+        class _Bad(Connector):  # no source_type
+            def discover(self, query=None):
+                return []
+
+            def fetch(self, ref):
+                return RawDocument(ref=ref, content=b"")
+
+            def parse(self, raw):
+                return []
+
+
+def test_register_and_resolve_custom_connector():
+    @register_connector
+    class DummyConnector(Connector):
+        source_type = "note"
+
+        def discover(self, query=None):
+            yield SourceRef(locator="note-1")
+
+        def fetch(self, ref):
+            return RawDocument(ref=ref, content="hello")
+
+        def parse(self, raw):
+            return []
+
+    assert is_registered("note")
+    assert isinstance(get_connector("note"), DummyConnector)
+
+
+# --------------------------------------------------------------------------- #
+# News connector
+# --------------------------------------------------------------------------- #
+
+
+def _news_connector(http_get=None, feeds=None):
+    feeds = feeds or [Feed("Test Feed", "https://example.com/feed", "Business")]
+    return NewsConnector(feeds=feeds, http_get=http_get or (lambda url: SAMPLE_RSS))
+
+
+def test_news_discover_yields_one_ref_per_feed():
+    conn = _news_connector()
+    refs = list(conn.discover())
+    assert len(refs) == 1
+    assert refs[0].locator == "https://example.com/feed"
+    assert refs[0].metadata["category"] == "Business"
+
+
+def test_news_parse_produces_valid_documents(validator):
+    conn = _news_connector()
+    raw = conn.fetch(next(iter(conn.discover())))
+    docs = conn.parse(raw)
+
+    assert len(docs) == 2
+    for doc in docs:
+        payload = doc.to_dict()
+        validator.validate_document(payload)  # must satisfy document-ingest-v1
+        assert payload["source_type"] == "news"
+        assert payload["metadata"]["category"] == "Business"
+        assert payload["url"].startswith("https://example.com/")
+        # Enrichments must not be part of the core record.
+        assert "sentiment_score" not in payload
+        assert "sentiment" not in payload
+
+
+def test_news_harvest_chains_pipeline(validator):
+    conn = _news_connector()
+    docs = list(conn.harvest())
+    assert len(docs) == 2
+    titles = {d.title for d in docs}
+    assert "Markets surge on strong earnings" in titles
+
+
+def test_news_harvest_skips_unreachable_feeds():
+    def flaky_get(url):
+        if "bad" in url:
+            raise OSError("boom")
+        return SAMPLE_RSS
+
+    feeds = [
+        Feed("Good", "https://example.com/good", "World"),
+        Feed("Bad", "https://example.com/bad", "World"),
+    ]
+    conn = NewsConnector(feeds=feeds, http_get=flaky_get)
+    docs = list(conn.harvest())
+    # Only the good feed contributes; the bad one is skipped, not fatal.
+    assert len(docs) == 2
+
+
+def test_news_enrichments_separated_from_core():
+    conn = _news_connector()
+    raw = conn.fetch(next(iter(conn.discover())))
+    articles = conn._si.parse_feed(SAMPLE_RSS, conn._feeds[0], limit=25)
+    enr = NewsConnector.enrichments_for(articles[0])
+    assert "sentiment" in enr
+    assert -1.0 <= enr["sentiment"]["score"] <= 1.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

Second step of the knowledge-engine pivot, building on the document model merged in #526. Adds a pluggable connector framework so each media type can plug in behind one interface, decoupling ingestion from the source format. `news` becomes the first connector on top of the existing RSS ingest.

## What changed

- **`src/ingestion/connectors/base.py`**: `Connector` ABC with `SourceRef` and `RawDocument`, plus a resilient `harvest()` that chains `discover -> fetch -> parse` and skips sources that fail (one bad feed does not abort the run).
- **`src/ingestion/connectors/registry.py`**: `source_type` to connector registry (`register_connector` decorator, `get_connector`, `available_source_types`, `is_registered`).
- **`src/ingestion/connectors/news.py`**: `NewsConnector`, the first connector, wrapping the existing RSS/Atom ingest and producing `source_type=news` `Document` records. Sentiment, which the legacy ingester computes inline, is exposed as an enrichment via `enrichments_for` rather than baked into the core record.
- **`src/ingestion/scrapy_integration.py`**: made the DuckDB warehouse imports lazy so the pure fetch/parse helpers are reusable without pulling in storage. The legacy warehouse path is otherwise unchanged.
- **`src/ingestion/connectors/README.md`**: framework docs and how to add a connector.

## Testing

- PASS: `tests/ingestion/test_connectors.py`, 9 tests: registry register/resolve/list/errors, news discover/fetch/parse, document-ingest-v1 validation of connector output, `harvest()` chaining, and harvest resilience to unreachable feeds.
- PASS: confirmed the legacy `parse_feed` path still works and the document-model contract tests (16) still pass.

## Exit criteria (per #514): met

- Common `discover/fetch/parse/Document` interface in place.
- Existing news ingest runs through the framework as the `news` connector, with the legacy path unchanged.