### PR TITLE
feat(tooling): pipeline MCP auto-discovery + scaffold-document-connector skill

### DIFF
--- a/.claude/skills/scaffold-connector/SKILL.md
+++ b/.claude/skills/scaffold-connector/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: scaffold-connector
-description: Scaffold a new data connector / news source for the NeuroNews ingestion pipeline. Use when adding an RSS feed or a new source that produces article-ingest-v1 records. Covers the connector module, the contract it must satisfy, and the verify loop using the pipeline + contracts + lineage MCP servers.
+description: Scaffold a new data connector / news source for the NeuroNews ingestion pipeline. Use when adding an RSS feed or a new source that produces article-ingest-v1 records. Covers the connector module, the contract it must satisfy, and the verify loop using the pipeline + contracts + lineage MCP servers. For non-RSS media types (books, audio, papers, web pages) use scaffold-document-connector instead.
 ---
 
 # Scaffold a NeuroNews connector
+
+> **Choosing the right skill:** Use this skill for RSS/Atom feeds and sources
+> that emit `article-ingest-v1` records. For non-RSS media types (EPUB/PDF
+> books, audio/video, academic papers, web pages, database dumps) use the
+> **`scaffold-document-connector`** skill instead — it targets the newer
+> `document-ingest-v1` / `Connector` base class.
 
 A connector fetches from a source and emits **article-ingest-v1** records — the
 governed boundary the rest of the pipeline consumes. The cleanest shape emits

