### PR TITLE
Papers connector and citation graph (#517)

### DIFF
--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -15,8 +15,9 @@ from src.ingestion.connectors.registry import (
     register_connector,
 )
 
-# Importing the module triggers @register_connector for the built-in connectors.
+# Importing the modules triggers @register_connector for the built-in connectors.
 from src.ingestion.connectors import news  # noqa: E402,F401
+from src.ingestion.connectors import paper  # noqa: E402,F401
 
 __all__ = [
     "Connector",

--- a/src/ingestion/connectors/paper/README.md
+++ b/src/ingestion/connectors/paper/README.md
@@ -1,0 +1,53 @@
+# Papers connector
+
+Ingests academic papers (arXiv) as `document-ingest-v1` records and into the
+knowledge graph, turning a paper's references into first-class `CITES` edges.
+First end-to-end source type of the knowledge-engine pivot; see
+`docs/architecture/KNOWLEDGE_ENGINE_PIVOT_PLAN.md`.
+
+## Modules
+
+- `models.py`: `PaperMetadata` and `Reference`, plus `paper_id` (stable document
+  id preferring arXiv id, then DOI, then a title hash, so a paper and the papers
+  that cite it line up).
+- `arxiv.py`: `ArxivClient` (HTTP injectable) and `parse_atom` for the arXiv
+  Atom API.
+- `references.py`: reference providers. arXiv does not expose a reference list,
+  so citations come from a Semantic-Scholar-style API (`SemanticScholarReferences`,
+  HTTP injectable) or a `StaticReferencesProvider` for tests/offline use.
+- `pdf_parser.py`: best-effort PDF text + section outline. Uses PyMuPDF when
+  installed and degrades gracefully when not; `split_sections` is pure and
+  dependency-free. GROBID can be slotted in here later for higher-fidelity
+  structure.
+- `citation_graph.py`: `build_citation_graph` adds the paper, `AUTHORED_BY`
+  edges to resolved Person nodes, and `CITES` edges to each referenced work.
+- `connector.py`: `PaperConnector` implementing the connector interface plus
+  `ingest_to_kg`.
+
+## Usage
+
+```python
+from src.ingestion.connectors import get_connector
+from src.knowledge_graph.foundation import KnowledgeGraphStore
+
+connector = get_connector("paper")          # network-backed by default
+
+# As documents (document-ingest-v1):
+for document in connector.harvest("1706.03762"):
+    ...
+
+# Into the knowledge graph (references -> CITES edges):
+store = KnowledgeGraphStore()
+paper_node = connector.ingest_to_kg(store, "1706.03762")
+cites = store.triples(subject=paper_node.node_id)
+```
+
+For offline use or tests, inject an `ArxivClient(http_get=...)` and a
+`StaticReferencesProvider`.
+
+## Scope / follow-ups
+
+- Reference extraction uses the metadata API rather than parsing the PDF; a
+  GROBID-backed `pdf_parser` path can supplement it.
+- PubMed/Crossref discovery and PDF-to-object-storage upload are planned
+  extensions of this connector.

--- a/src/ingestion/connectors/paper/__init__.py
+++ b/src/ingestion/connectors/paper/__init__.py
@@ -1,0 +1,34 @@
+"""
+Papers connector: arXiv ingestion, PDF parsing, and citation-graph construction.
+
+Importing this package registers the ``paper`` connector.
+"""
+
+from src.ingestion.connectors.paper.arxiv import ArxivClient, parse_atom
+from src.ingestion.connectors.paper.citation_graph import build_citation_graph
+from src.ingestion.connectors.paper.connector import (
+    PaperConnector,
+    paper_metadata_to_document,
+)
+from src.ingestion.connectors.paper.models import PaperMetadata, Reference, paper_id
+from src.ingestion.connectors.paper.references import (
+    ReferencesProvider,
+    SemanticScholarReferences,
+    StaticReferencesProvider,
+    parse_s2_references,
+)
+
+__all__ = [
+    "ArxivClient",
+    "parse_atom",
+    "PaperConnector",
+    "paper_metadata_to_document",
+    "build_citation_graph",
+    "PaperMetadata",
+    "Reference",
+    "paper_id",
+    "ReferencesProvider",
+    "StaticReferencesProvider",
+    "SemanticScholarReferences",
+    "parse_s2_references",
+]

--- a/src/ingestion/connectors/paper/arxiv.py
+++ b/src/ingestion/connectors/paper/arxiv.py
@@ -1,0 +1,113 @@
+"""
+arXiv discovery and metadata parsing.
+
+Fetches paper metadata from the arXiv Atom API and parses it into
+``PaperMetadata``. The HTTP layer is injectable so callers (and tests) can
+supply recorded responses instead of hitting the network.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+import xml.etree.ElementTree as ET
+
+from src.ingestion.connectors.paper.models import PaperMetadata
+
+_ATOM = "{http://www.w3.org/2005/Atom}"
+_ARXIV = "{http://arxiv.org/schemas/atom}"
+
+ARXIV_API = "http://export.arxiv.org/api/query"
+USER_AGENT = "NeuroNewsBot/1.0 (+https://github.com/Ikey168/NeuroNews)"
+HTTP_TIMEOUT = 20
+
+HttpGet = Callable[[str], bytes]
+
+
+def _default_http_get(url: str) -> bytes:
+    from urllib.request import Request, urlopen
+
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _strip_version(arxiv_id: str) -> str:
+    """Drop a trailing version suffix, e.g. ``1706.03762v7`` -> ``1706.03762``."""
+    return re.sub(r"v\d+$", "", arxiv_id.strip())
+
+
+def _parse_date(raw: Optional[str]) -> Optional[datetime]:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def parse_atom(xml_bytes: bytes) -> List[PaperMetadata]:
+    """Parse an arXiv Atom API response into one PaperMetadata per entry."""
+    root = ET.fromstring(xml_bytes)
+    papers: List[PaperMetadata] = []
+
+    for entry in root.findall(f"{_ATOM}entry"):
+        raw_id = (entry.findtext(f"{_ATOM}id") or "").strip()
+        arxiv_id = None
+        if "/abs/" in raw_id:
+            arxiv_id = _strip_version(raw_id.rsplit("/abs/", 1)[1])
+
+        title = re.sub(r"\s+", " ", (entry.findtext(f"{_ATOM}title") or "").strip())
+        abstract = re.sub(r"\s+", " ", (entry.findtext(f"{_ATOM}summary") or "").strip())
+        authors = [
+            (a.findtext(f"{_ATOM}name") or "").strip()
+            for a in entry.findall(f"{_ATOM}author")
+            if (a.findtext(f"{_ATOM}name") or "").strip()
+        ]
+
+        doi = entry.findtext(f"{_ARXIV}doi")
+        primary_el = entry.find(f"{_ARXIV}primary_category")
+        primary_category = primary_el.get("term") if primary_el is not None else None
+        categories = [
+            c.get("term") for c in entry.findall(f"{_ATOM}category") if c.get("term")
+        ]
+
+        pdf_url = None
+        for link in entry.findall(f"{_ATOM}link"):
+            if link.get("type") == "application/pdf" or link.get("title") == "pdf":
+                pdf_url = link.get("href")
+                break
+
+        papers.append(
+            PaperMetadata(
+                title=title,
+                arxiv_id=arxiv_id,
+                doi=doi.strip() if doi else None,
+                authors=authors,
+                abstract=abstract,
+                categories=categories,
+                primary_category=primary_category,
+                published=_parse_date(entry.findtext(f"{_ATOM}published")),
+                pdf_url=pdf_url,
+            )
+        )
+    return papers
+
+
+class ArxivClient:
+    """Thin client for fetching arXiv metadata by id."""
+
+    def __init__(self, http_get: Optional[HttpGet] = None, api_url: str = ARXIV_API):
+        self._http_get = http_get or _default_http_get
+        self._api_url = api_url
+
+    def fetch_by_id(self, arxiv_id: str) -> bytes:
+        url = f"{self._api_url}?id_list={_strip_version(arxiv_id)}&max_results=1"
+        return self._http_get(url)
+
+    def get_metadata(self, arxiv_id: str) -> PaperMetadata:
+        papers = parse_atom(self.fetch_by_id(arxiv_id))
+        if not papers:
+            raise ValueError(f"No arXiv entry found for {arxiv_id!r}")
+        return papers[0]

--- a/src/ingestion/connectors/paper/citation_graph.py
+++ b/src/ingestion/connectors/paper/citation_graph.py
@@ -1,0 +1,70 @@
+"""
+Build the citation graph for a paper in the knowledge graph.
+
+Turns a ``PaperMetadata`` into knowledge-graph facts: a Document node for the
+paper, Document nodes for each cited work joined by first-class ``CITES`` edges,
+and ``AUTHORED_BY`` edges to resolved Person nodes. Every edge is cited back to
+the paper via provenance.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from src.ingestion.connectors.paper.models import PaperMetadata
+from src.knowledge_graph.foundation import (
+    EntityResolver,
+    EntityType,
+    KnowledgeGraphStore,
+    Node,
+    Provenance,
+    RelationType,
+    Triple,
+)
+
+EXTRACTOR = "paper-connector"
+
+
+def build_citation_graph(
+    store: KnowledgeGraphStore,
+    meta: PaperMetadata,
+    resolver: Optional[EntityResolver] = None,
+) -> Node:
+    """Add the paper, its authors, and its references to the knowledge graph.
+
+    Returns the paper's Document node. References become ``CITES`` edges
+    (Document -> Document); authors become ``AUTHORED_BY`` edges to canonical
+    Person nodes.
+    """
+    resolver = resolver or EntityResolver()
+
+    paper_node = store.add_node(
+        Node(EntityType.DOCUMENT, meta.title or meta.document_id, node_id=meta.document_id)
+    )
+    prov = Provenance(source_doc=meta.document_id, confidence=1.0, extractor=EXTRACTOR)
+
+    for name in meta.authors:
+        person = resolver.resolve(EntityType.PERSON, name)
+        store.add_node(person)
+        store.add_triple(
+            Triple(paper_node.node_id, RelationType.AUTHORED_BY, person.node_id, provenance=prov)
+        )
+
+    for ref in meta.references:
+        if ref.document_id == paper_node.node_id:
+            continue  # ignore self-citation
+        ref_node = store.add_node(
+            Node(EntityType.DOCUMENT, ref.title or ref.document_id, node_id=ref.document_id)
+        )
+        properties = {"year": ref.year} if ref.year else {}
+        store.add_triple(
+            Triple(
+                paper_node.node_id,
+                RelationType.CITES,
+                ref_node.node_id,
+                provenance=prov,
+                properties=properties,
+            )
+        )
+
+    return paper_node

--- a/src/ingestion/connectors/paper/connector.py
+++ b/src/ingestion/connectors/paper/connector.py
@@ -1,0 +1,119 @@
+"""
+Papers connector: ingest academic papers (arXiv) as documents and into the KG.
+
+Implements the connector interface (`discover` -> `fetch` -> `parse` ->
+`Document`) for `source_type="paper"`, and additionally exposes
+`ingest_to_kg`, which builds the citation graph (references as `CITES` edges,
+authors as `AUTHORED_BY` edges) for a paper.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Iterable, List, Optional, Union
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.paper.arxiv import ArxivClient, parse_atom
+from src.ingestion.connectors.paper.citation_graph import build_citation_graph
+from src.ingestion.connectors.paper.models import PaperMetadata
+from src.ingestion.connectors.paper.references import ReferencesProvider
+from src.ingestion.connectors.registry import register_connector
+from src.knowledge_graph.foundation import EntityResolver, KnowledgeGraphStore, Node
+
+
+def _to_millis(dt) -> Optional[int]:
+    return int(dt.timestamp() * 1000) if dt is not None else None
+
+
+def paper_metadata_to_document(meta: PaperMetadata, ingested_at: int) -> Document:
+    """Map paper metadata to a document-ingest-v1 record.
+
+    References are not embedded here (they live in the knowledge graph); only
+    lightweight, contract-valid scalars and string arrays go in ``metadata``.
+    """
+    metadata = {
+        "arxiv_id": meta.arxiv_id,
+        "doi": meta.doi,
+        "primary_category": meta.primary_category,
+        "categories": list(meta.categories),
+        "reference_count": len(meta.references),
+        "reference_ids": [r.document_id for r in meta.references],
+    }
+    metadata = {k: v for k, v in metadata.items() if v not in (None, [])}
+
+    url = f"https://arxiv.org/abs/{meta.arxiv_id}" if meta.arxiv_id else None
+    return Document(
+        document_id=meta.document_id,
+        source_type="paper",
+        language="en",
+        ingested_at=ingested_at,
+        source_id="arxiv" if meta.arxiv_id else None,
+        url=url,
+        title=meta.title,
+        content=meta.abstract or None,
+        content_ref=meta.pdf_url,
+        authors=list(meta.authors),
+        created_at=_to_millis(meta.published),
+        metadata=metadata,
+    )
+
+
+@register_connector
+class PaperConnector(Connector):
+    """Ingest academic papers from arXiv as documents and citation-graph facts."""
+
+    source_type = "paper"
+
+    def __init__(
+        self,
+        arxiv_client: Optional[ArxivClient] = None,
+        references_provider: Optional[ReferencesProvider] = None,
+        http_get=None,
+    ):
+        self._arxiv = arxiv_client or ArxivClient(http_get=http_get)
+        self._references = references_provider
+
+    def discover(self, query: Optional[Union[str, Iterable[str]]] = None) -> Iterable[SourceRef]:
+        """Yield a SourceRef per arXiv id. ``query`` is an id or list of ids."""
+        if query is None:
+            return
+        ids = [query] if isinstance(query, str) else list(query)
+        for arxiv_id in ids:
+            yield SourceRef(locator=arxiv_id, metadata={"arxiv_id": arxiv_id})
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        return RawDocument(
+            ref=ref,
+            content=self._arxiv.fetch_by_id(ref.locator),
+            content_type="application/atom+xml",
+        )
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        content = raw.content
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        documents = []
+        for meta in parse_atom(content):
+            if self._references is not None:
+                meta.references = self._references.references_for(meta)
+            documents.append(paper_metadata_to_document(meta, raw.fetched_at))
+        return documents
+
+    # ---- metadata + knowledge graph ------------------------------------ #
+
+    def metadata_for(self, arxiv_id: str) -> PaperMetadata:
+        """Fetch full metadata for a paper, including references if a provider is set."""
+        meta = self._arxiv.get_metadata(arxiv_id)
+        if self._references is not None:
+            meta.references = self._references.references_for(meta)
+        return meta
+
+    def ingest_to_kg(
+        self,
+        store: KnowledgeGraphStore,
+        arxiv_id: str,
+        resolver: Optional[EntityResolver] = None,
+    ) -> Node:
+        """Ingest a paper by id into the knowledge graph (references -> CITES)."""
+        return build_citation_graph(store, self.metadata_for(arxiv_id), resolver=resolver)

--- a/src/ingestion/connectors/paper/models.py
+++ b/src/ingestion/connectors/paper/models.py
@@ -1,0 +1,62 @@
+"""
+Data models for the papers connector: paper metadata and references.
+
+These are the connector's internal representation of an academic paper and its
+citations, independent of the document-ingest contract and the knowledge graph
+(both of which are produced from these).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+
+def paper_id(arxiv_id: Optional[str] = None, doi: Optional[str] = None, title: Optional[str] = None) -> str:
+    """Stable document id for a paper, preferring arXiv id, then DOI, then title.
+
+    The id is reused for both the document-ingest record and the knowledge-graph
+    Document node so a paper and the papers that cite it line up.
+    """
+    if arxiv_id:
+        return f"arxiv:{arxiv_id}"
+    if doi:
+        return f"doi:{doi.lower()}"
+    digest = hashlib.md5((title or "").strip().lower().encode()).hexdigest()[:12]
+    return f"paper:{digest}"
+
+
+@dataclass
+class Reference:
+    """A work cited by a paper."""
+
+    title: Optional[str] = None
+    arxiv_id: Optional[str] = None
+    doi: Optional[str] = None
+    year: Optional[int] = None
+
+    @property
+    def document_id(self) -> str:
+        return paper_id(self.arxiv_id, self.doi, self.title)
+
+
+@dataclass
+class PaperMetadata:
+    """Normalized metadata for a single academic paper."""
+
+    title: str
+    arxiv_id: Optional[str] = None
+    doi: Optional[str] = None
+    authors: List[str] = field(default_factory=list)
+    abstract: str = ""
+    categories: List[str] = field(default_factory=list)
+    primary_category: Optional[str] = None
+    published: Optional[datetime] = None
+    pdf_url: Optional[str] = None
+    references: List[Reference] = field(default_factory=list)
+
+    @property
+    def document_id(self) -> str:
+        return paper_id(self.arxiv_id, self.doi, self.title)

--- a/src/ingestion/connectors/paper/pdf_parser.py
+++ b/src/ingestion/connectors/paper/pdf_parser.py
@@ -1,0 +1,81 @@
+"""
+PDF parsing for papers.
+
+Best-effort extraction of plain text and a section outline from a paper PDF.
+Text extraction uses PyMuPDF (``fitz``) when installed and degrades gracefully
+when it is not. The reference list for the citation graph is sourced from the
+metadata API (see ``references.py``), not from PDF parsing; GROBID can be slotted
+in here later for higher-fidelity structure extraction.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# Common top-level section headings found in academic papers.
+_HEADING = re.compile(
+    r"^\s*(?:\d+\.?\s+)?("
+    r"abstract|introduction|background|related work|methods?|methodology|"
+    r"approach|experiments?|results?|evaluation|discussion|conclusions?|"
+    r"references|acknowledge?ments?|appendix"
+    r")\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class Section:
+    heading: str
+    body: str
+
+
+@dataclass
+class ParsedPdf:
+    text: str = ""
+    sections: List[Section] = field(default_factory=list)
+    extractor: str = "none"
+
+
+def split_sections(text: str) -> List[Section]:
+    """Split paper text into sections by recognized headings.
+
+    Pure and dependency-free, so it is testable without a PDF backend. Text
+    before the first recognized heading is captured under a ``preamble`` section.
+    """
+    sections: List[Section] = []
+    heading = "preamble"
+    buffer: List[str] = []
+
+    for line in text.splitlines():
+        match = _HEADING.match(line)
+        if match:
+            if buffer and any(b.strip() for b in buffer):
+                sections.append(Section(heading=heading, body="\n".join(buffer).strip()))
+            heading = match.group(1).strip().lower()
+            buffer = []
+        else:
+            buffer.append(line)
+
+    if buffer and any(b.strip() for b in buffer):
+        sections.append(Section(heading=heading, body="\n".join(buffer).strip()))
+    return sections
+
+
+def extract_pdf_text(pdf_bytes: bytes) -> Optional[str]:
+    """Extract plain text from PDF bytes using PyMuPDF, or None if unavailable."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        return None
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        return "\n".join(page.get_text() for page in doc)
+
+
+def parse_pdf(pdf_bytes: bytes) -> ParsedPdf:
+    """Parse PDF bytes into text plus a best-effort section outline."""
+    text = extract_pdf_text(pdf_bytes)
+    if text is None:
+        return ParsedPdf(extractor="none")
+    return ParsedPdf(text=text, sections=split_sections(text), extractor="pymupdf")

--- a/src/ingestion/connectors/paper/references.py
+++ b/src/ingestion/connectors/paper/references.py
@@ -1,0 +1,85 @@
+"""
+Reference (citation) providers.
+
+arXiv metadata does not include a paper's reference list, so references that
+become CITES edges are sourced separately. The default provider talks to a
+Semantic-Scholar-style API (HTTP injectable); a static provider is handy for
+tests and offline ingestion.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, List, Optional
+
+from src.ingestion.connectors.paper.models import PaperMetadata, Reference
+
+HttpGet = Callable[[str], bytes]
+
+
+class ReferencesProvider:
+    """Interface: given a paper, return the works it cites."""
+
+    def references_for(self, paper: PaperMetadata) -> List[Reference]:
+        raise NotImplementedError
+
+
+class StaticReferencesProvider(ReferencesProvider):
+    """Returns references from an in-memory map keyed by document id."""
+
+    def __init__(self, by_document_id: Optional[dict] = None):
+        self._by_id = by_document_id or {}
+
+    def references_for(self, paper: PaperMetadata) -> List[Reference]:
+        return list(self._by_id.get(paper.document_id, []))
+
+
+def parse_s2_references(payload: bytes | str | dict) -> List[Reference]:
+    """Parse a Semantic Scholar ``/paper/{id}/references`` response."""
+    if isinstance(payload, (bytes, str)):
+        data = json.loads(payload)
+    else:
+        data = payload
+
+    references: List[Reference] = []
+    for item in data.get("data", []):
+        cited = item.get("citedPaper") or {}
+        external = cited.get("externalIds") or {}
+        references.append(
+            Reference(
+                title=cited.get("title"),
+                arxiv_id=external.get("ArXiv"),
+                doi=external.get("DOI"),
+                year=cited.get("year"),
+            )
+        )
+    return references
+
+
+class SemanticScholarReferences(ReferencesProvider):
+    """Fetches references from the Semantic Scholar Graph API."""
+
+    API = "https://api.semanticscholar.org/graph/v1"
+
+    def __init__(self, http_get: Optional[HttpGet] = None, api_url: Optional[str] = None):
+        self._http_get = http_get or self._default_http_get
+        self._api_url = api_url or self.API
+
+    @staticmethod
+    def _default_http_get(url: str) -> bytes:
+        from urllib.request import Request, urlopen
+
+        req = Request(url, headers={"User-Agent": "NeuroNewsBot/1.0"})
+        with urlopen(req, timeout=20) as resp:
+            return resp.read()
+
+    def references_for(self, paper: PaperMetadata) -> List[Reference]:
+        if paper.arxiv_id:
+            key = f"arXiv:{paper.arxiv_id}"
+        elif paper.doi:
+            key = f"DOI:{paper.doi}"
+        else:
+            return []
+        fields = "title,year,externalIds"
+        url = f"{self._api_url}/paper/{key}/references?fields={fields}&limit=1000"
+        return parse_s2_references(self._http_get(url))

--- a/tests/ingestion/fixtures/arxiv_1706.03762.xml
+++ b/tests/ingestion/fixtures/arxiv_1706.03762.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <title type="html">ArXiv Query: id_list=1706.03762</title>
+  <entry>
+    <id>http://arxiv.org/abs/1706.03762v7</id>
+    <updated>2023-08-02T00:00:00Z</updated>
+    <published>2017-06-12T00:00:00Z</published>
+    <title>Attention Is All You Need</title>
+    <summary>  The dominant sequence transduction models are based on complex recurrent or
+convolutional neural networks. We propose a new simple network architecture, the
+Transformer, based solely on attention mechanisms, dispensing with recurrence
+and convolutions entirely.
+</summary>
+    <author><name>Ashish Vaswani</name></author>
+    <author><name>Noam Shazeer</name></author>
+    <author><name>Niki Parmar</name></author>
+    <author><name>Jakob Uszkoreit</name></author>
+    <author><name>Llion Jones</name></author>
+    <author><name>Aidan N. Gomez</name></author>
+    <author><name>Lukasz Kaiser</name></author>
+    <author><name>Illia Polosukhin</name></author>
+    <arxiv:doi>10.48550/arXiv.1706.03762</arxiv:doi>
+    <link title="doi" href="https://dx.doi.org/10.48550/arXiv.1706.03762" rel="related"/>
+    <arxiv:primary_category xmlns:arxiv="http://arxiv.org/schemas/atom" term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+    <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+    <link href="http://arxiv.org/abs/1706.03762v7" rel="alternate" type="text/html"/>
+    <link title="pdf" href="http://arxiv.org/pdf/1706.03762v7" rel="related" type="application/pdf"/>
+  </entry>
+</feed>

--- a/tests/ingestion/fixtures/s2_references_1706.03762.json
+++ b/tests/ingestion/fixtures/s2_references_1706.03762.json
@@ -1,0 +1,26 @@
+{
+  "offset": 0,
+  "data": [
+    {
+      "citedPaper": {
+        "title": "Neural Machine Translation by Jointly Learning to Align and Translate",
+        "year": 2014,
+        "externalIds": { "ArXiv": "1409.0473", "DOI": "10.48550/arXiv.1409.0473" }
+      }
+    },
+    {
+      "citedPaper": {
+        "title": "Sequence to Sequence Learning with Neural Networks",
+        "year": 2014,
+        "externalIds": { "DOI": "10.5555/2969033.2969173" }
+      }
+    },
+    {
+      "citedPaper": {
+        "title": "Long Short-Term Memory",
+        "year": 1997,
+        "externalIds": {}
+      }
+    }
+  ]
+}

--- a/tests/ingestion/test_paper_connector.py
+++ b/tests/ingestion/test_paper_connector.py
@@ -1,0 +1,182 @@
+"""
+Tests for the papers connector and citation graph (#517).
+
+Uses recorded fixtures (an arXiv Atom response and a Semantic-Scholar-style
+references payload) so nothing hits the network. Covers the exit criterion:
+ingest a paper by id and its references appear as CITES edges in the KG.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.ingest.common.document_contracts import DocumentIngestValidator
+from src.ingestion.connectors import get_connector, is_registered
+from src.ingestion.connectors.paper import (
+    ArxivClient,
+    PaperConnector,
+    StaticReferencesProvider,
+    parse_atom,
+    parse_s2_references,
+)
+from src.ingestion.connectors.paper.models import PaperMetadata, Reference, paper_id
+from src.ingestion.connectors.paper.pdf_parser import parse_pdf, split_sections
+from src.knowledge_graph.foundation import (
+    EntityType,
+    KnowledgeGraphStore,
+    RelationType,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+ARXIV_ID = "1706.03762"
+
+
+def _atom_bytes() -> bytes:
+    return (FIXTURES / "arxiv_1706.03762.xml").read_bytes()
+
+
+def _references():
+    payload = (FIXTURES / "s2_references_1706.03762.json").read_bytes()
+    return parse_s2_references(payload)
+
+
+def _connector_with_refs() -> PaperConnector:
+    meta = parse_atom(_atom_bytes())[0]
+    provider = StaticReferencesProvider({meta.document_id: _references()})
+    client = ArxivClient(http_get=lambda url: _atom_bytes())
+    return PaperConnector(arxiv_client=client, references_provider=provider)
+
+
+# --------------------------------------------------------------------------- #
+# arXiv parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_atom_extracts_metadata():
+    meta = parse_atom(_atom_bytes())[0]
+    assert meta.arxiv_id == "1706.03762"  # version stripped
+    assert meta.title == "Attention Is All You Need"
+    assert meta.doi == "10.48550/arXiv.1706.03762"
+    assert meta.primary_category == "cs.CL"
+    assert "cs.LG" in meta.categories
+    assert meta.authors[0] == "Ashish Vaswani"
+    assert len(meta.authors) == 8
+    assert meta.pdf_url.endswith(".pdf") or "pdf" in meta.pdf_url
+    assert meta.published.year == 2017
+
+
+def test_paper_id_prefers_arxiv_then_doi_then_title():
+    assert paper_id(arxiv_id="1706.03762") == "arxiv:1706.03762"
+    assert paper_id(doi="10.1/X") == "doi:10.1/x"
+    assert paper_id(title="Some Title").startswith("paper:")
+
+
+def test_parse_s2_references():
+    refs = _references()
+    assert len(refs) == 3
+    assert refs[0].arxiv_id == "1409.0473"
+    assert refs[0].document_id == "arxiv:1409.0473"
+    assert refs[1].document_id == "doi:10.5555/2969033.2969173"
+    assert refs[2].document_id.startswith("paper:")  # no external ids
+
+
+# --------------------------------------------------------------------------- #
+# Connector -> Document
+# --------------------------------------------------------------------------- #
+
+
+def test_paper_connector_is_registered():
+    assert is_registered("paper")
+    assert isinstance(get_connector("paper"), PaperConnector)
+
+
+def test_connector_parse_produces_valid_paper_document():
+    connector = _connector_with_refs()
+    ref = next(iter(connector.discover(ARXIV_ID)))
+    raw = connector.fetch(ref)
+    docs = connector.parse(raw)
+
+    assert len(docs) == 1
+    payload = docs[0].to_dict()
+    DocumentIngestValidator().validate_document(payload)  # contract-valid
+    assert payload["source_type"] == "paper"
+    assert payload["document_id"] == "arxiv:1706.03762"
+    assert payload["content_ref"].endswith("pdf") or "pdf" in payload["content_ref"]
+    assert payload["metadata"]["reference_count"] == 3
+    assert payload["metadata"]["arxiv_id"] == "1706.03762"
+    assert "arxiv:1409.0473" in payload["metadata"]["reference_ids"]
+
+
+def test_connector_harvest_yields_documents():
+    connector = _connector_with_refs()
+    docs = list(connector.harvest(ARXIV_ID))
+    assert len(docs) == 1
+    assert docs[0].title == "Attention Is All You Need"
+
+
+# --------------------------------------------------------------------------- #
+# Citation graph (exit criterion)
+# --------------------------------------------------------------------------- #
+
+
+def test_ingest_to_kg_creates_cites_edges():
+    connector = _connector_with_refs()
+    store = KnowledgeGraphStore()
+
+    paper_node = connector.ingest_to_kg(store, ARXIV_ID)
+
+    assert paper_node.node_id == "arxiv:1706.03762"
+    assert paper_node.type == EntityType.DOCUMENT
+
+    # Exit criterion: references appear as CITES edges from the paper.
+    cites = store.triples(subject=paper_node.node_id, predicate=RelationType.CITES)
+    assert len(cites) == 3
+    cited_ids = {t.object for t in cites}
+    assert "arxiv:1409.0473" in cited_ids
+    assert "doi:10.5555/2969033.2969173" in cited_ids
+
+    # Every CITES edge is cited back to the paper (provenance).
+    for t in cites:
+        assert t.provenance.source_doc == paper_node.node_id
+
+    # Authors became AUTHORED_BY edges to Person nodes.
+    authored = store.triples(subject=paper_node.node_id, predicate=RelationType.AUTHORED_BY)
+    assert len(authored) == 8
+    assert len(store.nodes_by_type(EntityType.PERSON)) == 8
+    # Cited works plus the paper are Document nodes.
+    assert len(store.nodes_by_type(EntityType.DOCUMENT)) == 4
+
+
+def test_citation_graph_ignores_self_citation():
+    meta = PaperMetadata(title="Self", arxiv_id="9999.99999")
+    meta.references = [Reference(title="Self", arxiv_id="9999.99999")]  # cites itself
+    store = KnowledgeGraphStore()
+    from src.ingestion.connectors.paper import build_citation_graph
+
+    node = build_citation_graph(store, meta)
+    assert store.triples(subject=node.node_id, predicate=RelationType.CITES) == []
+
+
+# --------------------------------------------------------------------------- #
+# PDF section splitting (pure, no PDF backend needed)
+# --------------------------------------------------------------------------- #
+
+
+def test_split_sections_recognizes_headings():
+    text = "title line\nAbstract\nwe present\n1. Introduction\nbackground here\nReferences\n[1] foo"
+    sections = split_sections(text)
+    headings = [s.heading for s in sections]
+    assert "abstract" in headings
+    assert "introduction" in headings
+    assert "references" in headings
+
+
+def test_parse_pdf_without_backend_degrades_gracefully():
+    # No PyMuPDF in this environment -> empty parse, no crash.
+    parsed = parse_pdf(b"%PDF-1.4 not really a pdf")
+    assert parsed.extractor in ("none", "pymupdf")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

First end-to-end source type of the knowledge-engine pivot: ingest academic papers (arXiv) as `document-ingest-v1` records and into the knowledge graph, turning a paper's references into first-class `CITES` edges. Builds on the document model (#513), connector framework (#514), KG foundation (#515), and entity resolution (#516), all merged.

## What changed

New subpackage `src/ingestion/connectors/paper/`:

- **`models.py`**: `PaperMetadata`, `Reference`, and a stable `paper_id` (arXiv id, then DOI, then title hash) shared by the document record and the KG node, so a paper and the papers that cite it line up.
- **`arxiv.py`**: `ArxivClient` (HTTP injectable) and `parse_atom` for the arXiv Atom API.
- **`references.py`**: reference providers. arXiv has no reference list, so citations come from a Semantic-Scholar-style API (`SemanticScholarReferences`, HTTP injectable) or a `StaticReferencesProvider` for offline/tests.
- **`pdf_parser.py`**: best-effort PDF text plus a pure, dependency-free section splitter. Uses PyMuPDF when installed and degrades gracefully when not. GROBID can be slotted in here later.
- **`citation_graph.py`**: `build_citation_graph` creates the paper Document node, `AUTHORED_BY` edges to resolved Person nodes (via entity resolution), and `CITES` edges to each referenced work, all cited back via provenance.
- **`connector.py`**: `PaperConnector` implementing `discover`/`fetch`/`parse` plus `ingest_to_kg`; registered as `source_type="paper"`.

## Testing

- PASS: `tests/ingestion/test_paper_connector.py`, 10 tests using recorded arXiv Atom and Semantic-Scholar references fixtures (no network): metadata parsing, contract-valid paper documents, registry wiring, citation-graph construction, self-citation handling, and PDF section splitting.
- PASS: full ingestion, knowledge graph, and document-contract suites green (68 tests).

## Exit criteria (per #517): met

- Ingest a paper by id, and its references appear as `CITES` edges in the KG (`test_ingest_to_kg_creates_cites_edges`).

## Scope notes

- Reference extraction uses the metadata API rather than parsing the PDF (arXiv PDFs do not yield references without GROBID); the `pdf_parser` GROBID path is a follow-up.
- PubMed/Crossref discovery and PDF-to-object-storage upload are planned extensions of this connector.