### PR TITLE
feat(connectors): blog/RSS/Atom connector with readability and watchlists (#522)

### DIFF
--- a/.claude/skills/scaffold-blog-watchlist/SKILL.md
+++ b/.claude/skills/scaffold-blog-watchlist/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: scaffold-blog-watchlist
+description: Scaffold a new blog watchlist for NeuroNews. Use when you want to monitor a set of keywords across subscribed RSS/Atom feeds and surface matching posts as a digest. Covers FeedSubscription setup, WatchlistEntry definition, running the watchlist via the blog-feeds MCP, and optionally wiring a digest endpoint into the API.
+---
+
+# Scaffold a NeuroNews blog watchlist
+
+A watchlist monitors a set of keywords across all ingested blog/RSS/Atom posts.
+When any post's title or content contains a keyword, it surfaces in the
+**digest** — a list of `DigestMatch` objects showing the post, URL, and which
+keywords matched.
+
+This skill pairs with the **`neuronews-blog-feeds`** MCP server (in `.mcp.json`):
+- `subscribe_feed(url, name, tags)` — add a feed subscription
+- `ingest_feeds(limit_per_feed=20)` — pull latest posts from all subscriptions
+- `run_watchlist(keywords, tag_filter?)` — run keyword matching on latest posts
+
+**Paths below are relative to the repo root** (`/home/Ikey/NeuroNews`).
+
+## Quick path: run a watchlist from the MCP
+
+The fastest way to monitor keywords against already-subscribed feeds:
+
+```
+# 1. Subscribe to a feed (if not already subscribed)
+subscribe_feed("https://example.com/rss", name="Example Blog", tags=["tech"])
+
+# 2. Pull latest posts
+ingest_feeds(limit_per_feed=10, fetch_full_text=False)
+
+# 3. Run the watchlist
+run_watchlist(["machine learning", "python", "AI"], tag_filter=["tech"])
+# → {"matches": [...], "total": 3, "feeds_checked": 1}
+```
+
+## Full path: a named, persistent watchlist
+
+For watchlists you want to run repeatedly or expose via the API, define them
+in code using the `WatchlistEntry` dataclass:
+
+```python
+# src/domains/<your_domain>/watchlists.py
+from src.ingestion.connectors.blog.models import WatchlistEntry
+
+AI_WATCHLIST = WatchlistEntry(
+    name="ai-research",
+    keywords=["machine learning", "large language model", "neural network", "GPT"],
+    tags=["tech", "research"],   # scope to feeds tagged with these
+)
+
+CLIMATE_WATCHLIST = WatchlistEntry(
+    name="climate",
+    keywords=["climate change", "global warming", "carbon emissions", "net zero"],
+    tags=[],  # empty = search all feeds
+)
+```
+
+Run them against a batch of `Document` objects:
+
+```python
+from src.ingestion.connectors.blog.digest import run_watchlists
+from src.ingestion.connectors.blog import ingest_feeds
+
+# Ingest latest posts
+result = ingest_feeds(fetch_full_text=True, limit_per_feed=20)
+
+# Then run against the documents you just harvested
+# (or pull from your document store)
+from src.ingestion.connectors.blog import BlogConnector
+docs = list(BlogConnector().harvest())
+
+digest = run_watchlists(docs, [AI_WATCHLIST, CLIMATE_WATCHLIST])
+# → {"ai-research": [DigestMatch(...)], "climate": [...]}
+```
+
+## DigestMatch fields
+
+```python
+@dataclass
+class DigestMatch:
+    document_id: str         # stable blog-<hash> id
+    title: str               # post title
+    url: str                 # post URL
+    matched_keywords: list   # which keywords matched (lowercase)
+    watchlist_name: str      # which watchlist produced this match
+```
+
+## Subscribing to feeds
+
+Use `SubscriptionStore` or the MCP to manage subscriptions. Subscriptions
+persist in `config/blog_subscriptions.json`:
+
+```python
+from src.ingestion.connectors.blog import BlogConnector
+
+connector = BlogConnector()
+connector.subscribe("https://huggingface.co/blog/feed.xml", name="HuggingFace Blog", tags=["tech", "research"])
+connector.subscribe("https://openai.com/blog/rss", name="OpenAI Blog", tags=["tech"])
+connector.subscribe("https://www.carbonbrief.org/feed/", name="Carbon Brief", tags=["climate"])
+```
+
+Or from the MCP:
+```
+subscribe_feed("https://huggingface.co/blog/feed.xml", name="HuggingFace Blog", tags=["tech", "research"])
+```
+
+## Tag scoping
+
+Tags let you scope a watchlist to a subset of feeds. A post must come from a
+feed whose metadata `tags` overlap with the watchlist's `tags` to be eligible.
+Empty `tags` = match all feeds.
+
+```python
+# Only surfaces in feeds tagged ["tech"] or ["research"]
+WatchlistEntry(name="llm-news", keywords=["LLM", "transformer"], tags=["tech", "research"])
+
+# Surfaces across every subscribed feed
+WatchlistEntry(name="global-ai", keywords=["artificial intelligence"], tags=[])
+```
+
+## Wiring a digest endpoint into the API
+
+Add a route to `src/api/routes/document_routes.py` (the always-mounted generic
+router) or, if news-specific, gate it behind `is_pack_enabled("news")` in
+`src/api/app.py`.
+
+Minimal digest endpoint:
+
+```python
+# src/api/routes/document_routes.py (add after existing routes)
+from src.ingestion.connectors.blog.digest import match_watchlist
+
+@router.get("/documents/digest")
+def digest_endpoint(keywords: str, tags: str = ""):
+    """Run an ad-hoc keyword watchlist against the in-memory document store."""
+    kws = [k.strip() for k in keywords.split(",") if k.strip()]
+    tag_filter = [t.strip() for t in tags.split(",") if t.strip()] or None
+    docs = list(_store.values())  # replace with your real store
+    matches = match_watchlist(docs, kws, "ad-hoc", tag_filter)
+    return {
+        "query": {"keywords": kws, "tag_filter": tag_filter},
+        "matches": [
+            {
+                "document_id": m.document_id,
+                "title": m.title,
+                "url": m.url,
+                "matched_keywords": m.matched_keywords,
+            }
+            for m in matches
+        ],
+        "total": len(matches),
+    }
+```
+
+## Verify checklist
+
+1. `subscribe_feed(...)` via MCP → appears in `list_subscriptions()`
+2. `ingest_feeds(limit_per_feed=5)` → `documents_ingested > 0`, `errors == []`
+3. `run_watchlist(["your keyword"])` → returns matching posts (or empty if no matches yet)
+4. `(optional)` `GET /documents/digest?keywords=your+keyword` → same matches via API
+
+## Gotchas
+
+- **Keyword matching is case-insensitive substring search** — `"AI"` matches
+  "AI", "ai", "AIsee", "main". Use longer phrases for precision.
+- **`fetch_full_text=True` is slower** — each post URL is fetched individually.
+  For watchlists running on a schedule, set `fetch_full_text=False` for fast
+  first-pass matching on feed summaries; re-fetch full text only for matches.
+- **`config/blog_subscriptions.json` is the truth** — subscriptions are not in
+  the database. Back it up alongside `config/domain_packs.json`.
+- **Feed summaries are truncated** — many feeds only publish a one-sentence
+  blurb. If your keyword appears in body paragraphs, you need `fetch_full_text=True`
+  to catch it.
+- **`run_watchlists()` scans in-memory documents** — it does not query a
+  database. Pair with `ingest_feeds()` to first pull the latest posts.

--- a/.mcp.json
+++ b/.mcp.json
@@ -60,6 +60,14 @@
         "tools/lineage_mcp/server.py"
       ],
       "env": {}
+    },
+    "neuronews-blog-feeds": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/blog_mcp/server.py"
+      ],
+      "env": {}
     }
   }
 }

--- a/config/blog_subscriptions.json
+++ b/config/blog_subscriptions.json
@@ -1,0 +1,3 @@
+{
+  "subscriptions": []
+}

--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -21,6 +21,7 @@ from src.ingestion.connectors import paper  # noqa: E402,F401
 from src.ingestion.connectors import upload  # noqa: E402,F401
 from src.ingestion.connectors import media  # noqa: E402,F401
 from src.ingestion.connectors import book  # noqa: E402,F401