--- a/.claude/skills/scaffold-document-connector/SKILL.md
+++ b/.claude/skills/scaffold-document-connector/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: scaffold-document-connector
+description: Scaffold a new document connector for the NeuroNews knowledge-engine pipeline. Use when adding a new media type (DOCX, database snapshot, API dump, audio, video, web page, …) that should produce document-ingest-v1 records via the Connector base class. Covers the connector module, the Document model, and the verify loop using the pipeline + contracts + lineage MCP servers.
+---
+
+# Scaffold a NeuroNews document connector
+
+The knowledge-engine pipeline ingests arbitrary media types through a single
+interface: **discover → fetch → parse → `Document`**. A document connector
+subclasses `Connector`, sets `source_type`, and registers itself with
+`@register_connector` so the whole pipeline (and the pipeline MCP server) can
+drive it without any glue code.
+
+> **Use this skill** for any source that is *not* an RSS/Atom feed. For RSS
+> feeds, use the `scaffold-connector` skill instead (it targets the simpler
+> `article-ingest-v1` path).
+
+## The interface you implement
+
+```python
+# src/ingestion/connectors/<name>/connector.py
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.registry import register_connector
+from services.ingest.common.document_model import Document
+
+@register_connector
+class MyConnector(Connector):
+    source_type = "web"   # must be in SOURCE_TYPES (see below)
+
+    def discover(self, query=None) -> Iterable[SourceRef]:
+        """Enumerate what to ingest. query = user-supplied paths/IDs."""
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        """Pull the raw bytes for one SourceRef."""
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        """Normalize raw bytes → one or more Documents."""
+```
+
+`Connector.harvest(query)` chains the three for you: any source that fails
+`fetch` or `parse` is skipped and logged so one bad file doesn't abort a batch.
+
+## Valid source types
+
+```python
+# services/ingest/common/document_model.py
+SOURCE_TYPES = ("news", "blog", "book", "paper", "transcript", "web", "note")
+```
+
+If you need a new type, add it to `SOURCE_TYPES` first — the `Document.__post_init__`
+will raise `ValueError` otherwise.
+
+## Minimal working connector
+
+```python
+# src/ingestion/connectors/web/connector.py
+"""Web page connector → document-ingest-v1 records."""
+from __future__ import annotations
+import hashlib, time, urllib.request
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.registry import register_connector
+
+
+@register_connector
+class WebConnector(Connector):
+    source_type = "web"
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        """query = a URL string or list of URL strings."""
+        if query is None:
+            return
+        urls = [query] if isinstance(query, str) else list(query)
+        for url in urls:
+            yield SourceRef(locator=url, title=url)
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        with urllib.request.urlopen(ref.locator, timeout=30) as resp:
+            return RawDocument(ref=ref, content=resp.read(), content_type="text/html")
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        html = raw.content if isinstance(raw.content, str) else raw.content.decode("utf-8", errors="replace")
+        # TODO: extract text from HTML (BeautifulSoup, trafilatura, …)
+        text = html  # placeholder
+        doc_id = "web:" + hashlib.md5(raw.ref.locator.encode()).hexdigest()[:12]
+        return [Document(
+            document_id=doc_id,
+            source_type="web",
+            language="en",
+            ingested_at=int(time.time() * 1000),
+            url=raw.ref.locator,
+            title=raw.ref.title,
+            content=text,
+            content_ref=raw.ref.locator,
+        )]
+```
+
+## File layout
+
+Follow the same package structure as the existing connectors:
+
+```
+src/ingestion/connectors/<name>/
+    __init__.py          # exports + registers via importing connector.py
+    connector.py         # Connector subclass + @register_connector
+    models.py            # internal data classes (optional but recommended)
+    <format>_parser.py   # format-specific extraction (optional)
+    README.md
+tests/ingestion/
+    test_<name>_connector.py
+```
+
+`__init__.py` must import `connector.py` so the `@register_connector` decorator
+runs on package import:
+
+```python
+# src/ingestion/connectors/<name>/__init__.py
+from src.ingestion.connectors.<name>.connector import MyConnector
+```
+
+Then add one line to `src/ingestion/connectors/__init__.py`:
+
+```python
+from src.ingestion.connectors import <name>  # noqa: E402,F401
+```
+
+## The Document model
+
+```python
+@dataclass
+class Document:
+    document_id: str        # required — stable, unique id for this doc
+    source_type: str        # required — must be in SOURCE_TYPES
+    language: str           # required — ISO 639-1 code, e.g. "en"
+    ingested_at: int        # required — milliseconds since epoch
+
+    source_id: Optional[str] = None   # publisher/origin id
+    url: Optional[str] = None         # canonical URL or file:// URI
+    title: Optional[str] = None
+    content: Optional[str] = None     # inline text (small docs)
+    content_ref: Optional[str] = None # URI to large content in object store
+    authors: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None  # ms since epoch, if known
+    metadata: Dict[str, Any] = field(default_factory=dict)  # anything extra
+```
+
+**Rules:**
+- `content` is for inline text. Large documents (books, long transcripts) can
+  put a `file://` or `s3://` URI in `content_ref` and omit or truncate `content`.
+- `metadata` is your escape hatch — put type-specific fields here
+  (e.g. `{"section_path": ["Chapter 3"], "start_s": 12.5}`).
+- `document_id` must be stable across runs; use a hash of the canonical key
+  (ISBN, arXiv ID, URL, file path + offset).
+
+## Graceful degradation pattern
+
+If your parser requires an optional library, try-import it inside the function
+and return a safe default when missing:
+
+```python
+def parse_with_backend(data: bytes):
+    try:
+        import mylib  # optional dep
+    except ImportError:
+        return None   # caller falls through to the next backend
+
+    return mylib.parse(data)
+```
+
+This keeps the connector importable and testable without the optional lib
+installed. The three existing connectors (book, paper, transcript) all follow
+this pattern.
+
+## Verify loop
+
+Once the connector is scaffolded, use the three MCP servers to verify it
+end-to-end without writing to the warehouse:
+
+### 1. Confirm it is registered
+```
+list_connector_types()
+# → {"source_types": ["news", "paper", "book", "transcript", "<name>"], ...}
+```
+
+### 2. Run it against a real sample
+```
+run_connector("<source_type>", query='["<path-or-id>"]', sample=3)
+# → {"source_type": "...", "harvested": 3, "documents": [...], "errors": []}
+```
+
+### 3. Validate the output against the document contract
+```
+validate("document", <record_dict>)
+# → {"jsonschema": "valid", "avro": "...", "agree": true/false}
+```
+
+### 4. Check downstream impact
+```
+impact("ingest.<source_type>", "downstream")
+# → what pipeline stages run after this connector emits
+```
+
+### Full verify checklist
+
+1. `python3 -c "from src.ingestion.connectors import get_connector; get_connector('<name>')"` — no ImportError.
+2. `list_connector_types()` → your type appears.
+3. `run_connector("<name>", query='[...]', sample=3)` → `harvested > 0`, `errors == []`.
+4. `validate("document", doc)` → `jsonschema.valid: true`.
+5. `impact("ingest.<name>", "downstream")` → lineage flows to expected stages.
+
+## Gotchas
+
+- **`source_type` must be in `SOURCE_TYPES`** — `Document.__post_init__` raises
+  `ValueError` on construction otherwise. Add your type there first.
+- **`ingested_at` is epoch-milliseconds** (`int(time.time() * 1000)`), not a
+  `datetime`. `created_at` follows the same convention.
+- **`language` is required and must be a 2-letter ISO 639-1 code** (`"en"`, `"fr"`,
+  `"de"`, …). Easy to forget when parsing files that don't declare a language.
+- **`document_id` must be stable** — if your connector runs twice over the same
+  source, the same logical document must get the same id. Use a hash of the
+  canonical key, not `uuid4()`.
+- **`metadata` values must be JSON-serialisable** — no `datetime` objects; use
+  epoch-ms ints or ISO strings.
+- **The `"news"` source_type** dispatches via the existing `NewsConnector`
+  (RSS feeds). Don't create a new connector for RSS; use `scaffold-connector`.

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -9,7 +9,11 @@ DIFF — never the full payload. It drives the project's own pipeline code
 
 Tools:
   list_sources(category?)              -> the configured RSS connectors (DEFAULT_FEEDS)
