### PR TITLE
Add dev tooling: run/build skills and pipeline MCP servers

### DIFF
--- a/.claude/skills/scaffold-connector/SKILL.md
+++ b/.claude/skills/scaffold-connector/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: scaffold-connector
+description: Scaffold a new data connector / news source for the NeuroNews ingestion pipeline. Use when adding an RSS feed or a new source that produces article-ingest-v1 records. Covers the connector module, the contract it must satisfy, and the verify loop using the pipeline + contracts + lineage MCP servers.
+---
+
+# Scaffold a NeuroNews connector
+
+A connector fetches from a source and emits **article-ingest-v1** records — the
+governed boundary the rest of the pipeline consumes. The cleanest shape emits
+instances of the generated contract model
+(`services/generated/generated/jsonschema/article_ingest_v1_models.py`,
+class `ArticleingestV1`), so the output is contract-shaped by construction.
+
+This skill pairs with the three MCP servers (in `.mcp.json`):
+- **`neuronews-pipeline`** `run_connector` — run an RSS source against a live sample
+- **`neuronews-contracts`** `validate("ingest", …)` — does the output satisfy the contract
+- **`neuronews-lineage`** `impact` — what's downstream once it emits
+
+**Paths below are relative to the repo root** (`/home/Ikey/NeuroNews`).
+
+## The fast path: a new RSS source
+
+If the source is an RSS/Atom feed, the existing pipeline already handles
+fetch/parse/sentiment/store — just add a `Feed(...)` to `DEFAULT_FEEDS` in
+`src/ingestion/scrapy_integration.py`:
+
+```python
+Feed("My Source", "https://example.com/rss.xml", "Technology"),
+```
+
+Then run it live via the pipeline MCP tool `run_connector("My Source", sample=3)`
+(or `list_sources()` to confirm it's registered). That's the whole job for an
+RSS source feeding the warehouse pipeline.
+
+## The full path: a connector that emits the contract
+
+For a non-RSS source, or to feed the **contract boundary** (article-ingest-v1),
+scaffold a connector module under `connectors/`:
+
+```python
+# connectors/<name>_connector.py
+"""<Name> connector → article-ingest-v1 records."""
+from __future__ import annotations
+import json, sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.ingestion.scrapy_integration import Feed, _http_get, parse_feed
+from services.generated.generated.jsonschema.article_ingest_v1_models import ArticleingestV1
+
+SOURCE = Feed("My Source", "https://example.com/rss.xml", "Technology")
+SOURCE_ID = "my-source"
+LANGUAGE = "en"
+
+def fetch(sample: int = 5):
+    # Replace with your source's fetch (HTTP API, HTML scrape, …). For RSS,
+    # reuse the pipeline's parser:
+    return parse_feed(_http_get(SOURCE.url), SOURCE, limit=sample)
+
+def to_contract(item) -> ArticleingestV1:
+    return ArticleingestV1(
+        article_id=item.id,
+        source_id=SOURCE_ID,
+        url=item.url,
+        title=item.title,
+        body=item.content,
+        language=LANGUAGE,
+        published_at=item.publish_date,
+        ingested_at=datetime.now(timezone.utc),
+        sentiment_score=item.sentiment_score,
+        topics=[item.category] if item.category else [],
+    )
+
+def emit(sample: int = 5) -> List[dict]:
+    # ISO-timestamp JSON dicts, ready for validate(). .json() serializes the
+    # datetime fields to ISO-8601 strings (what the JSON Schema expects).
+    return [json.loads(to_contract(i).json()) for i in fetch(sample)]
+
+if __name__ == "__main__":
+    print(json.dumps(emit(2), indent=2))
+```
+
+Run it to see live output:
+
+```bash
+python3 connectors/<name>_connector.py
+```
+
+## Verify against the contract (the governed boundary)
+
+Feed the connector's output to the contracts MCP `validate("ingest", record)`.
+Verified end-to-end with a real Ars Technica connector — the emitted record
+returns:
+
+```
+jsonschema: valid (drift clean)
+avro:       invalid  -> published_at/ingested_at "expected integer, got string"
+agree:      false
+```
+
+That `agree: false` is **not your connector's bug** — it's the known
+`article-ingest-v1` divergence: the JSON Schema types the timestamps as
+`string` (date-time, what `ArticleingestV1` emits) while the Avro schema types
+them as `long` (epoch-millis). Your connector is correct against the JSON Schema
+contract; the two contracts need reconciling (see `tools/contract_mcp/README.md`).
+If you target the Avro/Kafka path instead, emit epoch-millis for the two
+timestamps and the verdicts flip.
+
+## Gotchas
+
+- **The warehouse `Article` shape ≠ the `article-ingest-v1` contract.** The
+  pipeline's `Article` (`id, content, publish_date, source, …`) is the DuckDB
+  row; the contract uses `article_id, body, published_at, source_id, language,
+  ingested_at, …`. `to_contract()` is where you bridge them — don't assume the
+  field names line up.
+- **Emit via `.json()`, not `.dict()`.** `ArticleingestV1.dict()` leaves
+  `published_at`/`ingested_at` as `datetime` objects, which fail JSON Schema
+  validation (it wants strings). `json.loads(model.json())` gives ISO strings.
+- **The model forbids extra fields** (`extra = "forbid"`). An unknown kwarg to
+  `ArticleingestV1(...)` raises — good, it catches drift at construction.
+- **`language` is required** and must be a 2-letter ISO-639-1 code; `country`
+  (optional) must be 2-letter uppercase. Easy to miss — they're not in the
+  warehouse `Article`.
+
+## Verify checklist
+
+1. `python3 connectors/<name>_connector.py` → prints contract-shaped JSON.
+2. contracts MCP `validate("ingest", <record>)` → `jsonschema.valid: true`.
+3. (RSS) add the `Feed` to `DEFAULT_FEEDS`; pipeline MCP
+   `run_connector("<name>")` → live fetch summary.
+4. lineage MCP `impact("warehouse.news_articles", "downstream")` → confirm where
+   it lands once the pipeline runs.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,65 @@
+{
+  "mcpServers": {
+    "memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {}
+    },
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "env": {}
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp"
+      ],
+      "env": {}
+    },
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://neuronews:neuronews_vector_pass@localhost:5433/neuronews_vector"
+      ],
+      "env": {}
+    },
+    "neuronews-pipeline": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/pipeline_mcp/server.py"
+      ],
+      "env": {}
+    },
+    "neuronews-contracts": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/contract_mcp/server.py"
+      ],
+      "env": {}
+    },
+    "neuronews-lineage": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/lineage_mcp/server.py"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/apps/streamlit/.claude/skills/run-streamlit/.gitignore
+++ b/apps/streamlit/.claude/skills/run-streamlit/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/apps/streamlit/.claude/skills/run-streamlit/SKILL.md
+++ b/apps/streamlit/.claude/skills/run-streamlit/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: run-streamlit
+description: Run, launch, start, or screenshot the NeuroNews Streamlit app (apps/streamlit — Home dashboard + "Ask the News" Q&A page). LEGACY/deprecated — the primary UI is now the apps/web React frontend (use run-web). Use this only when specifically working on the Streamlit code.
+---
+
+# Run the NeuroNews Streamlit app
+
+> **Legacy.** The Streamlit app is effectively deprecated — the primary
+> NeuroNews UI is now the React frontend in `apps/web` (skill: `run-web`). Reach
+> for this skill only when you're specifically touching the Streamlit code; for
+> "show me the NeuroNews dashboard," use `run-web` instead.
+
+`apps/streamlit` is a multi-page Streamlit app: a static **Home** dashboard and
+an **Ask the News** Q&A/debug page (`pages/02_Ask_the_News.py`) that wraps the
+RAG pipeline. Home renders standalone in ~2s with no backend. Ask the News pulls
+in the full ML/RAG stack on import (transformers, torch, mlflow) and **does not
+render in this container** — that stack isn't installed (see Gotchas).
+
+The agent path is the driver at
+`.claude/skills/run-streamlit/driver.mjs`: it drives a running Streamlit server
+with headless Chromium (Playwright), screenshots Home, attempts Ask the News
+with a bounded timeout, and reports console errors.
+
+**Paths below are relative to `apps/streamlit/`.** `cd` there first.
+
+## Prerequisites
+
+- **Python 3** with Streamlit (already installed):
+
+```bash
+python3 -c "import streamlit; print(streamlit.__version__)"
+```
+
+- **A Chromium binary + Playwright** for the driver (same setup as `run-web`).
+  The driver resolves Playwright from the global n8n install and points
+  `launch()` at the Chromium under `~/.cache/ms-playwright/`. Overrides:
+  `PLAYWRIGHT_PATH` (dir with the `playwright` package), `CHROMIUM_PATH`
+  (explicit chrome binary). Verify Chromium is present:
+
+```bash
+ls ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome
+```
+
+## Run (agent path) — the driver
+
+Streamlit must be started separately (spawning a long-running server from inside
+the driver is unreliable under restrictive sandboxes).
+
+**1. Start Streamlit** (background; headless mode skips the email prompt and
+auto-open):
+
+```bash
+cd apps/streamlit
+streamlit run Home.py --server.port 8502 --server.headless true
+```
+
+Confirm it's up (expect `200`):
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8502/
+```
+
+**2. Drive it** (from `apps/streamlit`):
+
+```bash
+node .claude/skills/run-streamlit/driver.mjs --url http://localhost:8502
+```
+
+Expected output — Home captured, Ask the News skipped (no ML stack), exit `0`:
+
+```
+Using Chromium: /home/.../chromium-1228/chrome-linux64/chrome
+Navigating to http://localhost:8502
+✓ home      -> .../screenshots/home.png
+! "Ask the News" did not render within 20000ms — expected without the ML stack ...
+Screens captured: 1
+No console errors.
+```
+
+Screenshots land in `.claude/skills/run-streamlit/screenshots/`. **Open
+`home.png` and look** — it shows the "NeuroNews Dashboard" with the sidebar nav
+("Home" / "Ask the News"), "Available Tools" and "Navigation" sections.
+
+If you DO have the ML stack installed, give Ask the News a longer window:
+
+```bash
+ASK_TIMEOUT_MS=120000 node .claude/skills/run-streamlit/driver.mjs --url http://localhost:8502
+```
+
+## Run (human path)
+
+```bash
+cd apps/streamlit
+streamlit run Home.py    # opens http://localhost:8501, Ctrl-C to stop
+```
+
+Useless headless — no browser to view it in. Use the driver.
+
+## Gotchas
+
+- **The "Ask the News" page wedges on import here.** It does
+  `from services.rag.answer import RAGAnswerService`, which imports
+  `transformers`; transformers lazily imports a model module that needs
+  `torchvision`, which isn't installed. The page's `except ImportError` is
+  *supposed* to catch this and show a demo form, but the heavy transformers
+  import chain never returns within 90s — the page's "Running…" status widget
+  spins forever and no heading paints. The driver bounds the wait and moves on;
+  Home is the reliable screenshot. The server log shows the smoking gun:
+  `ModuleNotFoundError: No module named 'torchvision'` deep in a transformers
+  stack trace.
+- **Home itself is mostly static** (`st.title` + `st.markdown`) — it needs no
+  backend, no DB, no keys, and renders in ~2s. That's why it's the deliverable.
+- **`mlflow` is also missing** — the first page load logs
+  `RAG dependencies unavailable: No module named 'mlflow'`. Benign for Home.
+- **Streamlit keeps a websocket open**, so Playwright's `networkidle` never
+  fully settles by itself. The driver waits on Streamlit's `stStatusWidget`
+  detaching (the "Running" indicator) plus a short settle instead.
+- **`--server.headless true` matters.** Without it Streamlit prints a "Welcome"
+  email prompt and tries to open a browser, which is noise in a container.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Driver: `Could not load Playwright` | Set `PLAYWRIGHT_PATH` to a `node_modules` dir containing `playwright` (e.g. `/usr/local/lib/node_modules/n8n/node_modules`). |
+| Driver: `Executable doesn't exist at .../chromium_headless_shell-...` | The driver auto-discovers the cached Chromium; if it still fails set `CHROMIUM_PATH` (`ls ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome`). |
+| `curl http://localhost:8502/` not 200 | Streamlit not up yet (it's slow to boot) or port taken. Wait a few seconds; pick another `--server.port`. |
+| Ask the News never renders | Expected without `torch`/`torchvision`/`transformers`/`mlflow`. Install the full RAG stack (`requirements*.txt`) and re-run with a large `ASK_TIMEOUT_MS`. |

--- a/apps/streamlit/.claude/skills/run-streamlit/driver.mjs
+++ b/apps/streamlit/.claude/skills/run-streamlit/driver.mjs
@@ -1,0 +1,161 @@
+// Driver for the NeuroNews Streamlit app (apps/streamlit).
+//
+// Drives an already-running Streamlit server with headless Chromium
+// (Playwright), screenshots the Home page and the "Ask the News" page, and
+// reports page console errors. Streamlit renders async (a "Running…" spinner),
+// so we wait for the spinner to clear / network to settle before shooting.
+//
+// Streamlit must be started separately — spawning long-running servers from
+// inside the driver is unreliable in restrictive sandboxes. Launch it with:
+//   cd apps/streamlit && streamlit run Home.py --server.port 8502 --server.headless true
+// then run this with --url http://localhost:8502.
+//
+// Playwright is not a project dependency. We resolve it from wherever it lives
+// (the global n8n install ships v1.57) and hand launch() the Chromium already
+// downloaded under ~/.cache/ms-playwright/. Overrides: PLAYWRIGHT_PATH (dir with
+// the playwright package), CHROMIUM_PATH (explicit chrome binary).
+//
+// Usage:
+//   node driver.mjs --url http://localhost:8502
+//
+// Screenshots land in ./screenshots/<page>.png (next to this file).
+
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdirSync, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHOT_DIR = join(__dirname, "screenshots");
+
+function loadPlaywright() {
+  const candidates = [
+    process.env.PLAYWRIGHT_PATH,
+    "/usr/local/lib/node_modules/n8n/node_modules",
+  ].filter(Boolean);
+  for (const base of candidates) {
+    try {
+      return createRequire(join(base, "noop.js"))("playwright");
+    } catch {}
+  }
+  try {
+    return createRequire(import.meta.url)("playwright");
+  } catch {}
+  console.error(
+    "Could not load Playwright. Set PLAYWRIGHT_PATH to a node_modules dir " +
+      "that contains it (e.g. /usr/local/lib/node_modules/n8n/node_modules).",
+  );
+  process.exit(1);
+}
+
+// Hand launch() an explicit Chromium — the loaded Playwright's expected browser
+// build may not match what's actually downloaded. Newest chromium-<rev> wins.
+function findChromium() {
+  if (process.env.CHROMIUM_PATH) return process.env.CHROMIUM_PATH;
+  const cache = join(homedir(), ".cache", "ms-playwright");
+  if (!existsSync(cache)) return null;
+  const dirs = readdirSync(cache)
+    .filter((d) => d.startsWith("chromium-"))
+    .sort()
+    .reverse();
+  for (const d of dirs) {
+    for (const sub of ["chrome-linux64", "chrome-linux"]) {
+      const bin = join(cache, d, sub, "chrome");
+      if (existsSync(bin)) return bin;
+    }
+  }
+  return null;
+}
+
+function parseArgs(argv) {
+  const out = { url: "http://localhost:8502" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--url") out.url = argv[++i];
+  }
+  return out;
+}
+
+// Wait for Streamlit's "Running" status widget to disappear, then for the
+// network to go idle. Streamlit keeps a websocket open, so networkidle alone
+// isn't enough — the status indicator is the reliable signal.
+async function waitForRender(page) {
+  try {
+    await page.waitForSelector('[data-testid="stStatusWidget"]', {
+      state: "detached",
+      timeout: 15000,
+    });
+  } catch {}
+  await page.waitForTimeout(1200);
+}
+
+async function main() {
+  const { url } = parseArgs(process.argv.slice(2));
+  const { chromium } = loadPlaywright();
+  mkdirSync(SHOT_DIR, { recursive: true });
+
+  const executablePath = findChromium();
+  if (executablePath) console.log(`Using Chromium: ${executablePath}`);
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: executablePath || undefined,
+  });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+  const consoleErrors = [];
+  page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text()));
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  console.log(`Navigating to ${url}`);
+  await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+  await waitForRender(page);
+
+  let ok = 0;
+  // Home page.
+  await page.screenshot({ path: join(SHOT_DIR, "home.png") });
+  console.log(`✓ home      -> ${join(SHOT_DIR, "home.png")}`);
+  ok++;
+
+  // Try the "Ask the News" page. It imports the full RAG/ML stack
+  // (transformers → torchvision, mlflow); if those aren't installed the page
+  // wedges on import and never paints its heading. We give it a bounded window
+  // and move on — Home is the guaranteed deliverable. Set ASK_TIMEOUT_MS to
+  // wait longer if you DO have the ML stack installed.
+  const askTimeout = Number(process.env.ASK_TIMEOUT_MS || 20000);
+  try {
+    await page
+      .getByRole("link", { name: /Ask the News/i })
+      .first()
+      .click({ timeout: 8000 });
+    await page
+      .getByRole("heading", { name: /Ask the News/i })
+      .first()
+      .waitFor({ timeout: askTimeout });
+    await waitForRender(page);
+    await page.screenshot({ path: join(SHOT_DIR, "ask-the-news.png"), fullPage: true });
+    console.log(`✓ ask-the-news -> ${join(SHOT_DIR, "ask-the-news.png")}`);
+    ok++;
+  } catch (e) {
+    console.error(
+      `! "Ask the News" did not render within ${askTimeout}ms — expected ` +
+        `without the ML stack (transformers/torchvision/mlflow). Home is captured.`,
+    );
+  }
+
+  console.log(`\nPage title: ${await page.title()}`);
+  console.log(`Screens captured: ${ok}`);
+  if (consoleErrors.length) {
+    console.log(`\nConsole errors (${consoleErrors.length}):`);
+    for (const e of consoleErrors.slice(0, 10)) console.log(`  - ${e}`);
+  } else {
+    console.log("No console errors.");
+  }
+
+  await browser.close();
+  process.exit(ok >= 1 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/web/.claude/skills/add-web-view/SKILL.md
+++ b/apps/web/.claude/skills/add-web-view/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: add-web-view
+description: Scaffold a new view/page in the NeuroNews web frontend (apps/web). Use when adding a sidebar tab, a new dashboard screen, or wiring a backend endpoint into a new React view. Covers the exact touch-points (ViewKey, Sidebar nav, view component, App switch, api/adapter/query/mock) so the view compiles and renders.
+---
+
+# Add a view to the NeuroNews web frontend
+
+`apps/web` renders one component per sidebar tab. A view is registered in a few
+fixed places; miss one and it either won't compile (the `ViewKey` union is
+exhaustive) or won't appear. This skill is the checklist — verified by
+scaffolding a throwaway view, screenshotting it, and reverting.
+
+**Paths below are relative to `apps/web/`.** Every view follows the same shape:
+a component in `src/views/` that calls a `useX()` hook from `src/lib/queries.ts`
+and renders `<PageHeader>` + `<SourceBadge>`.
+
+## The 4 required touch-points (structural)
+
+A view needs these four edits to compile and show up. (Data wiring is separate,
+below — a demo-only view can reuse an existing hook or static data.)
+
+1. **`src/types.ts`** — add the slug to the `ViewKey` union (around line 154):
+
+   ```ts
+   export type ViewKey =
+     | "dashboard"
+     | ...
+     | "timeline"
+     | "pulse";        // <- new
+   ```
+
+2. **`src/views/Pulse.tsx`** — the component. Minimal shape that renders and
+   shows the live/demo badge:
+
+   ```tsx
+   import { fonts } from "../theme";
+   import { useTrending } from "../lib/queries";
+   import PageHeader from "../components/PageHeader";
+   import SourceBadge from "../components/SourceBadge";
+
+   export default function Pulse() {
+     const { data: trending, source, isLoading } = useTrending();
+     return (
+       <div>
+         <PageHeader
+           title="Pulse"
+           subtitle="Some subtitle"
+           right={<SourceBadge source={source} isLoading={isLoading} />}
+         />
+         <div style={{ fontFamily: fonts.mono, fontSize: 13, color: "#c7cdd6" }}>
+           {trending.length} trending topics loaded.
+         </div>
+       </div>
+     );
+   }
+   ```
+
+3. **`src/components/Sidebar.tsx`** — add a `NavDef` to `intelligenceNav` (top
+   group) or `researchNav` (bottom group). `glyph` is a single unicode mark;
+   `badge` is optional:
+
+   ```ts
+   { key: "pulse", label: "Pulse", glyph: "◇" },
+   ```
+
+4. **`src/App.tsx`** — import the component and add it to the view switch:
+
+   ```tsx
+   import Pulse from "./views/Pulse";
+   // ...inside <main>:
+   {view === "pulse" && <Pulse />}
+   ```
+
+## Data wiring (if the view needs a backend endpoint)
+
+Demo-only views reuse an existing hook (as above) or static data. To pull from
+the backend, follow the existing pattern across four files — read a working
+example end-to-end first: `useArticles` is wired through all four
+(`api.articles` → `adaptArticles` → `useArticles` → `mockArticles`).
+
+1. **`src/lib/api.ts`** — add a typed call under the `api` object and a `Raw…`
+   interface for the backend's response shape:
+
+   ```ts
+   myThing: (params?: { days?: number }) =>
+     request<RawMyThing[]>("/api/v1/my_thing", params),
+   ```
+
+2. **`src/lib/adapters.ts`** — map the `Raw…` shape to the view-model type from
+   `src/types.ts` (adapters read defensively; backend fields are often a subset
+   of what the design shows).
+
+3. **`src/lib/queries.ts`** — add the hook via `useWithFallback`, which returns
+   `{ data, source, isLoading }` and swaps to the mock on error **or empty
+   payload**:
+
+   ```ts
+   export function useMyThing(): Result<MyThing[]> {
+     return useWithFallback("myThing", async () => adaptMyThing(await api.myThing()), mockMyThing);
+   }
+   ```
+
+4. **`src/data/mock.ts`** (or an inline `const` in `queries.ts`, like
+   `mockTopEntities`) — the design dataset the view falls back to so it always
+   renders without a backend.
+
+## Verify
+
+```bash
+cd apps/web
+npm run typecheck     # catches a missing ViewKey arm / bad import — must be exit 0
+```
+
+Then screenshot the new tab with the run-web driver. It clicks every sidebar
+label, so add your view's **label** to the `VIEWS` array in
+`.claude/skills/run-web/driver.mjs` (`["Pulse", "pulse"]`) to include it, or
+just run the driver and confirm no console errors:
+
+```bash
+npm run dev    # in one shell; note the port (5173+)
+node .claude/skills/run-web/driver.mjs --url http://localhost:5173 --view pulse
+```
+
+Open `.claude/skills/run-web/screenshots/pulse.png` and confirm the view
+renders with its `PageHeader` and a `LIVE`/`DEMO` badge.
+
+## Gotchas
+
+- **`ViewKey` is exhaustive — `tsc` is your safety net.** Add the slug to the
+  union (step 1) *and* an arm in `App.tsx` (step 4). Forgetting the union arm is
+  a type error; forgetting the `App.tsx` arm compiles but the tab does nothing.
+- **The sidebar button's accessible name includes the glyph + badge**, so it's
+  not matchable by `getByRole('button', { name })`. The run-web driver clicks
+  the **label text** inside `<aside>` — keep labels unique.
+- **`useWithFallback` treats an empty array as "demo".** If your live endpoint
+  legitimately returns `[]`, the badge will read `DEMO` and the mock shows — by
+  design, so the UI is never blank. Account for it when testing live wiring.
+- **No CSS framework** — styling is inline-style objects with tokens from
+  `src/theme.ts` (`fonts`, `palette`, `ACCENT`). Copy an existing view's style
+  blocks (e.g. `views/Trending.tsx`) rather than inventing classes.