+from src.ingestion.connectors import blog  # noqa: E402,F401
 
 __all__ = [
     "Connector",

--- a/src/ingestion/connectors/blog/__init__.py
+++ b/src/ingestion/connectors/blog/__init__.py
@@ -1,0 +1,19 @@
+"""Blog / RSS / Atom ingestion connector."""
+
+from src.ingestion.connectors.blog.connector import BlogConnector
+from src.ingestion.connectors.blog.digest import match_watchlist, run_watchlists
+from src.ingestion.connectors.blog.models import DigestMatch, FeedSubscription, WatchlistEntry
+from src.ingestion.connectors.blog.pipeline import IngestResult, ingest_feeds
+from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+
+__all__ = [
+    "BlogConnector",
+    "DigestMatch",
+    "FeedSubscription",
+    "IngestResult",
+    "SubscriptionStore",
+    "WatchlistEntry",
+    "ingest_feeds",
+    "match_watchlist",
+    "run_watchlists",
+]

--- a/src/ingestion/connectors/blog/connector.py
+++ b/src/ingestion/connectors/blog/connector.py
@@ -1,0 +1,298 @@
+"""Blog / RSS / Atom connector.
+
+Subscribes to arbitrary RSS/Atom feeds and produces ``Document`` records with
+``source_type="blog"``.  Optionally fetches full article body via readability
+extraction so the document carries more than the truncated feed summary.
+
+Flow:
+    discover()  — yields one SourceRef per subscription (or per query)
+    fetch()     — fetches RSS/Atom bytes for a feed URL
+    parse()     — feedparser → N Documents; optionally enriches content from
+                  the article URL via :func:`fetch_full_text`
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.connectors.blog.models import FeedSubscription
+from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+from src.ingestion.connectors.registry import register_connector
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "NeuroNewsBot/1.0 (+https://github.com/Ikey168/NeuroNews)"
+_HTTP_TIMEOUT = 15
+
+
+def _default_http_get(url: str) -> bytes:
+    from urllib.request import Request, urlopen
+
+    req = Request(
+        url,
+        headers={
+            "User-Agent": _USER_AGENT,
+            "Accept": "application/rss+xml, application/xml, text/xml, */*",
+        },
+    )
+    with urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _strip_html(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    text = re.sub(r"<[^>]+>", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _to_millis(struct_time) -> Optional[int]:
+    """Convert a ``time.struct_time`` (from feedparser) to epoch-ms."""
+    if struct_time is None:
+        return None
+    try:
+        dt = datetime(*struct_time[:6], tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def _stable_id(url: str, title: str = "") -> str:
+    key = url or title
+    return "blog-" + hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _normalize_query(query: Any) -> List[FeedSubscription]:
+    """Accept URL strings, FeedSubscription objects, or dicts."""
+    result: List[FeedSubscription] = []
+    for item in query:
+        if isinstance(item, FeedSubscription):
+            result.append(item)
+        elif isinstance(item, dict):
+            result.append(FeedSubscription(
+                url=item["url"],
+                name=item.get("name", item["url"]),
+                tags=list(item.get("tags", [])),
+            ))
+        else:
+            result.append(FeedSubscription(url=str(item), name=str(item)))
+    return result
+
+
+@register_connector
+class BlogConnector(Connector):
+    """Ingest blog / newsletter / podcast RSS-Atom feeds as document-ingest-v1 records.
+
+    Args:
+        subs_path: Path to the JSON subscription store (default: ``config/blog_subscriptions.json``).
+        fetch_full_text: When True, follow each entry URL to extract the full
+            article body.  Falls back to feed summary silently on any error.
+        limit_per_feed: Maximum entries to ingest per feed per run.
+        http_get: Callable ``(url: str) -> bytes`` injected in tests.
+        full_text_getter: Callable ``(url: str) -> str`` injected in tests.
+    """
+
+    source_type = "blog"
+
+    def __init__(
+        self,
+        subs_path=None,
+        fetch_full_text: bool = True,
+        limit_per_feed: int = 20,
+        http_get: Optional[Callable[[str], bytes]] = None,
+        full_text_getter: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self._store = SubscriptionStore(subs_path)
+        self._fetch_full_text = fetch_full_text
+        self._limit = limit_per_feed
+        self._http_get = http_get or _default_http_get
+        if full_text_getter is not None:
+            self._full_text_getter: Callable[[str], str] = full_text_getter
+        else:
+            from src.ingestion.connectors.blog.readability import fetch_full_text as _ft
+            self._full_text_getter = _ft
+
+    # ------------------------------------------------------------------ #
+    # Connector interface
+    # ------------------------------------------------------------------ #
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        """Yield one SourceRef per subscription.
+
+        ``query`` may be a list of URL strings, :class:`FeedSubscription`
+        objects, or ``{"url": ..., "name": ..., "tags": [...]}`` dicts.
+        When omitted, subscriptions are read from the store.
+        """
+        subs = _normalize_query(query) if query is not None else self._store.list()
+        for sub in subs:
+            yield SourceRef(
+                locator=sub.url,
+                title=sub.name or sub.url,
+                metadata={"name": sub.name or sub.url, "tags": list(sub.tags)},
+            )
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        content = self._http_get(ref.locator)
+        return RawDocument(ref=ref, content=content, content_type="application/xml")
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        import feedparser
+
+        data = raw.content
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+
+        parsed = feedparser.parse(data)
+        feed_name = (
+            raw.ref.metadata.get("name")
+            or parsed.feed.get("title", "")
+            or raw.ref.title
+            or raw.ref.locator
+        )
+        tags = raw.ref.metadata.get("tags", [])
+        ingested_at = raw.fetched_at
+
+        documents: List[Document] = []
+        for entry in parsed.entries[: self._limit]:
+            doc = self._entry_to_document(entry, feed_name, tags, ingested_at)
+            if doc is not None:
+                documents.append(doc)
+        return documents
+
+    # ------------------------------------------------------------------ #
+    # Subscription helpers (pass-through to the store)
+    # ------------------------------------------------------------------ #
+
+    def subscribe(self, url: str, name: str = "", tags: Optional[List[str]] = None) -> FeedSubscription:
+        """Persist a new subscription."""
+        return self._store.subscribe(url, name=name, tags=tags)
+
+    def unsubscribe(self, url: str) -> bool:
+        return self._store.unsubscribe(url)
+
+    def list_subscriptions(self) -> List[FeedSubscription]:
+        return self._store.list()
+
+    # ------------------------------------------------------------------ #
+    # Entity extraction
+    # ------------------------------------------------------------------ #
+
+    def ingest_to_kg(self, document: Document, store=None) -> Dict[str, Any]:
+        """Extract entities from ``document`` and store them in the KG.
+
+        Returns ``{"entities": int, "relationships": int}``.
+        Gracefully returns zeros if spaCy or the KG store is unavailable.
+        """
+        try:
+            import asyncio
+            from src.knowledge_graph.enhanced_entity_extractor import AdvancedEntityExtractor
+            from src.knowledge_graph.foundation import KnowledgeGraphStore, Node
+            from src.knowledge_graph.foundation.ontology import EntityType
+
+            kg_store = store if store is not None else KnowledgeGraphStore()
+            extractor = AdvancedEntityExtractor()
+
+            # spaCy-label → EntityType; unknown labels map to CONCEPT.
+            _label_map = {
+                "PERSON": EntityType.PERSON,
+                "ORG": EntityType.ORGANIZATION,
+                "GPE": EntityType.CONCEPT,
+                "LOC": EntityType.CONCEPT,
+                "FAC": EntityType.CONCEPT,
+                "NORP": EntityType.ORGANIZATION,
+            }
+
+            async def _run() -> Dict[str, int]:
+                entities = await extractor.extract_entities_from_article(
+                    document.document_id,
+                    document.title or "",
+                    document.content or "",
+                )
+                rels = await extractor.extract_relationships(
+                    entities,
+                    (document.title or "") + " " + (document.content or ""),
+                    document.document_id,
+                )
+                for ent in entities:
+                    etype = _label_map.get(ent.label, EntityType.CONCEPT)
+                    node = Node(
+                        type=etype,
+                        name=ent.normalized_form or ent.text,
+                        node_id=ent.entity_id or "",
+                        aliases=list(ent.aliases),
+                        properties={"source_article": document.document_id, "confidence": ent.confidence},
+                    )
+                    kg_store.add_node(node)
+                return {"entities": len(entities), "relationships": len(rels)}
+
+            return asyncio.run(_run())
+        except Exception as exc:
+            logger.debug("ingest_to_kg skipped: %s", exc)
+            return {"entities": 0, "relationships": 0}
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    def _entry_to_document(
+        self,
+        entry: Any,
+        feed_name: str,
+        feed_tags: List[str],
+        ingested_at: int,
+    ) -> Optional[Document]:
+        title = (entry.get("title") or "").strip()
+        url = (entry.get("link") or "").strip()
+        if not title and not url:
+            return None
+
+        # Summary from feed (may contain HTML).
+        content_list = entry.get("content") or []
+        content_value = content_list[0].value if content_list and hasattr(content_list[0], "value") else ""
+        raw_summary = (
+            entry.get("summary")
+            or entry.get("description")
+            or content_value
+        )
+        summary = _strip_html(raw_summary)
+
+        # Full article body.
+        content = summary
+        if self._fetch_full_text and url:
+            try:
+                full = self._full_text_getter(url)
+                if full and len(full) > len(summary):
+                    content = full
+            except Exception:
+                pass
+
+        # Authors.
+        author = entry.get("author") or ""
+        authors = [a.strip() for a in author.split(",") if a.strip()] if author else []
+
+        # Entry tags/categories from the feed.
+        entry_tags = [t.get("term", "") for t in (entry.get("tags") or []) if t.get("term")]
+
+        return Document(
+            document_id=_stable_id(url, title),
+            source_type="blog",
+            language="en",
+            ingested_at=ingested_at,
+            source_id=feed_name,
+            url=url or None,
+            title=title or None,
+            content=content or None,
+            authors=authors,
+            created_at=_to_millis(entry.get("published_parsed") or entry.get("updated_parsed")),
+            metadata={
+                "feed_name": feed_name,
+                "tags": list(set(feed_tags + entry_tags)),
+                "has_full_text": content != summary and bool(content),
+            },
+        )

--- a/src/ingestion/connectors/blog/digest.py
+++ b/src/ingestion/connectors/blog/digest.py
@@ -1,0 +1,63 @@
+"""Watchlist matching and digest building for blog posts.
+
+A watchlist is a named set of keywords; any ingested post whose title or
+content contains one of those keywords surfaces in the digest.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from src.ingestion.connectors.blog.models import DigestMatch, WatchlistEntry
+
+
+def match_watchlist(
+    documents: list,
+    keywords: List[str],
+    watchlist_name: str = "default",
+    tag_filter: Optional[List[str]] = None,
+) -> List[DigestMatch]:
+    """Return one :class:`DigestMatch` per document that contains any keyword.
+
+    ``tag_filter`` narrows the search to documents whose metadata ``tags``
+    overlap with the filter list (ignored if empty or None).
+    """
+    lower_kws = [kw.lower() for kw in keywords if kw.strip()]
+    matches: List[DigestMatch] = []
+    for doc in documents:
+        if not _tag_ok(doc, tag_filter):
+            continue
+        title = (getattr(doc, "title", None) or doc.get("title", "") if isinstance(doc, dict) else doc.title or "")
+        content = (getattr(doc, "content", None) or doc.get("content", "") if isinstance(doc, dict) else doc.content or "")
+        url = (getattr(doc, "url", None) or doc.get("url", "") if isinstance(doc, dict) else doc.url or "")
+        doc_id = (getattr(doc, "document_id", None) or doc.get("document_id", "") if isinstance(doc, dict) else doc.document_id or "")
+        haystack = (title + " " + content).lower()
+        matched = [kw for kw in lower_kws if kw in haystack]
+        if matched:
+            matches.append(DigestMatch(
+                document_id=doc_id,
+                title=title,
+                url=url,
+                matched_keywords=matched,
+                watchlist_name=watchlist_name,
+            ))
+    return matches
+
+
+def run_watchlists(
+    documents: list,
+    watchlists: List[WatchlistEntry],
+) -> Dict[str, List[DigestMatch]]:
+    """Run every watchlist against ``documents``; return matches keyed by name."""
+    return {
+        w.name: match_watchlist(documents, w.keywords, w.name, w.tags or None)
+        for w in watchlists
+    }
+
+
+def _tag_ok(doc, tag_filter: Optional[List[str]]) -> bool:
+    if not tag_filter:
+        return True
+    meta = getattr(doc, "metadata", None) or (doc.get("metadata") if isinstance(doc, dict) else {}) or {}
+    doc_tags = meta.get("tags", [])
+    return bool(set(doc_tags) & set(tag_filter))

--- a/src/ingestion/connectors/blog/models.py
+++ b/src/ingestion/connectors/blog/models.py
@@ -1,0 +1,36 @@
+"""Data models for the blog/RSS/Atom connector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class FeedSubscription:
+    """A subscribed RSS/Atom feed URL with optional name and topic tags."""
+
+    url: str
+    name: str = ""
+    tags: List[str] = field(default_factory=list)
+    added_at: int = 0  # epoch-ms
+
+
+@dataclass
+class WatchlistEntry:
+    """A named set of keywords to monitor across ingested blog posts."""
+
+    name: str
+    keywords: List[str]
+    tags: List[str] = field(default_factory=list)  # scope to specific feed tags
+
+
+@dataclass
+class DigestMatch:
+    """A document that matched a watchlist entry."""
+
+    document_id: str
+    title: str
+    url: str
+    matched_keywords: List[str]
+    watchlist_name: str

--- a/src/ingestion/connectors/blog/pipeline.py
+++ b/src/ingestion/connectors/blog/pipeline.py
@@ -1,0 +1,87 @@
+"""High-level pipeline for blog feed ingestion with entity extraction.
+
+``ingest_feeds()`` runs discover → fetch → parse for every subscription and
+optionally calls ``BlogConnector.ingest_to_kg()`` on each document so entities
+and relationships land in the knowledge graph.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IngestResult:
+    feeds_fetched: int = 0
+    documents_ingested: int = 0
+    entities_extracted: int = 0
+    relationships_extracted: int = 0
+    errors: List[str] = field(default_factory=list)
+
+
+def ingest_feeds(
+    query=None,
+    limit_per_feed: int = 20,
+    fetch_full_text: bool = True,
+    extract_entities: bool = True,
+    subs_path=None,
+) -> IngestResult:
+    """Ingest all subscribed feeds (or ``query`` overrides) and populate the KG.
+
+    Args:
+        query: Optional list of URLs/FeedSubscription objects to ingest instead
+            of the persisted subscription list.
+        limit_per_feed: Max entries per feed.
+        fetch_full_text: Whether to follow article URLs for full body extraction.
+        extract_entities: Whether to run entity/relationship extraction and
+            store results in the knowledge graph.
+        subs_path: Override path to subscription JSON store.
+
+    Returns:
+        :class:`IngestResult` with counts and any non-fatal error messages.
+    """
+    from src.ingestion.connectors.blog.connector import BlogConnector
+
+    connector = BlogConnector(
+        subs_path=subs_path,
+        fetch_full_text=fetch_full_text,
+        limit_per_feed=limit_per_feed,
+    )
+    result = IngestResult()
+
+    refs = list(connector.discover(query))
+    result.feeds_fetched = len(refs)
+
+    for ref in refs:
+        try:
+            raw = connector.fetch(ref)
+        except Exception as exc:
+            msg = f"fetch failed for {ref.locator}: {exc}"
+            logger.warning(msg)
+            result.errors.append(msg)
+            continue
+
+        try:
+            docs = connector.parse(raw)
+        except Exception as exc:
+            msg = f"parse failed for {ref.locator}: {exc}"
+            logger.warning(msg)
+            result.errors.append(msg)
+            continue
+
+        result.documents_ingested += len(docs)
+
+        if extract_entities:
+            for doc in docs:
+                try:
+                    kg_stats = connector.ingest_to_kg(doc)
+                    result.entities_extracted += kg_stats.get("entities", 0)
+                    result.relationships_extracted += kg_stats.get("relationships", 0)
+                except Exception as exc:
+                    logger.debug("entity extraction skipped for %s: %s", doc.document_id, exc)
+
+    return result

--- a/src/ingestion/connectors/blog/readability.py
+++ b/src/ingestion/connectors/blog/readability.py
@@ -1,0 +1,102 @@
+"""Full-text article body extraction for blog posts.
+
+Tries readability-lxml if installed; falls back to a bs4 heuristic that finds
+the largest semantic content block (<article> / <main> / biggest <div>) and
+strips navigation, scripts, and boilerplate.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.request import Request, urlopen
+
+_USER_AGENT = "NeuroNewsBot/1.0 (+https://github.com/Ikey168/NeuroNews)"
+_HTTP_TIMEOUT = 15
+
+# Tags whose content is always boilerplate — strip before scoring.
+_NOISE_TAGS = {
+    "script", "style", "nav", "header", "footer", "aside",
+    "form", "iframe", "button", "noscript", "figure", "figcaption",
+}
+
+# Minimum characters for full text to be considered useful.
+_MIN_CHARS = 200
+
+
+def fetch_full_text(url: str, _http_get=None) -> str:
+    """Fetch ``url`` and extract the main readable text.
+
+    Returns an empty string on any network or parse error so callers can
+    fall back to the feed summary without crashing.
+    """
+    try:
+        getter = _http_get or _default_http_get
+        html = getter(url)
+    except Exception:
+        return ""
+
+    if not html:
+        return ""
+
+    # Try readability-lxml first (much better extraction quality).
+    try:
+        from readability import Document as ReadabilityDoc  # type: ignore
+
+        doc = ReadabilityDoc(html if isinstance(html, str) else html.decode("utf-8", errors="replace"))
+        cleaned = doc.summary()
+        text = _strip_tags(cleaned).strip()
+        if len(text) >= _MIN_CHARS:
+            return text
+    except Exception:
+        pass
+
+    # bs4 fallback.
+    try:
+        return _bs4_extract(html if isinstance(html, bytes) else html.encode("utf-8"))
+    except Exception:
+        return ""
+
+
+def _default_http_get(url: str) -> bytes:
+    req = Request(
+        url,
+        headers={"User-Agent": _USER_AGENT, "Accept": "text/html,application/xhtml+xml,*/*"},
+    )
+    with urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _bs4_extract(html: bytes) -> str:
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Remove noise elements in-place.
+    for tag in soup.find_all(_NOISE_TAGS):
+        tag.decompose()
+
+    # Prefer semantic content containers.
+    for selector in ("article", "main", '[role="main"]', ".post-content", ".entry-content", ".article-body"):
+        el = soup.select_one(selector)
+        if el:
+            text = _normalize(el.get_text(separator=" "))
+            if len(text) >= _MIN_CHARS:
+                return text
+
+    # Fall back to the largest <div> by text length (heuristic).
+    best_text = ""
+    for div in soup.find_all("div"):
+        t = _normalize(div.get_text(separator=" "))
+        if len(t) > len(best_text):
+            best_text = t
+
+    return best_text if len(best_text) >= _MIN_CHARS else ""
+
+
+def _strip_tags(html: str) -> str:
+    """Remove HTML tags from a string."""
+    return re.sub(r"<[^>]+>", " ", html)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()

--- a/src/ingestion/connectors/blog/subscriptions.py
+++ b/src/ingestion/connectors/blog/subscriptions.py
@@ -1,0 +1,87 @@
+"""JSON-backed subscription store for blog/RSS/Atom feeds."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from src.ingestion.connectors.blog.models import FeedSubscription
+
+_DEFAULT_PATH = Path(__file__).parents[4] / "config" / "blog_subscriptions.json"
+
+
+class SubscriptionStore:
+    """Persist and query RSS/Atom feed subscriptions in a JSON file."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = Path(path) if path is not None else _DEFAULT_PATH
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def subscribe(self, url: str, name: str = "", tags: Optional[List[str]] = None) -> FeedSubscription:
+        """Add or update a subscription. Existing entries are updated in-place."""
+        subs = self._load()
+        existing = next((s for s in subs if s.url == url), None)
+        if existing is not None:
+            subs.remove(existing)
+        sub = FeedSubscription(
+            url=url,
+            name=name or url,
+            tags=list(tags or []),
+            added_at=int(time.time() * 1000),
+        )
+        subs.append(sub)
+        self._save(subs)
+        return sub
+
+    def unsubscribe(self, url: str) -> bool:
+        """Remove a subscription by URL. Returns True if it was present."""
+        subs = self._load()
+        before = len(subs)
+        subs = [s for s in subs if s.url != url]
+        if len(subs) < before:
+            self._save(subs)
+            return True
+        return False
+
+    def list(self) -> List[FeedSubscription]:
+        return self._load()
+
+    def get(self, url: str) -> Optional[FeedSubscription]:
+        return next((s for s in self._load() if s.url == url), None)
+
+    # ------------------------------------------------------------------ #
+    # Persistence
+    # ------------------------------------------------------------------ #
+
+    def _load(self) -> List[FeedSubscription]:
+        if not self._path.exists():
+            return []
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return [
+                FeedSubscription(
+                    url=r["url"],
+                    name=r.get("name", r["url"]),
+                    tags=list(r.get("tags", [])),
+                    added_at=int(r.get("added_at", 0)),
+                )
+                for r in raw.get("subscriptions", [])
+                if r.get("url")
+            ]
+        except Exception:
+            return []
+
+    def _save(self, subs: List[FeedSubscription]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "subscriptions": [
+                {"url": s.url, "name": s.name, "tags": s.tags, "added_at": s.added_at}
+                for s in subs
+            ]
+        }
+        self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/ingestion/test_blog_connector.py
+++ b/tests/ingestion/test_blog_connector.py
@@ -1,0 +1,614 @@
+"""
+Tests for the blog / RSS / Atom connector (issue #522).
+
+Covers:
+- SubscriptionStore: subscribe, unsubscribe, list, persistence
+- Readability: bs4 extraction, noise tag removal, min-char threshold
+- BlogConnector: discover (query override + store), fetch, parse
+- Document output: source_type="blog", stable IDs, metadata, authors, dates
+- Full-text injection via mock full_text_getter
+- Watchlist: match_watchlist, run_watchlists, tag filtering
+- Pipeline: ingest_feeds with mocked connector + entity extraction path
+- Registry: "blog" registered after import
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ingestion.connectors.blog.connector import BlogConnector, _stable_id, _strip_html
+from src.ingestion.connectors.blog.digest import match_watchlist, run_watchlists
+from src.ingestion.connectors.blog.models import DigestMatch, FeedSubscription, WatchlistEntry
+from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+
+
+# --------------------------------------------------------------------------- #
+# Minimal RSS and Atom feed bytes
+# --------------------------------------------------------------------------- #
+
+_RSS = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Blog</title>
+    <link>https://example.com</link>
+    <item>
+      <title>First Post</title>
+      <link>https://example.com/first</link>
+      <description>Hello &amp; welcome to the &lt;b&gt;blog&lt;/b&gt;.</description>
+      <pubDate>Wed, 01 Jan 2025 12:00:00 GMT</pubDate>
+      <author>alice@example.com (Alice Smith)</author>
+    </item>
+    <item>
+      <title>Second Post</title>
+      <link>https://example.com/second</link>
+      <description>Python is great for AI and ML projects.</description>
+      <pubDate>Thu, 02 Jan 2025 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"""
+
+_ATOM = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Blog</title>
+  <entry>
+    <title>Atom Entry</title>
+    <link href="https://example.com/atom-1"/>
+    <id>urn:uuid:atom-1</id>
+    <updated>2025-03-15T10:30:00Z</updated>
+    <author><name>Bob Jones</name></author>
+    <summary>An entry from an Atom feed about machine learning.</summary>
+  </entry>
+</feed>"""
+
+_HTML_ARTICLE = b"""<!DOCTYPE html>
+<html>
+  <head><title>Full Article</title></head>
+  <body>
+    <nav>Nav stuff here</nav>
+    <article>
+      <h1>The Real Content</h1>
+      <p>This is the full article body with enough text to meet the minimum
+      character threshold for readability extraction. It contains substantial
+      content about topics that are interesting to readers of the blog.</p>
+      <p>More paragraphs follow here to ensure we hit the minimum length.</p>
+    </article>
+    <footer>Footer boilerplate</footer>
+    <script>alert('noise')</script>
+  </body>
+</html>"""
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _make_connector(tmp_path, feed_bytes=_RSS, full_text="", fetch_full_text=True):
+    http_get = MagicMock(return_value=feed_bytes)
+    ft_getter = MagicMock(return_value=full_text)
+    connector = BlogConnector(
+        subs_path=tmp_path / "subs.json",
+        fetch_full_text=fetch_full_text,
+        http_get=http_get,
+        full_text_getter=ft_getter,
+    )
+    return connector, http_get, ft_getter
+
+
+# --------------------------------------------------------------------------- #
+# SubscriptionStore
+# --------------------------------------------------------------------------- #
+
+class TestSubscriptionStore:
+    def test_empty_store_returns_empty_list(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        assert store.list() == []
+
+    def test_subscribe_creates_entry(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        sub = store.subscribe("https://example.com/rss", name="Example", tags=["tech"])
+        assert sub.url == "https://example.com/rss"
+        assert sub.name == "Example"
+        assert sub.tags == ["tech"]
+        assert sub.added_at > 0
+
+    def test_subscribe_persists_across_instances(self, tmp_path):
+        p = tmp_path / "subs.json"
+        SubscriptionStore(p).subscribe("https://a.com/rss", name="A")
+        loaded = SubscriptionStore(p).list()
+        assert len(loaded) == 1
+        assert loaded[0].url == "https://a.com/rss"
+
+    def test_subscribe_upserts_existing(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        store.subscribe("https://a.com/rss", name="A")
+        store.subscribe("https://a.com/rss", name="A Updated", tags=["new"])
+        subs = store.list()
+        assert len(subs) == 1
+        assert subs[0].name == "A Updated"
+        assert subs[0].tags == ["new"]
+
+    def test_unsubscribe_removes_entry(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        store.subscribe("https://a.com/rss")
+        store.subscribe("https://b.com/rss")
+        removed = store.unsubscribe("https://a.com/rss")
+        assert removed is True
+        remaining = store.list()
+        assert len(remaining) == 1
+        assert remaining[0].url == "https://b.com/rss"
+
+    def test_unsubscribe_missing_returns_false(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        assert store.unsubscribe("https://nothere.com/rss") is False
+
+    def test_get_returns_subscription(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        store.subscribe("https://a.com/rss", name="A")
+        sub = store.get("https://a.com/rss")
+        assert sub is not None
+        assert sub.name == "A"
+
+    def test_get_missing_returns_none(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        assert store.get("https://nothere.com") is None
+
+    def test_multiple_subscriptions(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "subs.json")
+        for i in range(5):
+            store.subscribe(f"https://feed{i}.com/rss", name=f"Feed {i}")
+        assert len(store.list()) == 5
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        store = SubscriptionStore(tmp_path / "nonexistent" / "subs.json")
+        assert store.list() == []
+
+
+# --------------------------------------------------------------------------- #
+# Readability
+# --------------------------------------------------------------------------- #
+
+class TestReadability:
+    def test_bs4_extracts_article_content(self):
+        from src.ingestion.connectors.blog.readability import _bs4_extract
+        text = _bs4_extract(_HTML_ARTICLE)
+        assert "The Real Content" in text
+        assert "full article body" in text
+
+    def test_bs4_removes_nav_footer_script(self):
+        from src.ingestion.connectors.blog.readability import _bs4_extract
+        text = _bs4_extract(_HTML_ARTICLE)
+        assert "Nav stuff" not in text
+        assert "Footer boilerplate" not in text
+        assert "alert" not in text
+
+    def test_bs4_returns_empty_for_short_content(self):
+        from src.ingestion.connectors.blog.readability import _bs4_extract
+        html = b"<html><body><article>Short.</article></body></html>"
+        text = _bs4_extract(html)
+        assert text == ""
+
+    def test_fetch_full_text_network_error_returns_empty(self):
+        from src.ingestion.connectors.blog.readability import fetch_full_text
+        text = fetch_full_text("https://definitely-not-real-domain.invalid/")
+        assert text == ""
+
+    def test_fetch_full_text_calls_http_get(self):
+        from src.ingestion.connectors.blog.readability import fetch_full_text
+        getter = MagicMock(return_value=_HTML_ARTICLE)
+        text = fetch_full_text("https://example.com/article", _http_get=getter)
+        getter.assert_called_once_with("https://example.com/article")
+        assert "The Real Content" in text
+
+    def test_fetch_full_text_empty_response_returns_empty(self):
+        from src.ingestion.connectors.blog.readability import fetch_full_text
+        getter = MagicMock(return_value=b"")
+        text = fetch_full_text("https://example.com", _http_get=getter)
+        assert text == ""
+
+
+# --------------------------------------------------------------------------- #
+# BlogConnector — discover
+# --------------------------------------------------------------------------- #
+
+class TestBlogConnectorDiscover:
+    def test_discover_reads_from_store(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        connector.subscribe("https://a.com/rss", name="A")
+        connector.subscribe("https://b.com/rss", name="B")
+        refs = list(connector.discover())
+        urls = [r.locator for r in refs]
+        assert "https://a.com/rss" in urls
+        assert "https://b.com/rss" in urls
+
+    def test_discover_query_url_strings(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        refs = list(connector.discover(["https://x.com/rss", "https://y.com/rss"]))
+        assert len(refs) == 2
+        assert refs[0].locator == "https://x.com/rss"
+
+    def test_discover_query_subscription_objects(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        subs = [FeedSubscription(url="https://z.com/rss", name="Z", tags=["ai"])]
+        refs = list(connector.discover(subs))
+        assert refs[0].locator == "https://z.com/rss"
+        assert refs[0].metadata["tags"] == ["ai"]
+
+    def test_discover_query_dicts(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        refs = list(connector.discover([{"url": "https://q.com/rss", "name": "Q", "tags": ["news"]}]))
+        assert refs[0].locator == "https://q.com/rss"
+        assert refs[0].title == "Q"
+
+    def test_discover_empty_store_yields_nothing(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        assert list(connector.discover()) == []
+
+
+# --------------------------------------------------------------------------- #
+# BlogConnector — fetch
+# --------------------------------------------------------------------------- #
+
+class TestBlogConnectorFetch:
+    def test_fetch_calls_http_get(self, tmp_path):
+        connector, http_get, _ = _make_connector(tmp_path)
+        from src.ingestion.connectors.base import SourceRef
+        ref = SourceRef(locator="https://example.com/rss", metadata={"name": "X", "tags": []})
+        raw = connector.fetch(ref)
+        http_get.assert_called_once_with("https://example.com/rss")
+        assert raw.content == _RSS
+        assert raw.content_type == "application/xml"
+
+    def test_fetch_stores_ref(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        from src.ingestion.connectors.base import SourceRef
+        ref = SourceRef(locator="https://example.com/rss", metadata={"name": "X", "tags": []})
+        raw = connector.fetch(ref)
+        assert raw.ref is ref
+
+
+# --------------------------------------------------------------------------- #
+# BlogConnector — parse (RSS)
+# --------------------------------------------------------------------------- #
+
+class TestBlogConnectorParseRSS:
+    def _parse_rss(self, tmp_path, full_text="", fetch_full_text=True):
+        connector, http_get, _ = _make_connector(tmp_path, _RSS, full_text, fetch_full_text)
+        from src.ingestion.connectors.base import RawDocument, SourceRef
+        ref = SourceRef(locator="https://example.com/rss", metadata={"name": "Test Blog", "tags": ["tech"]})
+        raw = RawDocument(ref=ref, content=_RSS, content_type="application/xml")
+        return connector.parse(raw)
+
+    def test_parse_returns_two_documents(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        assert len(docs) == 2
+
+    def test_document_source_type(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        assert all(d.source_type == "blog" for d in docs)
+
+    def test_document_titles(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        titles = {d.title for d in docs}
+        assert "First Post" in titles
+        assert "Second Post" in titles
+
+    def test_document_urls(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        urls = {d.url for d in docs}
+        assert "https://example.com/first" in urls
+
+    def test_document_html_stripped_from_summary(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        first = next(d for d in docs if d.title == "First Post")
+        assert "<b>" not in (first.content or "")
+        assert "Hello" in (first.content or "")
+        assert "welcome" in (first.content or "")
+
+    def test_document_stable_id(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        for d in docs:
+            assert d.document_id.startswith("blog-")
+            assert len(d.document_id) == len("blog-") + 16
+
+    def test_document_source_id_is_feed_name(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        assert all(d.source_id == "Test Blog" for d in docs)
+
+    def test_document_tags_from_ref_metadata(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        assert all("tech" in (d.metadata or {}).get("tags", []) for d in docs)
+
+    def test_document_created_at_populated(self, tmp_path):
+        docs = self._parse_rss(tmp_path)
+        first = next(d for d in docs if d.title == "First Post")
+        assert first.created_at is not None
+        assert first.created_at > 0
+
+    def test_full_text_used_when_longer(self, tmp_path):
+        long_full_text = "x" * 500
+        docs = self._parse_rss(tmp_path, full_text=long_full_text)
+        first = next(d for d in docs if d.title == "First Post")
+        assert first.content == long_full_text
+        assert first.metadata.get("has_full_text") is True
+
+    def test_summary_used_when_full_text_shorter(self, tmp_path):
+        docs = self._parse_rss(tmp_path, full_text="tiny")
+        first = next(d for d in docs if d.title == "First Post")
+        assert first.content != "tiny"
+
+    def test_full_text_not_fetched_when_disabled(self, tmp_path):
+        _, _, ft_getter = _make_connector(tmp_path, _RSS, "", fetch_full_text=False)
+        # Re-build with disabled flag
+        connector = BlogConnector(
+            subs_path=tmp_path / "subs.json",
+            fetch_full_text=False,
+            http_get=MagicMock(return_value=_RSS),
+            full_text_getter=ft_getter,
+        )
+        from src.ingestion.connectors.base import RawDocument, SourceRef
+        ref = SourceRef(locator="https://example.com/rss", metadata={"name": "T", "tags": []})
+        raw = RawDocument(ref=ref, content=_RSS)
+        connector.parse(raw)
+        ft_getter.assert_not_called()
+
+    def test_limit_per_feed_respected(self, tmp_path):
+        connector = BlogConnector(
+            subs_path=tmp_path / "subs.json",
+            limit_per_feed=1,
+            http_get=MagicMock(return_value=_RSS),
+            full_text_getter=MagicMock(return_value=""),
+        )
+        from src.ingestion.connectors.base import RawDocument, SourceRef
+        ref = SourceRef(locator="https://example.com/rss", metadata={"name": "T", "tags": []})
+        raw = RawDocument(ref=ref, content=_RSS)
+        docs = connector.parse(raw)
+        assert len(docs) == 1
+
+
+# --------------------------------------------------------------------------- #
+# BlogConnector — parse (Atom)
+# --------------------------------------------------------------------------- #
+
+class TestBlogConnectorParseAtom:
+    def test_atom_feed_parsed(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path, _ATOM, "")
+        from src.ingestion.connectors.base import RawDocument, SourceRef
+        ref = SourceRef(locator="https://example.com/atom", metadata={"name": "Atom Blog", "tags": []})
+        raw = RawDocument(ref=ref, content=_ATOM)
+        docs = connector.parse(raw)
+        assert len(docs) == 1
+        assert docs[0].title == "Atom Entry"
+        assert docs[0].source_type == "blog"
+        assert "machine learning" in (docs[0].content or "")
+
+    def test_atom_author_populated(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path, _ATOM, "")
+        from src.ingestion.connectors.base import RawDocument, SourceRef
+        ref = SourceRef(locator="https://example.com/atom", metadata={"name": "Atom Blog", "tags": []})
+        raw = RawDocument(ref=ref, content=_ATOM)
+        docs = connector.parse(raw)
+        assert "Bob Jones" in docs[0].authors
+
+
+# --------------------------------------------------------------------------- #
+# BlogConnector — harvest (integration)
+# --------------------------------------------------------------------------- #
+
+class TestBlogConnectorHarvest:
+    def test_harvest_yields_documents(self, tmp_path):
+        connector, _, _ = _make_connector(tmp_path)
+        connector.subscribe("https://example.com/rss", name="Test")
+        docs = list(connector.harvest())
+        assert len(docs) == 2
+        assert all(d.source_type == "blog" for d in docs)
+
+    def test_harvest_skips_failed_fetch(self, tmp_path):
+        connector, http_get, _ = _make_connector(tmp_path)
+        connector.subscribe("https://good.com/rss", name="Good")
+        connector.subscribe("https://bad.com/rss", name="Bad")
+        http_get.side_effect = lambda url: _RSS if "good" in url else (_ for _ in ()).throw(OSError("fail"))
+        docs = list(connector.harvest())
+        assert len(docs) == 2  # only from good feed
+
+
+# --------------------------------------------------------------------------- #
+# Watchlist / digest
+# --------------------------------------------------------------------------- #
+
+class TestWatchlist:
+    def _make_docs(self):
+        from services.ingest.common.document_model import Document
+        now = int(time.time() * 1000)
+        return [
+            Document(
+                document_id="blog-001",
+                source_type="blog",
+                language="en",
+                ingested_at=now,
+                title="Python and AI are booming",
+                content="Many developers use Python for machine learning projects.",
+                url="https://example.com/1",
+                metadata={"tags": ["tech"]},
+            ),
+            Document(
+                document_id="blog-002",
+                source_type="blog",
+                language="en",
+                ingested_at=now,
+                title="Climate change research",
+                content="Scientists publish new findings on global warming effects.",
+                url="https://example.com/2",
+                metadata={"tags": ["science"]},
+            ),
+            Document(
+                document_id="blog-003",
+                source_type="blog",
+                language="en",
+                ingested_at=now,
+                title="Stock market drops",
+                content="Markets fell sharply on inflation concerns.",
+                url="https://example.com/3",
+                metadata={"tags": ["finance"]},
+            ),
+        ]
+
+    def test_match_by_content_keyword(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["machine learning"], "ai-watch")
+        assert len(matches) == 1
+        assert matches[0].document_id == "blog-001"
+        assert "machine learning" in matches[0].matched_keywords
+
+    def test_match_by_title_keyword(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["climate"], "env-watch")
+        assert len(matches) == 1
+        assert matches[0].document_id == "blog-002"
+
+    def test_no_match_returns_empty(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["blockchain"], "crypto-watch")
+        assert matches == []
+
+    def test_multiple_keywords_match(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["python", "warming"], "wide-watch")
+        assert len(matches) == 2
+
+    def test_case_insensitive_matching(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["PYTHON"], "case-watch")
+        assert len(matches) == 1
+
+    def test_tag_filter_narrows_results(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["python", "warming"], "filtered", tag_filter=["tech"])
+        assert len(matches) == 1
+        assert matches[0].document_id == "blog-001"
+
+    def test_run_watchlists_returns_dict(self):
+        docs = self._make_docs()
+        watchlists = [
+            WatchlistEntry(name="ai", keywords=["python", "machine learning"]),
+            WatchlistEntry(name="climate", keywords=["warming", "climate"]),
+        ]
+        result = run_watchlists(docs, watchlists)
+        assert "ai" in result
+        assert "climate" in result
+        assert len(result["ai"]) == 1
+        assert len(result["climate"]) == 1
+
+    def test_digest_match_fields(self):
+        docs = self._make_docs()
+        matches = match_watchlist(docs, ["python"], "test-watch")
+        m = matches[0]
+        assert isinstance(m, DigestMatch)
+        assert m.watchlist_name == "test-watch"
+        assert m.title == "Python and AI are booming"
+        assert m.url == "https://example.com/1"
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline
+# --------------------------------------------------------------------------- #
+
+class TestIngestFeeds:
+    def test_ingest_feeds_returns_result(self, tmp_path):
+        from src.ingestion.connectors.blog.pipeline import ingest_feeds
+
+        connector_mock = MagicMock()
+        from src.ingestion.connectors.base import SourceRef, RawDocument
+        from services.ingest.common.document_model import Document
+
+        ref = SourceRef(locator="https://x.com/rss", metadata={"name": "X", "tags": []})
+        doc = Document(
+            document_id="blog-aaa",
+            source_type="blog",
+            language="en",
+            ingested_at=int(time.time() * 1000),
+            title="Test",
+            content="Content",
+        )
+        connector_mock.discover.return_value = [ref]
+        connector_mock.fetch.return_value = RawDocument(ref=ref, content=b"")
+        connector_mock.parse.return_value = [doc]
+        connector_mock.ingest_to_kg.return_value = {"entities": 3, "relationships": 1}
+
+        with patch("src.ingestion.connectors.blog.connector.BlogConnector", return_value=connector_mock):
+            result = ingest_feeds(
+                query=["https://x.com/rss"],
+                extract_entities=True,
+                subs_path=tmp_path / "subs.json",
+            )
+
+        assert result.feeds_fetched == 1
+        assert result.documents_ingested == 1
+        assert result.entities_extracted == 3
+        assert result.relationships_extracted == 1
+        assert result.errors == []
+
+    def test_ingest_feeds_fetch_error_recorded(self, tmp_path):
+        from src.ingestion.connectors.blog.pipeline import ingest_feeds
+
+        connector_mock = MagicMock()
+        from src.ingestion.connectors.base import SourceRef
+
+        ref = SourceRef(locator="https://bad.com/rss", metadata={"name": "Bad", "tags": []})
+        connector_mock.discover.return_value = [ref]
+        connector_mock.fetch.side_effect = OSError("timeout")
+
+        with patch("src.ingestion.connectors.blog.connector.BlogConnector", return_value=connector_mock):
+            result = ingest_feeds(extract_entities=False, subs_path=tmp_path / "subs.json")
+
+        assert result.documents_ingested == 0
+        assert len(result.errors) == 1
+        assert "fetch failed" in result.errors[0]
+
+    def test_ingest_feeds_no_entity_extraction(self, tmp_path):
+        from src.ingestion.connectors.blog.pipeline import ingest_feeds
+
+        connector_mock = MagicMock()
+        from src.ingestion.connectors.base import SourceRef, RawDocument
+        from services.ingest.common.document_model import Document
+
+        ref = SourceRef(locator="https://x.com/rss", metadata={"name": "X", "tags": []})
+        doc = Document(document_id="blog-bbb", source_type="blog", language="en", ingested_at=int(time.time() * 1000), title="T", content="C")
+        connector_mock.discover.return_value = [ref]
+        connector_mock.fetch.return_value = RawDocument(ref=ref, content=b"")
+        connector_mock.parse.return_value = [doc]
+
+        with patch("src.ingestion.connectors.blog.connector.BlogConnector", return_value=connector_mock):
+            result = ingest_feeds(extract_entities=False, subs_path=tmp_path / "subs.json")
+
+        connector_mock.ingest_to_kg.assert_not_called()
+        assert result.entities_extracted == 0
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+class TestRegistry:
+    def test_blog_registered(self):
+        from src.ingestion.connectors.registry import is_registered
+        import src.ingestion.connectors.blog  # noqa: F401
+        assert is_registered("blog")
+
+    def test_stable_id_deterministic(self):
+        id1 = _stable_id("https://example.com/post")
+        id2 = _stable_id("https://example.com/post")
+        assert id1 == id2
+        assert id1.startswith("blog-")
+
+    def test_stable_id_distinct_urls(self):
+        assert _stable_id("https://a.com/1") != _stable_id("https://b.com/2")
+
+    def test_strip_html(self):
+        assert _strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+        assert _strip_html("") == ""
+        assert _strip_html(None) == ""

--- a/tools/blog_mcp/requirements.txt
+++ b/tools/blog_mcp/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp>=3.0
+feedparser>=6.0
+beautifulsoup4>=4.12

--- a/tools/blog_mcp/server.py
+++ b/tools/blog_mcp/server.py
@@ -1,0 +1,365 @@
+"""
+NeuroNews Blog-feeds MCP server.
+
+Developer tool for managing RSS/Atom feed subscriptions, running watchlists,
+and triggering ingestion from the Claude interface without touching the
+filesystem directly.
+
+Tools
+-----
+list_subscriptions()
+    All subscribed feeds with their name, tags, and subscription date.
+
+subscribe_feed(url, name?, tags?)
+    Add (or update) a feed subscription. Persists to
+    ``config/blog_subscriptions.json``.
+
+unsubscribe_feed(url)
+    Remove a subscription by URL.
+
+feed_status()
+    Summary: subscription count, source_type registered in connector
+    registry, whether readability-lxml is available.
+
+ingest_feeds(limit_per_feed?, fetch_full_text?, extract_entities?,
+             feed_urls?)
+    Trigger a live ingestion run — fetch latest posts from all subscriptions
+    (or a subset via feed_urls) and optionally run entity extraction.
+    Returns a run summary; does NOT write to a database.
+
+run_watchlist(keywords, tag_filter?, limit_per_feed?, fetch_full_text?)
+    Fetch latest posts from subscriptions and immediately run keyword
+    matching against them.  Returns matched posts with which keywords
+    triggered the match.
+
+harvest_feed(url, name?, limit?)
+    Fetch and parse a single feed URL (without persisting a subscription)
+    and return a post summary.  Good for previewing a feed before
+    subscribing.
+
+Design constraints (same as other NeuroNews MCP servers):
+  * Lazy imports inside every tool body — server starts in <100 ms.
+  * Summaries, not payloads — content fields are previewed at 300 chars.
+  * ``config/blog_subscriptions.json`` is the authoritative store for
+    subscriptions; each mutating tool reads then writes it atomically.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SUBS_PATH = REPO_ROOT / "config" / "blog_subscriptions.json"
+
+mcp = FastMCP("neuronews-blog-feeds")
+
+CONTENT_PREVIEW = 300
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _store():
+    from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+    return SubscriptionStore(SUBS_PATH)
+
+
+
+def _preview(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    if len(text) > CONTENT_PREVIEW:
+        return text[:CONTENT_PREVIEW] + f"… [{len(text)} chars]"
+    return text
+
+
+def _doc_summary(doc) -> dict:
+    return {
+        "document_id": doc.document_id,
+        "title": doc.title or "",
+        "url": doc.url or "",
+        "source_id": doc.source_id or "",
+        "authors": list(doc.authors or []),
+        "created_at": doc.created_at,
+        "content_preview": _preview(doc.content),
+        "has_full_text": bool((doc.metadata or {}).get("has_full_text")),
+        "tags": list((doc.metadata or {}).get("tags", [])),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Tools
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def list_subscriptions() -> dict:
+    """List all subscribed RSS/Atom feeds.
+
+    Returns:
+        count         - number of subscriptions
+        subscriptions - list of {url, name, tags, added_at}
+    """
+    subs = _store().list()
+    return {
+        "count": len(subs),
+        "subscriptions": [
+            {
+                "url": s.url,
+                "name": s.name,
+                "tags": s.tags,
+                "added_at": s.added_at,
+            }
+            for s in subs
+        ],
+    }
+
+
+@mcp.tool
+def subscribe_feed(url: str, name: str = "", tags: str = "") -> dict:
+    """Add or update a feed subscription.
+
+    Persists to ``config/blog_subscriptions.json``.
+
+    Args:
+        url:  Full RSS/Atom feed URL.
+        name: Human-readable label (defaults to the URL).
+        tags: Comma-separated topic tags, e.g. ``"tech,research"``.
+              Used by watchlists to scope keyword matching.
+
+    Returns:
+        subscription - the stored entry
+        action       - "added" or "updated"
+    """
+    store = _store()
+    existing = store.get(url)
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+    sub = store.subscribe(url, name=name or url, tags=tag_list)
+    return {
+        "action": "updated" if existing else "added",
+        "subscription": {
+            "url": sub.url,
+            "name": sub.name,
+            "tags": sub.tags,
+            "added_at": sub.added_at,
+        },
+        "total_subscriptions": len(store.list()),
+    }
+
+
+@mcp.tool
+def unsubscribe_feed(url: str) -> dict:
+    """Remove a feed subscription by URL.
+
+    Args:
+        url: The RSS/Atom feed URL to remove.
+
+    Returns:
+        removed              - True if it was present and removed
+        remaining            - number of remaining subscriptions
+    """
+    store = _store()
+    removed = store.unsubscribe(url)
+    return {
+        "removed": removed,
+        "url": url,
+        "remaining": len(store.list()),
+    }
+
+
+@mcp.tool
+def feed_status() -> dict:
+    """Summary of the blog connector state.
+
+    Returns:
+        subscriptions        - number of stored subscriptions
+        connector_registered - True if "blog" is in the connector registry
+        readability_lxml     - True if the optional readability-lxml library is installed
+        subs_path            - path to the subscription JSON file
+    """
+    subs = _store().list()
+
+    try:
+        from src.ingestion.connectors.registry import is_registered
+        registered = is_registered("blog")
+    except Exception:
+        registered = False
+
+    try:
+        import importlib
+        importlib.import_module("readability")
+        has_readability = True
+    except ImportError:
+        has_readability = False
+
+    return {
+        "subscriptions": len(subs),
+        "connector_registered": registered,
+        "readability_lxml": has_readability,
+        "subs_path": str(SUBS_PATH),
+        "subs_exist": SUBS_PATH.exists(),
+    }
+
+
+@mcp.tool
+def ingest_feeds(
+    limit_per_feed: int = 20,
+    fetch_full_text: bool = False,
+    extract_entities: bool = False,
+    feed_urls: Optional[str] = None,
+) -> dict:
+    """Trigger a live ingestion run against all subscribed feeds.
+
+    Fetches the latest posts and optionally runs entity extraction.
+    Does NOT write to the warehouse database.
+
+    Args:
+        limit_per_feed:   Max posts to ingest per feed (default 20).
+        fetch_full_text:  Follow article URLs for full-body extraction
+                          (slower — one HTTP request per post).
+        extract_entities: Run AdvancedEntityExtractor + KG ingestion
+                          (requires spaCy; silently skipped if unavailable).
+        feed_urls:        JSON array of URL strings to ingest instead of all
+                          subscriptions, e.g. ``'["https://example.com/rss"]'``.
+
+    Returns:
+        feeds_fetched        - number of feeds processed
+        documents_ingested   - total posts parsed
+        entities_extracted   - KG entities stored (0 if extract_entities=False)
+        relationships_extracted
+        errors               - list of per-feed error messages
+    """
+    from src.ingestion.connectors.blog.pipeline import ingest_feeds as _ingest
+
+    query = None
+    if feed_urls:
+        import json as _json
+        try:
+            query = _json.loads(feed_urls)
+        except Exception:
+            return {"error": f"feed_urls must be a JSON array, got: {feed_urls!r}"}
+
+    result = _ingest(
+        query=query,
+        limit_per_feed=limit_per_feed,
+        fetch_full_text=fetch_full_text,
+        extract_entities=extract_entities,
+        subs_path=SUBS_PATH,
+    )
+    return {
+        "feeds_fetched": result.feeds_fetched,
+        "documents_ingested": result.documents_ingested,
+        "entities_extracted": result.entities_extracted,
+        "relationships_extracted": result.relationships_extracted,
+        "errors": result.errors,
+    }
+
+
+@mcp.tool
+def run_watchlist(
+    keywords: str,
+    tag_filter: str = "",
+    limit_per_feed: int = 20,
+    fetch_full_text: bool = False,
+) -> dict:
+    """Fetch the latest posts and immediately run keyword matching.
+
+    Args:
+        keywords:       Comma-separated keywords, e.g. ``"machine learning,python,AI"``.
+        tag_filter:     Comma-separated feed tags to scope the search, e.g.
+                        ``"tech,research"``.  Empty = search all feeds.
+        limit_per_feed: Max posts to pull per feed before matching.
+        fetch_full_text: Follow article URLs for full body (slower but more thorough).
+
+    Returns:
+        matches     - list of {document_id, title, url, matched_keywords}
+        total       - number of matched posts
+        keywords    - normalised keyword list used
+        tag_filter  - tag filter applied
+        feeds_checked - number of subscriptions scanned
+    """
+    from src.ingestion.connectors.blog.connector import BlogConnector
+    from src.ingestion.connectors.blog.digest import match_watchlist as _match
+
+    kw_list = [k.strip() for k in keywords.split(",") if k.strip()]
+    if not kw_list:
+        return {"error": "keywords must be a non-empty comma-separated list"}
+
+    tag_list = [t.strip() for t in tag_filter.split(",") if t.strip()] or None
+
+    connector = BlogConnector(
+        subs_path=SUBS_PATH,
+        fetch_full_text=fetch_full_text,
+        limit_per_feed=limit_per_feed,
+    )
+
+    subs = connector.list_subscriptions()
+    docs = list(connector.harvest())
+    matches = _match(docs, kw_list, "mcp-watchlist", tag_filter=tag_list)
+
+    return {
+        "matches": [
+            {
+                "document_id": m.document_id,
+                "title": m.title,
+                "url": m.url,
+                "matched_keywords": m.matched_keywords,
+            }
+            for m in matches
+        ],
+        "total": len(matches),
+        "keywords": kw_list,
+        "tag_filter": tag_list or [],
+        "feeds_checked": len(subs),
+        "posts_scanned": len(docs),
+    }
+
+
+@mcp.tool
+def harvest_feed(url: str, name: str = "", limit: int = 10) -> dict:
+    """Fetch and parse a single feed URL without persisting a subscription.
+
+    Good for previewing a feed before subscribing.
+
+    Args:
+        url:   Full RSS/Atom feed URL.
+        name:  Optional display name (defaults to the URL).
+        limit: Max posts to return (default 10).
+
+    Returns:
+        feed_url  - the URL that was fetched
+        count     - number of posts parsed
+        posts     - list of post summaries (id, title, url, content_preview, authors, date)
+        error     - present only if the fetch or parse failed
+    """
+    from src.ingestion.connectors.blog.connector import BlogConnector
+    from src.ingestion.connectors.blog.models import FeedSubscription
+
+    connector = BlogConnector(
+        subs_path=SUBS_PATH,
+        fetch_full_text=False,
+        limit_per_feed=limit,
+    )
+
+    sub = FeedSubscription(url=url, name=name or url, tags=[])
+    try:
+        docs = list(connector.harvest([sub]))
+    except Exception as exc:
+        return {"feed_url": url, "count": 0, "posts": [], "error": str(exc)}
+
+    return {
+        "feed_url": url,
+        "count": len(docs),
+        "posts": [_doc_summary(d) for d in docs],
+    }
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

Closes #522. Implements an RSS/Atom feed subscription connector with full-body article extraction and keyword-based watchlists.

- **`BlogConnector`** (`source_type="blog"`) — subscribe to any RSS or Atom feed URL; follows the standard `discover → fetch → parse` interface. `feedparser` handles both feed formats; full article body optionally extracted via `fetch_full_text`.
- **`SubscriptionStore`** — JSON-backed store at `config/blog_subscriptions.json`; `subscribe / unsubscribe / list / get` operations, safe across restarts.
- **Readability** (`readability.py`) — tries `readability-lxml` if installed, falls back to a bs4 heuristic (`<article>` / `<main>` / largest `<div>`). Noise tags (`<nav>`, `<footer>`, `<script>`, etc.) are stripped. Returns empty string gracefully on network/parse error.
- **Watchlists** (`digest.py`) — `match_watchlist(docs, keywords)` filters ingested posts by keyword across title + content; `run_watchlists(docs, watchlists)` runs multiple watchlists in one call; tag filtering scopes a watchlist to specific feed tags.
- **Pipeline** (`pipeline.py`) — `ingest_feeds()` chains all stages and optionally runs `AdvancedEntityExtractor` → `KnowledgeGraphStore`; errors per-feed are logged but non-fatal.
- **KG integration** — `BlogConnector.ingest_to_kg(doc, store)` maps spaCy NER labels to `EntityType`, builds `Node` objects, and calls `store.add_node`. Returns `{"entities": int, "relationships": int}`; silently no-ops if spaCy is unavailable.

## Files

| File | Purpose |
|------|---------|
| `src/ingestion/connectors/blog/models.py` | `FeedSubscription`, `WatchlistEntry`, `DigestMatch` |
| `src/ingestion/connectors/blog/subscriptions.py` | JSON subscription store |
| `src/ingestion/connectors/blog/readability.py` | Full-body extraction (readability-lxml + bs4 fallback) |
| `src/ingestion/connectors/blog/connector.py` | `BlogConnector` — main connector class |
| `src/ingestion/connectors/blog/digest.py` | Watchlist matching and digest building |
| `src/ingestion/connectors/blog/pipeline.py` | `ingest_feeds()` orchestration |
| `config/blog_subscriptions.json` | Initial empty subscription store |
| `tests/ingestion/test_blog_connector.py` | 55 tests, all passing |

## Test plan
- [x] 55 new tests: subscriptions (10), readability (6), discover (5), fetch (2), parse RSS (13), parse Atom (2), harvest (2), watchlist (8), pipeline (3), registry (4)
- [x] 162 existing ingestion tests: no regressions
- [x] `BlogConnector` registered as `"blog"` in the connector registry
- [x] Full-text injection via mock `full_text_getter` tested with and without length threshold
- [x] Error paths: network failure, missing subscriptions, bad fetch — all logged and non-fatal