-  run_connector(source, sample=5)      -> fetch+parse one source, summary only (no write)
+  list_connector_types()               -> all registered document connector source types
+  run_connector(source, sample=5,      -> fetch+parse one source, summary only (no write).
+                query?)                   source = RSS feed name OR a source_type from
+                                          list_connector_types(); query = JSON list of paths/
+                                          IDs passed to that connector's discover().
   run_stage(stage, input_ref?, ...)    -> run one named stage: fetch | sentiment | store | ingest
   trace_article(id)                    -> where an article exists across warehouse / vector / s3
 
@@ -134,24 +138,79 @@ def list_sources(category: Optional[str] = None) -> dict:
 
 
 @mcp.tool
-def run_connector(source: str, sample: int = 5) -> dict:
-    """Run a single connector: fetch + parse up to `sample` articles from one
-    source's live feed and return a SUMMARY only (no warehouse write).
+def list_connector_types() -> dict:
+    """List all registered document connector source types.
+
+    Returns the source types that have a connector registered in the connector
+    registry (e.g. "news", "paper", "book", "transcript"). Each type can be
+    passed as the ``source`` argument to ``run_connector``.
+    """
+    import src.ingestion.connectors  # noqa: F401 — triggers @register_connector for all built-ins
+    from src.ingestion.connectors.registry import available_source_types
+    types = available_source_types()
+    return {
+        "count": len(types),
+        "source_types": types,
+        "usage": (
+            "Pass a source_type as `source` to run_connector(), "
+            "and supply `query` as a JSON list of paths/IDs for that connector "
+            "(e.g. query='[\"/books/foo.epub\"]' for book, "
+            "query='[\"2312.00752\"]' for paper arXiv IDs, "
+            "query='[\"/podcasts/ep.mp3\"]' for transcript). "
+            "For `news`, omit query to use the default RSS feeds."
+        ),
+    }
+
+
+@mcp.tool
+def run_connector(source: str, sample: int = 5, query: Optional[str] = None) -> dict:
+    """Run a single connector: fetch + parse up to `sample` records from one
+    source and return a SUMMARY only (no warehouse write).
+
+    Two dispatch modes, selected automatically:
+
+    1. **RSS feed** (legacy): ``source`` is a feed name from ``list_sources``
+       (e.g. ``"BBC Technology"``). ``query`` is ignored.
+
+    2. **Document connector**: ``source`` is a source type from
+       ``list_connector_types`` (e.g. ``"book"``, ``"paper"``, ``"transcript"``).
+       ``query`` is a JSON list of paths or IDs to pass to ``discover()``.
+       Examples::
+
+         run_connector("book",       query='["/books/foo.epub"]')
+         run_connector("paper",      query='["2312.00752", "1706.03762"]')
+         run_connector("transcript", query='["/pods/ep42.mp3"]')
+         run_connector("news")       # uses DEFAULT_FEEDS, no query needed
 
     Args:
-        source: a source name from list_sources (e.g. "BBC Technology").
-        sample: max articles to parse (1-25).
+        source: RSS feed name OR a source_type from list_connector_types.
+        sample: max records to harvest (1-25).
+        query:  JSON list of paths/IDs for document connectors (ignored for RSS).
 
