### PR TITLE
Knowledge graph foundation (#515)

### DIFF
--- a/src/knowledge_graph/foundation/README.md
+++ b/src/knowledge_graph/foundation/README.md
@@ -1,0 +1,76 @@
+# Knowledge graph foundation
+
+Turns the implicit, untyped entity-relationship graph (nodes were news `Article`
+vertices, edges were inferred by co-occurrence) into a real knowledge graph:
+typed entities, typed relations, reified provenance-bearing triples, and a
+backend-agnostic store that enforces an ontology on every write.
+
+Part of the knowledge-engine pivot; see
+`docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`.
+
+## What changed conceptually
+
+| Old (ER graph) | New (knowledge graph) |
+| --- | --- |
+| Nodes are documents (`Article`) | Nodes are typed; documents are anchors, `Concept`/`Claim` are the knowledge |
+| Edges inferred by co-occurrence | Typed relations validated against an ontology |
+| No provenance | Every triple carries `(source_doc, chunk_id, confidence, extractor)` |
+| Flat edges | Reified edges carry properties (e.g. `CITES.year`) |
+
+## Modules
+
+- `ontology.py`: `EntityType` (with an is-a hierarchy rooted at `Entity`),
+  `RelationType`, and subtype-aware domain/range constraints
+  (`is_valid_relation`, `validate_relation`).
+- `model.py`: `Node`, `Provenance` (required on every fact), and `Triple`
+  (reified, provenance-bearing edge with arbitrary properties).
+- `store.py`: `KnowledgeGraphStore`, an in-memory store that enforces the
+  ontology, requires both endpoints to exist, and accumulates provenance when a
+  fact is re-asserted. The interface is backend-agnostic so a Gremlin/Neptune
+  implementation can follow without changing callers.
+
+## Ontology
+
+Entity types: `Entity` (root), `Person`, `Organization`, `Concept`, `Document`,
+`Claim`, `Method` (a kind of `Concept`), `Dataset`.
+
+Relation types and where they are allowed:
+
+| Relation | Permitted (subject -> object) |
+| --- | --- |
+| `AUTHORED_BY` | Document -> Person, Document -> Organization |
+| `CITES` | Document -> Document |
+| `INSTANCE_OF` | Entity -> Concept |
+| `PART_OF` | Concept -> Concept, Document -> Document |
+| `DEFINES` | Document -> Concept |
+| `SUPPORTS` | Document -> Claim, Claim -> Claim |
+| `CONTRADICTS` | Document -> Claim, Claim -> Claim |
+| `MENTIONS` | Document -> Entity (any subtype) |
+
+Matching is subtype-aware: where a relation permits `Entity`, any subtype
+(`Person`, `Concept`, ...) satisfies it.
+
+## Usage
+
+```python
+from src.knowledge_graph.foundation import (
+    KnowledgeGraphStore, Node, Triple, Provenance, EntityType, RelationType,
+)
+
+kg = KnowledgeGraphStore()
+paper = kg.add_node(Node(EntityType.DOCUMENT, "Attention Is All You Need"))
+concept = kg.add_node(Node(EntityType.CONCEPT, "Transformer"))
+
+kg.add_triple(Triple(
+    paper.node_id, RelationType.DEFINES, concept.node_id,
+    provenance=Provenance(source_doc=paper.node_id, confidence=0.9, chunk_id="abstract"),
+))
+```
+
+## Not in scope here
+
+- Entity resolution (canonicalizing `Hinton` / `G. Hinton` across documents) is
+  tracked separately (#516); `make_node_id` here is a stable surrogate key, not
+  resolution.
+- Claim extraction that populates `Claim` nodes is tracked in #519.
+- A persistent Gremlin/Neptune-backed store implementation.

--- a/src/knowledge_graph/foundation/__init__.py
+++ b/src/knowledge_graph/foundation/__init__.py
@@ -1,0 +1,42 @@
+"""
+Knowledge graph foundation: typed ontology, reified provenance-bearing triples,
+and a backend-agnostic store.
+
+Replaces the implicit, untyped entity-relationship graph with a real knowledge
+graph centered on concepts and claims, where documents are anchors and every
+fact is a cited triple. See ``docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md``.
+"""
+
+from src.knowledge_graph.foundation.model import (
+    Node,
+    Provenance,
+    Triple,
+    make_node_id,
+)
+from src.knowledge_graph.foundation.ontology import (
+    EntityType,
+    OntologyViolation,
+    RelationType,
+    ancestors,
+    allowed_pairs,
+    is_subtype,
+    is_valid_relation,
+    validate_relation,
+)
+from src.knowledge_graph.foundation.store import KnowledgeGraphStore
+
+__all__ = [
+    "EntityType",
+    "RelationType",
+    "OntologyViolation",
+    "ancestors",
+    "allowed_pairs",
+    "is_subtype",
+    "is_valid_relation",
+    "validate_relation",
+    "Node",
+    "Provenance",
+    "Triple",
+    "make_node_id",
+    "KnowledgeGraphStore",
+]

--- a/src/knowledge_graph/foundation/model.py
+++ b/src/knowledge_graph/foundation/model.py
@@ -1,0 +1,122 @@
+"""
+Knowledge graph data model: nodes, provenance, and reified triples.
+
+The graph is a set of typed nodes connected by reified triples. Every triple
+carries provenance ``(source_doc, chunk_id, confidence, extractor)`` so the
+graph is a database of *cited* facts rather than anonymous edges, and may carry
+arbitrary edge properties (e.g. ``CITES`` with a ``year``).
+
+Re-centering note: ``DOCUMENT`` nodes are anchors (where a fact was asserted);
+``CONCEPT`` and ``CLAIM`` nodes are the knowledge the graph is built around.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from src.knowledge_graph.foundation.ontology import EntityType, RelationType
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip().lower()
+
+
+def make_node_id(entity_type: EntityType, name: str) -> str:
+    """Deterministic node id from type + normalized name.
+
+    This is a stable surrogate key, not entity resolution (tracked separately);
+    it simply keeps repeated mentions of the same surface form collapsed.
+    """
+    digest = hashlib.md5(f"{entity_type.value}:{_normalize(name)}".encode()).hexdigest()
+    return f"{entity_type.value.lower()}:{digest[:12]}"
+
+
+@dataclass
+class Node:
+    """A typed entity in the knowledge graph."""
+
+    type: EntityType
+    name: str
+    node_id: str = ""
+    aliases: List[str] = field(default_factory=list)
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.type, EntityType):
+            self.type = EntityType(self.type)
+        if not self.node_id:
+            self.node_id = make_node_id(self.type, self.name)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "type": self.type.value,
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "properties": dict(self.properties),
+        }
+
+
+@dataclass
+class Provenance:
+    """Where a fact came from and how confident we are in it."""
+
+    source_doc: str
+    confidence: float = 1.0
+    chunk_id: Optional[str] = None
+    extractor: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.source_doc:
+            raise ValueError("Provenance.source_doc is required (a fact must be cited)")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError(f"Provenance.confidence must be in [0, 1], got {self.confidence}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_doc": self.source_doc,
+            "confidence": self.confidence,
+            "chunk_id": self.chunk_id,
+            "extractor": self.extractor,
+        }
+
+
+@dataclass
+class Triple:
+    """A reified, provenance-bearing edge: subject --predicate--> object.
+
+    ``subject`` and ``object`` are node ids. ``properties`` holds reified edge
+    attributes (e.g. ``{"year": 2023, "context": "..."}`` on a ``CITES`` edge).
+    Ontology validity is enforced by the store, which knows the node types.
+    """
+
+    subject: str
+    predicate: RelationType
+    object: str
+    provenance: Provenance
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.predicate, RelationType):
+            self.predicate = RelationType(self.predicate)
+        if not self.subject or not self.object:
+            raise ValueError("Triple requires non-empty subject and object node ids")
+        if not isinstance(self.provenance, Provenance):
+            raise TypeError("Triple.provenance must be a Provenance instance")
+
+    @property
+    def key(self) -> tuple:
+        """Identity of the asserted fact, independent of provenance/properties."""
+        return (self.subject, self.predicate.value, self.object)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "predicate": self.predicate.value,
+            "object": self.object,
+            "provenance": self.provenance.to_dict(),
+            "properties": dict(self.properties),
+        }

--- a/src/knowledge_graph/foundation/ontology.py
+++ b/src/knowledge_graph/foundation/ontology.py
@@ -1,0 +1,149 @@
+"""
+Knowledge graph ontology: typed entities, typed relations, and constraints.
+
+This replaces the implicit, untyped entity-relationship graph (where nodes were
+news ``Article`` vertices and edges were inferred by co-occurrence) with a
+typed ontology that validates what entity and relation types may exist and which
+relations are allowed between which entity types.
+
+See ``docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`` (knowledge graph
+foundation).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, FrozenSet, Set, Tuple
+
+
+class EntityType(str, Enum):
+    """Typed node classes in the knowledge graph.
+
+    ``ENTITY`` is the root; every other type is a subtype of it. ``DOCUMENT`` is
+    an anchor type (a source a fact came from); ``CONCEPT`` and ``CLAIM`` are the
+    knowledge-bearing types the graph is centered on.
+    """
+
+    ENTITY = "Entity"
+    PERSON = "Person"
+    ORGANIZATION = "Organization"
+    CONCEPT = "Concept"
+    DOCUMENT = "Document"
+    CLAIM = "Claim"
+    METHOD = "Method"
+    DATASET = "Dataset"
+
+
+# is-a hierarchy: child -> direct parent. ENTITY is the root.
+# METHOD is a kind of CONCEPT; everything else hangs directly off ENTITY.
+_PARENT: Dict[EntityType, EntityType] = {
+    EntityType.PERSON: EntityType.ENTITY,
+    EntityType.ORGANIZATION: EntityType.ENTITY,
+    EntityType.CONCEPT: EntityType.ENTITY,
+    EntityType.DOCUMENT: EntityType.ENTITY,
+    EntityType.CLAIM: EntityType.ENTITY,
+    EntityType.METHOD: EntityType.CONCEPT,
+    EntityType.DATASET: EntityType.ENTITY,
+}
+
+
+def ancestors(entity_type: EntityType) -> Set[EntityType]:
+    """Return ``entity_type`` plus all of its supertypes (including ENTITY)."""
+    chain: Set[EntityType] = {entity_type}
+    current = entity_type
+    while current in _PARENT:
+        current = _PARENT[current]
+        chain.add(current)
+    return chain
+
+
+def is_subtype(child: EntityType, parent: EntityType) -> bool:
+    """True if ``child`` is ``parent`` or a (transitive) subtype of it."""
+    return parent in ancestors(child)
+
+
+class RelationType(str, Enum):
+    """Typed, directed edges in the knowledge graph."""
+
+    AUTHORED_BY = "AUTHORED_BY"
+    CITES = "CITES"
+    INSTANCE_OF = "INSTANCE_OF"
+    PART_OF = "PART_OF"
+    DEFINES = "DEFINES"
+    SUPPORTS = "SUPPORTS"
+    CONTRADICTS = "CONTRADICTS"
+    MENTIONS = "MENTIONS"
+
+
+# Allowed (subject_type, object_type) pairs per relation. Matching is
+# subtype-aware: a subject/object satisfies a pair if it is-a the listed type.
+_CONSTRAINTS: Dict[RelationType, FrozenSet[Tuple[EntityType, EntityType]]] = {
+    RelationType.AUTHORED_BY: frozenset({
+        (EntityType.DOCUMENT, EntityType.PERSON),
+        (EntityType.DOCUMENT, EntityType.ORGANIZATION),
+    }),
+    RelationType.CITES: frozenset({
+        (EntityType.DOCUMENT, EntityType.DOCUMENT),
+    }),
+    RelationType.INSTANCE_OF: frozenset({
+        (EntityType.ENTITY, EntityType.CONCEPT),
+    }),
+    RelationType.PART_OF: frozenset({
+        (EntityType.CONCEPT, EntityType.CONCEPT),
+        (EntityType.DOCUMENT, EntityType.DOCUMENT),
+    }),
+    RelationType.DEFINES: frozenset({
+        (EntityType.DOCUMENT, EntityType.CONCEPT),
+    }),
+    RelationType.SUPPORTS: frozenset({
+        (EntityType.DOCUMENT, EntityType.CLAIM),
+        (EntityType.CLAIM, EntityType.CLAIM),
+    }),
+    RelationType.CONTRADICTS: frozenset({
+        (EntityType.DOCUMENT, EntityType.CLAIM),
+        (EntityType.CLAIM, EntityType.CLAIM),
+    }),
+    RelationType.MENTIONS: frozenset({
+        (EntityType.DOCUMENT, EntityType.ENTITY),
+    }),
+}
+
+
+class OntologyViolation(ValueError):
+    """Raised when a node or relation violates the ontology."""
+
+
+def allowed_pairs(relation: RelationType) -> FrozenSet[Tuple[EntityType, EntityType]]:
+    return _CONSTRAINTS[relation]
+
+
+def is_valid_relation(
+    relation: RelationType,
+    subject_type: EntityType,
+    object_type: EntityType,
+) -> bool:
+    """True if ``subject_type --relation--> object_type`` is permitted.
+
+    A triple is valid when the subject is-a the allowed domain type and the
+    object is-a the allowed range type for at least one configured pair.
+    """
+    for domain, range_ in _CONSTRAINTS[relation]:
+        if is_subtype(subject_type, domain) and is_subtype(object_type, range_):
+            return True
+    return False
+
+
+def validate_relation(
+    relation: RelationType,
+    subject_type: EntityType,
+    object_type: EntityType,
+) -> None:
+    """Raise :class:`OntologyViolation` if the relation is not permitted."""
+    if not is_valid_relation(relation, subject_type, object_type):
+        permitted = ", ".join(
+            f"{d.value}->{r.value}" for d, r in sorted(_CONSTRAINTS[relation])
+        )
+        raise OntologyViolation(
+            f"{relation.value} not allowed from {subject_type.value} to "
+            f"{object_type.value}; permitted: {permitted}"
+        )

--- a/src/knowledge_graph/foundation/store.py
+++ b/src/knowledge_graph/foundation/store.py
@@ -1,0 +1,124 @@
+"""
+In-memory knowledge graph store.
+
+Stores typed nodes and reified, provenance-bearing triples, enforcing the
+ontology on every write (entity/relation types must exist; relations must be
+permitted between the subject's and object's types). The interface is backend
+agnostic so a Gremlin/Neptune-backed implementation can follow without changing
+callers.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from src.knowledge_graph.foundation.model import Node, Provenance, Triple
+from src.knowledge_graph.foundation.ontology import (
+    EntityType,
+    OntologyViolation,
+    RelationType,
+    validate_relation,
+)
+
+
+class KnowledgeGraphStore:
+    """A typed, provenance-enforcing knowledge graph held in memory."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Node] = {}
+        # Triples keyed by fact identity; repeated assertions accumulate provenance.
+        self._triples: Dict[tuple, Triple] = {}
+        self._provenance: Dict[tuple, List[Provenance]] = {}
+
+    # ---- nodes ---------------------------------------------------------- #
+
+    def add_node(self, node: Node) -> Node:
+        """Add or merge a node. Re-adding the same id merges aliases/properties."""
+        existing = self._nodes.get(node.node_id)
+        if existing is None:
+            self._nodes[node.node_id] = node
+            return node
+        if existing.type != node.type:
+            raise OntologyViolation(
+                f"Node {node.node_id} already exists as {existing.type.value}, "
+                f"cannot redefine as {node.type.value}"
+            )
+        for alias in node.aliases:
+            if alias not in existing.aliases:
+                existing.aliases.append(alias)
+        existing.properties.update(node.properties)
+        return existing
+
+    def get_node(self, node_id: str) -> Optional[Node]:
+        return self._nodes.get(node_id)
+
+    def nodes_by_type(self, entity_type: EntityType) -> List[Node]:
+        return [n for n in self._nodes.values() if n.type == entity_type]
+
+    # ---- triples -------------------------------------------------------- #
+
+    def add_triple(self, triple: Triple) -> Triple:
+        """Validate against the ontology and store the triple as a cited fact.
+
+        Both endpoints must already exist as nodes, and the relation must be
+        permitted between their types. Re-asserting the same fact appends its
+        provenance to the existing triple rather than duplicating it.
+        """
+        subject = self._nodes.get(triple.subject)
+        obj = self._nodes.get(triple.object)
+        if subject is None:
+            raise OntologyViolation(f"Unknown subject node {triple.subject!r}; add it first")
+        if obj is None:
+            raise OntologyViolation(f"Unknown object node {triple.object!r}; add it first")
+
+        validate_relation(triple.predicate, subject.type, obj.type)
+
+        key = triple.key
+        if key in self._triples:
+            self._provenance[key].append(triple.provenance)
+            # Keep the highest-confidence provenance as the representative one.
+            best = max(self._provenance[key], key=lambda p: p.confidence)
+            self._triples[key].provenance = best
+            self._triples[key].properties.update(triple.properties)
+            return self._triples[key]
+
+        self._triples[key] = triple
+        self._provenance[key] = [triple.provenance]
+        return triple
+
+    def provenance_for(self, triple: Triple) -> List[Provenance]:
+        """All provenance records backing a fact (one per assertion)."""
+        return list(self._provenance.get(triple.key, []))
+
+    def triples(
+        self,
+        subject: Optional[str] = None,
+        predicate: Optional[RelationType] = None,
+        object: Optional[str] = None,
+    ) -> List[Triple]:
+        """Query stored facts, optionally filtered by any of subject/predicate/object."""
+        results: Iterable[Triple] = self._triples.values()
+        if subject is not None:
+            results = [t for t in results if t.subject == subject]
+        if predicate is not None:
+            results = [t for t in results if t.predicate == predicate]
+        if object is not None:
+            results = [t for t in results if t.object == object]
+        return list(results)
+
+    def neighbors(self, node_id: str) -> List[Triple]:
+        """All facts with ``node_id`` as subject or object."""
+        return [t for t in self._triples.values() if node_id in (t.subject, t.object)]
+
+    # ---- stats ---------------------------------------------------------- #
+
+    def __len__(self) -> int:
+        return len(self._triples)
+
+    @property
+    def node_count(self) -> int:
+        return len(self._nodes)
+
+    @property
+    def triple_count(self) -> int:
+        return len(self._triples)

--- a/tests/knowledge_graph/test_kg_foundation.py
+++ b/tests/knowledge_graph/test_kg_foundation.py
@@ -1,0 +1,201 @@
+"""
+Tests for the knowledge graph foundation (ontology, model, store).
+
+Covers the exit criteria: facts are stored as cited triples, and the ontology
+validates entity and relation types (including subtype-aware domain/range
+constraints, provenance on every triple, and reified edge properties).
+"""
+
+import pytest
+
+from src.knowledge_graph.foundation import (
+    EntityType,
+    KnowledgeGraphStore,
+    Node,
+    OntologyViolation,
+    Provenance,
+    RelationType,
+    Triple,
+    is_subtype,
+    is_valid_relation,
+    make_node_id,
+    validate_relation,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Ontology
+# --------------------------------------------------------------------------- #
+
+
+def test_is_subtype_hierarchy():
+    assert is_subtype(EntityType.PERSON, EntityType.ENTITY)
+    assert is_subtype(EntityType.METHOD, EntityType.CONCEPT)
+    assert is_subtype(EntityType.METHOD, EntityType.ENTITY)  # transitive
+    assert is_subtype(EntityType.CONCEPT, EntityType.CONCEPT)  # reflexive
+    assert not is_subtype(EntityType.PERSON, EntityType.ORGANIZATION)
+    assert not is_subtype(EntityType.ENTITY, EntityType.PERSON)
+
+
+@pytest.mark.parametrize(
+    "relation,subj,obj",
+    [
+        (RelationType.AUTHORED_BY, EntityType.DOCUMENT, EntityType.PERSON),
+        (RelationType.AUTHORED_BY, EntityType.DOCUMENT, EntityType.ORGANIZATION),
+        (RelationType.CITES, EntityType.DOCUMENT, EntityType.DOCUMENT),
+        (RelationType.DEFINES, EntityType.DOCUMENT, EntityType.CONCEPT),
+        (RelationType.MENTIONS, EntityType.DOCUMENT, EntityType.PERSON),  # subtype of Entity
+        (RelationType.INSTANCE_OF, EntityType.PERSON, EntityType.CONCEPT),
+        (RelationType.INSTANCE_OF, EntityType.METHOD, EntityType.CONCEPT),
+        (RelationType.SUPPORTS, EntityType.CLAIM, EntityType.CLAIM),
+        (RelationType.CONTRADICTS, EntityType.DOCUMENT, EntityType.CLAIM),
+        (RelationType.PART_OF, EntityType.CONCEPT, EntityType.CONCEPT),
+    ],
+)
+def test_valid_relations(relation, subj, obj):
+    assert is_valid_relation(relation, subj, obj)
+
+
+@pytest.mark.parametrize(
+    "relation,subj,obj",
+    [
+        (RelationType.CITES, EntityType.PERSON, EntityType.DOCUMENT),
+        (RelationType.AUTHORED_BY, EntityType.DOCUMENT, EntityType.DOCUMENT),
+        (RelationType.DEFINES, EntityType.PERSON, EntityType.CONCEPT),
+        (RelationType.SUPPORTS, EntityType.PERSON, EntityType.CLAIM),
+        (RelationType.PART_OF, EntityType.CONCEPT, EntityType.DOCUMENT),
+    ],
+)
+def test_invalid_relations_raise(relation, subj, obj):
+    assert not is_valid_relation(relation, subj, obj)
+    with pytest.raises(OntologyViolation):
+        validate_relation(relation, subj, obj)
+
+
+# --------------------------------------------------------------------------- #
+# Model
+# --------------------------------------------------------------------------- #
+
+
+def test_node_id_is_deterministic_and_type_aware():
+    a = Node(type=EntityType.CONCEPT, name="Knowledge Graph")
+    b = Node(type=EntityType.CONCEPT, name="  knowledge   graph ")
+    assert a.node_id == b.node_id == make_node_id(EntityType.CONCEPT, "knowledge graph")
+    # Same name, different type -> different node.
+    assert Node(type=EntityType.PERSON, name="Knowledge Graph").node_id != a.node_id
+
+
+def test_provenance_requires_source_and_valid_confidence():
+    with pytest.raises(ValueError):
+        Provenance(source_doc="")
+    with pytest.raises(ValueError):
+        Provenance(source_doc="doc-1", confidence=1.5)
+    p = Provenance(source_doc="doc-1", confidence=0.9, chunk_id="c3", extractor="rules")
+    assert p.to_dict()["chunk_id"] == "c3"
+
+
+def test_triple_requires_provenance_and_carries_properties():
+    with pytest.raises(TypeError):
+        Triple("a", RelationType.CITES, "b", provenance={"source_doc": "x"})
+    t = Triple(
+        "doc:1",
+        RelationType.CITES,
+        "doc:2",
+        provenance=Provenance(source_doc="doc:1", confidence=1.0),
+        properties={"year": 2023, "context": "as shown in"},
+    )
+    assert t.key == ("doc:1", "CITES", "doc:2")
+    assert t.properties["year"] == 2023
+
+
+# --------------------------------------------------------------------------- #
+# Store
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def store():
+    return KnowledgeGraphStore()
+
+
+def _doc(store, name):
+    return store.add_node(Node(type=EntityType.DOCUMENT, name=name))
+
+
+def test_store_rejects_triple_with_unknown_nodes(store):
+    paper = _doc(store, "Paper A")
+    t = Triple(
+        paper.node_id,
+        RelationType.CITES,
+        "doc:missing",
+        provenance=Provenance(source_doc=paper.node_id),
+    )
+    with pytest.raises(OntologyViolation):
+        store.add_triple(t)
+
+
+def test_store_enforces_ontology_on_write(store):
+    paper = _doc(store, "Paper A")
+    person = store.add_node(Node(type=EntityType.PERSON, name="Ada Lovelace"))
+    # Document CITES Person is not permitted.
+    bad = Triple(
+        paper.node_id,
+        RelationType.CITES,
+        person.node_id,
+        provenance=Provenance(source_doc=paper.node_id),
+    )
+    with pytest.raises(OntologyViolation):
+        store.add_triple(bad)
+
+
+def test_store_stores_cited_triples_and_accumulates_provenance(store):
+    a = _doc(store, "Paper A")
+    b = _doc(store, "Paper B")
+    t1 = Triple(a.node_id, RelationType.CITES, b.node_id,
+                provenance=Provenance(source_doc=a.node_id, confidence=0.7, chunk_id="c1"))
+    store.add_triple(t1)
+    # Re-assert the same fact from another location with higher confidence.
+    t2 = Triple(a.node_id, RelationType.CITES, b.node_id,
+                provenance=Provenance(source_doc=a.node_id, confidence=0.95, chunk_id="c2"),
+                properties={"year": 2024})
+    stored = store.add_triple(t2)
+
+    assert store.triple_count == 1  # same fact, not duplicated
+    assert len(store.provenance_for(stored)) == 2  # both citations retained
+    assert stored.provenance.confidence == 0.95  # representative = highest confidence
+    assert stored.properties["year"] == 2024  # reified edge property merged
+
+
+def test_store_recenters_on_concepts_and_claims(store):
+    """Documents are anchors; concepts/claims are the knowledge, all cited."""
+    paper = _doc(store, "Attention Is All You Need")
+    concept = store.add_node(Node(type=EntityType.CONCEPT, name="Transformer"))
+    claim = store.add_node(Node(type=EntityType.CLAIM, name="Attention outperforms recurrence"))
+
+    prov = Provenance(source_doc=paper.node_id, confidence=0.9, chunk_id="abstract")
+    store.add_triple(Triple(paper.node_id, RelationType.DEFINES, concept.node_id, provenance=prov))
+    store.add_triple(Triple(paper.node_id, RelationType.SUPPORTS, claim.node_id, provenance=prov))
+    store.add_triple(Triple(paper.node_id, RelationType.MENTIONS, concept.node_id, provenance=prov))
+
+    assert store.node_count == 3
+    assert store.triple_count == 3
+    # Every fact about the concept is cited back to a document anchor.
+    for t in store.neighbors(concept.node_id):
+        assert t.provenance.source_doc == paper.node_id
+    assert len(store.triples(predicate=RelationType.DEFINES)) == 1
+    assert len(store.nodes_by_type(EntityType.CLAIM)) == 1
+
+
+def test_store_add_node_merges_aliases_not_type(store):
+    store.add_node(Node(type=EntityType.PERSON, name="Hinton", aliases=["G. Hinton"]))
+    merged = store.add_node(Node(type=EntityType.PERSON, name="Hinton", aliases=["Geoffrey Hinton"]))
+    assert set(merged.aliases) == {"G. Hinton", "Geoffrey Hinton"}
+    # Same id but conflicting type is rejected.
+    bad = Node(type=EntityType.ORGANIZATION, name="Hinton")
+    bad.node_id = merged.node_id
+    with pytest.raises(OntologyViolation):
+        store.add_node(bad)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

Replaces the implicit, untyped entity-relationship graph with a real knowledge graph. Today's `src/knowledge_graph/` stores news `Article` vertices with edges inferred by co-occurrence, no ontology, and no provenance. This adds a typed foundation so the graph becomes a database of cited facts centered on concepts and claims.

Depends only on the document model already merged in #526; independent of the connector framework in #527.

## What changed

New package `src/knowledge_graph/foundation/`:

- **`ontology.py`**: `EntityType` with an is-a hierarchy rooted at `Entity` (`Person`, `Organization`, `Concept`, `Document`, `Claim`, `Method` as a kind of `Concept`, `Dataset`), `RelationType` (`AUTHORED_BY`, `CITES`, `INSTANCE_OF`, `PART_OF`, `DEFINES`, `SUPPORTS`, `CONTRADICTS`, `MENTIONS`), and subtype-aware domain/range constraints (`is_valid_relation`, `validate_relation`).
- **`model.py`**: `Node`, `Provenance` (required on every fact: `source_doc`, `chunk_id`, `confidence`, `extractor`), and `Triple`, a reified provenance-bearing edge that carries arbitrary properties such as `CITES.year`.
- **`store.py`**: `KnowledgeGraphStore`, an in-memory, backend-agnostic store that enforces the ontology on every write, requires both endpoints to exist, and accumulates provenance when a fact is re-asserted. Re-centered on `Concept`/`Claim` nodes with `Document` nodes as anchors.

## Re-centering

The graph's center of gravity moves from document vertices to the knowledge itself: `Document` nodes are anchors (where a fact was asserted), while `Concept` and `Claim` nodes carry the knowledge, and every triple cites back to a document.

## Testing

- PASS: `tests/knowledge_graph/test_kg_foundation.py`, 24 tests: ontology subtype hierarchy, valid and invalid relation constraints, deterministic type-aware node ids, provenance requirements, reified edge properties, ontology enforcement on write, cited-triple storage, provenance accumulation, and the concept/claim re-centering example.

## Exit criteria (per #515): met

- Facts stored as cited triples.
- Ontology validates entity and relation types.

## Scope boundaries

- Entity resolution is tracked in #516 (`make_node_id` here is a stable surrogate key, not resolution).
- Claim extraction that populates `Claim` nodes is tracked in #519.
- A persistent Gremlin/Neptune-backed store implementation will follow; the interface is backend-agnostic.

## Next on the critical path

Entity resolution (#516).