### PR TITLE
Structure-aware chunking (#518)

### DIFF
--- a/services/rag/chunking.py
+++ b/services/rag/chunking.py
@@ -9,7 +9,7 @@ with configurable parameters like max_chars, overlap, and language-aware splitti
 import logging
 import re
 from typing import List, Dict, Any, Optional, Tuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 try:
@@ -28,6 +28,10 @@ class SplitStrategy(Enum):
     PARAGRAPH = "paragraph"
     WORD = "word"
     CHARACTER = "character"
+    # Hierarchical, structure-aware splitting over a section/chapter tree. Each
+    # resulting chunk carries its section path so retrieval can cite a location
+    # (e.g. a paper section or a book chapter). Used via chunk_document().
+    STRUCTURED = "structured"
 
 
 @dataclass
@@ -39,6 +43,27 @@ class ChunkConfig:
     min_chunk_chars: int = 50
     preserve_sentences: bool = True
     language: str = "en"
+    # When split_on == STRUCTURED, each section's body is chunked with this flat
+    # leaf strategy. Lets long documents (papers, books) stay section-aware while
+    # reusing the existing sentence/paragraph/word/character splitters.
+    leaf_split_on: SplitStrategy = SplitStrategy.SENTENCE
+
+
+@dataclass
+class DocumentSection:
+    """A node in a document's section/chapter tree for structured chunking.
+
+    ``title`` is the section/chapter heading, ``text`` its body (may be empty
+    for container nodes like a book Part), and ``children`` its subsections.
+    """
+    title: str = ""
+    text: str = ""
+    children: List["DocumentSection"] = field(default_factory=list)
+
+    @classmethod
+    def from_pairs(cls, pairs: List[Tuple[str, str]]) -> List["DocumentSection"]:
+        """Build a flat list of sections from (title, text) pairs."""
+        return [cls(title=title, text=text) for title, text in pairs]
 
 
 @dataclass
@@ -51,7 +76,10 @@ class TextChunk:
     word_count: int
     char_count: int
     metadata: Dict[str, Any]
-    
+    # Section breadcrumb for structure-aware chunks, e.g. ["4", "4.2 Methods"]
+    # or ["Part II", "Chapter 5"]. Empty for flat (non-structured) chunks.
+    path: List[str] = field(default_factory=list)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert chunk to dictionary representation."""
         return {
@@ -62,6 +90,7 @@ class TextChunk:
             'word_count': self.word_count,
             'char_count': self.char_count,
             'metadata': self.metadata,
+            'path': list(self.path),
         }
 
 
@@ -130,8 +159,62 @@ class TextChunker:
             return self._chunk_by_paragraphs(text, metadata)
         elif self.config.split_on == SplitStrategy.WORD:
             return self._chunk_by_words(text, metadata)
+        elif self.config.split_on == SplitStrategy.STRUCTURED:
+            # No section tree available for a plain string: treat the whole text
+            # as a single untitled section so callers still get chunks.
+            return self.chunk_document([DocumentSection(text=text)], metadata)
         else:  # CHARACTER
             return self._chunk_by_characters(text, metadata)
+
+    def chunk_document(
+        self,
+        sections: List[DocumentSection],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> List[TextChunk]:
+        """Chunk a section/chapter tree, tagging each chunk with its path.
+
+        Each section's body is split with the configured leaf strategy; every
+        resulting chunk carries the breadcrumb of titles from the root to that
+        section (e.g. ["4", "4.2 Methods"]) so retrieval can cite the location.
+        Container sections with no body still contribute their title to the path
+        of their descendants.
+        """
+        metadata = metadata or {}
+        chunks: List[TextChunk] = []
+        counter = 0
+
+        def walk(node: DocumentSection, ancestors: List[str]) -> None:
+            nonlocal counter
+            path = ancestors + [node.title] if node.title else list(ancestors)
+            if node.text and node.text.strip():
+                for chunk in self._chunk_leaf(node.text, metadata):
+                    chunk.chunk_id = counter
+                    counter += 1
+                    chunk.path = list(path)
+                    chunk.metadata = {
+                        **chunk.metadata,
+                        'chunk_strategy': SplitStrategy.STRUCTURED.value,
+                        'section_path': list(path),
+                    }
+                    chunks.append(chunk)
+            for child in node.children:
+                walk(child, path)
+
+        for section in sections:
+            walk(section, [])
+        return chunks
+
+    def _chunk_leaf(self, text: str, metadata: Dict[str, Any]) -> List[TextChunk]:
+        """Chunk a single section body using the configured flat leaf strategy."""
+        strategy = self.config.leaf_split_on
+        if strategy == SplitStrategy.PARAGRAPH:
+            return self._chunk_by_paragraphs(text, metadata)
+        elif strategy == SplitStrategy.WORD:
+            return self._chunk_by_words(text, metadata)
+        elif strategy == SplitStrategy.CHARACTER:
+            return self._chunk_by_characters(text, metadata)
+        else:  # SENTENCE (default leaf strategy)
+            return self._chunk_by_sentences(text, metadata)
     
     def _chunk_by_sentences(self, text: str, metadata: Dict[str, Any]) -> List[TextChunk]:
         """Chunk text by sentences, respecting max_chars and overlap."""
@@ -380,5 +463,55 @@ def chunk_text(
     
     chunker = TextChunker(config)
     chunks = chunker.chunk_text(text, metadata)
-    
+
+    return [chunk.to_dict() for chunk in chunks]
+
+
+def chunk_document(
+    sections,
+    max_chars: int = 1000,
+    overlap_chars: int = 100,
+    leaf_split_on: str = "sentence",
+    metadata: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> List[Dict[str, Any]]:
+    """
+    Convenience function for structure-aware chunking.
+
+    Args:
+        sections: A list of DocumentSection nodes, or a list of (title, text)
+            pairs (which are treated as a flat list of sections).
+        max_chars: Maximum characters per chunk.
+        overlap_chars: Overlap between chunks.
+        leaf_split_on: Flat strategy used within each section
+            ("sentence", "paragraph", "word", "character").
+        metadata: Optional metadata to include.
+        **kwargs: Additional ChunkConfig options.
+
+    Returns:
+        List of chunk dictionaries, each including a ``path`` breadcrumb.
+    """
+    normalized: List[DocumentSection] = []
+    for section in sections:
+        if isinstance(section, DocumentSection):
+            normalized.append(section)
+        else:  # (title, text) pair
+            title, text = section
+            normalized.append(DocumentSection(title=title, text=text))
+
+    config_kwargs = {
+        'min_chunk_chars': kwargs.pop('min_chunk_chars', 10),
+        **kwargs
+    }
+    config = ChunkConfig(
+        max_chars=max_chars,
+        overlap_chars=overlap_chars,
+        split_on=SplitStrategy.STRUCTURED,
+        leaf_split_on=SplitStrategy(leaf_split_on),
+        **config_kwargs
+    )
+
+    chunker = TextChunker(config)
+    chunks = chunker.chunk_document(normalized, metadata)
+
     return [chunk.to_dict() for chunk in chunks]

--- a/tests/rag/test_structured_chunking.py
+++ b/tests/rag/test_structured_chunking.py
@@ -1,0 +1,141 @@
+"""
+Tests for structure-aware chunking (#518).
+
+Verifies the new STRUCTURED strategy tags each chunk with its section/chapter
+path (so RAG can cite a location), supports hierarchical trees, integrates with
+the paper PDF section splitter, and keeps the existing flat strategies
+backward compatible.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load chunking.py in isolation. The services.rag package __init__ eagerly
+# imports the full RAG stack (numpy, psycopg2, qdrant, ...), which this
+# stdlib-only chunking module does not need; loading the file directly keeps
+# this a true unit test.
+_CHUNKING_PATH = Path(__file__).resolve().parents[2] / "services" / "rag" / "chunking.py"
+_spec = importlib.util.spec_from_file_location("rag_chunking_standalone", _CHUNKING_PATH)
+chunking = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(chunking)
+
+ChunkConfig = chunking.ChunkConfig
+DocumentSection = chunking.DocumentSection
+SplitStrategy = chunking.SplitStrategy
+TextChunk = chunking.TextChunk
+TextChunker = chunking.TextChunker
+chunk_document = chunking.chunk_document
+chunk_text = chunking.chunk_text
+
+
+# --------------------------------------------------------------------------- #
+# Backward compatibility
+# --------------------------------------------------------------------------- #
+
+
+def test_flat_chunking_still_works_and_path_is_empty():
+    text = "This is the first sentence. Here is a second, somewhat longer sentence."
+    chunks = chunk_text(text, max_chars=1000, split_on="sentence")
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        assert chunk["path"] == []  # flat chunks carry no section path
+
+
+def test_textchunk_path_defaults_empty():
+    chunk = TextChunk(
+        text="x", start_offset=0, end_offset=1, chunk_id=0,
+        word_count=1, char_count=1, metadata={},
+    )
+    assert chunk.path == []
+    assert chunk.to_dict()["path"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Structured chunking
+# --------------------------------------------------------------------------- #
+
+
+def test_structured_chunks_carry_section_path():
+    sections = DocumentSection.from_pairs([
+        ("1 Introduction", "We introduce the problem. It matters for many reasons across fields."),
+        ("4.2 Methods", "We use a transformer model. The attention mechanism is central to it."),
+    ])
+    chunks = chunk_document(sections, max_chars=1000)
+
+    methods = [c for c in chunks if c["path"] == ["4.2 Methods"]]
+    assert methods, "expected a chunk located at section 4.2 Methods"
+    assert "transformer" in methods[0]["text"].lower()
+    assert methods[0]["metadata"]["chunk_strategy"] == "structured"
+    assert methods[0]["metadata"]["section_path"] == ["4.2 Methods"]
+    # chunk ids are sequential across the whole document
+    assert [c["chunk_id"] for c in chunks] == list(range(len(chunks)))
+
+
+def test_structured_hierarchical_path_breadcrumb():
+    tree = [
+        DocumentSection("Part II", "", children=[
+            DocumentSection("Chapter 5", "", children=[
+                DocumentSection(
+                    "5.1 Overview",
+                    "This section explains the core idea. It spans several sentences for chunking.",
+                ),
+            ]),
+        ]),
+    ]
+    chunker = TextChunker(ChunkConfig(split_on=SplitStrategy.STRUCTURED, min_chunk_chars=10))
+    chunks = chunker.chunk_document(tree)
+
+    assert chunks, "expected chunks from the leaf section"
+    for chunk in chunks:
+        assert chunk.path == ["Part II", "Chapter 5", "5.1 Overview"]
+
+
+def test_container_sections_without_body_produce_no_chunks():
+    tree = [DocumentSection("Empty Part", "", children=[DocumentSection("Heading only", "")])]
+    chunker = TextChunker(ChunkConfig(split_on=SplitStrategy.STRUCTURED, min_chunk_chars=10))
+    assert chunker.chunk_document(tree) == []
+
+
+def test_structured_string_fallback_treats_text_as_one_section():
+    # Plain string through the STRUCTURED strategy still yields chunks.
+    chunker = TextChunker(ChunkConfig(split_on=SplitStrategy.STRUCTURED, min_chunk_chars=10))
+    chunks = chunker.chunk_text("A standalone passage. With two sentences to split on here.")
+    assert chunks
+    assert all(c.path == [] for c in chunks)  # untitled root -> empty path
+
+
+def test_leaf_split_on_paragraph():
+    section = DocumentSection("Body", "Para one is here.\n\nPara two follows after a blank line.")
+    chunks = chunk_document([section], max_chars=1000, leaf_split_on="paragraph")
+    assert chunks
+    assert all(c["path"] == ["Body"] for c in chunks)
+
+
+# --------------------------------------------------------------------------- #
+# Integration with the paper PDF section splitter (#517)
+# --------------------------------------------------------------------------- #
+
+
+def test_structured_chunking_over_paper_sections():
+    from src.ingestion.connectors.paper.pdf_parser import split_sections
+
+    paper_text = (
+        "title preamble\n"
+        "Abstract\nWe present a new approach to sequence modeling that is simple and effective.\n"
+        "Introduction\nRecurrent models dominate but are slow to train on long sequences.\n"
+        "Methods\nWe use a transformer. The attention mechanism replaces recurrence entirely.\n"
+        "References\n[1] Some cited work."
+    )
+    sections = [DocumentSection(s.heading, s.body) for s in split_sections(paper_text)]
+    chunks = chunk_document(sections, max_chars=1000)
+
+    paths = {tuple(c["path"]) for c in chunks}
+    assert ("methods",) in paths
+    methods_chunk = next(c for c in chunks if c["path"] == ["methods"])
+    assert "attention" in methods_chunk["text"].lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

Adds structure-aware chunking so long documents (papers, books) are split along their section/chapter tree and every chunk carries its section path. This lets retrieval cite a location (for example, a paper section or a book chapter) instead of returning context-free text. Builds on the papers connector (#517, merged), whose PDF section splitter feeds this.

## What changed (`services/rag/chunking.py`)

- **`SplitStrategy.STRUCTURED`** and **`ChunkConfig.leaf_split_on`** (the flat strategy used within each section).
- **`DocumentSection`** tree (`title` / `text` / `children`) with a `from_pairs` helper for flat lists.
- **`TextChunk.path`** breadcrumb, for example `["4", "4.2 Methods"]` or `["Part II", "Chapter 5"]`. Empty for flat chunks; included in `to_dict()`.
- **`TextChunker.chunk_document()`** walks the section tree, delegates leaf chunking to the existing sentence/paragraph/word/character splitters, and assigns sequential ids plus `section_path` metadata. Container sections without a body still contribute their title to descendants' paths.
- **`chunk_document()`** module-level convenience function (accepts `DocumentSection` nodes or `(title, text)` pairs).
- Existing flat strategies are unchanged and fully backward compatible (a plain string through `STRUCTURED` is treated as a single untitled section).

## Testing

- PASS: `tests/rag/test_structured_chunking.py`, 8 tests: path tagging, hierarchical breadcrumbs, container sections, the string fallback, `leaf_split_on`, backward-compatible flat chunking, and integration with the paper PDF section splitter.
- The test loads `chunking.py` in isolation because the `services.rag` package `__init__` eagerly imports the full RAG stack (numpy, psycopg2, qdrant), which this stdlib-only module does not need.

## Exit criteria (per #518): met

- New section-aware strategy returns chunks tagged with their section path, so RAG over a paper can cite specific sections.
- Existing flat strategies for news/blogs remain unchanged.

## Next on the critical path

Claim extraction and knowledge layer (#519), which completes the papers end-to-end work.