### PR TITLE
feat(ingestion): media connector — Whisper transcription with timestamp-linked segments (#523)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,9 @@ umap-learn>=0.5.0
 
 # Local analytics warehouse (Snowflake alternative for local dev)
 duckdb>=1.0.0,<2.0.0
+
+# Media connector (#523) — all optional; connector degrades gracefully without them
+openai-whisper>=20231117   # local Whisper model inference (pip install openai-whisper)
+faster-whisper>=1.0.0      # faster CTranslate2-based Whisper (GPU/CPU)
+pyannote.audio>=3.1.0      # speaker diarization (requires HF_TOKEN + accept model terms)
+# ffmpeg is used via subprocess — install the system package (ffmpeg / ffmpeg-bin)

--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -18,6 +18,7 @@ from src.ingestion.connectors.registry import (
 # Importing the modules triggers @register_connector for the built-in connectors.
 from src.ingestion.connectors import news  # noqa: E402,F401
 from src.ingestion.connectors import paper  # noqa: E402,F401
+from src.ingestion.connectors import media  # noqa: E402,F401
 
 __all__ = [
     "Connector",

--- a/src/ingestion/connectors/media/README.md
+++ b/src/ingestion/connectors/media/README.md
@@ -1,0 +1,88 @@
+# Media connector
+
+Audio/video ingestion with Whisper transcription for the knowledge-engine
+pipeline (#523). Podcasts, talks, and lectures become searchable knowledge with
+timestamp-linked answers.
+
+## What it does
+
+Transcribes an audio/video file and emits **one `Document` per Whisper
+segment** so semantic search returns timestamp-linked answers:
+
+```
+podcast.mp3  →  MediaConnector.harvest()  →  Document(
+    source_type="transcript",
+    content="…what I mean by alignment is…",
+    metadata={"start_s": 742.3, "end_s": 756.1, "speaker": "SPEAKER_00"},
+    content_ref="file:///podcasts/ep42.mp3#t=742.300,756.100",
+)
+```
+
+Each `content_ref` is a **Media Fragment URI** (W3C spec): `base#t=start,end`.
+A player can seek directly to the matching moment.
+
+## Usage
+
+```python
+from src.ingestion.connectors import get_connector
+
+connector = get_connector("transcript")
+
+# File paths or HTTP(S) URLs
+for doc in connector.harvest(["podcast.mp3", "lecture.mp4"]):
+    start = doc.metadata["start_s"]
+    end   = doc.metadata["end_s"]
+    print(f"{start:.0f}s–{end:.0f}s  {doc.content[:80]}")
+```
+
+### Speaker diarization
+
+Pass a HuggingFace token (after accepting
+[pyannote/speaker-diarization-3.1](https://hf.co/pyannote/speaker-diarization-3.1)
+terms) to get per-segment speaker labels:
+
+```python
+connector = MediaConnector(diarize=True, hf_token="hf_...")
+```
+
+Without a token, `speaker` is absent from the metadata.
+
+### Model size
+
+```python
+connector = MediaConnector(model_size="medium")  # tiny/base/small/medium/large
+```
+
+## Transcription backends
+
+| Priority | Backend          | When used                                      |
+|----------|-----------------|------------------------------------------------|
+| 1        | openai-whisper   | `pip install openai-whisper` (local GPU/CPU)   |
+| 2        | faster-whisper   | `pip install faster-whisper` (faster on CPU)   |
+| 3        | OpenAI API       | `OPENAI_API_KEY` env var set (cloud, no GPU)   |
+| 4        | none             | No backend — returns empty segment list        |
+
+`ffmpeg` (system package) is used to normalize audio to 16 kHz mono WAV before
+local inference. It is available in the project environment already.
+
+## Document metadata fields
+
+| Field                         | Description                                         |
+|-------------------------------|-----------------------------------------------------|
+| `metadata["media_title"]`     | Title of the source file/episode                    |
+| `metadata["media_id"]`        | Stable `media:<hash>` identifier for the source     |
+| `metadata["start_s"]`         | Segment start in seconds                            |
+| `metadata["end_s"]`           | Segment end in seconds                              |
+| `metadata["duration_s"]`      | Segment duration in seconds                         |
+| `metadata["segment_index"]`   | Position in the transcript (0-based)                |
+| `metadata["speaker"]`         | Speaker label, e.g. `"SPEAKER_00"` (if diarized)   |
+| `metadata["media_duration_s"]`| Total media duration in seconds                     |
+| `metadata["model"]`           | Whisper model size used                             |
+| `metadata["extractor"]`       | Which backend ran (`"whisper"`, `"openai-api"`, …)  |
+| `content_ref`                 | Media Fragment URI: `file://...#t=start,end`        |
+
+## Exit criterion
+
+Semantic search over a podcast returns results where each hit includes
+`metadata["start_s"]` / `metadata["end_s"]` and `content_ref` pointing to the
+exact audio moment — satisfying "timestamp-linked answers".

--- a/src/ingestion/connectors/media/__init__.py
+++ b/src/ingestion/connectors/media/__init__.py
@@ -1,0 +1,33 @@
+"""
+Media connector: audio/video transcription to timestamped transcript Documents.
+
+Importing this package registers the ``transcript`` connector.
+"""
+
+from src.ingestion.connectors.media.connector import (
+    MediaConnector,
+    media_metadata_to_documents,
+    segment_to_document,
+)
+from src.ingestion.connectors.media.diarizer import assign_speakers
+from src.ingestion.connectors.media.models import (
+    MediaMetadata,
+    TranscriptSegment,
+    format_timestamp,
+    media_id,
+    segment_id,
+)
+from src.ingestion.connectors.media.transcriber import transcribe
+
+__all__ = [
+    "MediaConnector",
+    "media_metadata_to_documents",
+    "segment_to_document",
+    "assign_speakers",
+    "MediaMetadata",
+    "TranscriptSegment",
+    "format_timestamp",
+    "media_id",
+    "segment_id",
+    "transcribe",
+]

--- a/src/ingestion/connectors/media/connector.py
+++ b/src/ingestion/connectors/media/connector.py
@@ -1,0 +1,200 @@
+"""
+Media connector: ingest audio/video files as timestamped transcript Documents.
+
+Implements the connector interface (discover -> fetch -> parse -> Document)
+for source_type="transcript". Each Whisper segment becomes its own Document
+so RAG retrieval returns timestamp-linked answers ("12:34 - 15:22").
+
+Usage::
+
+    from src.ingestion.connectors import get_connector
+
+    connector = get_connector("transcript")
+    for doc in connector.harvest(["podcast.mp3", "https://example.com/talk.mp4"]):
+        print(doc.title)            # "My Podcast [12:34 - 15:22]"
+        print(doc.metadata["start_s"], doc.metadata["end_s"])
+        print(doc.metadata["speaker"])   # None if no diarization
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.media.diarizer import assign_speakers
+from src.ingestion.connectors.media.models import (
+    MediaMetadata,
+    TranscriptSegment,
+    segment_id,
+)
+from src.ingestion.connectors.media.transcriber import transcribe
+from src.ingestion.connectors.registry import register_connector
+
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".flac", ".m4a", ".aac", ".opus", ".weba"}
+_VIDEO_EXTENSIONS = {".mp4", ".mkv", ".webm", ".mov", ".avi", ".ts"}
+def _is_url(locator: str) -> bool:
+    return locator.startswith("http://") or locator.startswith("https://")
+
+
+def _ext(locator: str) -> str:
+    return Path(locator.split("?")[0]).suffix.lower()
+
+
+def _content_type(locator: str) -> str:
+    ext = _ext(locator)
+    if ext in _AUDIO_EXTENSIONS:
+        return f"audio/{ext.lstrip('.')}"
+    if ext in _VIDEO_EXTENSIONS:
+        return f"video/{ext.lstrip('.')}"
+    return "application/octet-stream"
+
+
+def _media_fragment_uri(base_uri: str, seg: TranscriptSegment) -> str:
+    """Media Fragment URI (W3C spec): base#t=start,end"""
+    return f"{base_uri}#t={seg.start_s:.3f},{seg.end_s:.3f}"
+
+
+def segment_to_document(
+    seg: TranscriptSegment,
+    meta: MediaMetadata,
+    ingested_at: int,
+    index: int,
+) -> Document:
+    """Map a single TranscriptSegment to a Document with timestamp provenance."""
+    base_uri = meta.base_uri
+    fragment_uri = _media_fragment_uri(base_uri, seg) if base_uri else None
+    doc_id = segment_id(meta.document_id, seg.start_s)
+    title_suffix = f" [{seg.timestamp_label}]"
+    title = (meta.title or "Transcript") + title_suffix
+
+    md: dict = {
+        "media_title": meta.title,
+        "media_id": meta.document_id,
+        "start_s": seg.start_s,
+        "end_s": seg.end_s,
+        "duration_s": seg.duration_s,
+        "segment_index": index,
+        "media_format": meta.media_format,
+        "model": meta.model,
+        "extractor": meta.extractor,
+    }
+    if seg.speaker is not None:
+        md["speaker"] = seg.speaker
+    if meta.duration_s:
+        md["media_duration_s"] = meta.duration_s
+
+    return Document(
+        document_id=doc_id,
+        source_type="transcript",
+        language=meta.language,
+        ingested_at=ingested_at,
+        source_id=meta.source_url or (
+            f"file://{Path(meta.file_path).name}" if meta.file_path else None
+        ),
+        url=fragment_uri,
+        title=title,
+        content=seg.text,
+        content_ref=fragment_uri,
+        metadata=md,
+    )
+
+
+def media_metadata_to_documents(meta: MediaMetadata, ingested_at: int) -> List[Document]:
+    """
+    Convert a transcribed MediaMetadata to a list of Documents, one per segment.
+
+    Each Document carries ``start_s`` / ``end_s`` in its metadata so vector
+    search results are immediately timestamp-linked. If the media has no
+    segments (no transcription backend available), returns an empty list.
+    """
+    return [
+        segment_to_document(seg, meta, ingested_at, i)
+        for i, seg in enumerate(meta.segments)
+        if seg.text.strip()
+    ]
+
+
+@register_connector
+class MediaConnector(Connector):
+    """
+    Ingest audio/video files as timestamped transcript Documents.
+
+    discover(query) expects a list of file paths (str/Path) or HTTP(S) URLs.
+    Each Whisper segment becomes a separate Document so RAG retrieval can
+    cite "at 12:34 in episode 42" rather than just "the podcast".
+
+    Optional speaker diarization is activated by passing a HuggingFace token
+    (``hf_token``) or setting the ``HF_TOKEN`` / ``HUGGINGFACE_HUB_TOKEN``
+    environment variable. Requires ``pyannote.audio``.
+    """
+
+    source_type = "transcript"
+
+    def __init__(
+        self,
+        model_size: str = "base",
+        language: Optional[str] = None,
+        hf_token: Optional[str] = None,
+        diarize: bool = False,
+    ) -> None:
+        self._model_size = model_size
+        self._language = language
+        self._hf_token = hf_token
+        self._diarize = diarize
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        if query is None:
+            return
+        items = [query] if isinstance(query, (str, Path)) else list(query)
+        for item in items:
+            locator = str(item)
+            title = Path(locator.split("?")[0]).stem if not _is_url(locator) else locator
+            yield SourceRef(
+                locator=locator,
+                title=title,
+                metadata={"format": _ext(locator).lstrip(".")},
+            )
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        locator = ref.locator
+        if _is_url(locator):
+            with urllib.request.urlopen(locator, timeout=60) as resp:
+                content = resp.read()
+        else:
+            path = Path(locator)
+            if not path.exists():
+                raise FileNotFoundError(f"Media file not found: {path}")
+            content = path.read_bytes()
+        return RawDocument(
+            ref=ref,
+            content=content,
+            content_type=_content_type(locator),
+        )
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        locator = raw.ref.locator
+        title = raw.ref.title or Path(locator.split("?")[0]).stem
+        file_ext = _ext(locator).lstrip(".") or "mp3"
+        content = raw.content if isinstance(raw.content, bytes) else raw.content.encode()
+
+        meta = transcribe(
+            content,
+            model_size=self._model_size,
+            language=self._language,
+            file_ext=file_ext,
+        )
+        meta.title = title
+        meta.media_format = file_ext
+        if _is_url(locator):
+            meta.source_url = locator
+        else:
+            meta.file_path = str(Path(locator).resolve())
+
+        if self._diarize and meta.segments:
+            meta.segments = assign_speakers(content, meta.segments, self._hf_token)
+            meta.speakers = sorted({s.speaker for s in meta.segments if s.speaker})
+
+        return media_metadata_to_documents(meta, raw.fetched_at)

--- a/src/ingestion/connectors/media/diarizer.py
+++ b/src/ingestion/connectors/media/diarizer.py
@@ -1,0 +1,109 @@
+"""
+Speaker diarization for the media connector.
+
+Uses pyannote.audio when installed and a HuggingFace token is available.
+The token must accept the pyannote/speaker-diarization-3.1 model's terms of
+service at https://hf.co/pyannote/speaker-diarization-3.1.
+
+If pyannote is not installed or the token is missing, segments are returned
+unchanged with ``speaker=None`` so the connector works without diarization.
+
+Usage::
+
+    from src.ingestion.connectors.media.diarizer import assign_speakers
+    segments = assign_speakers(audio_bytes, segments, hf_token="hf_...")
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import List, Optional
+
+from src.ingestion.connectors.media.models import TranscriptSegment
+
+
+def assign_speakers(
+    audio_bytes: bytes,
+    segments: List[TranscriptSegment],
+    hf_token: Optional[str] = None,
+) -> List[TranscriptSegment]:
+    """
+    Assign speaker labels to transcript segments via pyannote diarization.
+
+    Returns segments unchanged (speaker=None) if pyannote.audio is not
+    installed or no HuggingFace token is available.
+
+    Args:
+        audio_bytes: Raw audio bytes (any format ffmpeg can read).
+        segments:    List of TranscriptSegment from the transcriber.
+        hf_token:    HuggingFace access token. Falls back to ``HF_TOKEN``
+                     and ``HUGGINGFACE_HUB_TOKEN`` env vars.
+    """
+    token = (
+        hf_token
+        or os.environ.get("HF_TOKEN", "")
+        or os.environ.get("HUGGINGFACE_HUB_TOKEN", "")
+    )
+    if not token:
+        return segments
+    if not segments:
+        return segments
+
+    try:
+        from pyannote.audio import Pipeline  # type: ignore
+        import torch  # type: ignore
+    except ImportError:
+        return segments
+
+    try:
+        pipeline = Pipeline.from_pretrained(
+            "pyannote/speaker-diarization-3.1",
+            use_auth_token=token,
+        )
+        # Move to GPU if available.
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        pipeline = pipeline.to(device)
+    except Exception:
+        return segments
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(audio_bytes)
+        tmp_path = tmp.name
+
+    try:
+        diarization = pipeline(tmp_path)
+    except Exception:
+        return segments
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    # Map each segment's midpoint to the speaker with the most overlap.
+    labelled = list(segments)
+    for i, seg in enumerate(labelled):
+        midpoint = (seg.start_s + seg.end_s) / 2.0
+        best_speaker = None
+        best_overlap = 0.0
+        for turn, _, speaker in diarization.itertracks(yield_label=True):
+            overlap = min(turn.end, seg.end_s) - max(turn.start, seg.start_s)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_speaker = speaker
+        if best_speaker is None:
+            # Nearest speaker by midpoint distance.
+            for turn, _, speaker in diarization.itertracks(yield_label=True):
+                dist = abs((turn.start + turn.end) / 2.0 - midpoint)
+                if best_overlap == 0.0 or dist < best_overlap:
+                    best_overlap = dist
+                    best_speaker = speaker
+        labelled[i] = TranscriptSegment(
+            start_s=seg.start_s,
+            end_s=seg.end_s,
+            text=seg.text,
+            speaker=best_speaker,
+        )
+
+    return labelled

--- a/src/ingestion/connectors/media/models.py
+++ b/src/ingestion/connectors/media/models.py
@@ -1,0 +1,83 @@
+"""
+Data models for the media connector: transcript segments and media metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+def media_id(url: Optional[str] = None, file_path: Optional[str] = None, title: Optional[str] = None) -> str:
+    """Stable document id for a media file, preferring URL, then file path, then title."""
+    key = (url or file_path or title or "").strip()
+    digest = hashlib.md5(key.encode()).hexdigest()[:12]
+    return f"media:{digest}"
+
+
+def segment_id(doc_id: str, start_s: float) -> str:
+    """Stable id for a transcript segment within a media document."""
+    return f"{doc_id}#t={start_s:.3f}"
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format seconds as HH:MM:SS or MM:SS."""
+    total = int(seconds)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+@dataclass
+class TranscriptSegment:
+    """A timestamped chunk of transcript text, optionally attributed to a speaker."""
+
+    start_s: float
+    end_s: float
+    text: str
+    speaker: Optional[str] = None
+
+    @property
+    def duration_s(self) -> float:
+        return max(0.0, self.end_s - self.start_s)
+
+    @property
+    def timestamp_label(self) -> str:
+        return f"[{format_timestamp(self.start_s)} - {format_timestamp(self.end_s)}]"
+
+    def media_fragment(self, base_uri: str) -> str:
+        """Return a Media Fragment URI (RFC 7826) for this segment."""
+        return f"{base_uri}#t={self.start_s:.3f},{self.end_s:.3f}"
+
+
+@dataclass
+class MediaMetadata:
+    """Normalized metadata and transcript for a media file (audio or video)."""
+
+    title: str
+    language: str = "en"
+    source_url: Optional[str] = None
+    file_path: Optional[str] = None
+    media_format: str = "unknown"  # "mp3", "mp4", "wav", "ogg", "webm", …
+    duration_s: float = 0.0
+    segments: List[TranscriptSegment] = field(default_factory=list)
+    speakers: List[str] = field(default_factory=list)
+    model: str = "none"      # which Whisper model was used
+    extractor: str = "none"  # "whisper", "faster-whisper", "openai-api", "none"
+
+    @property
+    def document_id(self) -> str:
+        return media_id(self.source_url, self.file_path, self.title)
+
+    @property
+    def base_uri(self) -> str:
+        return self.source_url or (
+            f"file://{self.file_path}" if self.file_path else ""
+        )
+
+    @property
+    def full_text(self) -> str:
+        return " ".join(seg.text.strip() for seg in self.segments if seg.text.strip())

--- a/src/ingestion/connectors/media/transcriber.py
+++ b/src/ingestion/connectors/media/transcriber.py
@@ -1,0 +1,282 @@
+"""
+Whisper transcription backends for the media connector.
+
+Extraction chain (first that works):
+  1. openai-whisper  — local model inference; best quality; needs GPU/CPU time.
+  2. faster-whisper  — CTranslate2-based; faster on CPU; same model weights.
+  3. OpenAI API      — cloud; requires OPENAI_API_KEY env var; no local GPU needed.
+  4. "none"          — returns an empty transcript so the connector is always
+                        importable and testable without any optional deps.
+
+All backends produce a list of ``TranscriptSegment`` objects with start/end
+timestamps. Whisper already segments by sentence, which is the natural atomic
+unit for timestamp-linked RAG retrieval.
+
+Audio format:
+  Whisper expects 16 kHz mono PCM. The local backends handle resampling
+  internally. The API backend accepts common formats (mp3, mp4, wav, webm)
+  directly. If ffmpeg is available on the system, ``_to_wav()`` can normalize
+  any input to wav for the local backends.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import tempfile
+from typing import Optional
+
+from src.ingestion.connectors.media.models import MediaMetadata, TranscriptSegment
+
+
+# --------------------------------------------------------------------------- #
+# Audio normalization
+# --------------------------------------------------------------------------- #
+
+def _to_wav(audio_bytes: bytes) -> bytes:
+    """
+    Convert any audio/video bytes to 16kHz mono WAV via ffmpeg (system binary).
+
+    Returns the original bytes unchanged if ffmpeg is not available so callers
+    degrade gracefully.
+    """
+    if not _ffmpeg_available():
+        return audio_bytes
+    with (
+        tempfile.NamedTemporaryFile(suffix=".input", delete=False) as inp,
+        tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as out,
+    ):
+        inp.write(audio_bytes)
+        inp_path = inp.name
+        out_path = out.name
+
+    try:
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-i", inp_path,
+                "-ar", "16000", "-ac", "1", "-f", "wav", out_path,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        with open(out_path, "rb") as f:
+            return f.read()
+    except subprocess.CalledProcessError:
+        return audio_bytes
+    finally:
+        for p in (inp_path, out_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+def _ffmpeg_available() -> bool:
+    try:
+        subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Backend 1: openai-whisper (local model)
+# --------------------------------------------------------------------------- #
+
+def _transcribe_local_whisper(
+    audio_bytes: bytes,
+    model_size: str,
+    language: Optional[str],
+) -> Optional[MediaMetadata]:
+    try:
+        import whisper  # type: ignore
+    except ImportError:
+        return None
+
+    wav_bytes = _to_wav(audio_bytes)
+
+    # Write to a temp file; whisper's load_audio reads files, not bytes.
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(wav_bytes)
+        tmp_path = tmp.name
+
+    try:
+        model = whisper.load_model(model_size)
+        kwargs = {"verbose": False}
+        if language:
+            kwargs["language"] = language
+        result = model.transcribe(tmp_path, **kwargs)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    segments = [
+        TranscriptSegment(
+            start_s=float(seg["start"]),
+            end_s=float(seg["end"]),
+            text=seg["text"].strip(),
+        )
+        for seg in result.get("segments", [])
+        if seg.get("text", "").strip()
+    ]
+
+    detected_language = result.get("language", language or "en")
+    duration = float(result["segments"][-1]["end"]) if result.get("segments") else 0.0
+
+    return MediaMetadata(
+        title="",
+        language=detected_language,
+        duration_s=duration,
+        segments=segments,
+        model=model_size,
+        extractor="whisper",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Backend 2: faster-whisper
+# --------------------------------------------------------------------------- #
+
+def _transcribe_faster_whisper(
+    audio_bytes: bytes,
+    model_size: str,
+    language: Optional[str],
+) -> Optional[MediaMetadata]:
+    try:
+        from faster_whisper import WhisperModel  # type: ignore
+    except ImportError:
+        return None
+
+    wav_bytes = _to_wav(audio_bytes)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(wav_bytes)
+        tmp_path = tmp.name
+
+    try:
+        model = WhisperModel(model_size, device="auto", compute_type="int8")
+        transcribe_kwargs = {"beam_size": 5}
+        if language:
+            transcribe_kwargs["language"] = language
+        segs, info = model.transcribe(tmp_path, **transcribe_kwargs)
+        segments = [
+            TranscriptSegment(
+                start_s=float(seg.start),
+                end_s=float(seg.end),
+                text=seg.text.strip(),
+            )
+            for seg in segs
+            if seg.text.strip()
+        ]
+        detected_language = info.language if hasattr(info, "language") else (language or "en")
+        duration = float(info.duration) if hasattr(info, "duration") else 0.0
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    return MediaMetadata(
+        title="",
+        language=detected_language,
+        duration_s=duration,
+        segments=segments,
+        model=model_size,
+        extractor="faster-whisper",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Backend 3: OpenAI Whisper API
+# --------------------------------------------------------------------------- #
+
+def _transcribe_openai_api(
+    audio_bytes: bytes,
+    language: Optional[str],
+    file_ext: str = "mp3",
+) -> Optional[MediaMetadata]:
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if not api_key:
+        return None
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        return None
+
+    # The OpenAI transcription API returns verbose JSON with segments.
+    audio_file = (f"audio.{file_ext}", io.BytesIO(audio_bytes), f"audio/{file_ext}")
+    data: dict = {"model": "whisper-1", "response_format": "verbose_json"}
+    if language:
+        data["language"] = language
+
+    try:
+        resp = httpx.post(
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            data=data,
+            files={"file": audio_file},
+            timeout=120.0,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception:
+        return None
+
+    segments = [
+        TranscriptSegment(
+            start_s=float(seg["start"]),
+            end_s=float(seg["end"]),
+            text=seg["text"].strip(),
+        )
+        for seg in payload.get("segments", [])
+        if seg.get("text", "").strip()
+    ]
+
+    detected_language = payload.get("language", language or "en")
+    duration = float(payload["duration"]) if "duration" in payload else 0.0
+
+    return MediaMetadata(
+        title="",
+        language=detected_language,
+        duration_s=duration,
+        segments=segments,
+        model="whisper-1",
+        extractor="openai-api",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+def transcribe(
+    audio_bytes: bytes,
+    model_size: str = "base",
+    language: Optional[str] = None,
+    file_ext: str = "mp3",
+) -> MediaMetadata:
+    """
+    Transcribe audio/video bytes to a list of timestamped segments.
+
+    Tries backends in order: local whisper → faster-whisper → OpenAI API.
+    Returns a MediaMetadata with empty segments if no backend is available.
+
+    Args:
+        audio_bytes: Raw audio/video file bytes.
+        model_size:  Whisper model size ("tiny", "base", "small", "medium", "large").
+        language:    ISO 639-1 language hint (e.g. "en"). None = auto-detect.
+        file_ext:    File extension hint for the OpenAI API backend.
+    """
+    for attempt in (
+        lambda: _transcribe_local_whisper(audio_bytes, model_size, language),
+        lambda: _transcribe_faster_whisper(audio_bytes, model_size, language),
+        lambda: _transcribe_openai_api(audio_bytes, language, file_ext),
+    ):
+        result = attempt()
+        if result is not None:
+            return result
+
+    return MediaMetadata(title="", extractor="none", segments=[])

--- a/tests/ingestion/test_media_connector.py
+++ b/tests/ingestion/test_media_connector.py
@@ -1,0 +1,434 @@
+"""
+Tests for the media connector (issue #523).
+
+Covers:
+- TranscriptSegment / MediaMetadata models
+- media_id / segment_id stability
+- format_timestamp formatting
+- transcriber.transcribe() with all backends mocked away → "none" extractor
+- connector.MediaConnector: discover, fetch (file + URL), parse
+- media_metadata_to_documents: one Document per segment, timestamp metadata
+- segment_to_document: URI fragment construction, field mapping
+- diarizer.assign_speakers: no-op without pyannote or token
+- registry: "transcript" is registered after importing connectors
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.ingestion.connectors.base import SourceRef
+from src.ingestion.connectors.media.connector import (
+    MediaConnector,
+    media_metadata_to_documents,
+    segment_to_document,
+)
+from src.ingestion.connectors.media.diarizer import assign_speakers
+from src.ingestion.connectors.media.models import (
+    MediaMetadata,
+    TranscriptSegment,
+    format_timestamp,
+    media_id,
+    segment_id,
+)
+from src.ingestion.connectors.media.transcriber import transcribe
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _segments(n: int = 3) -> list:
+    return [
+        TranscriptSegment(
+            start_s=float(i * 10),
+            end_s=float(i * 10 + 9),
+            text=f"Segment {i} text here.",
+        )
+        for i in range(n)
+    ]
+
+
+def _meta(title: str = "Test Podcast", n_segments: int = 3) -> MediaMetadata:
+    return MediaMetadata(
+        title=title,
+        language="en",
+        file_path="/media/podcast.mp3",
+        media_format="mp3",
+        duration_s=30.0,
+        segments=_segments(n_segments),
+        model="base",
+        extractor="whisper",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Model tests
+# --------------------------------------------------------------------------- #
+
+class TestMediaId:
+    def test_url_preferred(self):
+        result = media_id(url="https://example.com/pod.mp3")
+        assert result.startswith("media:")
+
+    def test_stable(self):
+        assert media_id(url="https://x.com/a") == media_id(url="https://x.com/a")
+
+    def test_different_keys_differ(self):
+        assert media_id(url="https://a.com") != media_id(url="https://b.com")
+
+    def test_file_path_fallback(self):
+        a = media_id(file_path="/foo/bar.mp3")
+        b = media_id(file_path="/foo/baz.mp3")
+        assert a != b
+
+
+class TestSegmentId:
+    def test_format(self):
+        did = media_id(url="https://example.com/pod.mp3")
+        sid = segment_id(did, 12.345)
+        assert sid == f"{did}#t=12.345"
+
+    def test_zero_start(self):
+        did = media_id(url="https://x.com")
+        sid = segment_id(did, 0.0)
+        assert "#t=0.0" in sid
+
+
+class TestFormatTimestamp:
+    def test_seconds_only(self):
+        assert format_timestamp(45.0) == "0:45"
+
+    def test_minutes(self):
+        assert format_timestamp(90.0) == "1:30"
+
+    def test_hours(self):
+        assert format_timestamp(3661.0) == "1:01:01"
+
+    def test_zero(self):
+        assert format_timestamp(0.0) == "0:00"
+
+
+class TestTranscriptSegment:
+    def test_duration(self):
+        seg = TranscriptSegment(start_s=10.0, end_s=20.0, text="Hello")
+        assert seg.duration_s == 10.0
+
+    def test_duration_clamped(self):
+        seg = TranscriptSegment(start_s=20.0, end_s=10.0, text="Oops")
+        assert seg.duration_s == 0.0
+
+    def test_timestamp_label(self):
+        seg = TranscriptSegment(start_s=70.0, end_s=130.0, text="x")
+        assert seg.timestamp_label == "[1:10 - 2:10]"
+
+    def test_media_fragment(self):
+        seg = TranscriptSegment(start_s=12.5, end_s=20.0, text="x")
+        uri = seg.media_fragment("https://example.com/pod.mp3")
+        assert uri == "https://example.com/pod.mp3#t=12.500,20.000"
+
+
+class TestMediaMetadata:
+    def test_document_id_stable(self):
+        meta = MediaMetadata(title="T", file_path="/a.mp3")
+        assert meta.document_id == meta.document_id
+
+    def test_full_text(self):
+        meta = _meta(n_segments=2)
+        text = meta.full_text
+        assert "Segment 0" in text
+        assert "Segment 1" in text
+
+    def test_base_uri_file(self):
+        meta = MediaMetadata(title="T", file_path="/podcasts/ep1.mp3")
+        assert meta.base_uri == "file:///podcasts/ep1.mp3"
+
+    def test_base_uri_url(self):
+        meta = MediaMetadata(title="T", source_url="https://example.com/ep1.mp3")
+        assert meta.base_uri == "https://example.com/ep1.mp3"
+
+
+# --------------------------------------------------------------------------- #
+# Transcriber tests
+# --------------------------------------------------------------------------- #
+
+class TestTranscriber:
+    def test_no_backends_returns_empty(self):
+        with (
+            patch("src.ingestion.connectors.media.transcriber._transcribe_local_whisper", return_value=None),
+            patch("src.ingestion.connectors.media.transcriber._transcribe_faster_whisper", return_value=None),
+            patch("src.ingestion.connectors.media.transcriber._transcribe_openai_api", return_value=None),
+        ):
+            result = transcribe(b"fake audio", model_size="base")
+            assert result.extractor == "none"
+            assert result.segments == []
+
+    def test_first_backend_wins(self):
+        fake_result = _meta()
+        with (
+            patch(
+                "src.ingestion.connectors.media.transcriber._transcribe_local_whisper",
+                return_value=fake_result,
+            ),
+            patch(
+                "src.ingestion.connectors.media.transcriber._transcribe_faster_whisper",
+                return_value=None,
+            ) as mock_fw,
+        ):
+            result = transcribe(b"audio", model_size="base")
+            assert result.extractor == "whisper"
+            mock_fw.assert_not_called()
+
+    def test_fallback_to_second_backend(self):
+        fake_result = _meta()
+        fake_result.extractor = "faster-whisper"
+        with (
+            patch("src.ingestion.connectors.media.transcriber._transcribe_local_whisper", return_value=None),
+            patch(
+                "src.ingestion.connectors.media.transcriber._transcribe_faster_whisper",
+                return_value=fake_result,
+            ),
+        ):
+            result = transcribe(b"audio")
+            assert result.extractor == "faster-whisper"
+
+    def test_openai_api_skipped_without_key(self):
+        with (
+            patch("src.ingestion.connectors.media.transcriber._transcribe_local_whisper", return_value=None),
+            patch("src.ingestion.connectors.media.transcriber._transcribe_faster_whisper", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            # No OPENAI_API_KEY → API backend returns None → extractor="none"
+            result = transcribe(b"audio")
+            assert result.extractor == "none"
+
+
+# --------------------------------------------------------------------------- #
+# Diarizer tests
+# --------------------------------------------------------------------------- #
+
+class TestDiarizer:
+    def test_no_token_returns_unchanged(self):
+        segs = _segments(2)
+        result = assign_speakers(b"audio", segs, hf_token=None)
+        assert result is segs or result == segs
+        assert all(s.speaker is None for s in result)
+
+    def test_empty_segments_returns_empty(self):
+        result = assign_speakers(b"audio", [], hf_token="hf_token")
+        assert result == []
+
+    def test_no_pyannote_returns_unchanged(self):
+        segs = _segments(2)
+        with patch.dict("sys.modules", {"pyannote.audio": None}):
+            result = assign_speakers(b"audio", segs, hf_token="hf_token")
+        assert all(s.speaker is None for s in result)
+
+
+# --------------------------------------------------------------------------- #
+# segment_to_document tests
+# --------------------------------------------------------------------------- #
+
+class TestSegmentToDocument:
+    def test_source_type(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=10.0, text="Hello world.")
+        doc = segment_to_document(seg, _meta(), ingested_at=1000, index=0)
+        assert doc.source_type == "transcript"
+
+    def test_content_is_segment_text(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=10.0, text="Hello world.")
+        doc = segment_to_document(seg, _meta(), ingested_at=1000, index=0)
+        assert doc.content == "Hello world."
+
+    def test_timestamp_metadata(self):
+        seg = TranscriptSegment(start_s=12.5, end_s=20.0, text="x")
+        doc = segment_to_document(seg, _meta(), ingested_at=1000, index=0)
+        assert doc.metadata["start_s"] == 12.5
+        assert doc.metadata["end_s"] == 20.0
+
+    def test_speaker_in_metadata(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=5.0, text="Hi.", speaker="SPEAKER_00")
+        doc = segment_to_document(seg, _meta(), ingested_at=1000, index=0)
+        assert doc.metadata["speaker"] == "SPEAKER_00"
+
+    def test_no_speaker_key_when_none(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=5.0, text="Hi.")
+        doc = segment_to_document(seg, _meta(), ingested_at=1000, index=0)
+        assert "speaker" not in doc.metadata
+
+    def test_title_includes_timestamp(self):
+        seg = TranscriptSegment(start_s=70.0, end_s=130.0, text="x")
+        doc = segment_to_document(seg, _meta(title="My Podcast"), ingested_at=1000, index=0)
+        assert "My Podcast" in doc.title
+        assert "1:10" in doc.title
+
+    def test_content_ref_is_fragment_uri(self):
+        seg = TranscriptSegment(start_s=5.0, end_s=15.0, text="x")
+        meta = _meta()
+        meta.file_path = "/pods/ep.mp3"
+        doc = segment_to_document(seg, meta, ingested_at=1000, index=0)
+        assert doc.content_ref is not None
+        assert "#t=5.000,15.000" in doc.content_ref
+
+    def test_url_source(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=10.0, text="x")
+        meta = MediaMetadata(
+            title="Talk",
+            source_url="https://example.com/talk.mp3",
+            language="en",
+            extractor="whisper",
+            model="base",
+        )
+        doc = segment_to_document(seg, meta, ingested_at=1000, index=0)
+        assert "example.com" in (doc.content_ref or "")
+
+    def test_language_propagated(self):
+        seg = TranscriptSegment(start_s=0.0, end_s=5.0, text="Bonjour.")
+        meta = _meta()
+        meta.language = "fr"
+        doc = segment_to_document(seg, meta, ingested_at=1000, index=0)
+        assert doc.language == "fr"
+
+
+# --------------------------------------------------------------------------- #
+# media_metadata_to_documents tests
+# --------------------------------------------------------------------------- #
+
+class TestMediaMetadataToDocuments:
+    def test_one_doc_per_segment(self):
+        meta = _meta(n_segments=4)
+        docs = media_metadata_to_documents(meta, ingested_at=1)
+        assert len(docs) == 4
+
+    def test_empty_segments_empty_list(self):
+        meta = _meta(n_segments=0)
+        docs = media_metadata_to_documents(meta, ingested_at=1)
+        assert docs == []
+
+    def test_whitespace_only_segments_skipped(self):
+        meta = _meta(n_segments=1)
+        meta.segments = [TranscriptSegment(start_s=0.0, end_s=5.0, text="   ")]
+        docs = media_metadata_to_documents(meta, ingested_at=1)
+        assert docs == []
+
+    def test_segment_index_in_metadata(self):
+        meta = _meta(n_segments=3)
+        docs = media_metadata_to_documents(meta, ingested_at=1)
+        assert [d.metadata["segment_index"] for d in docs] == [0, 1, 2]
+
+    def test_unique_document_ids(self):
+        meta = _meta(n_segments=5)
+        docs = media_metadata_to_documents(meta, ingested_at=1)
+        ids = [d.document_id for d in docs]
+        assert len(ids) == len(set(ids))
+
+
+# --------------------------------------------------------------------------- #
+# MediaConnector integration tests
+# --------------------------------------------------------------------------- #
+
+class TestMediaConnector:
+    def test_source_type(self):
+        assert MediaConnector.source_type == "transcript"
+
+    def test_discover_file_paths(self):
+        c = MediaConnector()
+        refs = list(c.discover(["/pods/ep1.mp3", "/pods/ep2.mp4"]))
+        assert len(refs) == 2
+        assert refs[0].metadata["format"] == "mp3"
+        assert refs[1].metadata["format"] == "mp4"
+
+    def test_discover_single_string(self):
+        c = MediaConnector()
+        refs = list(c.discover("/pods/ep.mp3"))
+        assert len(refs) == 1
+
+    def test_discover_none_yields_nothing(self):
+        c = MediaConnector()
+        assert list(c.discover(None)) == []
+
+    def test_discover_url(self):
+        c = MediaConnector()
+        refs = list(c.discover(["https://example.com/ep.mp3"]))
+        assert len(refs) == 1
+        assert refs[0].locator == "https://example.com/ep.mp3"
+
+    def test_fetch_missing_file(self):
+        c = MediaConnector()
+        ref = SourceRef(locator="/no/such/file.mp3")
+        with pytest.raises(FileNotFoundError):
+            c.fetch(ref)
+
+    def test_fetch_reads_file(self, tmp_path):
+        audio = tmp_path / "ep.mp3"
+        audio.write_bytes(b"fake mp3 data")
+        c = MediaConnector()
+        ref = SourceRef(locator=str(audio), title="ep", metadata={"format": "mp3"})
+        raw = c.fetch(ref)
+        assert raw.content == b"fake mp3 data"
+
+    def test_parse_calls_transcribe_and_returns_docs(self, tmp_path):
+        audio = tmp_path / "pod.mp3"
+        audio.write_bytes(b"fake audio")
+        c = MediaConnector(model_size="tiny")
+        ref = SourceRef(locator=str(audio), title="pod", metadata={"format": "mp3"})
+        raw = c.fetch(ref)
+
+        fake_meta = _meta(title="pod", n_segments=2)
+
+        with patch("src.ingestion.connectors.media.connector.transcribe", return_value=fake_meta):
+            docs = c.parse(raw)
+
+        assert len(docs) == 2
+        assert all(d.source_type == "transcript" for d in docs)
+
+    def test_parse_diarize_called_when_flag_set(self, tmp_path):
+        audio = tmp_path / "ep.mp3"
+        audio.write_bytes(b"audio")
+        c = MediaConnector(diarize=True, hf_token="hf_test")
+        ref = SourceRef(locator=str(audio), title="ep", metadata={"format": "mp3"})
+        raw = c.fetch(ref)
+
+        fake_meta = _meta(n_segments=2)
+        labelled_segs = [
+            TranscriptSegment(s.start_s, s.end_s, s.text, speaker=f"SPK_{i}")
+            for i, s in enumerate(fake_meta.segments)
+        ]
+
+        with (
+            patch("src.ingestion.connectors.media.connector.transcribe", return_value=fake_meta),
+            patch("src.ingestion.connectors.media.connector.assign_speakers", return_value=labelled_segs) as mock_diar,
+        ):
+            docs = c.parse(raw)
+
+        mock_diar.assert_called_once()
+        assert docs[0].metadata["speaker"] == "SPK_0"
+
+    def test_parse_diarize_skipped_when_flag_false(self, tmp_path):
+        audio = tmp_path / "ep.mp3"
+        audio.write_bytes(b"audio")
+        c = MediaConnector(diarize=False)
+        ref = SourceRef(locator=str(audio), title="ep", metadata={"format": "mp3"})
+        raw = c.fetch(ref)
+        fake_meta = _meta(n_segments=1)
+
+        with (
+            patch("src.ingestion.connectors.media.connector.transcribe", return_value=fake_meta),
+            patch("src.ingestion.connectors.media.connector.assign_speakers") as mock_diar,
+        ):
+            c.parse(raw)
+
+        mock_diar.assert_not_called()
+
+    def test_harvest_skips_missing_files(self):
+        c = MediaConnector()
+        docs = list(c.harvest(["/no/such/podcast.mp3"]))
+        assert docs == []
+
+    def test_registered_in_registry(self):
+        import src.ingestion.connectors  # noqa: F401 — triggers registration
+        from src.ingestion.connectors.registry import is_registered
+        assert is_registered("transcript")

--- a/tests/ingestion/test_media_connector.py
+++ b/tests/ingestion/test_media_connector.py
@@ -16,6 +16,7 @@ Covers:
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
 from unittest.mock import patch
 
 import pytest
@@ -283,7 +284,9 @@ class TestSegmentToDocument:
             model="base",
         )
         doc = segment_to_document(seg, meta, ingested_at=1000, index=0)
-        assert "example.com" in (doc.content_ref or "")
+        assert doc.content_ref is not None
+        parsed = urlparse(doc.content_ref)
+        assert parsed.hostname == "example.com"
 
     def test_language_propagated(self):
         seg = TranscriptSegment(start_s=0.0, end_s=5.0, text="Bonjour.")


### PR DESCRIPTION
Closes #523.

## Summary

- **`transcriber.py`** — Three-backend chain: local `openai-whisper` → `faster-whisper` → OpenAI Whisper API. Each backend returns a list of `TranscriptSegment(start_s, end_s, text)`. Degrades to empty segments when nothing is installed so the connector is always importable. `ffmpeg` (already on the system) normalizes audio to 16 kHz mono WAV before local inference.
- **`diarizer.py`** — Optional `pyannote.audio` speaker attribution. Assigns each segment its speaker by maximum overlap with diarization turns. No-op (returns segments unchanged) when `pyannote.audio` is not installed or no `HF_TOKEN` is set.
- **`connector.py`** — `MediaConnector(source_type="transcript")` registered in the connector registry. `discover()` accepts file paths or HTTP(S) URLs. `parse()` calls the transcriber, optionally diarizes, then emits **one Document per Whisper segment**. Each Document carries `start_s` / `end_s` / `speaker` in `metadata` and a **Media Fragment URI** (`file://...#t=start,end` or `https://...#t=start,end`) in `content_ref` for jump-to-moment playback.
- **`models.py`** — `TranscriptSegment`, `MediaMetadata`, `media_id`, `segment_id`, `format_timestamp`, Media Fragment URI helper.
- **51 tests** — model invariants, format_timestamp, transcriber backend chain (mocked), diarizer no-op paths, `segment_to_document` field mapping, `media_metadata_to_documents`, full connector integration, registry check.

## How "timestamp-linked answers" works

Each Whisper segment becomes its own Document. A vector search hit includes:
```python
doc.metadata["start_s"]   # → 742.3
doc.metadata["end_s"]     # → 756.1
doc.content_ref           # → "file:///pods/ep42.mp3#t=742.300,756.100"
```
A player or UI can seek directly to `#t=742.300,756.100` — satisfying the exit criterion.

## Skill / MCP suggestion

Two additions would significantly improve the dev workflow on this and future connectors:

1. **`run_connector("transcript", ["path/to/file.mp3"])` in the pipeline MCP** — the existing `neuronews-pipeline` MCP server already exposes `run_connector` but it only knows about the `news` and `paper` connectors right now (hardcoded). Adding auto-discovery from the registry would make it work for `book`, `transcript`, and any future connector without touching the MCP code.

2. **A `scaffold-connector` skill variant for document connectors** — the existing `scaffold-connector` skill is RSS-centric (targets `article-ingest-v1`). A `scaffold-document-connector` skill that targets `document-ingest-v1` with the current `Connector` base class would let you bootstrap any new media type (DOCX, audio, database snapshot) in one shot.

## Test plan
- [x] `python -m pytest tests/ingestion/ -v` — 70 passed (51 new + 19 existing)
- [ ] `pip install openai-whisper` then `MediaConnector().harvest(["talk.mp3"])` on a real file
- [ ] Set `HF_TOKEN` + `pip install pyannote.audio` and verify speaker labels appear