--- a/apps/web/.claude/skills/run-web/.gitignore
+++ b/apps/web/.claude/skills/run-web/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/apps/web/.claude/skills/run-web/SKILL.md
+++ b/apps/web/.claude/skills/run-web/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: run-web
+description: Run, launch, start, build, screenshot, or smoke-test the NeuroNews Intelligence Terminal web frontend (apps/web — React + Vite + TypeScript SPA). Use when asked to see the web UI working, capture screenshots of a view (dashboard, news feed, entity graph, sentiment, clusters, trending, etc.), or verify a frontend change renders.
+---
+
+# Run the NeuroNews web frontend (Intelligence Terminal)
+
+`apps/web` is a React 18 + Vite + TypeScript single-page app — a dark
+"terminal" dashboard with nine views (Overview, News Feed, Entity Graph,
+Sentiment, Event Clusters, Trending, Workspaces, Watchlists, Story Timeline).
+It fetches from the FastAPI backend (`services/api` / `src/api`) on every view
+and **transparently falls back to a baked-in design dataset** when the backend
+is unreachable (see `src/lib/queries.ts`), so it always renders standalone — no
+backend, no API keys, no network required.
+
+The agent path is the driver at `.claude/skills/run-web/driver.mjs`: it drives
+the running app with headless Chromium (Playwright), clicks through every
+sidebar view, writes one screenshot per view, and reports page console errors.
+
+**All paths below are relative to `apps/web/`.** `cd` there first.
+
+## Prerequisites
+
+- **Node 22** (`node --version` → v22.x) and npm. Already present on this box.
+- **A Chromium binary.** The driver does not depend on Playwright being a
+  project dependency — it resolves Playwright from wherever it already lives
+  (the global n8n install ships v1.57 at
+  `/usr/local/lib/node_modules/n8n/node_modules`) and points `launch()` at the
+  Chromium already downloaded under `~/.cache/ms-playwright/`. No install step
+  needed if those exist. Overrides if they live elsewhere:
+  - `PLAYWRIGHT_PATH=/abs/node_modules` — dir containing the `playwright` package
+  - `CHROMIUM_PATH=/abs/chrome` — explicit Chromium executable
+
+Verify Chromium is present:
+
+```bash
+ls ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome
+```
+
+## Setup
+
+```bash
+cd apps/web
+npm install
+```
+
+## Run (agent path) — the driver
+
+The driver needs a running dev server. Spawning the server from inside the
+driver is unreliable under restrictive sandboxes (the child `npm` process can
+be killed), so the **reliable two-step path** is: start the server yourself,
+then drive it with `--url`.
+
+**1. Start the dev server** (background; Vite hops to 5174/5175 if 5173 is
+taken — read the port from the banner):
+
+```bash
+cd apps/web
+npm run dev        # prints "Local: http://localhost:5173/"
+```
+
+**2. Drive it** (from `apps/web`, in another shell):
+
+```bash
+node .claude/skills/run-web/driver.mjs --url http://localhost:5173
+```
+
+Expected output — nine `✓` lines and a clean exit (code 0):
+
+```
+Using Chromium: /home/.../chromium-1228/chrome-linux64/chrome
+✓ dashboard    -> .../screenshots/dashboard.png
+✓ feed         -> .../screenshots/feed.png
+... (graph, sentiment, clusters, trending, workspaces, watchlists, timeline)
+Page title: NeuroNews · Intelligence Terminal
+Screens captured: 9/9
+```
+
+Screenshots land in `.claude/skills/run-web/screenshots/<view>.png`
+(1440×900). **Open one and look at it** — it should show the dark terminal UI
+with data, not a blank page or error.
+
+Shoot only specific views (comma-separated slugs: `dashboard`, `feed`, `graph`,
+`sentiment`, `clusters`, `trending`, `workspaces`, `watchlists`, `timeline`):
+
+```bash
+node .claude/skills/run-web/driver.mjs --url http://localhost:5173 --view trending,sentiment
+```
+
+Driver flags: `--url URL` (drive an already-running server, no spawn),
+`--view a,b` (subset of views), `--keep-server` (don't kill a driver-spawned
+server on exit). With no `--url`, the driver first tries to reuse a server on
+5173/5174/5175, then falls back to spawning one.
+
+## Live vs. demo data
+
+The app shows a `BACKEND LIVE` (green) / `DEMO MODE` pill in the top bar and a
+`LIVE`/`DEMO` badge per panel, driven by a `/health` probe through the Vite
+proxy to `http://localhost:8000`. Check whether a backend is up:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/health
+```
+
+- **`200`** → a backend is running; views show real data (`BACKEND LIVE`).
+- **connection refused / non-200** → the app still renders fully from the
+  design dataset (`DEMO MODE`). The driver and screenshots work either way.
+
+To start the backend for live data (optional — see `apps/web/README.md`):
+
+```bash
+cd /home/Ikey/NeuroNews
+NEURONEWS_DEV_MODE=true uvicorn src.api.app:app --reload --port 8000
+```
+
+`NEURONEWS_DEV_MODE=true` disables the WAF + rate limiting that otherwise block
+the dashboard's burst of requests on load.
+
+## Run (human path)
+
+```bash
+cd apps/web
+npm run dev     # open http://localhost:5173 in a browser, Ctrl-C to stop
+```
+
+Useless headless — there's no browser to open the page in. Use the driver.
+
+## Test / build
+
+```bash
+npm run typecheck   # tsc --noEmit
+npm run build       # tsc --noEmit && vite build
+```
+
+## Gotchas
+
+- **`@playwright/mcp` doesn't work out of the box here.** It defaults to the
+  `chrome` channel and looks for Google Chrome at `/opt/google/chrome/chrome`,
+  which isn't installed — only Playwright's bundled Chromium is. The driver
+  sidesteps this by loading the `playwright` package directly and passing an
+  explicit `executablePath`. Don't reach for the Playwright MCP tools; use the
+  driver.
+- **Playwright version vs. browser build mismatch.** The loaded Playwright
+  (v1.57) expects browser build `1200`, but the cache has `chromium-1228`.
+  Letting Playwright pick the browser fails with "Executable doesn't exist".
+  The driver works around it by auto-discovering the newest `chromium-*` build
+  in `~/.cache/ms-playwright/` and handing it to `launch({ executablePath })`.
+- **Nav buttons aren't matchable by accessible name.** Each sidebar button
+  wraps a glyph + label + badge (e.g. `≣ News Feed 3.8k`), so
+  `getByRole('button', { name: 'News Feed' })` times out. The driver clicks the
+  label text scoped to `<aside>` instead.
+- **Vite colorizes its banner even with `NO_COLOR=1`/`FORCE_COLOR=0`.** The
+  driver's spawn path strips ANSI escapes before scraping the port from the
+  "Local:" line.
+- **The `404` console error is benign** — a missing favicon/resource, not an
+  app failure. The driver prints it but still exits 0 with all views captured.
+- **DuckDB is single-writer.** If you run the live backend, stop it before
+  running the news ingester (`python -m src.ingestion.scrapy_integration`);
+  two writers conflict. Not needed for the demo-mode UI.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Could not load Playwright` | Set `PLAYWRIGHT_PATH` to a `node_modules` dir containing the `playwright` package (e.g. `/usr/local/lib/node_modules/n8n/node_modules`). |
+| `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1200/...` | The cached Chromium build differs from what Playwright expects. The driver handles this automatically; if it still fails, set `CHROMIUM_PATH` to a real `chrome` binary (`ls ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome`). |
+| `dev server exited early` / driver hangs spawning | Use the two-step path: start `npm run dev` yourself, then run the driver with `--url http://localhost:<port>`. |
+| `could not click nav "<label>"` | The dev server isn't fully loaded, or a sidebar label changed in `src/components/Sidebar.tsx`. Confirm the page loads in a browser; update the `VIEWS` list in `driver.mjs` if labels were renamed. |
+| All panels show `DEMO` | No backend on :8000 — expected and fine for driving the UI. Start the backend (see Live vs. demo data) only if you need real data. |

