### PR TITLE
Entity resolution (#516)

### DIFF
--- a/src/knowledge_graph/foundation/README.md
+++ b/src/knowledge_graph/foundation/README.md
@@ -28,6 +28,34 @@ Part of the knowledge-engine pivot; see
   ontology, requires both endpoints to exist, and accumulates provenance when a
   fact is re-asserted. The interface is backend-agnostic so a Gremlin/Neptune
   implementation can follow without changing callers.
+- `resolution.py`: `EntityResolver` assigns canonical entity ids so different
+  surface forms of one entity collapse into a single node, and
+  `canonicalize_store` backfills an existing store (merging duplicate nodes and
+  rewriting triples to canonical ids).
+
+## Entity resolution
+
+`EntityResolver` matches a candidate against existing canonical entities of the
+same type, in order:
+
+1. **Alias index** exact match on the normalized surface form.
+2. **Name-aware matching** for people: same surname with compatible given names,
+   so "Hinton", "Geoffrey Hinton", and "G. Hinton" resolve together while
+   "John Smith" and "Jane Smith" stay apart.
+3. **Generic fuzzy/containment** matching (token containment or
+   `SequenceMatcher` ratio above a threshold), handling organization suffixes
+   ("OpenAI" / "OpenAI Inc." / "Open AI") and plurals ("Transformer" /
+   "Transformers").
+4. **Embedding similarity** fallback when an `embedder` is supplied, catching
+   lexically distant aliases ("NYC" / "New York City").
+
+```python
+from src.knowledge_graph.foundation import EntityResolver, EntityType
+
+r = EntityResolver()
+r.resolve(EntityType.PERSON, "Hinton")
+r.resolve(EntityType.PERSON, "Geoffrey Hinton")  # same canonical node
+```
 
 ## Ontology
 

--- a/src/knowledge_graph/foundation/__init__.py
+++ b/src/knowledge_graph/foundation/__init__.py
@@ -23,9 +23,15 @@ from src.knowledge_graph.foundation.ontology import (
     is_valid_relation,
     validate_relation,
 )
+from src.knowledge_graph.foundation.resolution import (
+    EntityResolver,
+    canonicalize_store,
+)
 from src.knowledge_graph.foundation.store import KnowledgeGraphStore
 
 __all__ = [
+    "EntityResolver",
+    "canonicalize_store",
     "EntityType",
     "RelationType",
     "OntologyViolation",

--- a/src/knowledge_graph/foundation/resolution.py
+++ b/src/knowledge_graph/foundation/resolution.py
@@ -1,0 +1,264 @@
+"""
+Entity resolution: collapse different surface forms of the same real-world
+entity into one canonical knowledge-graph node.
+
+Without this, "Geoffrey Hinton", "Hinton", and "G. Hinton" become three nodes
+and the graph fragments. The resolver assigns canonical entity ids that survive
+across documents, using (in order) an alias index, name-aware matching for
+people, generic fuzzy/containment matching, and an optional embedding
+similarity fallback. It can also backfill an existing store, merging duplicate
+nodes and rewriting triples to canonical ids.
+
+See ``docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from difflib import SequenceMatcher
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from src.knowledge_graph.foundation.model import Node, Triple, make_node_id
+from src.knowledge_graph.foundation.ontology import EntityType
+from src.knowledge_graph.foundation.store import KnowledgeGraphStore
+
+Embedder = Callable[[str], Sequence[float]]
+
+_ORG_SUFFIX = re.compile(
+    r"\b(inc|llc|corp|corporation|ltd|co|company|plc|gmbh|sa|ag)\b", re.IGNORECASE
+)
+
+
+def _normalize_name(entity_type: EntityType, name: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace; drop org suffixes."""
+    text = (name or "").lower()
+    if entity_type == EntityType.ORGANIZATION:
+        text = _ORG_SUFFIX.sub(" ", text)
+    text = re.sub(r"[^\w\s]", " ", text)  # punctuation -> space (so "g." -> "g")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _token_compatible(x: str, y: str) -> bool:
+    """Two name tokens match if equal or one is an initial of the other."""
+    if x == y:
+        return True
+    if len(x) == 1 and y.startswith(x):
+        return True
+    if len(y) == 1 and x.startswith(y):
+        return True
+    return False
+
+
+def _person_compatible(a_norm: str, b_norm: str) -> bool:
+    """Name-aware match for people: same surname, compatible given names.
+
+    Handles surname-only ("Hinton"), initials ("G. Hinton"), and full names
+    ("Geoffrey Hinton") resolving together, while keeping different surnames
+    ("John Smith" vs "Jane Smith") apart.
+    """
+    ta, tb = a_norm.split(), b_norm.split()
+    if not ta or not tb:
+        return False
+    if ta[-1] != tb[-1]:  # surnames must match
+        return False
+    given_a, given_b = ta[:-1], tb[:-1]
+    shorter, longer = (given_a, given_b) if len(given_a) <= len(given_b) else (given_b, given_a)
+    used = [False] * len(longer)
+    for tok in shorter:
+        for i, other in enumerate(longer):
+            if not used[i] and _token_compatible(tok, other):
+                used[i] = True
+                break
+        else:
+            return False
+    return True
+
+
+def _ratio(a: str, b: str) -> float:
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _cosine(u: Sequence[float], v: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(u, v))
+    nu = math.sqrt(sum(x * x for x in u))
+    nv = math.sqrt(sum(y * y for y in v))
+    if nu == 0 or nv == 0:
+        return 0.0
+    return dot / (nu * nv)
+
+
+class EntityResolver:
+    """Assigns canonical entity ids, merging surface variants of one entity."""
+
+    def __init__(
+        self,
+        similarity_threshold: float = 0.88,
+        embedder: Optional[Embedder] = None,
+        embedding_threshold: float = 0.83,
+    ):
+        self.similarity_threshold = similarity_threshold
+        self.embedder = embedder
+        self.embedding_threshold = embedding_threshold
+        # canonical node_id -> Node
+        self._canonical: Dict[str, Node] = {}
+        # (type, normalized surface form) -> canonical node_id
+        self._exact: Dict[Tuple[EntityType, str], str] = {}
+        # type -> list of canonical node_ids (fuzzy scan space)
+        self._by_type: Dict[EntityType, List[str]] = {}
+        self._embedding_cache: Dict[str, Sequence[float]] = {}
+
+    # ---- public API ----------------------------------------------------- #
+
+    def resolve(
+        self,
+        entity_type: EntityType,
+        name: str,
+        aliases: Optional[Sequence[str]] = None,
+        properties: Optional[dict] = None,
+    ) -> Node:
+        """Return the canonical Node for ``name``, creating it if new.
+
+        The surface form (and any provided aliases) are registered on the
+        canonical node so future variants resolve to the same id.
+        """
+        if not isinstance(entity_type, EntityType):
+            entity_type = EntityType(entity_type)
+        norm = _normalize_name(entity_type, name)
+        surfaces = [name] + list(aliases or [])
+
+        match = self._find_match(entity_type, name, norm)
+        if match is not None:
+            self._register(match, entity_type, surfaces)
+            # Prefer the most complete surface form as the display name.
+            if len(name.split()) > len(match.name.split()):
+                match.name = name
+            if properties:
+                match.properties.update(properties)
+            return match
+
+        canonical = Node(
+            type=entity_type,
+            name=name,
+            aliases=list(dict.fromkeys(surfaces)),
+            properties=dict(properties or {}),
+        )
+        self._canonical[canonical.node_id] = canonical
+        self._by_type.setdefault(entity_type, []).append(canonical.node_id)
+        self._register(canonical, entity_type, surfaces)
+        return canonical
+
+    @property
+    def canonical_nodes(self) -> List[Node]:
+        return list(self._canonical.values())
+
+    def canonical_count(self, entity_type: Optional[EntityType] = None) -> int:
+        if entity_type is None:
+            return len(self._canonical)
+        return len(self._by_type.get(entity_type, []))
+
+    # ---- matching ------------------------------------------------------- #
+
+    def _find_match(self, entity_type: EntityType, name: str, norm: str) -> Optional[Node]:
+        if not norm:
+            return None
+        exact_id = self._exact.get((entity_type, norm))
+        if exact_id is not None:
+            return self._canonical[exact_id]
+
+        best: Optional[Node] = None
+        best_score = 0.0
+        for node_id in self._by_type.get(entity_type, []):
+            cand = self._canonical[node_id]
+            cand_forms = [cand.name] + cand.aliases
+            cand_norms = {_normalize_name(entity_type, f) for f in cand_forms}
+
+            if entity_type in (EntityType.PERSON,):
+                if any(_person_compatible(norm, cn) for cn in cand_norms):
+                    return cand
+                continue
+
+            for cn in cand_norms:
+                if not cn:
+                    continue
+                if self._token_containment(norm, cn):
+                    return cand
+                score = _ratio(norm, cn)
+                if score > best_score:
+                    best, best_score = cand, score
+
+        if best is not None and best_score >= self.similarity_threshold:
+            return best
+
+        if self.embedder is not None:
+            return self._embedding_match(entity_type, name)
+        return None
+
+    @staticmethod
+    def _token_containment(a: str, b: str) -> bool:
+        ta, tb = set(a.split()), set(b.split())
+        if not ta or not tb:
+            return False
+        return ta <= tb or tb <= ta
+
+    def _embedding_match(self, entity_type: EntityType, name: str) -> Optional[Node]:
+        vec = self._embed(name)
+        best: Optional[Node] = None
+        best_sim = 0.0
+        for node_id in self._by_type.get(entity_type, []):
+            cand = self._canonical[node_id]
+            sim = _cosine(vec, self._embed(cand.name))
+            if sim > best_sim:
+                best, best_sim = cand, sim
+        if best is not None and best_sim >= self.embedding_threshold:
+            return best
+        return None
+
+    def _embed(self, name: str) -> Sequence[float]:
+        if name not in self._embedding_cache:
+            self._embedding_cache[name] = self.embedder(name)
+        return self._embedding_cache[name]
+
+    def _register(self, canonical: Node, entity_type: EntityType, surfaces: Sequence[str]) -> None:
+        for surface in surfaces:
+            if surface and surface not in canonical.aliases:
+                canonical.aliases.append(surface)
+            self._exact[(entity_type, _normalize_name(entity_type, surface))] = canonical.node_id
+
+
+def canonicalize_store(
+    store: KnowledgeGraphStore,
+    resolver: Optional[EntityResolver] = None,
+    embedder: Optional[Embedder] = None,
+) -> Tuple[KnowledgeGraphStore, Dict[str, str]]:
+    """Backfill an existing store: merge duplicate nodes, remap triples.
+
+    Returns a new canonicalized store plus an ``old_id -> canonical_id`` map.
+    Re-asserted facts merge (accumulating provenance); triples that collapse to
+    a self-loop after merging are dropped.
+    """
+    resolver = resolver or EntityResolver(embedder=embedder)
+    new_store = KnowledgeGraphStore()
+    id_map: Dict[str, str] = {}
+
+    # Resolve every existing node to a canonical node.
+    for entity_type in EntityType:
+        for node in store.nodes_by_type(entity_type):
+            canonical = resolver.resolve(node.type, node.name, node.aliases, node.properties)
+            id_map[node.node_id] = canonical.node_id
+
+    for canonical in resolver.canonical_nodes:
+        new_store.add_node(canonical)
+
+    # Remap and re-add triples with their original provenance/properties.
+    for triple in store.triples():
+        subj = id_map.get(triple.subject, triple.subject)
+        obj = id_map.get(triple.object, triple.object)
+        if subj == obj:
+            continue
+        for prov in store.provenance_for(triple):
+            new_store.add_triple(
+                Triple(subj, triple.predicate, obj, provenance=prov, properties=dict(triple.properties))
+            )
+
+    return new_store, id_map

--- a/tests/knowledge_graph/test_entity_resolution.py
+++ b/tests/knowledge_graph/test_entity_resolution.py
@@ -1,0 +1,153 @@
+"""
+Tests for entity resolution (#516).
+
+Covers the exit criterion ("Geoffrey Hinton" / "Hinton" / "G. Hinton" resolve to
+one canonical node) plus organization/concept fuzzy matching, an optional
+embedding fallback, guarding against over-merging, and store backfill that
+merges duplicate nodes and rewrites triples to canonical ids.
+"""
+
+import pytest
+
+from src.knowledge_graph.foundation import (
+    EntityResolver,
+    EntityType,
+    KnowledgeGraphStore,
+    Node,
+    Provenance,
+    RelationType,
+    Triple,
+    canonicalize_store,
+)
+
+
+# --------------------------------------------------------------------------- #
+# People
+# --------------------------------------------------------------------------- #
+
+
+def test_person_variants_resolve_to_one_node():
+    r = EntityResolver()
+    a = r.resolve(EntityType.PERSON, "Hinton")
+    b = r.resolve(EntityType.PERSON, "Geoffrey Hinton")
+    c = r.resolve(EntityType.PERSON, "G. Hinton")
+
+    assert a.node_id == b.node_id == c.node_id
+    assert r.canonical_count(EntityType.PERSON) == 1
+    # The most complete surface form becomes the display name; all are aliases.
+    assert b.name == "Geoffrey Hinton"
+    assert {"Hinton", "Geoffrey Hinton", "G. Hinton"} <= set(a.aliases)
+
+
+def test_different_surnames_not_merged():
+    r = EntityResolver()
+    s1 = r.resolve(EntityType.PERSON, "John Smith")
+    s2 = r.resolve(EntityType.PERSON, "Jane Smith")
+    assert s1.node_id != s2.node_id
+    assert r.canonical_count(EntityType.PERSON) == 2
+
+
+def test_same_surname_incompatible_given_names_not_merged():
+    r = EntityResolver()
+    a = r.resolve(EntityType.PERSON, "Geoffrey Hinton")
+    b = r.resolve(EntityType.PERSON, "Martin Hinton")
+    assert a.node_id != b.node_id
+
+
+# --------------------------------------------------------------------------- #
+# Organizations / concepts (fuzzy + containment + suffix)
+# --------------------------------------------------------------------------- #
+
+
+def test_org_suffix_and_spacing_variants_merge():
+    r = EntityResolver()
+    a = r.resolve(EntityType.ORGANIZATION, "OpenAI")
+    b = r.resolve(EntityType.ORGANIZATION, "OpenAI Inc.")
+    c = r.resolve(EntityType.ORGANIZATION, "Open AI")
+    assert a.node_id == b.node_id == c.node_id
+    assert r.canonical_count(EntityType.ORGANIZATION) == 1
+
+
+def test_concept_plural_merges_but_distinct_stays_separate():
+    r = EntityResolver()
+    t1 = r.resolve(EntityType.CONCEPT, "Transformer")
+    t2 = r.resolve(EntityType.CONCEPT, "Transformers")
+    other = r.resolve(EntityType.CONCEPT, "Recurrent Neural Network")
+    assert t1.node_id == t2.node_id
+    assert other.node_id != t1.node_id
+    assert r.canonical_count(EntityType.CONCEPT) == 2
+
+
+def test_same_name_different_type_not_merged():
+    r = EntityResolver()
+    person = r.resolve(EntityType.PERSON, "Apple")  # a person named Apple
+    org = r.resolve(EntityType.ORGANIZATION, "Apple")
+    assert person.node_id != org.node_id
+
+
+# --------------------------------------------------------------------------- #
+# Embedding fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_embedding_fallback_merges_lexically_distant_names():
+    # Lexically these never match; the embedder says they are the same.
+    vectors = {
+        "New York City": [1.0, 0.0, 0.0],
+        "NYC": [0.99, 0.01, 0.0],
+        "Los Angeles": [0.0, 1.0, 0.0],
+    }
+    r = EntityResolver(embedder=lambda name: vectors[name])
+    a = r.resolve(EntityType.CONCEPT, "New York City")
+    b = r.resolve(EntityType.CONCEPT, "NYC")
+    c = r.resolve(EntityType.CONCEPT, "Los Angeles")
+    assert a.node_id == b.node_id
+    assert c.node_id != a.node_id
+
+
+# --------------------------------------------------------------------------- #
+# Store backfill
+# --------------------------------------------------------------------------- #
+
+
+def test_canonicalize_store_merges_nodes_and_remaps_triples():
+    store = KnowledgeGraphStore()
+    paper = store.add_node(Node(EntityType.DOCUMENT, "Deep Learning Review"))
+    hinton = store.add_node(Node(EntityType.PERSON, "Hinton"))
+    geoff = store.add_node(Node(EntityType.PERSON, "Geoffrey Hinton"))
+    assert hinton.node_id != geoff.node_id  # two fragments before resolution
+
+    prov = Provenance(source_doc=paper.node_id, confidence=0.9, chunk_id="c1")
+    store.add_triple(Triple(paper.node_id, RelationType.AUTHORED_BY, hinton.node_id, provenance=prov))
+    store.add_triple(Triple(paper.node_id, RelationType.MENTIONS, geoff.node_id, provenance=prov))
+
+    new_store, id_map = canonicalize_store(store)
+
+    # The two person fragments collapse into one canonical node.
+    assert len(new_store.nodes_by_type(EntityType.PERSON)) == 1
+    assert id_map[hinton.node_id] == id_map[geoff.node_id]
+    # Both triples survive, now pointing at the canonical person.
+    canonical_person = id_map[hinton.node_id]
+    assert len(new_store.triples(object=canonical_person)) == 2
+    assert new_store.node_count == 2  # one document + one person
+
+
+def test_canonicalize_store_accumulates_provenance_on_merged_facts():
+    store = KnowledgeGraphStore()
+    a = store.add_node(Node(EntityType.DOCUMENT, "Paper"))
+    concept1 = store.add_node(Node(EntityType.CONCEPT, "Transformer"))
+    concept2 = store.add_node(Node(EntityType.CONCEPT, "Transformers"))
+
+    store.add_triple(Triple(a.node_id, RelationType.DEFINES, concept1.node_id,
+                            provenance=Provenance(source_doc=a.node_id, confidence=0.8, chunk_id="x")))
+    store.add_triple(Triple(a.node_id, RelationType.DEFINES, concept2.node_id,
+                            provenance=Provenance(source_doc=a.node_id, confidence=0.6, chunk_id="y")))
+
+    new_store, _ = canonicalize_store(store)
+    defines = new_store.triples(predicate=RelationType.DEFINES)
+    assert len(defines) == 1  # both DEFINES facts collapse to one
+    assert len(new_store.provenance_for(defines[0])) == 2  # provenance retained
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

Adds entity resolution on top of the knowledge graph foundation (#515, merged): collapse different surface forms of the same real-world entity into one canonical node so the graph does not fragment across documents.

## What changed

- **`src/knowledge_graph/foundation/resolution.py`**:
  - `EntityResolver` matches a candidate against existing canonical entities of the same type, in order:
    1. Alias index exact match on the normalized surface form.
    2. Name-aware matching for people: same surname with compatible given names/initials, so "Hinton", "Geoffrey Hinton", and "G. Hinton" resolve together while "John Smith" and "Jane Smith" stay apart.
    3. Generic fuzzy/containment matching (token containment or `SequenceMatcher` ratio above threshold), handling organization suffixes ("OpenAI" / "OpenAI Inc." / "Open AI") and plurals ("Transformer" / "Transformers").
    4. Optional embedding-similarity fallback when an `embedder` is supplied, catching lexically distant aliases ("NYC" / "New York City").
  - `canonicalize_store` backfills an existing store: merges duplicate nodes and remaps triples to canonical ids, dropping self-loops and accumulating provenance on collapsed facts.
- stdlib-only (`difflib` + `math`); the embedder is injectable, so no model dependency is required.

## Testing

- PASS: `tests/knowledge_graph/test_entity_resolution.py`, 9 tests: person/org/concept merging, over-merge guards (different surnames, same name different type), embedding fallback, and store backfill with provenance accumulation.
- PASS: full knowledge graph and connector suites still green (42 tests).

## Exit criteria (per #516): met

- "Geoffrey Hinton" / "Hinton" / "G. Hinton" resolve to one canonical node.
- Canonical entity ids survive across documents.
- Existing nodes can be backfilled to canonical ids.

## Next on the critical path

Papers connector and citation graph (#517).