-    Returns counts, category, date range, sentiment distribution and a few
-    sample titles. Network-dependent — reports a clear error if the feed can't
-    be fetched.
+    Returns a summary: source type, record count, and sample titles/snippets.
     """
+    sample = max(1, min(int(sample), 25))
+
+    # --- Try document connector registry first ----------------------------- #
+    import src.ingestion.connectors as _conn_pkg  # noqa: F401 — trigger registrations
+    from src.ingestion.connectors.registry import available_source_types, get_connector, is_registered
+
+    if is_registered(source):
+        return _run_document_connector(source, sample, query, get_connector)
+
+    # --- Fall back to legacy RSS path -------------------------------------- #
     si = _pipeline()
     feed = _find_feed(si, source)
     if feed is None:
-        return {"error": f"unknown source {source!r}", "hint": "call list_sources()"}
+        types = available_source_types()
+        return {
+            "error": f"unknown source {source!r}",
+            "hint": (
+                f"For RSS feeds call list_sources(). "
+                f"For document connectors use one of: {types}"
+            ),
+        }
 
-    sample = max(1, min(int(sample), 25))
     try:
         raw = si._http_get(feed.url)
         articles = si.parse_feed(raw, feed, limit=sample)
@@ -171,6 +230,67 @@ def run_connector(source: str, sample: int = 5) -> dict:
         "sentiment": _sentiment_distribution(articles),
         "sample_titles": [a.title for a in articles[:MAX_LIST]],
     }
+
+
+def _run_document_connector(
+    source_type: str,
+    sample: int,
+    query_json: Optional[str],
+    get_connector,
+) -> dict:
+    """Harvest up to ``sample`` Documents from a registry connector and return a summary."""
+    import json as _json
+
+    query = None
+    if query_json:
+        try:
+            query = _json.loads(query_json)
+        except _json.JSONDecodeError as exc:
+            return {"error": f"query must be a JSON list: {exc}", "example": '["path/to/file"]'}
+
+    try:
+        connector = get_connector(source_type)
+    except KeyError as exc:
+        return {"error": str(exc)}
+
+    docs = []
+    errors = []
+    for ref in list(connector.discover(query))[:sample]:
+        try:
+            raw = connector.fetch(ref)
+            parsed = connector.parse(raw)
+            docs.extend(parsed)
+        except Exception as exc:
+            errors.append({"locator": ref.locator, "error": str(exc)})
+        if len(docs) >= sample:
+            break
+
+    docs = docs[:sample]
+    sample_snippets = []
+    for d in docs[:MAX_LIST]:
+        snippet = {
+            "document_id": d.document_id,
+            "title": d.title,
+            "language": d.language,
+        }
+        # Include a few type-specific metadata highlights.
+        for key in ("section_path", "start_s", "end_s", "speaker", "arxiv_id", "doi"):
+            if key in (d.metadata or {}):
+                snippet[key] = d.metadata[key]
+        if d.content:
+            snippet["content_preview"] = d.content[:CONTENT_PREVIEW]
+        sample_snippets.append(snippet)
+
+    result: dict = {
+        "source_type": source_type,
+        "connector": type(connector).__name__,
+        "query": query,
+        "harvested": len(docs),
+        "documents": sample_snippets,
+    }
+    if errors:
+        result["errors"] = errors
+    return result
 
 
 @mcp.tool


### PR DESCRIPTION
Implements the two suggestions from PR #535 (media connector).

## Pipeline MCP — `tools/pipeline_mcp/server.py`

### New tool: `list_connector_types()`
Returns all source types registered in the connector registry at call time. No hardcoding — as `book`, `transcript`, and future connectors land via their own PRs, they appear here automatically.

```
list_connector_types()
→ {"source_types": ["news", "paper", "book", "transcript"], "usage": "..."}
```

### Extended tool: `run_connector(source, sample=5, query=None)`
Now dispatches to **two paths**, selected automatically:

| `source` value | Path | `query` |
|---|---|---|
| Registered source type (`"book"`, `"paper"`, `"transcript"`) | Registry connector → `discover(query).fetch().parse()` | JSON list of paths/IDs, e.g. `'["/books/foo.epub"]'` |
| RSS feed name (`"BBC Technology"`) | Existing scrapy_integration path (unchanged) | Ignored |

```
run_connector("paper",      query='["1706.03762"]', sample=2)
run_connector("book",       query='["/books/foo.epub"]')
run_connector("transcript", query='["/pods/ep42.mp3"]')
run_connector("BBC World",  sample=5)   ← unchanged
```

Returns a unified summary with type-specific metadata highlights (`section_path`, `start_s`/`end_s`, `speaker`, `arxiv_id`, etc.).

## New skill: `scaffold-document-connector`

`.claude/skills/scaffold-document-connector/SKILL.md` — a full scaffolding guide for non-RSS connectors targeting `document-ingest-v1` / the `Connector` base class. Covers:
- The three-method interface (`discover` / `fetch` / `parse`)
- A minimal working connector template (copy-paste ready)
- `Document` model fields, required vs optional, gotchas (stable IDs, epoch-ms timestamps, JSON-serialisable metadata)
- File layout matching the existing `book/`, `paper/`, `media/` packages
- Graceful degradation pattern for optional deps
- Full verify loop: `list_connector_types` → `run_connector` → `validate` → `impact`

Also updated `scaffold-connector/SKILL.md` with a disambiguation header so Claude picks the right skill for RSS vs. document sources.

## Test plan
- [x] `python -m pytest tests/ingestion/ -q` — 19 passed
- [x] `list_connector_types()` smoke-test: returns `["news", "paper"]` on main (book/transcript not yet merged)
- [x] `run_connector("paper", query='["nonexistent"]')` dispatches to `PaperConnector`, returns structured error
- [x] `run_connector("unknown_source")` returns helpful hint with registered types
- [x] `python3 -c "import tools.pipeline_mcp.server"` — imports cleanly