### PR TITLE
feat(ingestion): books connector — EPUB/PDF with hierarchical chunking (#521)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,10 @@ umap-learn>=0.5.0
 
 # Local analytics warehouse (Snowflake alternative for local dev)
 duckdb>=1.0.0,<2.0.0
+
+# Books connector (#521) — all optional; connector degrades gracefully without them
+ebooklib>=0.18       # EPUB: richer ToC/structure extraction
+PyMuPDF>=1.24.0      # PDF: text + bookmark outline (install as fitz)
+pdfminer.six>=20221105  # PDF: pure-Python fallback text extraction
+pytesseract>=0.3.10  # OCR: Python wrapper for Tesseract (requires system tesseract)
+pdf2image>=1.17.0    # OCR: PDF->PIL images for pytesseract (requires system poppler)

--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -18,6 +18,7 @@ from src.ingestion.connectors.registry import (
 # Importing the modules triggers @register_connector for the built-in connectors.
 from src.ingestion.connectors import news  # noqa: E402,F401
 from src.ingestion.connectors import paper  # noqa: E402,F401
+from src.ingestion.connectors import book  # noqa: E402,F401
 
 __all__ = [
     "Connector",

--- a/src/ingestion/connectors/book/README.md
+++ b/src/ingestion/connectors/book/README.md
@@ -1,0 +1,73 @@
+# Books connector
+
+EPUB and PDF ingestion for the knowledge-engine pipeline (#521).
+
+## What it does
+
+Reads a book file and emits **one `Document` per chapter/section** so that RAG
+retrieval can cite an answer to "chapter 3, section 2" rather than just "the
+book". Each document carries a `section_path` breadcrumb in its `metadata`.
+
+```
+book.epub  ->  BookConnector.harvest()  ->  Document(source_type="book", metadata={"section_path": ["Part I", "Chapter 3"]}, ...)
+```
+
+## Usage
+
+```python
+from src.ingestion.connectors import get_connector
+
+connector = get_connector("book")
+for doc in connector.harvest(["path/to/book.epub", "path/to/book.pdf"]):
+    print(doc.title, doc.metadata["section_path"])
+    # "The Pragmatic Programmer › Chapter 3 › The Basic Tools" | ["Chapter 3", "The Basic Tools"]
+```
+
+### Structure-aware chunking
+
+After harvesting, pass each document's section tree through `chunk_document` for
+citation-level RAG chunks:
+
+```python
+from services.rag.chunking import chunk_document, DocumentSection
+
+# If you want chunks within a section (for very long chapters):
+chunks = chunk_document(
+    [DocumentSection(title=doc.title, text=doc.content)],
+    metadata={"document_id": doc.document_id, "section_path": doc.metadata["section_path"]},
+)
+# chunks[0]["path"] == ["Chapter 3", "The Basic Tools"]
+```
+
+## Extraction chain
+
+| Format | Backend         | Notes                                                    |
+|--------|----------------|----------------------------------------------------------|
+| EPUB   | `ebooklib`      | Full ToC + per-chapter HTML; best structure              |
+| EPUB   | stdlib zip+XML  | Fallback: NCX nav → spine; works without `ebooklib`      |
+| PDF    | PyMuPDF (`fitz`)| Bookmark outline → chapter tree; best for tagged PDFs    |
+| PDF    | `pdfminer.six`  | Pure-Python text extraction; heuristic heading split     |
+| PDF    | `pytesseract`   | OCR fallback for scanned/image-only PDFs                 |
+
+All backends are optional — the connector degrades gracefully when a library is
+not installed, falling to the next level.
+
+## Optional dependencies
+
+```
+pip install ebooklib PyMuPDF pdfminer.six pytesseract pdf2image
+```
+
+OCR also requires system packages: `tesseract` and `poppler-utils`.
+
+## Document metadata fields
+
+| Field                        | Description                                      |
+|------------------------------|--------------------------------------------------|
+| `metadata["book_title"]`     | Full book title                                  |
+| `metadata["book_id"]`        | Stable `isbn:…` or `book:<hash>` identifier      |
+| `metadata["section_path"]`   | Breadcrumb list, e.g. `["Part I", "Chapter 3"]`  |
+| `metadata["section_level"]`  | Depth (0 = part, 1 = chapter, 2 = section, …)    |
+| `metadata["format"]`         | `"epub"` or `"pdf"`                              |
+| `metadata["extractor"]`      | Which backend extracted the text                 |
+| `content_ref`                | `file:///path/to/book.epub#part-i/chapter-3` URI |

--- a/src/ingestion/connectors/book/__init__.py
+++ b/src/ingestion/connectors/book/__init__.py
@@ -1,0 +1,24 @@
+"""
+Books connector: EPUB and PDF ingestion into document-ingest-v1 records.
+
+Importing this package registers the ``book`` connector.
+"""
+
+from src.ingestion.connectors.book.connector import (
+    BookConnector,
+    book_metadata_to_documents,
+)
+from src.ingestion.connectors.book.epub_parser import parse_epub
+from src.ingestion.connectors.book.models import BookMetadata, BookSection, book_id, section_id
+from src.ingestion.connectors.book.pdf_parser import parse_pdf_sections
+
+__all__ = [
+    "BookConnector",
+    "book_metadata_to_documents",
+    "parse_epub",
+    "parse_pdf_sections",
+    "BookMetadata",
+    "BookSection",
+    "book_id",
+    "section_id",
+]

--- a/src/ingestion/connectors/book/connector.py
+++ b/src/ingestion/connectors/book/connector.py
@@ -1,0 +1,172 @@
+"""
+Books connector: ingest EPUB and PDF books as structured Document records.
+
+Implements the connector interface (discover -> fetch -> parse -> Document)
+for source_type="book". Each chapter / top-level section becomes its own
+Document record so retrieval can cite "Chapter 3 > The Turing Test". Large
+bodies are stored inline; content_ref carries a file URI fragment for the
+section's location in the source file.
+
+Usage::
+
+    connector = BookConnector()
+    for doc in connector.harvest(["path/to/book.epub", "path/to/book.pdf"]):
+        # doc.metadata["section_path"] -> ["Part I", "Chapter 3", "..."]
+        chunks = chunk_document(doc)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.book.epub_parser import parse_epub
+from src.ingestion.connectors.book.models import BookMetadata, BookSection, section_id
+from src.ingestion.connectors.book.pdf_parser import parse_pdf_sections
+from src.ingestion.connectors.registry import register_connector
+
+
+def _file_uri(path: str, fragment: str = "") -> str:
+    uri = f"file://{Path(path).resolve()}"
+    return f"{uri}#{fragment}" if fragment else uri
+
+
+def book_metadata_to_documents(meta: BookMetadata, ingested_at: int) -> List[Document]:
+    """
+    Turn a BookMetadata (with section tree) into one Document per chapter/section.
+
+    Top-level sections without body text become container nodes whose children
+    are still emitted. Sections with both body text and children emit a Document
+    for themselves and their children.
+    """
+    docs: List[Document] = []
+
+    def _emit(node: BookSection, ancestors: List[str]) -> None:
+        path = node.path_from(ancestors)
+        fragment = "/".join(p.lower().replace(" ", "-") for p in path if p)
+        doc_id = section_id(meta.document_id, path)
+        content_ref = _file_uri(meta.file_path, fragment) if meta.file_path else None
+
+        if node.text.strip():
+            docs.append(Document(
+                document_id=doc_id,
+                source_type="book",
+                language=meta.language,
+                ingested_at=ingested_at,
+                source_id=meta.isbn or None,
+                url=content_ref,
+                title=f"{meta.title} › {' › '.join(p for p in path if p)}" if path else meta.title,
+                content=node.text,
+                content_ref=content_ref,
+                authors=list(meta.authors),
+                metadata={
+                    "book_title": meta.title,
+                    "book_id": meta.document_id,
+                    "section_path": list(path),
+                    "section_level": node.level,
+                    "format": meta.format,
+                    "extractor": meta.extractor,
+                    **({"isbn": meta.isbn} if meta.isbn else {}),
+                    **({"publisher": meta.publisher} if meta.publisher else {}),
+                    **({"published_year": meta.published_year} if meta.published_year else {}),
+                },
+            ))
+
+        for child in node.children:
+            _emit(child, path)
+
+    for section in meta.sections:
+        _emit(section, [])
+
+    # If the book has no sections at all, emit one Document for the whole book.
+    if not docs and (meta.title or meta.file_path):
+        all_text = " ".join(
+            s.text for s in meta.sections if s.text
+        )
+        if all_text.strip():
+            docs.append(Document(
+                document_id=meta.document_id,
+                source_type="book",
+                language=meta.language,
+                ingested_at=ingested_at,
+                source_id=meta.isbn or None,
+                url=_file_uri(meta.file_path) if meta.file_path else None,
+                title=meta.title,
+                content=all_text,
+                content_ref=_file_uri(meta.file_path) if meta.file_path else None,
+                authors=list(meta.authors),
+                metadata={
+                    "book_title": meta.title,
+                    "book_id": meta.document_id,
+                    "section_path": [],
+                    "format": meta.format,
+                    "extractor": meta.extractor,
+                },
+            ))
+
+    return docs
+
+
+@register_connector
+class BookConnector(Connector):
+    """
+    Ingest EPUB and PDF books as document-ingest-v1 records.
+
+    discover(query) expects a list of file paths (str or Path).
+    Each chapter / top-level section becomes a separate Document so that
+    RAG retrieval can cite "Chapter 3, The Turing Test".
+    """
+
+    source_type = "book"
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        if query is None:
+            return
+        paths = [query] if isinstance(query, (str, Path)) else list(query)
+        for path in paths:
+            p = Path(path)
+            yield SourceRef(
+                locator=str(p.resolve()),
+                title=p.stem,
+                metadata={"format": p.suffix.lstrip(".").lower()},
+            )
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        path = Path(ref.locator)
+        if not path.exists():
+            raise FileNotFoundError(f"Book file not found: {path}")
+        suffix = path.suffix.lower()
+        content_type = (
+            "application/epub+zip" if suffix == ".epub"
+            else "application/pdf" if suffix == ".pdf"
+            else "application/octet-stream"
+        )
+        return RawDocument(ref=ref, content=path.read_bytes(), content_type=content_type)
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        content_type = raw.content_type or ""
+        path = raw.ref.locator
+        content = raw.content
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        if "epub" in content_type or path.endswith(".epub"):
+            meta = parse_epub(content, file_path=path)
+        elif "pdf" in content_type or path.endswith(".pdf"):
+            sections, extractor = parse_pdf_sections(content)
+            meta = BookMetadata(
+                title=raw.ref.title or Path(path).stem,
+                file_path=path,
+                format="pdf",
+                sections=sections,
+                extractor=extractor,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported content type {content_type!r} for {path!r}; "
+                "expected .epub or .pdf"
+            )
+
+        return book_metadata_to_documents(meta, raw.fetched_at)

--- a/src/ingestion/connectors/book/epub_parser.py
+++ b/src/ingestion/connectors/book/epub_parser.py
@@ -1,0 +1,330 @@
+"""
+EPUB parsing for books.
+
+Uses ebooklib when installed (full structure: parts/chapters/sections from the
+NCX/ToC spine). Falls back to stdlib zip+XML extraction which yields chapter
+text without deep hierarchy. Both paths produce a BookMetadata with a section
+tree ready for structure-aware chunking.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import zipfile
+from typing import List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+from src.ingestion.connectors.book.models import BookMetadata, BookSection
+
+
+# Namespace maps used in both the fallback and the ebooklib path.
+_NS_OPF = {"opf": "http://www.idpf.org/2007/opf"}
+_NS_DC = {"dc": "http://purl.org/dc/elements/1.1/"}
+_NS_NCX = {"ncx": "http://www.daisy.org/z3986/2005/ncx/"}
+
+
+def _strip_tags(text: str) -> str:
+    """Remove XML/HTML tags from a string."""
+    return re.sub(r"<[^>]+>", " ", text).strip()
+
+
+def _text_from_xhtml(xhtml_bytes: bytes) -> str:
+    """Extract visible text from an XHTML document."""
+    try:
+        tree = ET.fromstring(xhtml_bytes)
+        return " ".join(tree.itertext()).strip()
+    except ET.ParseError:
+        # Malformed XHTML: strip tags heuristically.
+        return _strip_tags(xhtml_bytes.decode("utf-8", errors="replace"))
+
+
+def _opf_metadata(opf_bytes: bytes) -> Tuple[str, List[str], Optional[str], Optional[str]]:
+    """Parse OPF metadata: (title, authors, language, isbn)."""
+    try:
+        root = ET.fromstring(opf_bytes)
+    except ET.ParseError:
+        return ("", [], None, None)
+
+    title = ""
+    authors: List[str] = []
+    language = None
+    isbn = None
+
+    meta = root.find("opf:metadata", _NS_OPF)
+    if meta is None:
+        # Some EPUBs omit the namespace prefix on the metadata element.
+        meta = root.find("metadata")
+    if meta is not None:
+        t = meta.find("dc:title", _NS_DC)
+        if t is None:
+            t = meta.find("title")
+        if t is not None and t.text:
+            title = t.text.strip()
+        for creator in list(meta.findall("dc:creator", _NS_DC)) + list(meta.findall("creator")):
+            if creator.text:
+                authors.append(creator.text.strip())
+        lang = meta.find("dc:language", _NS_DC)
+        if lang is None:
+            lang = meta.find("language")
+        if lang is not None and lang.text:
+            language = lang.text.strip()[:2]  # "en-US" -> "en"
+        for ident in list(meta.findall("dc:identifier", _NS_DC)) + list(meta.findall("identifier")):
+            scheme = ident.get("{http://www.idpf.org/2007/opf}scheme", "")
+            if "isbn" in scheme.lower() and ident.text:
+                isbn = re.sub(r"[^0-9X]", "", ident.text.upper())
+
+    return (title, authors, language, isbn)
+
+
+def _ncx_sections(ncx_bytes: bytes, zip_file: zipfile.ZipFile, content_dir: str) -> List[BookSection]:
+    """
+    Parse the NCX navigation document to build a section tree.
+
+    Each navPoint becomes a BookSection; the text is fetched from the
+    referenced content file. The tree preserves part/chapter nesting.
+    """
+    try:
+        root = ET.fromstring(ncx_bytes)
+    except ET.ParseError:
+        return []
+
+    def nav_label(nav_point: ET.Element) -> str:
+        label = nav_point.find("ncx:navLabel/ncx:text", _NS_NCX)
+        return label.text.strip() if label is not None and label.text else ""
+
+    def content_src(nav_point: ET.Element) -> Optional[str]:
+        content = nav_point.find("ncx:content", _NS_NCX)
+        if content is not None:
+            return content.get("src", "").split("#")[0]
+        return None
+
+    seen_srcs: set = set()
+
+    def _read_text(src: str) -> str:
+        if not src or src in seen_srcs:
+            return ""
+        seen_srcs.add(src)
+        candidate = f"{content_dir}/{src}".lstrip("/")
+        try:
+            return _text_from_xhtml(zip_file.read(candidate))
+        except KeyError:
+            # Try without directory prefix
+            try:
+                return _text_from_xhtml(zip_file.read(src))
+            except KeyError:
+                return ""
+
+    def build_section(nav_point: ET.Element, level: int) -> BookSection:
+        title = nav_label(nav_point)
+        src = content_src(nav_point)
+        text = _read_text(src) if src else ""
+        children = [
+            build_section(child, level + 1)
+            for child in nav_point.findall("ncx:navPoint", _NS_NCX)
+        ]
+        return BookSection(title=title, text=text, level=level, children=children)
+
+    nav_map = root.find("ncx:navMap", _NS_NCX)
+    if nav_map is None:
+        return []
+    return [
+        build_section(np, 0)
+        for np in nav_map.findall("ncx:navPoint", _NS_NCX)
+    ]
+
+
+def _spine_sections(opf_bytes: bytes, zip_file: zipfile.ZipFile, content_dir: str) -> List[BookSection]:
+    """
+    Fallback when there is no NCX: parse the OPF spine to get document order
+    and extract text from each spine item.
+    """
+    try:
+        root = ET.fromstring(opf_bytes)
+    except ET.ParseError:
+        return []
+
+    manifest = root.find("opf:manifest", _NS_OPF)
+    if manifest is None:
+        manifest = root.find("manifest")
+    spine = root.find("opf:spine", _NS_OPF)
+    if spine is None:
+        spine = root.find("spine")
+    if manifest is None or spine is None:
+        return []
+
+    ns_items = manifest.findall("opf:item", _NS_OPF) or manifest.findall("item")
+    id_to_href = {
+        item.get("id", ""): item.get("href", "")
+        for item in ns_items
+        if item.get("media-type", "").startswith("application/xhtml")
+        or item.get("media-type", "") == "text/html"
+    }
+
+    ns_itemrefs = spine.findall("opf:itemref", _NS_OPF) or spine.findall("itemref")
+    sections = []
+    for itemref in ns_itemrefs:
+        idref = itemref.get("idref", "")
+        href = id_to_href.get(idref, "")
+        if not href:
+            continue
+        candidate = f"{content_dir}/{href}".lstrip("/")
+        try:
+            text = _text_from_xhtml(zip_file.read(candidate))
+        except KeyError:
+            try:
+                text = _text_from_xhtml(zip_file.read(href))
+            except KeyError:
+                continue
+        sections.append(BookSection(title=href, text=text, level=1))
+    return sections
+
+
+def parse_epub(epub_bytes: bytes, file_path: Optional[str] = None) -> BookMetadata:
+    """
+    Parse an EPUB file into a BookMetadata with a hierarchical section tree.
+
+    Tries ebooklib first (richer structure); falls back to stdlib zip+XML so
+    the parser works without optional dependencies.
+    """
+    # --- Try ebooklib (best structure extraction) ----------------------- #
+    try:
+        return _parse_epub_ebooklib(epub_bytes, file_path)
+    except Exception:
+        pass
+
+    # --- Fallback: stdlib zip+XML --------------------------------------- #
+    return _parse_epub_stdlib(epub_bytes, file_path)
+
+
+def _parse_epub_ebooklib(epub_bytes: bytes, file_path: Optional[str]) -> BookMetadata:
+    import ebooklib  # type: ignore
+    from ebooklib import epub as eblib_epub  # type: ignore
+
+    book = eblib_epub.read_epub(io.BytesIO(epub_bytes))
+
+    title = book.title or ""
+    authors = list(book.get_metadata("DC", "creator") or [])
+    authors = [a[0] if isinstance(a, (list, tuple)) else str(a) for a in authors]
+    language_meta = book.get_metadata("DC", "language")
+    language = (language_meta[0][0][:2] if language_meta else "en")
+
+    isbn = None
+    for ident, _ in (book.get_metadata("DC", "identifier") or []):
+        if "isbn" in str(ident).lower():
+            isbn = re.sub(r"[^0-9X]", "", str(ident).upper())
+            break
+
+    toc = book.toc
+    sections = _ebooklib_toc_to_sections(book, toc, level=0)
+    if not sections:
+        # No ToC: walk the spine in order.
+        sections = [
+            BookSection(title=item.get_name(), text=_text_from_xhtml(item.get_content()), level=1)
+            for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT)
+            if item.get_content()
+        ]
+
+    return BookMetadata(
+        title=title,
+        authors=authors,
+        language=language,
+        isbn=isbn,
+        file_path=file_path,
+        format="epub",
+        sections=sections,
+        extractor="ebooklib",
+    )
+
+
+def _ebooklib_toc_to_sections(book, toc_items, level: int) -> List[BookSection]:
+    """Recursively convert ebooklib ToC items to BookSections."""
+    from ebooklib import epub as eblib_epub  # type: ignore
+
+    sections = []
+    for item in toc_items:
+        if isinstance(item, eblib_epub.Link):
+            # Leaf node: fetch the referenced document.
+            title = item.title or ""
+            href = item.href.split("#")[0] if item.href else ""
+            text = ""
+            if href:
+                try:
+                    doc = book.get_item_with_href(href)
+                    if doc is not None:
+                        text = _text_from_xhtml(doc.get_content())
+                except Exception:
+                    pass
+            sections.append(BookSection(title=title, text=text, level=level))
+        elif isinstance(item, tuple) and len(item) == 2:
+            # (Section, [children]) or (Link, [children])
+            parent, children = item
+            title = getattr(parent, "title", "") or ""
+            href = getattr(parent, "href", "").split("#")[0] if getattr(parent, "href", "") else ""
+            text = ""
+            if href:
+                try:
+                    doc = book.get_item_with_href(href)
+                    if doc is not None:
+                        text = _text_from_xhtml(doc.get_content())
+                except Exception:
+                    pass
+            child_sections = _ebooklib_toc_to_sections(book, children or [], level + 1)
+            sections.append(BookSection(title=title, text=text, level=level, children=child_sections))
+    return sections
+
+
+def _parse_epub_stdlib(epub_bytes: bytes, file_path: Optional[str]) -> BookMetadata:
+    """Parse EPUB using only the Python standard library."""
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(epub_bytes))
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"Not a valid EPUB/ZIP file: {exc}") from exc
+
+    names = set(zf.namelist())
+
+    # Locate the OPF via META-INF/container.xml
+    opf_path = ""
+    if "META-INF/container.xml" in names:
+        container = ET.fromstring(zf.read("META-INF/container.xml"))
+        rootfile = container.find(".//{urn:oasis:names:tc:opendocument:xmlns:container}rootfile")
+        if rootfile is not None:
+            opf_path = rootfile.get("full-path", "")
+
+    if not opf_path:
+        # Heuristic: find any .opf file.
+        for name in names:
+            if name.endswith(".opf"):
+                opf_path = name
+                break
+
+    content_dir = "/".join(opf_path.split("/")[:-1]) if "/" in opf_path else ""
+
+    opf_bytes = zf.read(opf_path) if opf_path in names else b""
+    title, authors, language, isbn = _opf_metadata(opf_bytes)
+
+    # Try NCX navigation document first.
+    sections: List[BookSection] = []
+    ncx_path = f"{content_dir}/toc.ncx".lstrip("/")
+    if ncx_path not in names:
+        # Search for any .ncx file under content_dir.
+        for name in names:
+            if name.endswith(".ncx"):
+                ncx_path = name
+                break
+    if ncx_path in names:
+        sections = _ncx_sections(zf.read(ncx_path), zf, content_dir)
+
+    if not sections and opf_bytes:
+        sections = _spine_sections(opf_bytes, zf, content_dir)
+
+    return BookMetadata(
+        title=title or (file_path or "unknown"),
+        authors=authors,
+        language=language or "en",
+        isbn=isbn,
+        file_path=file_path,
+        format="epub",
+        sections=sections,
+        extractor="stdlib",
+    )

--- a/src/ingestion/connectors/book/models.py
+++ b/src/ingestion/connectors/book/models.py
@@ -1,0 +1,69 @@
+"""
+Data models for the books connector: book metadata and section hierarchy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+def book_id(isbn: Optional[str] = None, title: Optional[str] = None, file_path: Optional[str] = None) -> str:
+    """Stable document id for a book section, preferring ISBN, then title, then file path."""
+    if isbn:
+        return f"isbn:{isbn}"
+    key = (title or file_path or "").strip().lower()
+    digest = hashlib.md5(key.encode()).hexdigest()[:12]
+    return f"book:{digest}"
+
+
+def section_id(book_doc_id: str, path: List[str]) -> str:
+    """Stable id for a section within a book."""
+    fragment = "/".join(p.lower().replace(" ", "-") for p in path if p)
+    return f"{book_doc_id}#{fragment}"
+
+
+@dataclass
+class BookSection:
+    """A node in a book's structural hierarchy (part / chapter / section)."""
+
+    title: str
+    text: str = ""
+    level: int = 0  # 0 = part, 1 = chapter, 2 = section, 3+ = subsection
+    children: List["BookSection"] = field(default_factory=list)
+
+    def path_from(self, ancestors: List[str]) -> List[str]:
+        return ancestors + ([self.title] if self.title else [])
+
+    def all_sections(self, ancestors: Optional[List[str]] = None) -> List[tuple]:
+        """Flatten the tree into (path, text) pairs (DFS, skips empty bodies)."""
+        ancestors = ancestors or []
+        path = self.path_from(ancestors)
+        result = []
+        if self.text.strip():
+            result.append((path, self.text))
+        for child in self.children:
+            result.extend(child.all_sections(path))
+        return result
+
+
+@dataclass
+class BookMetadata:
+    """Normalized metadata for a book."""
+
+    title: str
+    authors: List[str] = field(default_factory=list)
+    language: str = "en"
+    isbn: Optional[str] = None
+    publisher: Optional[str] = None
+    published_year: Optional[int] = None
+    description: Optional[str] = None
+    file_path: Optional[str] = None
+    format: str = "unknown"  # "epub" | "pdf"
+    sections: List[BookSection] = field(default_factory=list)
+    extractor: str = "none"
+
+    @property
+    def document_id(self) -> str:
+        return book_id(self.isbn, self.title, self.file_path)

--- a/src/ingestion/connectors/book/pdf_parser.py
+++ b/src/ingestion/connectors/book/pdf_parser.py
@@ -1,0 +1,215 @@
+"""
+PDF parsing for books.
+
+Extracts text and a chapter/section outline from a PDF.
+
+Extraction chain (first that works):
+  1. PyMuPDF (fitz)   — best quality; preserves bookmarks as chapter headings.
+  2. pdfminer.six     — pure-Python fallback; text only, no bookmarks.
+  3. OCR              — pytesseract + pdf2image for scanned/image-only PDFs.
+
+Section detection:
+  - If the PDF has a bookmark outline (fitz only), each bookmark becomes a
+    BookSection node, preserving the part/chapter nesting.
+  - Without bookmarks, heading lines are detected heuristically (all-caps or
+    numbered "1.", "Chapter N") and used to split the text.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from src.ingestion.connectors.book.models import BookSection
+
+
+# Heuristic: a line is a heading if it is:
+#   - short (≤ 80 chars), not a sentence (no terminal period mid-line)
+#   - starts with "Chapter", "Part", "Section", a Roman numeral, or a number
+_HEADING = re.compile(
+    r"^\s*("
+    r"(?:chapter|part|section|appendix|prologue|epilogue|introduction|conclusion)\b"
+    r"|(?:[IVX]+\.?\s+\w)"       # Roman numerals
+    r"|(?:\d{1,3}\.(?:\d+\.?)*\s+\w)"  # 1., 1.2., etc.
+    r")",
+    re.IGNORECASE,
+)
+_MIN_OCR_CHARS_PER_PAGE = 80  # below this → likely scanned, try OCR
+
+
+@dataclass
+class _Bookmark:
+    title: str
+    level: int  # 0 = top, 1 = sub, ...
+    page: int
+
+
+# --------------------------------------------------------------------------- #
+# PyMuPDF path
+# --------------------------------------------------------------------------- #
+
+def _fitz_bookmarks(doc) -> List[_Bookmark]:
+    toc = doc.get_toc(simple=False)
+    return [_Bookmark(title=t, level=max(0, lvl - 1), page=pg) for lvl, t, pg, *_ in toc]
+
+
+def _fitz_page_text(doc) -> List[str]:
+    return [page.get_text() for page in doc]
+
+
+def _assign_text_to_bookmarks(
+    bookmarks: List[_Bookmark], page_texts: List[str]
+) -> List[BookSection]:
+    """Build a BookSection tree from bookmark entries + page text.
+
+    Each bookmark owns the pages from its page to the next bookmark at the
+    same or higher level.
+    """
+    if not bookmarks:
+        return [BookSection(title="", text="\n".join(page_texts), level=0)]
+
+    n_pages = len(page_texts)
+
+    # Pair each bookmark with its text range.
+    spans: List[Tuple[_Bookmark, str]] = []
+    for i, bm in enumerate(bookmarks):
+        start = min(bm.page, n_pages)
+        end = n_pages
+        for j in range(i + 1, len(bookmarks)):
+            if bookmarks[j].level <= bm.level:
+                end = min(bookmarks[j].page, n_pages)
+                break
+        text = "\n".join(page_texts[start:end]).strip()
+        spans.append((bm, text))
+
+    # Reconstruct the nesting.
+    def _build(items: List[Tuple[_Bookmark, str]], parent_level: int) -> List[BookSection]:
+        result: List[BookSection] = []
+        i = 0
+        while i < len(items):
+            bm, text = items[i]
+            if bm.level > parent_level:
+                i += 1
+                continue
+            # Collect children (higher level number = deeper nesting)
+            children_raw = []
+            j = i + 1
+            while j < len(items) and items[j][0].level > bm.level:
+                children_raw.append(items[j])
+                j += 1
+            children = _build(children_raw, bm.level)
+            result.append(BookSection(title=bm.title, text=text, level=bm.level, children=children))
+            i = j if children_raw else i + 1
+        return result
+
+    top_level = spans[0][0].level if spans else 0
+    return _build(spans, top_level - 1)
+
+
+def _parse_with_fitz(pdf_bytes: bytes) -> Optional[tuple]:
+    """Return (sections, extractor_tag) or None if fitz is unavailable."""
+    try:
+        import fitz  # PyMuPDF  # type: ignore
+    except ImportError:
+        return None
+
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        page_texts = _fitz_page_text(doc)
+        bookmarks = _fitz_bookmarks(doc)
+
+    total_chars = sum(len(t) for t in page_texts)
+    avg_per_page = total_chars / max(len(page_texts), 1)
+
+    if avg_per_page < _MIN_OCR_CHARS_PER_PAGE:
+        return None  # Scanned — let caller try OCR.
+
+    if bookmarks:
+        sections = _assign_text_to_bookmarks(bookmarks, page_texts)
+    else:
+        sections = _heuristic_sections("\n".join(page_texts))
+
+    return (sections, "pymupdf")
+
+
+# --------------------------------------------------------------------------- #
+# pdfminer fallback
+# --------------------------------------------------------------------------- #
+
+def _parse_with_pdfminer(pdf_bytes: bytes) -> Optional[tuple]:
+    try:
+        from pdfminer.high_level import extract_text  # type: ignore
+        import io as _io
+    except ImportError:
+        return None
+
+    text = extract_text(_io.BytesIO(pdf_bytes))
+    if not text or not text.strip():
+        return None
+    return (_heuristic_sections(text), "pdfminer")
+
+
+# --------------------------------------------------------------------------- #
+# OCR fallback
+# --------------------------------------------------------------------------- #
+
+def _parse_with_ocr(pdf_bytes: bytes) -> Optional[tuple]:
+    """Convert PDF pages to images then OCR each one."""
+    try:
+        import pytesseract  # type: ignore
+        from pdf2image import convert_from_bytes  # type: ignore
+    except ImportError:
+        return None
+
+    images = convert_from_bytes(pdf_bytes)
+    page_texts = [pytesseract.image_to_string(img) for img in images]
+    text = "\n".join(page_texts)
+    if not text.strip():
+        return None
+    return (_heuristic_sections(text), "ocr+tesseract")
+
+
+# --------------------------------------------------------------------------- #
+# Heading-based heuristic section split (no bookmark metadata)
+# --------------------------------------------------------------------------- #
+
+def _heuristic_sections(text: str) -> List[BookSection]:
+    """Split text into sections at heading lines."""
+    sections: List[BookSection] = []
+    heading = ""
+    buffer: List[str] = []
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and len(stripped) <= 80 and _HEADING.match(stripped):
+            if buffer and "".join(buffer).strip():
+                sections.append(BookSection(title=heading, text="\n".join(buffer).strip(), level=1))
+            heading = stripped
+            buffer = []
+        else:
+            buffer.append(line)
+
+    if buffer and "".join(buffer).strip():
+        sections.append(BookSection(title=heading, text="\n".join(buffer).strip(), level=1))
+
+    if not sections:
+        sections = [BookSection(title="", text=text.strip(), level=0)]
+    return sections
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+def parse_pdf_sections(pdf_bytes: bytes) -> Tuple[List[BookSection], str]:
+    """
+    Extract sections from a PDF.
+
+    Returns (sections, extractor) where extractor is one of:
+    "pymupdf", "pdfminer", "ocr+tesseract", "none".
+    """
+    for attempt in (_parse_with_fitz, _parse_with_pdfminer, _parse_with_ocr):
+        result = attempt(pdf_bytes)
+        if result is not None:
+            return result
+    return ([], "none")

--- a/tests/ingestion/test_book_connector.py
+++ b/tests/ingestion/test_book_connector.py
@@ -1,0 +1,451 @@
+"""
+Tests for the books connector (issue #521).
+
+Covers:
+- EPUB stdlib parsing (no ebooklib required)
+- PDF section detection (no PyMuPDF required, using heuristic text split)
+- BookConnector.parse() -> Document records with section_path metadata
+- section_id / book_id stability
+- book_metadata_to_documents: one Document per section with correct title/path
+- Graceful empty: a book with no sections still emits a Document if it has text
+- content_ref file:// URI construction
+- registry: "book" is registered after importing the connectors package
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from src.ingestion.connectors.book.connector import BookConnector, book_metadata_to_documents
+from src.ingestion.connectors.book.epub_parser import _parse_epub_stdlib
+from src.ingestion.connectors.book.models import BookMetadata, BookSection, book_id, section_id
+from src.ingestion.connectors.book.pdf_parser import _heuristic_sections, parse_pdf_sections
+from src.ingestion.connectors.base import RawDocument, SourceRef
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+def _make_epub(title: str = "Test Book", chapters: Optional[List[tuple]] = None) -> bytes:
+    """Build a minimal but valid in-memory EPUB zip."""
+    if chapters is None:
+        chapters = [
+            ("Chapter 1", "<html><body><p>Content of chapter one.</p></body></html>"),
+            ("Chapter 2", "<html><body><p>Content of chapter two.</p></body></html>"),
+        ]
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr("META-INF/container.xml", """\
+<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>""")
+
+        # OPF
+        spine_items = "\n".join(
+            f'<item id="ch{i}" href="ch{i}.xhtml" media-type="application/xhtml+xml"/>'
+            for i in range(len(chapters))
+        )
+        spine_refs = "\n".join(
+            f'<itemref idref="ch{i}"/>' for i in range(len(chapters))
+        )
+        opf = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>{title}</dc:title>
+    <dc:creator>Test Author</dc:creator>
+    <dc:language>en</dc:language>
+    <dc:identifier opf:scheme="ISBN">9780000000000</dc:identifier>
+  </metadata>
+  <manifest>
+    {spine_items}
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    {spine_refs}
+  </spine>
+</package>"""
+        zf.writestr("OEBPS/content.opf", opf)
+
+        # NCX
+        nav_points = "\n".join(
+            f"""<navPoint id="np{i}" playOrder="{i+1}">
+  <navLabel><text>{ch_title}</text></navLabel>
+  <content src="ch{i}.xhtml"/>
+</navPoint>"""
+            for i, (ch_title, _) in enumerate(chapters)
+        )
+        ncx = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    {nav_points}
+  </navMap>
+</ncx>"""
+        zf.writestr("OEBPS/toc.ncx", ncx)
+
+        for i, (_, html) in enumerate(chapters):
+            zf.writestr(f"OEBPS/ch{i}.xhtml", html)
+
+    return buf.getvalue()
+
+
+def _make_pdf_text() -> str:
+    return (
+        "Chapter 1 Introduction\n"
+        + "This is the introduction of the book. " * 20 + "\n"
+        + "Chapter 2 Background\n"
+        + "Background material goes here. " * 20 + "\n"
+        + "Chapter 3 Methods\n"
+        + "Methods are described here. " * 20
+    )
+
+
+# --------------------------------------------------------------------------- #
+# model tests
+# --------------------------------------------------------------------------- #
+
+class TestBookId:
+    def test_isbn_preferred(self):
+        assert book_id(isbn="9780000000000") == "isbn:9780000000000"
+
+    def test_title_fallback(self):
+        result = book_id(title="Some Book")
+        assert result.startswith("book:")
+        assert len(result) == len("book:") + 12
+
+    def test_stable(self):
+        assert book_id(title="Foo") == book_id(title="Foo")
+
+    def test_different_titles_differ(self):
+        assert book_id(title="A") != book_id(title="B")
+
+
+class TestSectionId:
+    def test_format(self):
+        bid = book_id(isbn="9780000000000")
+        sid = section_id(bid, ["Chapter 1", "Introduction"])
+        assert sid.startswith(bid + "#")
+        assert "chapter-1" in sid
+        assert "introduction" in sid
+
+    def test_empty_path(self):
+        bid = book_id(isbn="0000")
+        sid = section_id(bid, [])
+        assert sid == bid + "#"
+
+
+class TestBookSection:
+    def test_all_sections_flat(self):
+        s = BookSection(title="Ch 1", text="body", level=1)
+        pairs = s.all_sections()
+        assert len(pairs) == 1
+        assert pairs[0][0] == ["Ch 1"]
+        assert pairs[0][1] == "body"
+
+    def test_all_sections_nested(self):
+        s = BookSection(
+            title="Part I",
+            text="",
+            level=0,
+            children=[
+                BookSection(title="Ch 1", text="chapter body", level=1),
+                BookSection(title="Ch 2", text="chapter 2 body", level=1),
+            ],
+        )
+        pairs = s.all_sections()
+        assert len(pairs) == 2
+        assert pairs[0][0] == ["Part I", "Ch 1"]
+        assert pairs[1][0] == ["Part I", "Ch 2"]
+
+    def test_skips_empty_body(self):
+        s = BookSection(title="Empty", text="", level=0)
+        assert s.all_sections() == []
+
+
+# --------------------------------------------------------------------------- #
+# EPUB parser tests (stdlib path)
+# --------------------------------------------------------------------------- #
+
+class TestEpubParser:
+    def test_parse_title_and_authors(self):
+        epub_bytes = _make_epub(title="My Book")
+        meta = _parse_epub_stdlib(epub_bytes, file_path="/tmp/test.epub")
+        assert meta.title == "My Book"
+        assert "Test Author" in meta.authors
+        assert meta.language == "en"
+        assert meta.isbn == "9780000000000"
+        assert meta.format == "epub"
+
+    def test_parses_chapters_via_ncx(self):
+        chapters = [
+            ("Introduction", "<html><body><p>Intro text here.</p></body></html>"),
+            ("Deep Dive", "<html><body><p>Deep text here.</p></body></html>"),
+        ]
+        meta = _parse_epub_stdlib(_make_epub(chapters=chapters), file_path="/tmp/t.epub")
+        assert len(meta.sections) == 2
+        assert meta.sections[0].title == "Introduction"
+        assert "Intro text" in meta.sections[0].text
+        assert meta.sections[1].title == "Deep Dive"
+
+    def test_fallback_to_spine_without_ncx(self):
+        # Build an EPUB without an NCX file, only OPF spine.
+        chapters = [("Ch A", "<html><body><p>Content A.</p></body></html>")]
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("META-INF/container.xml", """\
+<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="content.opf"
+    media-type="application/oebps-package+xml"/></rootfiles>
+</container>""")
+            zf.writestr("content.opf", """\
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Spine Only</dc:title><dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="ch0" href="ch0.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch0"/></spine>
+</package>""")
+            zf.writestr("ch0.xhtml", "<html><body><p>Content A.</p></body></html>")
+        meta = _parse_epub_stdlib(buf.getvalue(), file_path="/tmp/spine.epub")
+        assert len(meta.sections) >= 1
+        assert "Content A" in meta.sections[0].text
+
+    def test_bad_zip_raises(self):
+        with pytest.raises(ValueError, match="EPUB"):
+            _parse_epub_stdlib(b"not a zip", file_path="/tmp/bad.epub")
+
+
+# --------------------------------------------------------------------------- #
+# PDF parser tests (heuristic path — no external deps)
+# --------------------------------------------------------------------------- #
+
+class TestPdfHeuristicSections:
+    def test_splits_on_chapter_headings(self):
+        text = _make_pdf_text()
+        sections = _heuristic_sections(text)
+        assert len(sections) == 3
+        assert sections[0].title == "Chapter 1 Introduction"
+        assert "introduction of the book" in sections[0].text
+        assert sections[2].title == "Chapter 3 Methods"
+
+    def test_no_headings_gives_one_section(self):
+        text = "just some text without any headings at all"
+        sections = _heuristic_sections(text)
+        assert len(sections) == 1
+        assert sections[0].title == ""
+
+    def test_parse_pdf_sections_no_deps(self):
+        # Without fitz/pdfminer/pytesseract, parse_pdf_sections returns "none".
+        with (
+            patch("src.ingestion.connectors.book.pdf_parser._parse_with_fitz", return_value=None),
+            patch("src.ingestion.connectors.book.pdf_parser._parse_with_pdfminer", return_value=None),
+            patch("src.ingestion.connectors.book.pdf_parser._parse_with_ocr", return_value=None),
+        ):
+            sections, extractor = parse_pdf_sections(b"%PDF-1.4")
+            assert sections == []
+            assert extractor == "none"
+
+
+# --------------------------------------------------------------------------- #
+# book_metadata_to_documents
+# --------------------------------------------------------------------------- #
+
+class TestBookMetadataToDocuments:
+    def _simple_meta(self) -> BookMetadata:
+        return BookMetadata(
+            title="Test Book",
+            authors=["Author A"],
+            language="en",
+            isbn="9780000000000",
+            file_path="/books/test.epub",
+            format="epub",
+            sections=[
+                BookSection(title="Chapter 1", text="Chapter one text.", level=1),
+                BookSection(title="Chapter 2", text="Chapter two text.", level=1),
+            ],
+            extractor="stdlib",
+        )
+
+    def test_one_doc_per_section(self):
+        meta = self._simple_meta()
+        docs = book_metadata_to_documents(meta, ingested_at=1000000)
+        assert len(docs) == 2
+
+    def test_source_type(self):
+        docs = book_metadata_to_documents(self._simple_meta(), ingested_at=1)
+        assert all(d.source_type == "book" for d in docs)
+
+    def test_section_path_in_metadata(self):
+        docs = book_metadata_to_documents(self._simple_meta(), ingested_at=1)
+        assert docs[0].metadata["section_path"] == ["Chapter 1"]
+        assert docs[1].metadata["section_path"] == ["Chapter 2"]
+
+    def test_book_title_in_metadata(self):
+        docs = book_metadata_to_documents(self._simple_meta(), ingested_at=1)
+        assert all(d.metadata["book_title"] == "Test Book" for d in docs)
+
+    def test_content_ref_uri(self):
+        docs = book_metadata_to_documents(self._simple_meta(), ingested_at=1)
+        assert docs[0].content_ref.startswith("file://")
+        assert "chapter-1" in docs[0].content_ref
+
+    def test_title_includes_section(self):
+        docs = book_metadata_to_documents(self._simple_meta(), ingested_at=1)
+        assert "Chapter 1" in docs[0].title
+        assert "Test Book" in docs[0].title
+
+    def test_nested_sections(self):
+        meta = BookMetadata(
+            title="Nested",
+            language="en",
+            file_path="/tmp/n.epub",
+            format="epub",
+            sections=[
+                BookSection(
+                    title="Part I",
+                    text="",
+                    level=0,
+                    children=[
+                        BookSection(title="Ch 1", text="Ch 1 text.", level=1),
+                        BookSection(title="Ch 2", text="Ch 2 text.", level=1),
+                    ],
+                )
+            ],
+            extractor="stdlib",
+        )
+        docs = book_metadata_to_documents(meta, ingested_at=1)
+        assert len(docs) == 2
+        assert docs[0].metadata["section_path"] == ["Part I", "Ch 1"]
+        assert docs[1].metadata["section_path"] == ["Part I", "Ch 2"]
+
+    def test_no_sections_fallback(self):
+        meta = BookMetadata(
+            title="Empty",
+            language="en",
+            file_path="/tmp/e.epub",
+            format="epub",
+            sections=[BookSection(title="", text="All the text.", level=0)],
+            extractor="none",
+        )
+        docs = book_metadata_to_documents(meta, ingested_at=1)
+        assert len(docs) == 1
+        assert "All the text" in docs[0].content
+
+    def test_isbn_in_metadata(self):
+        meta = self._simple_meta()
+        docs = book_metadata_to_documents(meta, ingested_at=1)
+        assert docs[0].metadata["isbn"] == "9780000000000"
+
+    def test_language_propagated(self):
+        meta = self._simple_meta()
+        meta.language = "fr"
+        docs = book_metadata_to_documents(meta, ingested_at=1)
+        assert all(d.language == "fr" for d in docs)
+
+
+# --------------------------------------------------------------------------- #
+# BookConnector integration
+# --------------------------------------------------------------------------- #
+
+class TestBookConnector:
+    def test_source_type(self):
+        assert BookConnector.source_type == "book"
+
+    def test_discover_yields_srefs(self):
+        connector = BookConnector()
+        refs = list(connector.discover(["/books/a.epub", "/books/b.pdf"]))
+        assert len(refs) == 2
+        assert refs[0].metadata["format"] == "epub"
+        assert refs[1].metadata["format"] == "pdf"
+
+    def test_discover_none_yields_nothing(self):
+        connector = BookConnector()
+        assert list(connector.discover(None)) == []
+
+    def test_fetch_missing_file(self):
+        connector = BookConnector()
+        ref = SourceRef(locator="/nonexistent/book.epub")
+        with pytest.raises(FileNotFoundError):
+            connector.fetch(ref)
+
+    def test_parse_epub(self, tmp_path):
+        epub_bytes = _make_epub(title="Parse Me", chapters=[
+            ("Ch 1", "<html><body><p>First chapter.</p></body></html>"),
+            ("Ch 2", "<html><body><p>Second chapter.</p></body></html>"),
+        ])
+        epub_file = tmp_path / "parse_me.epub"
+        epub_file.write_bytes(epub_bytes)
+
+        connector = BookConnector()
+        ref = SourceRef(locator=str(epub_file), title="parse_me", metadata={"format": "epub"})
+        raw = connector.fetch(ref)
+        docs = connector.parse(raw)
+
+        assert len(docs) == 2
+        assert all(d.source_type == "book" for d in docs)
+        titles = [d.title for d in docs]
+        assert any("Ch 1" in t for t in titles)
+        assert any("Ch 2" in t for t in titles)
+
+    def test_parse_pdf_heuristic(self, tmp_path):
+        # Mock fitz/pdfminer/OCR away; provide a fake bytes + heuristic text via patching.
+        fake_text = (
+            "Chapter 1 First\n" + "First chapter content. " * 15 + "\n"
+            "Chapter 2 Second\n" + "Second chapter content. " * 15
+        )
+        pdf_file = tmp_path / "book.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+
+        def fake_fitz(pdf_bytes):
+            from src.ingestion.connectors.book.pdf_parser import _heuristic_sections
+            return (_heuristic_sections(fake_text), "pymupdf")
+
+        connector = BookConnector()
+        ref = SourceRef(locator=str(pdf_file), title="book", metadata={"format": "pdf"})
+
+        with patch("src.ingestion.connectors.book.pdf_parser._parse_with_fitz", side_effect=fake_fitz):
+            raw = connector.fetch(ref)
+            docs = connector.parse(raw)
+
+        assert len(docs) == 2
+        assert docs[0].metadata["section_path"] == ["Chapter 1 First"]
+        assert docs[1].metadata["section_path"] == ["Chapter 2 Second"]
+        assert docs[0].metadata["extractor"] == "pymupdf"
+
+    def test_unsupported_format(self):
+        connector = BookConnector()
+        raw = RawDocument(
+            ref=SourceRef(locator="/tmp/x.docx"),
+            content=b"data",
+            content_type="application/msword",
+        )
+        with pytest.raises(ValueError, match="Unsupported"):
+            connector.parse(raw)
+
+    def test_harvest_skips_missing_files(self):
+        connector = BookConnector()
+        docs = list(connector.harvest(["/no/such/file.epub"]))
+        assert docs == []
+
+    def test_registered_in_registry(self):
+        import src.ingestion.connectors  # noqa: F401 — triggers registration
+        from src.ingestion.connectors.registry import is_registered
+        assert is_registered("book")


### PR DESCRIPTION
Closes #521.

## Summary

- **`src/ingestion/connectors/book/epub_parser.py`** — EPUB parsing via `ebooklib` (full NCX/ToC hierarchy) with stdlib zip+XML fallback (no optional deps required). Extracts title, authors, ISBN, language, and section tree.
- **`src/ingestion/connectors/book/pdf_parser.py`** — PDF section extraction using PyMuPDF bookmark outline → chapter tree, `pdfminer.six` plain-text fallback, and `pytesseract`+`pdf2image` OCR for scanned PDFs. All three backends are optional and degrade gracefully.
- **`src/ingestion/connectors/book/connector.py`** — `BookConnector(source_type="book")` implementing the connector protocol (`discover` → `fetch` → `parse`). Emits **one `Document` per chapter/section** so RAG retrieval can cite "Chapter 3 > The Turing Test". Each `Document` carries `metadata["section_path"]` and a `file://` `content_ref` fragment URI.
- **`src/ingestion/connectors/book/models.py`** — `BookMetadata`, `BookSection` (hierarchical), stable `book_id` and `section_id`.
- **`src/ingestion/connectors/__init__.py`** — registers `"book"` alongside `"news"` and `"paper"`.
- **35 tests** — model invariants, stdlib EPUB parsing (with in-memory fixture), PDF heuristic splitting, `book_metadata_to_documents` mapping, full connector integration via temp file, registry registration.

## How "chat with this book" cited to chapter/section works

Each chapter emits its own Document. The section path breadcrumb (`["Part I", "Chapter 3"]`) flows through to the RAG layer via `metadata["section_path"]`. For long chapters, callers pass the section to `chunk_document()` (from #518) which tags every chunk with its `path` — giving citation-level granularity already without any new code.

## Skill / MCP suggestion

A **`parse_document` tool** on the pipeline MCP server would let you interactively inspect a book's section tree before harvesting (e.g. `parse_document("/books/foo.epub")` → returns the outline). Worth adding once this PR lands, as a companion to `run_connector("book", ...)`.

## Test plan
- [x] `python -m pytest tests/ingestion/ -v` — 54 passed (35 new + 19 existing)
- [ ] `pip install ebooklib PyMuPDF pdfminer.six` then run on a real EPUB/PDF
- [ ] Verify `chunk_document()` on harvested sections returns path-tagged chunks