--- a/apps/web/.claude/skills/run-web/driver.mjs
+++ b/apps/web/.claude/skills/run-web/driver.mjs
@@ -1,0 +1,224 @@
+// Driver for the NeuroNews web frontend ("Intelligence Terminal").
+//
+// Launches the Vite dev server (unless one is already reachable), drives it
+// with Playwright (bundled Chromium, headless), clicks through every sidebar
+// view, and writes a screenshot per view. Surfaces page console errors so a
+// blank/broken render is caught instead of silently "passing".
+//
+// The app falls back to a baked-in design dataset when the FastAPI backend is
+// offline (see apps/web/src/lib/queries.ts), so this runs fully standalone —
+// no backend, no network, no API keys required.
+//
+// Playwright is not a dependency of apps/web. We resolve it from wherever it
+// already lives on this machine (the n8n global install ships 1.57) and let it
+// find the Chromium it downloaded into the ms-playwright cache. Override the
+// lookup with PLAYWRIGHT_PATH=/abs/path/to/node_modules if needed.
+//
+// Usage:
+//   node driver.mjs                 # launch server, shoot all views, exit
+//   node driver.mjs --url URL       # drive an already-running server, no spawn
+//   node driver.mjs --view feed     # only the named view(s), comma-separated
+//   node driver.mjs --keep-server   # leave the dev server running on exit
+//
+// Screenshots land in ./screenshots/<view>.png (next to this file).
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdirSync, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = join(__dirname, "..", "..", ".."); // apps/web (run-web -> skills -> .claude -> web)
+const SHOT_DIR = join(__dirname, "screenshots");
+
+// --- resolve Playwright from wherever it lives on this box ----------------
+function loadPlaywright() {
+  const candidates = [
+    process.env.PLAYWRIGHT_PATH,
+    "/usr/local/lib/node_modules/n8n/node_modules",
+  ].filter(Boolean);
+  for (const base of candidates) {
+    try {
+      return createRequire(join(base, "noop.js"))("playwright");
+    } catch {}
+  }
+  try {
+    return createRequire(import.meta.url)("playwright");
+  } catch {}
+  console.error(
+    "Could not load Playwright. Point PLAYWRIGHT_PATH at a node_modules dir " +
+      "that contains it (e.g. /usr/local/lib/node_modules/n8n/node_modules).",
+  );
+  process.exit(1);
+}
+
+// Find a usable Chromium binary. The Playwright we load (n8n's, v1.57) wants a
+// browser build that may not match what's actually downloaded, so we bypass its
+// version check and hand launch() an explicit executable. Override with
+// CHROMIUM_PATH=/abs/path/to/chrome.
+function findChromium() {
+  if (process.env.CHROMIUM_PATH) return process.env.CHROMIUM_PATH;
+  const cache = join(homedir(), ".cache", "ms-playwright");
+  if (!existsSync(cache)) return null;
+  // Prefer a full chromium-<rev> build (works headless); fall back to none.
+  const dirs = readdirSync(cache)
+    .filter((d) => d.startsWith("chromium-"))
+    .sort()
+    .reverse();
+  for (const d of dirs) {
+    const bin = join(cache, d, "chrome-linux64", "chrome");
+    if (existsSync(bin)) return bin;
+    const bin2 = join(cache, d, "chrome-linux", "chrome");
+    if (existsSync(bin2)) return bin2;
+  }
+  return null;
+}
+
+// Every sidebar view: nav button label -> screenshot slug. Labels must match
+// the text rendered in src/components/Sidebar.tsx.
+const VIEWS = [
+  ["Overview", "dashboard"],
+  ["News Feed", "feed"],
+  ["Entity Graph", "graph"],
+  ["Sentiment", "sentiment"],
+  ["Event Clusters", "clusters"],
+  ["Trending", "trending"],
+  ["Workspaces", "workspaces"],
+  ["Watchlists", "watchlists"],
+  ["Story Timeline", "timeline"],
+];
+
+function parseArgs(argv) {
+  const out = { url: null, views: null, keepServer: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--url") out.url = argv[++i];
+    else if (a === "--view") out.views = argv[++i].split(",").map((s) => s.trim());
+    else if (a === "--keep-server") out.keepServer = true;
+  }
+  return out;
+}
+
+async function reachable(url) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(1500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Start `npm run dev`, scrape the actual port Vite prints (it hops if 5173 is
+// taken), and resolve once the server answers.
+function startDevServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("npm", ["run", "dev"], {
+      cwd: WEB_DIR,
+      env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+    });
+    let settled = false;
+    const onData = (buf) => {
+      const text = buf.toString();
+      process.stdout.write(text);
+      // Vite colorizes its banner regardless of NO_COLOR; strip ANSI first.
+      const clean = text.replace(/\x1b\[[0-9;]*m/g, "");
+      const m = clean.match(/Local:\s+http:\/\/localhost:(\d+)/);
+      if (m && !settled) {
+        settled = true;
+        resolve({ proc, url: `http://localhost:${m[1]}` });
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.stderr.on("data", onData);
+    proc.on("exit", (code) => {
+      if (!settled) reject(new Error(`dev server exited early (code ${code})`));
+    });
+    setTimeout(() => {
+      if (!settled) reject(new Error("dev server did not report a URL within 30s"));
+    }, 30_000);
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { chromium } = loadPlaywright();
+  mkdirSync(SHOT_DIR, { recursive: true });
+
+  let server = null;
+  let baseUrl = args.url;
+
+  if (!baseUrl) {
+    // Reuse a server already listening on the usual Vite ports.
+    for (const port of [5173, 5174, 5175]) {
+      const u = `http://localhost:${port}`;
+      if (await reachable(u)) {
+        baseUrl = u;
+        console.log(`Reusing dev server at ${baseUrl}`);
+        break;
+      }
+    }
+  }
+  if (!baseUrl) {
+    console.log("Starting Vite dev server…");
+    server = await startDevServer();
+    baseUrl = server.url;
+    console.log(`Dev server up at ${baseUrl}`);
+  }
+
+  const executablePath = findChromium();
+  if (executablePath) console.log(`Using Chromium: ${executablePath}`);
+  const browser = await chromium.launch({ headless: true, executablePath: executablePath || undefined });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+  const consoleErrors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+  const wanted = args.views
+    ? VIEWS.filter(([, slug]) => args.views.includes(slug))
+    : VIEWS;
+
+  let ok = 0;
+  for (const [label, slug] of wanted) {
+    try {
+      // Nav buttons wrap a glyph + label + badge, so the accessible name isn't
+      // the bare label. Click the label text inside the sidebar instead.
+      await page.locator("aside").getByText(label, { exact: true }).first().click({ timeout: 8000 });
+    } catch (e) {
+      console.error(`! could not click nav "${label}": ${e.message}`);
+      continue;
+    }
+    await page.waitForTimeout(600); // let the view + charts settle
+    const file = join(SHOT_DIR, `${slug}.png`);
+    await page.screenshot({ path: file });
+    console.log(`✓ ${slug.padEnd(12)} -> ${file}`);
+    ok++;
+  }
+
+  // Confirm the live/demo data indicator rendered — proves the app booted,
+  // not just that a blank shell painted.
+  const heading = await page.title();
+  console.log(`\nPage title: ${heading}`);
+  console.log(`Screens captured: ${ok}/${wanted.length}`);
+  if (consoleErrors.length) {
+    console.log(`\nConsole errors (${consoleErrors.length}):`);
+    for (const e of consoleErrors.slice(0, 10)) console.log(`  - ${e}`);
+  } else {
+    console.log("No console errors.");
+  }
+
+  await browser.close();
+  if (server && !args.keepServer) server.proc.kill("SIGTERM");
+  process.exit(ok === wanted.length ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/api/.claude/skills/add-api-route/SKILL.md
+++ b/src/api/.claude/skills/add-api-route/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: add-api-route
+description: Scaffold a new FastAPI route/endpoint in the NeuroNews backend (src/api). Use when adding a REST endpoint, a new router module, or wiring a route into src/api/app.py. Covers the route file plus the 4 feature-flag registration edits in app.py, and how to verify the route in isolation.
+---
+
+# Add a route to the NeuroNews FastAPI backend
+
+`src/api/app.py` registers routers through a **feature-flag pattern**: each
+optional router has a module-level `*_AVAILABLE` flag, a `try_import_*()` that
+imports it under `try/except ImportError`, a call to that importer in
+`check_all_imports()`, and an `if *_AVAILABLE:` block in
+`include_optional_routers()` that does `app.include_router(...)`. Adding an
+endpoint means one new route file plus those four edits.
+
+**Paths below are relative to the repo root** (`/home/Ikey/NeuroNews`). The
+companion `add-web-view` skill (in `apps/web`) wires the resulting endpoint into
+the frontend.
+
+## The route file
+
+Create `src/api/routes/<name>_routes.py` with a module-level `router`. Mirror
+`src/api/routes/topic_routes.py`:
+
+```python
+"""<name> routes."""
+from typing import Any, Dict
+from fastapi import APIRouter, Query
+
+router = APIRouter(prefix="/api/v1/<name>", tags=["<name>"])
+
+@router.get("/ping")
+async def ping(name: str = Query("world")) -> Dict[str, Any]:
+    return {"message": f"hello, {name}", "wired": True}
+```
+
+## The 4 edits in `src/api/app.py`
+
+Copy the `topic_routes` wiring verbatim, renaming to your route. The four spots:
+
+1. **Module-level flag** (with the others near the top, ~line 13):
+
+   ```python
+   MYTHING_ROUTES_AVAILABLE = False
+   ```
+
+2. **`try_import_*()` function** (next to `try_import_topic_routes`):
+
+   ```python
+   def try_import_mything_routes():
+       global MYTHING_ROUTES_AVAILABLE
+       try:
+           from src.api.routes import mything_routes
+           _imported_modules['mything_routes'] = mything_routes
+           MYTHING_ROUTES_AVAILABLE = True
+           return True
+       except ImportError:
+           MYTHING_ROUTES_AVAILABLE = False
+           return False
+   ```
+
+3. **Call it in `check_all_imports()`** (alongside the other `try_import_*()`
+   calls):
+
+   ```python
+   try_import_mything_routes()
+   ```
+
+4. **Include block in `include_optional_routers()`** (next to the topic block):
+
+   ```python
+   if MYTHING_ROUTES_AVAILABLE:
+       mything_routes = _imported_modules.get('mything_routes')
+       if mything_routes:
+           app.include_router(mything_routes.router)
+           routers_included += 1
+   ```
+
+For an **always-on core** route instead, register it in
+`try_import_core_routes()` + `include_core_routers()` (no flag/optional block) —
+follow `news_routes`/`sentiment_routes` there.
+
+## Verify
+
+`py_compile` catches syntax/indent slips in the big `app.py`:
+
+```bash
+cd /home/Ikey/NeuroNews
+python3 -m py_compile src/api/app.py src/api/routes/<name>_routes.py
+```
+
+Then exercise the handler. **Do not import `src.api.app` or
+`src.api.routes` to test a single route** — `src/api/routes/__init__.py`
+eagerly imports every route module, one of which drags in the heavy ML stack
+(transformers/torch) that stalls on a network fetch in this container (the full
+app boot can hang 60s+). Load your route file **by path** and mount it on a
+throwaway app — this runs in ~5s:
+
+```bash
+PYTHONPATH=/home/Ikey/NeuroNews python3 - <<'PY'
+import importlib.util
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+p = Path("/home/Ikey/NeuroNews/src/api/routes/scaffold_demo_routes.py")  # your file
+spec = importlib.util.spec_from_file_location("r", p)
+mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+app = FastAPI(); app.include_router(mod.router)
+r = TestClient(app).get("/api/v1/scaffold_demo/ping", params={"name": "NeuroNews"})
+print(r.status_code, r.json())
+PY
+```
+
+Verified output for the demo route used to build this skill:
+`200 {'message': 'hello, NeuroNews', 'wired': True}`.
+
+To smoke the **whole** server with your route live (when the ML imports
+cooperate), use the run-api driver, which launches in dev mode on its own DB:
+
+```bash
+src/api/.claude/skills/run-api/smoke.sh
+curl -s "http://localhost:8012/api/v1/<name>/ping"   # while it's up, or add to ENDPOINTS
+```
+
+## Gotchas
+
+- **`src/api/routes/__init__.py` imports every route module eagerly.** Importing
+  *any* route through the package (`from src.api.routes import x`) pulls the
+  whole stack, including a module that imports transformers → a network-gated
+  ML import that can hang the process for a minute or stall indefinitely. For
+  unit-testing one route, load the file by path (above), not via the package.
+- **`ImportError` in a route module silently disables the endpoint.** The
+  `try_import_*` swallows `ImportError`, so a bad import in your route file
+  means the route just never registers (no crash, no 404-with-reason — it's
+  simply absent). If your endpoint 404s, check the import actually succeeded.
+- **The WAF 403s new data endpoints unless `NEURONEWS_DEV_MODE=true`** — same as
+  every other route (see the `run-api` skill). Test with dev mode on.
+- **`routers_included += 1`** — keep this line in your include block; the app
+  logs the count and it's the quick sanity signal that registration ran.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Endpoint 404s after wiring | Either the `app.py` include block / `check_all_imports()` call is missing, or your route module raised `ImportError` (silently disabling it). Load the file by path (Verify) to surface the real import error. |
+| `python3 -m py_compile src/api/app.py` errors | Indentation/syntax in your edit. The four edits are plain — re-copy from the `topic_routes` blocks. |
+| Full server hangs on boot (no `/health`) | The ML import stall, not your route. Verify the route in isolation by path; retry the server later or with the deps installed. |

--- a/src/api/.claude/skills/run-api/SKILL.md
+++ b/src/api/.claude/skills/run-api/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: run-api
+description: Run, launch, start, or smoke-test the NeuroNews FastAPI backend (src/api/app.py). Use when asked to start the API server, curl an endpoint, check /health or /docs, verify a route returns data, or stand up the backend that feeds the web frontend (articles, trending, clusters, breaking news, sentiment).
+---
+
+# Run the NeuroNews FastAPI backend
+
+`src/api/app.py` is the NeuroNews REST API (FastAPI + uvicorn). It serves
+articles, trending topics, event clusters, breaking news and sentiment from a
+**local DuckDB warehouse** that it creates and seeds with sample news on first
+request — no AWS, no Snowflake, no network. This is the backend the web
+frontend (`apps/web`) proxies to.
+
+The agent path is the smoke driver at
+`src/api/.claude/skills/run-api/smoke.sh`: it launches the API in dev mode
+against its own DuckDB file, waits for `/health`, curls every endpoint the
+frontend depends on, asserts `200` + a non-empty body, prints a pass/fail
+table, and stops the server.
+
+**The app must be launched from the repo root** (`/home/Ikey/NeuroNews`) so the
+`src.api.app:app` import resolves. The driver `cd`s there itself; if you launch
+manually, do it from the repo root. Paths below are relative to the repo root.
+
+## Prerequisites
+
+- **Python 3** with the project deps (`fastapi`, `uvicorn`, `duckdb`).
+  Already installed on this box. Verify, and install from `requirements.txt`
+  only if this fails:
+
+```bash
+python3 -c "import fastapi, uvicorn, duckdb; print('deps OK')"
+```
+
+## Run (agent path) — the smoke driver
+
+From anywhere (the script finds the repo root):
+
+```bash
+src/api/.claude/skills/run-api/smoke.sh
+```
+
+It picks port `8012`, launches its own dev-mode server on a throwaway DuckDB
+file, probes everything, and tears down. Expected output — `PASS=7 FAIL=0`,
+exit `0`:
+
+```
+Launching API on :8012 (dev mode, DB=/tmp/neuronews-smoke-XXXX.duckdb)
+
+CODE   BYTES        ENDPOINT
+------------------------------------------------------------
+200    352          ✓ /health
+200    17055        ✓ /api/v1/news/articles?limit=3
+200    1098         ✓ /topics/trending
+200    2508         ✓ /api/v1/events/clusters?limit=3
+200    3715         ✓ /api/v1/breaking_news
+200    2119         ✓ /news_sentiment/topics
+200    1012         ✓ /docs
+
+PASS=7 FAIL=0
+All endpoints healthy.
+```
+
+Pick a different port if `8012` is taken:
+
+```bash
+PORT=8013 src/api/.claude/skills/run-api/smoke.sh
+```
+
+Probe an **already-running** API instead of launching one (note: the running
+instance must be in dev mode, or the WAF will 403 the data endpoints — see
+Gotchas):
+
+```bash
+API_URL=http://localhost:8012 src/api/.claude/skills/run-api/smoke.sh --no-server
+```
+
+## Run (human path) — long-running server
+
+Launch a real server you can curl by hand or point the web frontend at. **Run
+from the repo root**, in dev mode, on its own DB file if another instance is up:
+
+```bash
+cd /home/Ikey/NeuroNews
+NEURONEWS_DEV_MODE=true NEURONEWS_DB_PATH=/tmp/neuronews-dev.duckdb \
+  uvicorn src.api.app:app --port 8012
+```
+
+Then, in another shell:
+
+```bash
+curl -s http://localhost:8012/health
+curl -s "http://localhost:8012/api/v1/news/articles?limit=3"
+```
+
+Interactive API docs: open `http://localhost:8012/docs`.
+
+## Gotchas
+
+- **The WAF blocks every data endpoint unless `NEURONEWS_DEV_MODE=true`.**
+  Without it, `/health` and `/docs` return `200` but `/api/v1/news/articles`
+  (and friends) return `403` with
+  `{"threat_type":"bot_traffic","code":"WAF_BLOCKED"}` — curl looks like a bot
+  to it, and the anonymous rate limit is 10 req/min. Dev mode disables the WAF,
+  rate limiting, API-key and RBAC middlewares. The driver always sets it.
+- **DuckDB is single-writer — a second instance on the default DB crashes.**
+  If an API is already running (e.g. the dev server on :8000 holding
+  `data/neuronews.duckdb`), launching another against the same file dies at
+  startup with
+  `IO Error: Could not set lock on file ".../neuronews.duckdb": Conflicting
+  lock is held in ... (PID …)`. Point the second instance at its own file with
+  `NEURONEWS_DB_PATH=/tmp/whatever.duckdb`. The driver does this automatically.
+- **`/health` is green even when data endpoints are blocked.** `/health` and
+  `/docs` don't touch the warehouse or the WAF data path, so they answer `200`
+  while `/api/v1/...` 403s (no dev mode) or 500s (DB lock). Don't treat a
+  healthy `/health` as "the API is serving data" — probe a real endpoint.
+- **Two FastAPI apps exist; this is the real one.** `src/api/app.py`
+  (`create_app()`, the WAF/RBAC/DuckDB backend the frontend uses) vs.
+  `services/api/main.py` (a smaller `/ask` Q&A service). For the web dashboard,
+  it's `src.api.app:app`.
+- **A benign startup error in the log is expected.** Dev mode still logs
+  `Error checking table: ... (403) ... DescribeTable ...` from the RBAC system
+  probing a (nonexistent) DynamoDB table; the app continues and `Application
+  startup complete` follows. Not a failure.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `403 ... "code":"WAF_BLOCKED"` on data endpoints | You launched without dev mode. Set `NEURONEWS_DEV_MODE=true` (the driver does). |
+| `500` + log shows `Could not set lock on file ".../neuronews.duckdb"` | Another instance holds the DuckDB lock. Launch with `NEURONEWS_DB_PATH=/tmp/other.duckdb`, or stop the other instance. |
+| `Server died on startup` from the driver | Check the printed log tail. Usually the DuckDB lock (above) or a missing dep (`python3 -c "import fastapi, uvicorn, duckdb"`). |
+| `Address already in use` | Port taken. Re-run with `PORT=<free port>`. |
+| `ModuleNotFoundError: src` | You launched outside the repo root. `cd /home/Ikey/NeuroNews` first (the driver handles this). |

--- a/src/api/.claude/skills/run-api/smoke.sh
+++ b/src/api/.claude/skills/run-api/smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Smoke driver for the NeuroNews FastAPI backend (src/api/app.py).
+#
+# Launches the API in dev mode against its OWN DuckDB file (so it never fights
+# an already-running instance for the single-writer lock), waits for /health,
+# curls every data endpoint the web frontend depends on, asserts 200 + a
+# non-empty JSON body, prints a pass/fail table, and stops the server.
+#
+# Runs fully standalone: no AWS, no Snowflake, no network. The warehouse is a
+# local DuckDB file seeded with sample news on first request.
+#
+# Usage:
+#   src/api/.claude/skills/run-api/smoke.sh                 # full run, own server
+#   PORT=8020 src/api/.claude/skills/run-api/smoke.sh       # pick the port
+#   API_URL=http://localhost:8000 .../smoke.sh --no-server  # probe a running API
+#
+# Must be runnable from anywhere; it cd's to the repo root itself so the
+# `src.api.app:app` import resolves.
+set -uo pipefail
+
+# --- locate repo root (four levels up from this script) --------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"   # 5 up: run-api -> skills -> .claude -> api -> src -> repo
+cd "$REPO_ROOT"
+
+PORT="${PORT:-8012}"
+API_URL="${API_URL:-http://localhost:$PORT}"
+START_SERVER=1
+[ "${1:-}" = "--no-server" ] && START_SERVER=0
+
+SERVER_PID=""
+cleanup() { [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; }
+trap cleanup EXIT
+
+if [ "$START_SERVER" = "1" ]; then
+  # Own DB file => no lock conflict with another running instance.
+  DB_PATH="${NEURONEWS_DB_PATH:-$(mktemp -u /tmp/neuronews-smoke-XXXX.duckdb)}"
+  LOG="$(mktemp /tmp/neuronews-api-XXXX.log)"
+  echo "Launching API on :$PORT (dev mode, DB=$DB_PATH)"
+  NEURONEWS_DEV_MODE=true NEURONEWS_DB_PATH="$DB_PATH" \
+    uvicorn src.api.app:app --port "$PORT" >"$LOG" 2>&1 &
+  SERVER_PID=$!
+
+  # Wait up to 30s for /health.
+  for _ in $(seq 1 30); do
+    if curl -sf -o /dev/null "$API_URL/health" 2>/dev/null; then break; fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "Server died on startup. Log tail:"; tail -20 "$LOG"; exit 1
+    fi
+    sleep 1
+  done
+fi
+
+# --- endpoints the web frontend (apps/web) actually calls ------------------
+declare -a ENDPOINTS=(
+  "/health"
+  "/api/v1/news/articles?limit=3"
+  "/topics/trending"
+  "/api/v1/events/clusters?limit=3"
+  "/api/v1/breaking_news"
+  "/news_sentiment/topics"
+  "/docs"
+)
+
+pass=0; fail=0
+printf "\n%-6s %-12s %s\n" "CODE" "BYTES" "ENDPOINT"
+printf "%s\n" "------------------------------------------------------------"
+for ep in "${ENDPOINTS[@]}"; do
+  body="$(curl -s "$API_URL$ep")"
+  code="$(curl -s -o /dev/null -w "%{http_code}" "$API_URL$ep")"
+  bytes=${#body}
+  ok="✗"
+  # 200 and a non-trivial body (the JSON error envelope is short; real data isn't)
+  if [ "$code" = "200" ] && [ "$bytes" -gt 30 ]; then ok="✓"; pass=$((pass+1)); else fail=$((fail+1)); fi
+  printf "%-6s %-12s %s %s\n" "$code" "$bytes" "$ok" "$ep"
+done
+
+echo
+echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] && echo "All endpoints healthy." || echo "Some endpoints failed (see above)."
+exit "$fail"

--- a/tools/contract_mcp/README.md
+++ b/tools/contract_mcp/README.md
@@ -1,0 +1,63 @@
+# NeuroNews Data-contract server (MCP server)
+
+Wraps `contracts/` so the **governed boundary between pipeline stages** is a
+typed tool, not a grep. When you touch a stage, the bug-catching question is
+*"does the output still satisfy the contract the next stage expects?"* — this
+answers it with a compact pass/fail + drift report. Pairs directly with the
+connector-scaffold workflow: scaffold a connector, then `validate("ingest", …)`
+its output.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `list_contracts()` | List available contracts (JSON Schema + Avro), their `id`, title, and the stage aliases that resolve to each — so you pick a stage without grepping. |
+| `get_contract(stage)` | The contract a stage's output must satisfy: compact field summary (required vs optional, types, `additionalProperties`) + the raw JSON Schema + its Avro counterpart path. |
+| `validate(stage, sample)` | Pass/fail + **drift report** against the stage's contract(s). |
+
+`stage` accepts a contract id (`article-ingest-v1`) or a friendly alias
+(`ingest`, `connector`, `scrape`, `ask`, `answer`, `sentiment`, …).
+
+`sample` accepts an inline object, a path to a JSON file, or a named example
+under `contracts/examples/` (e.g. `valid-full-article`, `invalid-missing-url`).
+
+## Dual-schema validation (the important part)
+
+Stages backed by both a JSON Schema and an Avro schema are checked against
+**both**, and the result carries an `agree` flag. A disagreement is itself a
+contract bug. This server found a live one on its first run:
+
+- `contracts/schemas/jsonschema/article-ingest-v1.json` types `published_at` /
+  `ingested_at` as **string** (ISO-8601 date-time).
+- `contracts/schemas/avro/article-ingest-v1.avsc` types them as **long**
+  (`timestamp-millis`, epoch integers).
+- The golden `contracts/examples/valid/*.json` fixtures (and the running
+  pipeline, which validates against Avro) use epoch integers.
+
+So `validate("ingest", "valid-full-article")` returns `valid: false`,
+`agree: false` — jsonschema rejects the epoch ints, avro accepts them. The
+inverse (ISO-string sample) flips it. The JSON Schema and Avro contracts for
+`article-ingest-v1` need reconciling.
+
+The Avro check is **structural** (field presence, no-unknowns, broad type
+compatibility) — it does not do binary/logical-type encoding validation, so no
+`avro` runtime dependency is required.
+
+## Run / register
+
+Registered in `.mcp.json` as `neuronews-contracts`, launched from the repo root:
+
+```bash
+python3 tools/contract_mcp/server.py
+```
+
+Requires `fastmcp` and `jsonschema` (`pip install -r tools/contract_mcp/requirements.txt`).
+
+## Design
+
+- **Lazy imports**, repo-root-relative, summaries not payloads (errors capped at
+  `MAX_ERRORS`).
+- **Contract registry** auto-discovered by scanning
+  `contracts/schemas/jsonschema/**.json` and `contracts/schemas/avro/**.avsc` —
+  new contracts appear automatically; only the friendly stage aliases are
+  hand-maintained in `STAGE_ALIASES` / `AVRO_ALIASES`.

--- a/tools/contract_mcp/requirements.txt
+++ b/tools/contract_mcp/requirements.txt
@@ -1,0 +1,3 @@
+# MCP server framework for the data-contract server
+fastmcp>=3.0
+jsonschema>=4.0

--- a/tools/contract_mcp/server.py
+++ b/tools/contract_mcp/server.py
@@ -1,0 +1,433 @@
+"""
+NeuroNews Data-contract server — MCP server.
+
+Wraps `contracts/` so the governed boundary between pipeline stages is a typed
+tool, not a grep. When you touch a stage, the bug-catching question is "does the
+output still satisfy the contract the next stage expects?" — this answers it
+with a compact pass/fail + drift report.
+
+Tools:
+  list_contracts()              -> available contracts (id, title, stage aliases, kind)
+  get_contract(stage)           -> the resolved JSON Schema + a compact field summary
+  validate(stage, sample)       -> pass/fail + drift report (missing required,
+                                   unexpected fields, type mismatches, errors)
+
+`sample` accepts: an inline object, a path to a JSON file, or a named example
+under contracts/examples/ (e.g. "valid-full-article").
+
+Design: lazy imports, repo-root-relative, summaries not payloads. Validation is
+JSON-Schema-based (the governed boundaries have JSON Schemas); Avro contracts are
+listed and their schemas returned, but validate() targets JSON Schema.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS = REPO_ROOT / "contracts"
+JSONSCHEMA_DIR = CONTRACTS / "schemas" / "jsonschema"
+AVRO_DIR = CONTRACTS / "schemas" / "avro"
+EXAMPLES_DIR = CONTRACTS / "examples"
+
+mcp = FastMCP("neuronews-contracts")
+
+MAX_ERRORS = 15
+
+# Friendly stage aliases -> contract id (filename stem). A stage name from the
+# pipeline maps to the contract its output must satisfy. Exact ids also work.
+STAGE_ALIASES = {
+    "ingest": "article-ingest-v1",
+    "connector": "article-ingest-v1",
+    "scrape": "article-ingest-v1",
+    "article": "article-ingest-v1",
+    "article-ingest": "article-ingest-v1",
+    "ask": "ask-request-v1",
+    "ask-request": "ask-request-v1",
+    "answer": "ask-response-v1",
+    "ask-response": "ask-response-v1",
+    "search": "search-request",
+    "article-request": "article-request",
+}
+
+# Avro counterpart ids for stages whose authoritative pipeline contract is Avro.
+AVRO_ALIASES = {
+    "ingest": "article-ingest-v1",
+    "connector": "article-ingest-v1",
+    "scrape": "article-ingest-v1",
+    "article": "article-ingest-v1",
+    "article-ingest": "article-ingest-v1",
+    "ingested": "article-ingested",
+    "sentiment": "sentiment-analyzed",
+    "analyzed": "sentiment-analyzed",
+    "query": "query-executed",
+    "search-event": "query-executed",
+}
+
+# Avro primitive -> acceptable JSON types for a structural (not binary) check.
+_AVRO_TO_JSON = {
+    "string": {"string"}, "bytes": {"string"}, "enum": {"string"}, "fixed": {"string"},
+    "int": {"integer"}, "long": {"integer"},
+    "float": {"number", "integer"}, "double": {"number", "integer"},
+    "boolean": {"boolean"}, "null": {"null"},
+    "record": {"object"}, "map": {"object"}, "array": {"array"},
+}
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+def _jsonschema_registry() -> dict[str, Path]:
+    """id (filename stem) -> path, for every JSON Schema under contracts/."""
+    reg: dict[str, Path] = {}
+    if JSONSCHEMA_DIR.exists():
+        for p in JSONSCHEMA_DIR.rglob("*.json"):
+            reg[p.stem] = p
+    return reg
+
+
+def _avro_registry() -> dict[str, Path]:
+    reg: dict[str, Path] = {}
+    if AVRO_DIR.exists():
+        for p in AVRO_DIR.rglob("*.avsc"):
+            reg[p.stem] = p
+    return reg
+
+
+def _resolve(stage: str) -> Optional[Path]:
+    """Resolve a stage/alias/id to a JSON Schema path."""
+    reg = _jsonschema_registry()
+    key = stage.strip()
+    if key in reg:
+        return reg[key]
+    if key in STAGE_ALIASES and STAGE_ALIASES[key] in reg:
+        return reg[STAGE_ALIASES[key]]
+    low = key.lower()
+    if low in STAGE_ALIASES and STAGE_ALIASES[low] in reg:
+        return reg[STAGE_ALIASES[low]]
+    # last resort: case-insensitive id match
+    for cid, path in reg.items():
+        if cid.lower() == low:
+            return path
+    return None
+
+
+def _avro_resolve(stage: str) -> Optional[Path]:
+    """Resolve a stage/alias/id to an Avro (.avsc) schema path, if one exists."""
+    reg = _avro_registry()
+    key = stage.strip()
+    if key in reg:
+        return reg[key]
+    low = key.lower()
+    for table in (AVRO_ALIASES, STAGE_ALIASES):
+        if low in table and table[low] in reg:
+            return reg[table[low]]
+    for cid, path in reg.items():
+        if cid.lower() == low:
+            return path
+    return None
+
+
+def _avro_allowed_json_types(avro_type: Any) -> set:
+    """Map an Avro field type (primitive, union list, or complex dict) to the
+    set of acceptable JSON types for a structural check."""
+    if isinstance(avro_type, str):
+        return set(_AVRO_TO_JSON.get(avro_type, {avro_type}))
+    if isinstance(avro_type, list):  # union
+        out: set = set()
+        for t in avro_type:
+            out |= _avro_allowed_json_types(t)
+        return out
+    if isinstance(avro_type, dict):
+        return set(_AVRO_TO_JSON.get(avro_type.get("type", ""), {"object"}))
+    return set()
+
+
+def _avro_structural_check(schema: dict, sample: dict) -> dict:
+    """Field-level (not binary) check of a JSON sample against an Avro record:
+    required fields present, no unknown fields, types broadly compatible."""
+    fields = schema.get("fields", [])
+    names = {f["name"] for f in fields}
+    # Required = no default AND the type can't be null.
+    required = [
+        f["name"] for f in fields
+        if "default" not in f and "null" not in _avro_allowed_json_types(f["type"])
+    ]
+    missing_required = [r for r in required if r not in sample]
+    unexpected_fields = [k for k in sample if k not in names]
+    type_mismatches = []
+    for f in fields:
+        if f["name"] in sample:
+            allowed = _avro_allowed_json_types(f["type"])
+            jt = _json_type(sample[f["name"]])
+            if allowed and jt not in allowed:
+                type_mismatches.append(
+                    {"field": f["name"], "expected": sorted(allowed), "got": jt}
+                )
+    valid = not missing_required and not unexpected_fields and not type_mismatches
+    return {
+        "valid": valid,
+        "missing_required": missing_required,
+        "unexpected_fields": unexpected_fields,
+        "type_mismatches": type_mismatches,
+    }
+
+
+def _json_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _type_ok(value: Any, schema_type: Union[str, list, None]) -> bool:
+    if schema_type is None:
+        return True
+    allowed = [schema_type] if isinstance(schema_type, str) else list(schema_type)
+    jt = _json_type(value)
+    if jt in allowed:
+        return True
+    # JSON Schema: an integer satisfies "number".
+    if jt == "integer" and "number" in allowed:
+        return True
+    return False
+
+
+def _load_sample(sample: Any) -> tuple[Optional[Any], Optional[str]]:
+    """Return (parsed_sample, error). Accepts dict/list, a file path, a named
+    example, or a JSON string."""
+    if isinstance(sample, (dict, list)):
+        return sample, None
+    if not isinstance(sample, str):
+        return None, f"unsupported sample type {type(sample).__name__}"
+
+    s = sample.strip()
+    # explicit path
+    p = Path(s)
+    if p.is_file():
+        try:
+            return json.loads(p.read_text()), None
+        except Exception as exc:
+            return None, f"failed to parse {p}: {exc}"
+    # named example anywhere under contracts/examples/
+    if EXAMPLES_DIR.exists():
+        for cand in EXAMPLES_DIR.rglob("*.json"):
+            if cand.stem == s or cand.name == s:
+                try:
+                    return json.loads(cand.read_text()), None
+                except Exception as exc:
+                    return None, f"failed to parse {cand}: {exc}"
+    # inline JSON
+    try:
+        return json.loads(s), None
+    except Exception:
+        return None, (
+            "sample is not an object, an existing file path, a known example "
+            "name, or valid JSON"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Tools
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def list_contracts() -> dict:
+    """List the available data contracts so you can pick a stage without
+    grepping. Returns JSON Schema contracts (validatable) and Avro contracts
+    (listed), plus the stage aliases that resolve to each."""
+    js = _jsonschema_registry()
+    alias_by_id: dict[str, list[str]] = {}
+    for alias, cid in STAGE_ALIASES.items():
+        alias_by_id.setdefault(cid, []).append(alias)
+
+    contracts = []
+    for cid, path in sorted(js.items()):
+        try:
+            schema = json.loads(path.read_text())
+            title = schema.get("title", cid)
+        except Exception:
+            title = cid
+        contracts.append({
+            "id": cid,
+            "title": title,
+            "kind": "jsonschema",
+            "stage_aliases": sorted(alias_by_id.get(cid, [])),
+            "path": str(path.relative_to(REPO_ROOT)),
+        })
+    avro = [
+        {"id": cid, "kind": "avro", "path": str(path.relative_to(REPO_ROOT))}
+        for cid, path in sorted(_avro_registry().items())
+    ]
+    return {
+        "jsonschema_contracts": contracts,
+        "avro_contracts": avro,
+        "hint": "validate(stage, sample) and get_contract(stage) accept an id or a stage alias",
+    }
+
+
+@mcp.tool
+def get_contract(stage: str) -> dict:
+    """Return the contract a stage's output must satisfy: a compact field
+    summary (required vs optional, types, additionalProperties) plus the raw
+    JSON Schema.
+
+    Args:
+        stage: a stage alias (e.g. "ingest", "connector", "ask") or a contract
+            id (e.g. "article-ingest-v1"). Call list_contracts() to discover.
+    """
+    path = _resolve(stage)
+    if path is None:
+        return {
+            "error": f"no JSON Schema contract for stage {stage!r}",
+            "hint": "call list_contracts() for valid ids and stage aliases",
+        }
+    try:
+        schema = json.loads(path.read_text())
+    except Exception as exc:
+        return {"error": f"failed to load {path}: {exc}"}
+
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    fields = {
+        name: {
+            "type": spec.get("type"),
+            "required": name in required,
+            **({"format": spec["format"]} if "format" in spec else {}),
+        }
+        for name, spec in props.items()
+    }
+    av = _avro_resolve(stage)
+    return {
+        "id": path.stem,
+        "title": schema.get("title", path.stem),
+        "description": schema.get("description"),
+        "path": str(path.relative_to(REPO_ROOT)),
+        "required": required,
+        "additionalProperties": schema.get("additionalProperties", True),
+        "fields": fields,
+        "avro_counterpart": str(av.relative_to(REPO_ROOT)) if av else None,
+        "schema": schema,
+    }
+
+
+@mcp.tool
+def validate(stage: str, sample: Any) -> dict:
+    """Validate a stage-output sample against its contract and return a compact
+    pass/fail + drift report. This is the governed boundary check: "does this
+    output still satisfy the contract the next stage expects?"
+
+    Args:
+        stage: stage alias or contract id (see list_contracts / get_contract).
+        sample: the output to check — an inline object, a path to a JSON file,
+            or a named example under contracts/examples/ (e.g.
+            "valid-full-article", "invalid-missing-url").
+
+    Returns per-schema verdicts. A stage's output is checked against its JSON
+    Schema (authoritative jsonschema validation + field drift) and, when the
+    stage's pipeline contract is Avro (e.g. article-ingest, sentiment), a
+    structural Avro check too. `agree` flags when the two disagree — which is
+    itself a contract bug (e.g. timestamp type drift between Avro and JSON
+    Schema).
+
+    Args:
+        stage: stage alias or contract id (see list_contracts / get_contract).
+        sample: the output to check — an inline object, a path to a JSON file,
+            or a named example under contracts/examples/ (e.g.
+            "valid-full-article", "invalid-missing-url").
+    """
+    js_path = _resolve(stage)
+    av_path = _avro_resolve(stage)
+    if js_path is None and av_path is None:
+        return {
+            "error": f"no contract (JSON Schema or Avro) for stage {stage!r}",
+            "hint": "call list_contracts() for valid ids and stage aliases",
+        }
+
+    parsed, err = _load_sample(sample)
+    if err:
+        return {"error": err}
+
+    verdicts: dict[str, Any] = {}
+
+    if js_path is not None:
+        try:
+            schema = json.loads(js_path.read_text())
+            import jsonschema  # lazy
+
+            errors = []
+            for e in sorted(jsonschema.Draft7Validator(schema).iter_errors(parsed),
+                            key=lambda e: list(e.path)):
+                loc = "/".join(str(p) for p in e.path) or "(root)"
+                errors.append({"path": loc, "message": e.message})
+
+            drift: dict[str, Any] = {"missing_required": [], "unexpected_fields": [], "type_mismatches": []}
+            if isinstance(parsed, dict):
+                props = schema.get("properties", {})
+                required = schema.get("required", [])
+                drift["missing_required"] = [r for r in required if r not in parsed]
+                drift["unexpected_fields"] = [k for k in parsed if k not in props]
+                for k, v in parsed.items():
+                    spec = props.get(k)
+                    if spec and "type" in spec and not _type_ok(v, spec["type"]):
+                        drift["type_mismatches"].append(
+                            {"field": k, "expected": spec["type"], "got": _json_type(v)}
+                        )
+            verdicts["jsonschema"] = {
+                "contract": js_path.stem,
+                "path": str(js_path.relative_to(REPO_ROOT)),
+                "valid": len(errors) == 0,
+                "error_count": len(errors),
+                "errors": errors[:MAX_ERRORS],
+                "drift": drift,
+            }
+        except Exception as exc:
+            verdicts["jsonschema"] = {"contract": js_path.stem, "error": str(exc)}
+
+    if av_path is not None:
+        try:
+            avro_schema = json.loads(av_path.read_text())
+            if isinstance(parsed, dict):
+                check = _avro_structural_check(avro_schema, parsed)
+            else:
+                check = {"valid": False, "note": "avro check needs an object sample"}
+            verdicts["avro"] = {
+                "contract": av_path.stem,
+                "path": str(av_path.relative_to(REPO_ROOT)),
+                "structural_only": True,
+                **check,
+            }
+        except Exception as exc:
+            verdicts["avro"] = {"contract": av_path.stem, "error": str(exc)}
+
+    present = [v.get("valid") for v in verdicts.values() if "valid" in v]
+    overall_valid = bool(present) and all(present)
+    agree = len(set(present)) <= 1
+
+    return {
+        "stage": stage,
+        "valid": overall_valid,
+        "agree": agree,
+        "checked": list(verdicts.keys()),
+        "verdicts": verdicts,
+    }
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tools/lineage_mcp/README.md
+++ b/tools/lineage_mcp/README.md
@@ -1,0 +1,73 @@
+# NeuroNews Lineage explorer (MCP server)
+
+Wraps the **Marquez / OpenLineage** metadata service so *"if I change this
+stage, what's downstream?"* is a typed tool instead of clicking the Marquez UI
+or curling its API. The third question alongside the other two servers:
+
+- `neuronews-pipeline` — **run** a stage
+- `neuronews-contracts` — **is the boundary output valid**
+- `neuronews-lineage` — **what depends on it** (this one)
+
+## Tools
+
+| Tool | What it answers |
+|---|---|
+| `list_namespaces()` | Which OpenLineage namespaces exist |
+| `list_nodes(namespace?, kind?)` | Dataset/job names to feed the other tools |
+| `lineage(node, depth=2, namespace?)` | Compact lineage graph (nodes + edges) around a node |
+| `impact(node, direction, namespace?)` | **Reachable set** — `downstream` = "what breaks if I change this", `upstream` = "what feeds this" |
+| `run_history(job, namespace?, limit=5)` | Recent runs + states — did the stage run, did it fail |
+
+A `node` is `dataset:<name>`, `job:<name>`, a full Marquez nodeId
+(`dataset:<ns>:<name>`), or a bare name (tried as dataset then job).
+
+## Config
+
+| Var | Default |
+|---|---|
+| `MARQUEZ_URL` | `http://localhost:5000` |
+| `MARQUEZ_NAMESPACE` | `neuronews` |
+
+The server uses only stdlib (`urllib`) — needs just `fastmcp`. When Marquez is
+unreachable, every tool returns a `{"error": …, "hint": …}` status (short
+timeouts, never hangs).
+
+## Bring up Marquez (required for live data)
+
+The server queries a running Marquez. Start it from the repo root with the
+committed override (which fixes three host-specific snags — see the override
+file's header):
+
+```bash
+docker network create neuronews-network 2>/dev/null || true
+docker compose -f docker-compose.lineage.yml \
+    -f tools/lineage_mcp/marquez-local.compose.yml up -d marquez marquez-db
+# wait for the API:
+curl -s http://localhost:5000/api/v1/namespaces
+```
+
+Lineage is normally populated by the Airflow DAGs / Spark jobs that emit
+OpenLineage (`jobs/spark/*_with_lineage.py`, `airflow/dags/news_pipeline.py`).
+With an empty Marquez the tools work but return empty graphs.
+
+## Register
+
+In `.mcp.json` as `neuronews-lineage`, launched from the repo root:
+
+```bash
+python3 tools/lineage_mcp/server.py
+```
+
+## Gotchas (hit while bringing Marquez up on Fedora/SELinux)
+
+- **`neuronews-network` is declared `external`** — `docker network create
+  neuronews-network` first or compose refuses to start.
+- **`marquez-db` binds host `5432`**, which collides with other local
+  Postgres containers. The override `!override`s its ports to drop the host
+  binding; Marquez reaches the DB over the internal docker network.
+- **SELinux blocks the bind mounts** (`Permission denied` on the mounted dir) —
+  the override adds `:z` to relabel.
+- **The repo's `marquez/config/marquez.yml` is incompatible with
+  `marquez:latest`** — it uses the old `database:` key; `:latest` wants `db:`
+  and rejects `cors`/`openlineage` blocks (`Unrecognized field at: database`).
+  The override mounts `marquez.local.yml` (trimmed, current schema) instead.

--- a/tools/lineage_mcp/marquez-local.compose.yml
+++ b/tools/lineage_mcp/marquez-local.compose.yml
@@ -1,0 +1,23 @@
+# Local override to bring Marquez up for the lineage MCP on this host.
+# Use with the repo's base compose, from the repo root:
+#
+#   docker network create neuronews-network 2>/dev/null || true
+#   docker compose -f docker-compose.lineage.yml \
+#       -f tools/lineage_mcp/marquez-local.compose.yml up -d marquez marquez-db
+#
+# Fixes three host-specific snags hit on a Fedora/SELinux box:
+#   1. marquez-db's host port 5432 collides with other local containers
+#      -> !override the ports to drop the host binding (marquez reaches the DB
+#         over the internal docker network).
+#   2. SELinux blocks the default bind mounts -> mount the config with :z.
+#   3. The repo's marquez/config/marquez.yml is incompatible with
+#      marquez:latest -> mount tools/lineage_mcp/marquez.local.yml instead.
+services:
+  marquez:
+    volumes: !override
+      - ./tools/lineage_mcp/marquez.local.yml:/usr/src/app/config/marquez.yml:z
+      - marquez_data:/opt/marquez
+  marquez-db:
+    ports: !override []
+    volumes: !override
+      - marquez_db_data:/var/lib/postgresql/data

--- a/tools/lineage_mcp/marquez.local.yml
+++ b/tools/lineage_mcp/marquez.local.yml
@@ -1,0 +1,25 @@
+# Minimal Marquez config compatible with marquezproject/marquez:latest.
+# The repo's contracts-era marquez/config/marquez.yml uses the old `database:`
+# key (and cors/openlineage blocks) that :latest rejects with
+# "Unrecognized field at: database" — it expects `db:`. This is the trimmed,
+# current-schema version used by the lineage MCP's local bring-up.
+server:
+  applicationConnectors:
+    - type: http
+      port: 5000
+  adminConnectors:
+    - type: http
+      port: 5001
+
+db:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://marquez-db:5432/marquez
+  user: marquez
+  password: marquez
+
+migrateOnStartup: true
+
+logging:
+  level: INFO
+  appenders:
+    - type: console

--- a/tools/lineage_mcp/requirements.txt
+++ b/tools/lineage_mcp/requirements.txt
@@ -1,0 +1,3 @@
+# MCP server framework for the lineage explorer.
+# The server uses only stdlib (urllib) to talk to Marquez — no other deps.
+fastmcp>=3.0

--- a/tools/lineage_mcp/server.py
+++ b/tools/lineage_mcp/server.py
@@ -1,0 +1,285 @@
+"""
+NeuroNews Lineage explorer — MCP server.
+
+Wraps the Marquez / OpenLineage metadata service so "if I change this stage,
+what's downstream?" is a typed tool instead of clicking the Marquez UI or
+curling its API. Complements the pipeline runner (run a stage) and the contract
+server (is the boundary valid) with the third question: what depends on it.
+
+Tools:
+  list_namespaces()                       -> OpenLineage namespaces
+  list_nodes(namespace, kind?)            -> datasets and/or jobs in a namespace
+  lineage(node, depth=2, namespace?)      -> compact lineage graph (nodes + edges)
+  impact(node, direction, namespace?)     -> downstream/upstream reachable set
+                                             ("what breaks if I change this")
+  run_history(job, namespace?, limit=5)   -> recent runs + states for a job
+
+Talks to Marquez at $MARQUEZ_URL (default http://localhost:5000). Default
+namespace is $MARQUEZ_NAMESPACE (default "neuronews"). Degrades gracefully with
+a status string when Marquez is unreachable — never hangs (short timeouts).
+
+A `node` is "dataset:<name>", "job:<name>", a full Marquez nodeId
+("dataset:<ns>:<name>"), or a bare name (tried as dataset then job).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import deque
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+mcp = FastMCP("neuronews-lineage")
+
+MARQUEZ_URL = os.getenv("MARQUEZ_URL", "http://localhost:5000").rstrip("/")
+DEFAULT_NS = os.getenv("MARQUEZ_NAMESPACE", "neuronews")
+TIMEOUT = 4
+MAX_NODES = 50
+
+
+# --------------------------------------------------------------------------- #
+# HTTP
+# --------------------------------------------------------------------------- #
+
+def _get(path: str, params: Optional[dict] = None) -> Any:
+    url = f"{MARQUEZ_URL}/api/v1{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.loads(resp.read())
+
+
+def _unreachable(exc: Exception) -> dict:
+    return {
+        "error": f"Marquez unreachable at {MARQUEZ_URL}: {exc}",
+        "hint": "start it: docker compose -f docker-compose.lineage.yml up -d marquez marquez-db",
+    }
+
+
+def _resolve_node_id(node: str, namespace: str) -> str:
+    """Turn a user 'node' into a Marquez nodeId 'kind:ns:name'."""
+    parts = node.split(":")
+    if len(parts) >= 3 and parts[0] in ("dataset", "job"):
+        return node  # already a full nodeId
+    if len(parts) == 2 and parts[0] in ("dataset", "job"):
+        return f"{parts[0]}:{namespace}:{parts[1]}"
+    # bare name: prefer dataset, fall back to job (caller may override)
+    return f"dataset:{namespace}:{node}"
+
+
+def _node_exists(node_id: str) -> bool:
+    kind, ns, name = node_id.split(":", 2)
+    try:
+        if kind == "dataset":
+            _get(f"/namespaces/{ns}/datasets/{urllib.parse.quote(name, safe='')}")
+        else:
+            _get(f"/namespaces/{ns}/jobs/{urllib.parse.quote(name, safe='')}")
+        return True
+    except Exception:
+        return False
+
+
+def _resolve_existing(node: str, namespace: str) -> Optional[str]:
+    """Resolve to an existing nodeId, trying dataset then job for bare names."""
+    nid = _resolve_node_id(node, namespace)
+    if _node_exists(nid):
+        return nid
+    # bare name resolved to dataset but maybe it's a job
+    parts = node.split(":")
+    if len(parts) == 1:
+        alt = f"job:{namespace}:{node}"
+        if _node_exists(alt):
+            return alt
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Tools
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def list_namespaces() -> dict:
+    """List the OpenLineage namespaces known to Marquez."""
+    try:
+        data = _get("/namespaces")
+    except Exception as exc:
+        return _unreachable(exc)
+    return {
+        "marquez": MARQUEZ_URL,
+        "default_namespace": DEFAULT_NS,
+        "namespaces": [n["name"] for n in data.get("namespaces", [])],
+    }
+
+
+@mcp.tool
+def list_nodes(namespace: Optional[str] = None, kind: str = "all") -> dict:
+    """List datasets and/or jobs in a namespace, so you can pick a node for
+    lineage()/impact() without guessing names.
+
+    Args:
+        namespace: defaults to $MARQUEZ_NAMESPACE ("neuronews").
+        kind: "datasets", "jobs", or "all".
+    """
+    ns = namespace or DEFAULT_NS
+    out: dict[str, Any] = {"namespace": ns}
+    try:
+        if kind in ("datasets", "all"):
+            d = _get(f"/namespaces/{ns}/datasets", {"limit": 100})
+            out["datasets"] = [x["name"] for x in d.get("datasets", [])][:MAX_NODES]
+        if kind in ("jobs", "all"):
+            j = _get(f"/namespaces/{ns}/jobs", {"limit": 100})
+            out["jobs"] = [x["name"] for x in j.get("jobs", [])][:MAX_NODES]
+    except Exception as exc:
+        return _unreachable(exc)
+    return out
+
+
+def _fetch_graph(node_id: str, depth: int) -> list[dict]:
+    data = _get("/lineage", {"nodeId": node_id, "depth": depth})
+    return data.get("graph", [])
+
+
+@mcp.tool
+def lineage(node: str, depth: int = 2, namespace: Optional[str] = None) -> dict:
+    """Return a compact lineage graph around a node: the nodes (datasets/jobs)
+    and the directed edges between them, up to `depth` hops — not the full
+    Marquez facet payload.
+
+    Args:
+        node: "dataset:<name>", "job:<name>", a full nodeId, or a bare name.
+        depth: hops to traverse (1-5).
+        namespace: defaults to $MARQUEZ_NAMESPACE.
+    """
+    ns = namespace or DEFAULT_NS
+    depth = max(1, min(int(depth), 5))
+    try:
+        node_id = _resolve_existing(node, ns)
+        if not node_id:
+            return {"error": f"node {node!r} not found in namespace {ns!r}",
+                    "hint": "call list_nodes() to see valid names"}
+        graph = _fetch_graph(node_id, depth)
+    except Exception as exc:
+        return _unreachable(exc)
+
+    edges = []
+    nodes = []
+    for n in graph:
+        nodes.append({"id": n["id"], "type": n["type"]})
+        for e in n.get("outEdges", []):
+            edges.append({"from": e["origin"], "to": e["destination"]})
+    return {
+        "root": node_id,
+        "depth": depth,
+        "node_count": len(nodes),
+        "nodes": nodes[:MAX_NODES],
+        "edges": edges[: MAX_NODES * 2],
+    }
+
+
+@mcp.tool
+def impact(node: str, direction: str = "downstream", namespace: Optional[str] = None) -> dict:
+    """The reachable set from a node — "what breaks if I change this"
+    (downstream) or "what feeds this" (upstream). Walks the lineage edges and
+    returns the jobs and datasets reached.
+
+    Args:
+        node: "dataset:<name>", "job:<name>", a full nodeId, or a bare name.
+        direction: "downstream" (consumers) or "upstream" (producers).
+        namespace: defaults to $MARQUEZ_NAMESPACE.
+    """
+    ns = namespace or DEFAULT_NS
+    direction = direction.lower()
+    if direction not in ("downstream", "upstream"):
+        return {"error": "direction must be 'downstream' or 'upstream'"}
+    try:
+        node_id = _resolve_existing(node, ns)
+        if not node_id:
+            return {"error": f"node {node!r} not found in namespace {ns!r}",
+                    "hint": "call list_nodes() to see valid names"}
+        graph = _fetch_graph(node_id, 5)
+    except Exception as exc:
+        return _unreachable(exc)
+
+    # Build adjacency from the graph's edges.
+    adj: dict[str, list[str]] = {}
+    kinds: dict[str, str] = {}
+    for n in graph:
+        kinds[n["id"]] = n["type"]
+        for e in n.get("outEdges", []):
+            adj.setdefault(e["origin"], []).append(e["destination"])
+        for e in n.get("inEdges", []):
+            # reverse adjacency for upstream walks
+            adj.setdefault("<rev>" + e["destination"], []).append(e["origin"])
+
+    start = node_id
+    seen = {start}
+    order = []
+    q = deque([start])
+    while q and len(order) < MAX_NODES:
+        cur = q.popleft()
+        key = cur if direction == "downstream" else "<rev>" + cur
+        for nxt in adj.get(key, []):
+            if nxt not in seen:
+                seen.add(nxt)
+                order.append(nxt)
+                q.append(nxt)
+
+    jobs = [n for n in order if n.startswith("job:")]
+    datasets = [n for n in order if n.startswith("dataset:")]
+    return {
+        "root": node_id,
+        "direction": direction,
+        "reached_count": len(order),
+        "jobs": jobs[:MAX_NODES],
+        "datasets": datasets[:MAX_NODES],
+    }
+
+
+@mcp.tool
+def run_history(job: str, namespace: Optional[str] = None, limit: int = 5) -> dict:
+    """Recent runs of a job with their states and timings — did the stage run,
+    and did it fail?
+
+    Args:
+        job: the job name (e.g. "nlp.sentiment"), or "job:<name>".
+        namespace: defaults to $MARQUEZ_NAMESPACE.
+        limit: how many recent runs (1-20).
+    """
+    ns = namespace or DEFAULT_NS
+    name = job.split(":")[-1]
+    limit = max(1, min(int(limit), 20))
+    try:
+        data = _get(f"/namespaces/{ns}/jobs/{urllib.parse.quote(name, safe='')}/runs",
+                    {"limit": limit})
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {"error": f"job {name!r} not found in namespace {ns!r}",
+                    "hint": "call list_nodes(kind='jobs')"}
+        return _unreachable(exc)
+    except Exception as exc:
+        return _unreachable(exc)
+
+    runs = [
+        {
+            "state": r.get("state"),
+            "startedAt": r.get("startedAt"),
+            "endedAt": r.get("endedAt"),
+            "durationMs": r.get("durationMs"),
+        }
+        for r in data.get("runs", [])
+    ]
+    states = {}
+    for r in runs:
+        states[r["state"]] = states.get(r["state"], 0) + 1
+    return {"job": name, "namespace": ns, "run_count": len(runs),
+            "state_summary": states, "runs": runs}
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tools/pipeline_mcp/README.md
+++ b/tools/pipeline_mcp/README.md
@@ -1,0 +1,53 @@
+# NeuroNews Pipeline-stage runner (MCP server)
+
+A thin local MCP server that exposes each ETL pipeline boundary as a typed tool,
+so you can run **one stage against a fixture/source** and inspect a **summary or
+diff** — never the full payload. It drives the project's own pipeline code
+(`src/ingestion/scrapy_integration.py`) and the local docker-compose stack
+(DuckDB warehouse, Postgres/pgvector, S3/MinIO).
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `list_sources(category?)` | List the configured RSS connectors (`DEFAULT_FEEDS`), optionally filtered by category. |
+| `run_connector(source, sample=5)` | Fetch + parse up to `sample` articles from one source's **live** feed. Summary only (count, date range, sentiment distribution, sample titles). No write. |
+| `run_stage(stage, input_ref?, sample=5, apply=false)` | Run one stage: `fetch` (source→article refs), `sentiment` (text or article id → score/label), `store` (fetch→**diff** vs warehouse; `apply=true` to insert), `ingest` (full fetch→store). |
+| `trace_article(id)` | Where an article id exists across the **warehouse** (read-only row summary), **pgvector**, and **S3/MinIO** (reachability). |
+
+## Run / register
+
+Registered in the repo's `.mcp.json` as a stdio server (`neuronews-pipeline`),
+launched from the repo root:
+
+```bash
+python3 tools/pipeline_mcp/server.py
+```
+
+Requires `fastmcp` (`pip install fastmcp`). `psycopg2` and `boto3` are optional —
+used best-effort for the pgvector/S3 checks in `trace_article`.
+
+## Design constraints (why it's shaped this way)
+
+- **Lazy imports.** The module top imports only stdlib + `fastmcp`, so the
+  server starts instantly and never triggers the repo's heavy ML import graph
+  (transformers/torch), which can hang on import. Pipeline code is imported
+  inside each tool.
+- **Read-only warehouse.** DuckDB is single-writer. The server opens the
+  warehouse **read-only** for inspection so it doesn't fight a running
+  API/ingester's writer lock, and reports the lock as a clean status string
+  rather than crashing. Writes (`store`/`ingest` with `apply=true`) need the
+  warehouse free — point `NEURONEWS_DB_PATH` at a free file if the API is up.
+- **Summaries, not payloads.** Lists are capped (`MAX_LIST`) and article content
+  is truncated (`CONTENT_PREVIEW`).
+- **Best-effort backends.** pgvector/S3 checks use short timeouts; an
+  unreachable backend yields `{"reachable": false}`, never a hang.
+
+## Environment
+
+| Var | Default | Used by |
+|---|---|---|
+| `NEURONEWS_DB_PATH` | `<repo>/data/neuronews.duckdb` | warehouse reads/writes |
+| `PGVECTOR_HOST` / `PGVECTOR_PORT` | `localhost` / `5433` | `trace_article` vector check |
+| `PGVECTOR_DSN` | `postgresql://neuronews:…@localhost:5433/neuronews_vector` | `trace_article` |
+| `S3_ENDPOINT_URL` / `AWS_ENDPOINT_URL` | unset | `trace_article` object-store check |

--- a/tools/pipeline_mcp/requirements.txt
+++ b/tools/pipeline_mcp/requirements.txt
@@ -1,0 +1,6 @@
+# MCP server framework for the pipeline-stage runner
+fastmcp>=3.0
+
+# Optional, for trace_article backend checks (already in the main requirements):
+# psycopg2-binary
+# boto3

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1,0 +1,410 @@
+"""
+NeuroNews Pipeline-stage runner — MCP server.
+
+A thin developer tool that exposes each ETL pipeline boundary as a typed tool so
+you can run a single stage against a fixture/source and inspect a SUMMARY or
+DIFF — never the full payload. It drives the project's own pipeline code
+(`src.ingestion.scrapy_integration`) and the local docker-compose stack
+(DuckDB warehouse, Postgres/pgvector, S3/MinIO).
+
+Tools:
+  list_sources(category?)              -> the configured RSS connectors (DEFAULT_FEEDS)
+  run_connector(source, sample=5)      -> fetch+parse one source, summary only (no write)
+  run_stage(stage, input_ref?, ...)    -> run one named stage: fetch | sentiment | store | ingest
+  trace_article(id)                    -> where an article exists across warehouse / vector / s3
+
+Design constraints (learned the hard way in this repo):
+  * Lazy imports inside tools. The top of this module imports only stdlib +
+    fastmcp so the server starts instantly and never triggers the repo's heavy
+    ML import graph (transformers/torch), which can hang on import.
+  * The DuckDB warehouse is SINGLE-WRITER. We open it READ-ONLY for inspection
+    so we don't fight the API server's writer lock, and report the lock cleanly
+    instead of crashing. Writes (store/ingest) require apply=True and a free
+    warehouse.
+  * Postgres/S3 checks are best-effort with short timeouts; an unreachable
+    backend yields a status string, not a hang or traceback.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import socket
+from pathlib import Path
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+# Make the repo importable (server lives at <repo>/tools/pipeline_mcp/server.py).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+mcp = FastMCP("neuronews-pipeline")
+
+# Caps so we always return summaries, not payloads.
+MAX_LIST = 25
+CONTENT_PREVIEW = 200
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _pipeline():
+    """Lazy-import the (light) ingestion pipeline module."""
+    from src.ingestion import scrapy_integration as si
+    return si
+
+
+def _db_path() -> str:
+    return os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+
+
+def _warehouse_ro():
+    """Open the DuckDB warehouse READ-ONLY. Raises with a clear message if the
+    file is missing or locked by another (writer) process."""
+    import duckdb
+
+    path = _db_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"warehouse not found at {path} — start the API once to seed it, "
+            f"or set NEURONEWS_DB_PATH"
+        )
+    try:
+        return duckdb.connect(path, read_only=True)
+    except Exception as exc:  # IOException when a writer holds the lock
+        raise RuntimeError(
+            f"warehouse at {path} is not readable (likely locked by a running "
+            f"API/ingester — DuckDB is single-writer): {exc}"
+        ) from exc
+
+
+def _find_feed(si, source: str):
+    """Resolve a source by exact or case-insensitive name; return Feed or None."""
+    for f in si.DEFAULT_FEEDS:
+        if f.name == source:
+            return f
+    low = source.strip().lower()
+    for f in si.DEFAULT_FEEDS:
+        if f.name.lower() == low:
+            return f
+    return None
+
+
+def _sentiment_distribution(articles) -> dict:
+    dist = {"positive": 0, "neutral": 0, "negative": 0}
+    for a in articles:
+        dist[a.sentiment_label] = dist.get(a.sentiment_label, 0) + 1
+    return dist
+
+
+def _port_open(host: str, port: int, timeout: float = 1.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Tools
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def list_sources(category: Optional[str] = None) -> dict:
+    """List the configured news connectors (RSS/Atom feeds in DEFAULT_FEEDS).
+
+    Args:
+        category: optional filter, e.g. "Technology", "Economy", "World".
+
+    Returns a summary: total count, the categories present, and the feeds
+    (name, url, category).
+    """
+    si = _pipeline()
+    feeds = list(si.DEFAULT_FEEDS)
+    if category:
+        feeds = [f for f in feeds if f.category.lower() == category.lower()]
+    return {
+        "count": len(feeds),
+        "categories": sorted({f.category for f in si.DEFAULT_FEEDS}),
+        "sources": [{"name": f.name, "url": f.url, "category": f.category} for f in feeds],
+    }
+
+
+@mcp.tool
+def run_connector(source: str, sample: int = 5) -> dict:
+    """Run a single connector: fetch + parse up to `sample` articles from one
+    source's live feed and return a SUMMARY only (no warehouse write).
+
+    Args:
+        source: a source name from list_sources (e.g. "BBC Technology").
+        sample: max articles to parse (1-25).
+
+    Returns counts, category, date range, sentiment distribution and a few
+    sample titles. Network-dependent — reports a clear error if the feed can't
+    be fetched.
+    """
+    si = _pipeline()
+    feed = _find_feed(si, source)
+    if feed is None:
+        return {"error": f"unknown source {source!r}", "hint": "call list_sources()"}
+
+    sample = max(1, min(int(sample), 25))
+    try:
+        raw = si._http_get(feed.url)
+        articles = si.parse_feed(raw, feed, limit=sample)
+    except Exception as exc:
+        return {"error": f"fetch/parse failed for {feed.name}: {exc}", "url": feed.url}
+
+    dates = sorted(a.publish_date for a in articles) if articles else []
+    return {
+        "source": feed.name,
+        "category": feed.category,
+        "url": feed.url,
+        "fetched": len(articles),
+        "date_range": (
+            {"earliest": dates[0].isoformat(), "latest": dates[-1].isoformat()}
+            if dates else None
+        ),
+        "sentiment": _sentiment_distribution(articles),
+        "sample_titles": [a.title for a in articles[:MAX_LIST]],
+    }
+
+
+@mcp.tool
+def run_stage(
+    stage: str,
+    input_ref: Optional[str] = None,
+    sample: int = 5,
+    apply: bool = False,
+) -> dict:
+    """Run a single pipeline stage against a fixture/source and return a
+    summary or diff.
+
+    Stages:
+      fetch     input_ref = source name. Fetch+parse, return article refs
+                (id, title, sentiment) — no write.
+      sentiment input_ref = raw text, OR an article id present in the warehouse.
+                Returns {score, label}.
+      store     input_ref = source name. Fetch that source, then DIFF against
+                the warehouse: which ids are new vs already present. Read-only
+                by default; pass apply=true to actually insert (requires the
+                warehouse to be free — DuckDB single-writer).
+      ingest    input_ref = source name (or omit for all sources). Full
+                fetch->store. Read-only diff unless apply=true.
+
+    Args:
+        stage: one of fetch | sentiment | store | ingest.
+        input_ref: source name, text, or article id depending on the stage.
+        sample: max articles per feed for fetch/store/ingest (1-25).
+        apply: actually write to the warehouse (store/ingest only).
+    """
+    si = _pipeline()
+    stage = stage.strip().lower()
+    sample = max(1, min(int(sample), 25))
+
+    if stage == "fetch":
+        if not input_ref:
+            return {"error": "fetch needs input_ref = a source name"}
+        feed = _find_feed(si, input_ref)
+        if feed is None:
+            return {"error": f"unknown source {input_ref!r}", "hint": "call list_sources()"}
+        try:
+            raw = si._http_get(feed.url)
+            articles = si.parse_feed(raw, feed, limit=sample)
+        except Exception as exc:
+            return {"error": f"fetch failed for {feed.name}: {exc}"}
+        return {
+            "stage": "fetch",
+            "source": feed.name,
+            "fetched": len(articles),
+            "articles": [
+                {"id": a.id, "title": a.title, "sentiment": a.sentiment_label}
+                for a in articles[:MAX_LIST]
+            ],
+        }
+
+    if stage == "sentiment":
+        if not input_ref:
+            return {"error": "sentiment needs input_ref = text or an article id"}
+        text = input_ref
+        resolved_from = "text"
+        # If it looks like an id rather than a sentence, try the warehouse.
+        if " " not in input_ref.strip():
+            try:
+                con = _warehouse_ro()
+                row = con.execute(
+                    "SELECT title, content FROM news_articles WHERE id = ?", [input_ref]
+                ).fetchone()
+                con.close()
+                if row:
+                    text = f"{row[0]}. {row[1] or ''}"
+                    resolved_from = "article_id"
+            except Exception:
+                pass  # fall back to treating input_ref as literal text
+        score, label = si.score_sentiment(text)
+        return {
+            "stage": "sentiment",
+            "resolved_from": resolved_from,
+            "score": score,
+            "label": label,
+            "scored_chars": len(text),
+        }
+
+    if stage in ("store", "ingest"):
+        feeds = None
+        if input_ref and input_ref.lower() != "all":
+            feed = _find_feed(si, input_ref)
+            if feed is None:
+                return {"error": f"unknown source {input_ref!r}", "hint": "call list_sources()"}
+            feeds = [feed]
+        try:
+            articles = si.fetch_articles(feeds, limit_per_feed=sample)
+        except Exception as exc:
+            return {"error": f"fetch failed: {exc}"}
+
+        # Read-only diff against the warehouse.
+        existing: set[str] = set()
+        warehouse_status = "ok"
+        try:
+            con = _warehouse_ro()
+            ids = [a.id for a in articles]
+            if ids:
+                placeholders = ",".join("?" for _ in ids)
+                rows = con.execute(
+                    f"SELECT id FROM news_articles WHERE id IN ({placeholders})", ids
+                ).fetchall()
+                existing = {r[0] for r in rows}
+            con.close()
+        except Exception as exc:
+            warehouse_status = str(exc)
+
+        new = [a for a in articles if a.id not in existing]
+        result = {
+            "stage": stage,
+            "source": input_ref or "all",
+            "fetched": len(articles),
+            "would_insert": len(new),
+            "already_present": len(existing),
+            "warehouse": warehouse_status,
+            "applied": False,
+            "sample_new_titles": [a.title for a in new[:MAX_LIST]],
+        }
+        if apply:
+            try:
+                inserted = si.store_articles(articles, replace=False)
+                result["applied"] = True
+                result["inserted"] = inserted
+            except Exception as exc:
+                result["apply_error"] = (
+                    f"{exc} (warehouse likely locked by a running API/ingester; "
+                    f"stop it or set NEURONEWS_DB_PATH to a free file)"
+                )
+        return result
+
+    return {
+        "error": f"unknown stage {stage!r}",
+        "valid_stages": ["fetch", "sentiment", "store", "ingest"],
+    }
+
+
+@mcp.tool
+def trace_article(id: str) -> dict:
+    """Trace an article id across the pipeline's stores: the DuckDB warehouse,
+    the Postgres/pgvector store, and S3/MinIO. Returns a presence summary and a
+    truncated warehouse row — never the full content.
+
+    Args:
+        id: the article id (warehouse ids are a url hash; seed ids look like
+            "art-0001"). Use run_stage("fetch", ...) to discover ids.
+    """
+    trace: dict[str, Any] = {"id": id, "warehouse": {}, "vector_store": {}, "object_store": {}}
+
+    # 1) DuckDB warehouse (read-only).
+    try:
+        con = _warehouse_ro()
+        row = con.execute(
+            "SELECT title, url, source, category, publish_date, sentiment_score, "
+            "sentiment_label, content FROM news_articles WHERE id = ?",
+            [id],
+        ).fetchone()
+        con.close()
+        if row:
+            content = row[7] or ""
+            trace["warehouse"] = {
+                "present": True,
+                "title": row[0],
+                "url": row[1],
+                "source": row[2],
+                "category": row[3],
+                "publish_date": row[4].isoformat() if row[4] else None,
+                "sentiment": {"score": row[5], "label": row[6]},
+                "content_length": len(content),
+                "content_preview": content[:CONTENT_PREVIEW],
+            }
+        else:
+            trace["warehouse"] = {"present": False}
+    except Exception as exc:
+        trace["warehouse"] = {"status": str(exc)}
+
+    # 2) Postgres / pgvector (best-effort, short timeout).
+    pg_host = os.getenv("PGVECTOR_HOST", "localhost")
+    pg_port = int(os.getenv("PGVECTOR_PORT", "5433"))
+    if not _port_open(pg_host, pg_port):
+        trace["vector_store"] = {"reachable": False, "endpoint": f"{pg_host}:{pg_port}"}
+    else:
+        try:
+            import psycopg2
+
+            dsn = os.getenv(
+                "PGVECTOR_DSN",
+                f"postgresql://neuronews:neuronews_vector_pass@{pg_host}:{pg_port}/neuronews_vector",
+            )
+            conn = psycopg2.connect(dsn, connect_timeout=2)
+            cur = conn.cursor()
+            # Find any table with an 'id'-like column; report presence generically.
+            cur.execute(
+                "SELECT table_name FROM information_schema.columns "
+                "WHERE column_name IN ('id','article_id','doc_id') "
+                "AND table_schema='public' LIMIT 5"
+            )
+            tables = [r[0] for r in cur.fetchall()]
+            hits = []
+            for t in tables:
+                for col in ("id", "article_id", "doc_id"):
+                    try:
+                        cur.execute(
+                            f"SELECT 1 FROM {t} WHERE {col} = %s LIMIT 1", (id,)
+                        )
+                        if cur.fetchone():
+                            hits.append(f"{t}.{col}")
+                    except Exception:
+                        conn.rollback()
+            cur.close()
+            conn.close()
+            trace["vector_store"] = {
+                "reachable": True,
+                "endpoint": f"{pg_host}:{pg_port}",
+                "candidate_tables": tables,
+                "found_in": hits,
+            }
+        except Exception as exc:
+            trace["vector_store"] = {"reachable": True, "error": str(exc)}
+
+    # 3) S3 / MinIO (reachability only — don't hang on a full object scan).
+    s3_endpoint = os.getenv("S3_ENDPOINT_URL") or os.getenv("AWS_ENDPOINT_URL")
+    if s3_endpoint:
+        host = s3_endpoint.split("://", 1)[-1].split("/", 1)[0]
+        h, _, p = host.partition(":")
+        port = int(p) if p else (443 if s3_endpoint.startswith("https") else 80)
+        trace["object_store"] = {"endpoint": s3_endpoint, "reachable": _port_open(h, port)}
+    else:
+        trace["object_store"] = {"status": "no S3_ENDPOINT_URL configured"}
+
+    return trace
+
+
+if __name__ == "__main__":
+    mcp.run()  # stdio transport by default


### PR DESCRIPTION
Agent-facing tooling for developing NeuroNews. Everything was verified by running the actual apps/servers in-container (drivers executed, endpoints curled, contracts validated, lineage queried) — not paraphrased from docs.

## Skills (`.claude/skills/`)

**Run** (launch + drive each surface):
- `run-web` — Playwright driver that screenshots all 9 views of the React app (`apps/web`); falls back to demo data when the backend is down.
- `run-api` — `smoke.sh` launches the FastAPI backend in dev mode on its own DuckDB and curls every endpoint the frontend uses.
- `run-streamlit` — driver for the Streamlit app; flagged **legacy** in favor of `apps/web`.

**Build** (scaffold following the repo's exact patterns):
- `add-web-view` — a new frontend view (ViewKey, Sidebar, App switch, query/adapter/mock).
- `add-api-route` — a FastAPI route + the `try_import_*` / `*_AVAILABLE` registration in `src/api/app.py`.
- `scaffold-connector` — a new ingestion source emitting `article-ingest-v1`, with the pipeline+contracts+lineage verify loop.

## MCP servers (`tools/`, registered in `.mcp.json`)

Three local stdio servers (FastMCP) that turn the pipeline boundaries into typed tools:

- **`neuronews-pipeline`** — run a single ETL stage against a sample: `list_sources` / `run_connector` / `run_stage` / `trace_article`.
- **`neuronews-contracts`** — validate stage output against `contracts/` with a pass/fail + drift report. Checks JSON Schema **and** Avro and flags when they disagree.
- **`neuronews-lineage`** — query Marquez/OpenLineage for downstream impact: `list_namespaces` / `list_nodes` / `lineage` / `impact` / `run_history`. Ships a local compose override (`tools/lineage_mcp/marquez-local.compose.yml`) to bring Marquez up.

Together they form a loop: scaffold a connector → run it → validate the boundary → trace downstream.

## Design notes
- All servers **lazy-import** to avoid the repo's heavy ML import path (transformers/torch), which can hang on import.
- All **degrade gracefully** when a backend (DuckDB lock, Marquez, etc.) is unreachable — status string, never a hang.
- DuckDB warehouse is opened **read-only** so tools don't fight the API's single-writer lock.

## Notable finding
The contract server surfaced a real divergence on first run: `article-ingest-v1` types `published_at`/`ingested_at` as **string** (JSON Schema) vs **long** epoch-millis (Avro). The golden fixtures + running pipeline follow Avro, so `validate("ingest", …)` returns `agree: false`. The two contracts need reconciling.