### PR TITLE
feat(reports): scheduled email delivery + smtp-test skill (#52)

### DIFF
--- a/.claude/skills/smtp-test/SKILL.md
+++ b/.claude/skills/smtp-test/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: smtp-test
+description: End-to-end smoke test for the scheduled report email delivery path. Spins up a local SMTP sink, creates a test subscription, fires the delivery job, captures the email, and cleans up — no real SMTP server or API server needed. Use when iterating on email templates, changing the SMTP sender, or verifying a new report format sends correctly.
+---
+
+# smtp-test skill
+
+Runs a full delivery cycle locally in ~5 seconds with no external dependencies:
+
+1. Starts a minimal async SMTP sink on a random localhost port
+2. Creates a test subscription in DuckDB (cleaned up on exit)
+3. Calls `_deliver_subscriptions(freq)` directly — no API server needed
+4. Waits for the message to arrive at the sink
+5. Pretty-prints headers, body preview, and attachment info
+6. Deletes the test subscription and stops the sink
+
+**All paths are relative to the repo root** (`/home/Ikey/NeuroNews`).
+
+## Usage
+
+```bash
+bash .claude/skills/smtp-test/smtp-test.sh [OPTIONS]
+
+# or directly:
+python3 .claude/skills/smtp-test/run_test.py [OPTIONS]
+```
+
+### Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--to EMAIL` | `test@noesis.local` | Recipient address (captured by local sink) |
+| `--topic TOPIC` | `AI` | Topic keyword for the report |
+| `--freq weekly\|monthly` | `weekly` | Delivery frequency (`weekly` → last_7_days, `monthly` → last_30_days) |
+| `--format pdf\|csv` | `pdf` | Report attachment format |
+| `--timeout SECS` | `15` | How long to wait for the sink to receive the message |
+
+## Examples
+
+```bash
+# Default: weekly PDF for "AI"
+bash .claude/skills/smtp-test/smtp-test.sh
+
+# Monthly CSV for "Iran", custom recipient
+bash .claude/skills/smtp-test/smtp-test.sh --to dev@example.com --topic "Iran" --freq monthly --format csv
+
+# Quick topic data check with short timeout
+bash .claude/skills/smtp-test/smtp-test.sh --topic "SpaceX" --timeout 8
+```
+
+## Expected output
+
+```
+──────────────────────────────────────────────────────────────
+  1/5  Starting local SMTP sink
+──────────────────────────────────────────────────────────────
+  SMTP sink listening on 127.0.0.1:40405
+
+  ...
+
+  4/5  Waiting for SMTP message
+──────────────────────────────────────────────────────────────
+  Message received!  (6856 raw bytes)
+
+  From:    reports@noesis.local
+  To:      smoke@noesis.local
+  Subject: [Noesis] Weekly report: Iran (last 7 days)
+
+  Body (text):
+    Noesis Report: Iran  Your weekly report for 'Iran' covering last 7
+    days is attached.
+
+  Attachments:
+    noesis_report_iran_last_7_days.pdf  (3,832 bytes, application/pdf)
+
+  RESULT: PASS — email delivered end-to-end via SMTP
+```
+
+Exit code `0` = PASS, `1` = FAIL (timeout or delivery error).
+
+## Testing against a real SMTP server
+
+The test honours the standard SMTP env vars. Set them before running to route
+through a real provider instead of the local sink:
+
+```bash
+SMTP_HOST=smtp.sendgrid.net \
+SMTP_PORT=587 \
+SMTP_USER=apikey \
+SMTP_PASSWORD=<key> \
+SMTP_FROM=reports@yourdomain.com \
+bash .claude/skills/smtp-test/smtp-test.sh --to your@email.com
+```
+
+When real SMTP vars are set, the local sink is still started (for the SMTP
+handshake fallback), but `email_sender.py` will use the configured host.
+Actually: when `SMTP_HOST` is already set in the environment before the script
+runs, the script **overrides** it to point at the sink. To use a real server,
+call `run_test.py` and patch `email_sender._send_raw` instead — or just call
+the API endpoint directly.
+
+## How it differs from calling the API
+
+The `POST /api/v1/reports/trigger/weekly` endpoint does the same thing but
+requires the full FastAPI stack to be running (which pulls in the heavy ML
+imports). This skill calls `_deliver_subscriptions()` directly — starts in
+under a second with no server boot.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `TIMEOUT — no message received` | Delivery raised an exception (check stderr). Topic may have 0 articles — try `--topic Iran` or `--topic AI`. |
+| `0 bytes` attachment | Report generation returned empty bytes. Run `report-preview` for the same topic to diagnose. |
+| `Connection refused` on port | Port was taken; the sink picks a random free port, so this shouldn't happen — restart and retry. |

--- a/.claude/skills/smtp-test/run_test.py
+++ b/.claude/skills/smtp-test/run_test.py
@@ -1,0 +1,168 @@
+"""
+smtp-test: end-to-end smoke test for scheduled report email delivery.
+
+1. Starts a local SMTP sink on a random port (no external service needed).
+2. Points the email_sender at the sink via env vars.
+3. Creates a test subscription in DuckDB.
+4. Fires the weekly delivery job directly (no API server needed).
+5. Waits for the message to arrive at the sink.
+6. Pretty-prints the email headers, body preview, and attachment info.
+7. Cleans up the test subscription.
+
+Usage:
+    python3 .claude/skills/smtp-test/run_test.py [--to EMAIL] [--topic TOPIC] [--freq weekly|monthly]
+"""
+
+from __future__ import annotations
+
+import argparse
+import email as email_lib
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+# Ensure repo root is on sys.path regardless of CWD
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+SKILL_DIR = Path(__file__).resolve().parent
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="SMTP delivery smoke test for Noesis reports")
+    p.add_argument("--to", default="test@noesis.local", help="Recipient email address")
+    p.add_argument("--topic", default="AI", help="Report topic keyword")
+    p.add_argument("--freq", choices=["weekly", "monthly"], default="weekly")
+    p.add_argument("--format", choices=["pdf", "csv"], default="pdf", dest="fmt")
+    p.add_argument("--timeout", type=float, default=15.0, help="Seconds to wait for SMTP delivery")
+    return p.parse_args()
+
+
+def _section(title: str) -> None:
+    print(f"\n{'─' * 60}")
+    print(f"  {title}")
+    print(f"{'─' * 60}")
+
+
+def _parse_email_summary(raw: str) -> None:
+    """Print a readable summary of the captured raw email."""
+    msg = email_lib.message_from_string(raw)
+    print(f"  From:    {msg['From']}")
+    print(f"  To:      {msg['To']}")
+    print(f"  Subject: {msg['Subject']}")
+    print()
+
+    parts_info = []
+    body_shown = False
+
+    for part in msg.walk():
+        ct = part.get_content_type()
+        cd = part.get("Content-Disposition", "")
+
+        if ct == "text/plain" and not body_shown:
+            payload = part.get_payload(decode=True)
+            if payload:
+                text = payload.decode("utf-8", errors="replace").strip()
+                print("  Body (text):")
+                for line in textwrap.wrap(text, 70):
+                    print(f"    {line}")
+                body_shown = True
+
+        elif ct == "text/html" and not body_shown:
+            payload = part.get_payload(decode=True)
+            if payload:
+                html = payload.decode("utf-8", errors="replace")
+                # strip tags for preview
+                import re
+                plain = re.sub(r"<[^>]+>", "", html).strip()
+                plain = re.sub(r"\s+", " ", plain)
+                print("  Body (html preview):")
+                for line in textwrap.wrap(plain[:300], 70):
+                    print(f"    {line}")
+                body_shown = True
+
+        if "attachment" in cd:
+            fname = part.get_filename() or "attachment"
+            payload = part.get_payload(decode=True) or b""
+            parts_info.append((fname, len(payload), ct))
+
+    if parts_info:
+        print()
+        print("  Attachments:")
+        for fname, size, ct in parts_info:
+            print(f"    {fname}  ({size:,} bytes, {ct})")
+
+
+def main() -> int:
+    args = _parse_args()
+
+    # ------------------------------------------------------------------ sink
+    _section("1/5  Starting local SMTP sink")
+    sys.path.insert(0, str(SKILL_DIR))
+    from smtp_sink import start_sink, wait_for_message, stop_sink
+
+    port = start_sink()
+    print(f"  SMTP sink listening on 127.0.0.1:{port}")
+
+    # Point email_sender at the sink
+    os.environ["SMTP_HOST"] = "127.0.0.1"
+    os.environ["SMTP_PORT"] = str(port)
+    os.environ["SMTP_TLS"] = "false"
+    os.environ["SMTP_SSL"] = "false"
+    os.environ.pop("SMTP_USER", None)
+    os.environ.pop("SMTP_PASSWORD", None)
+    os.environ["SMTP_FROM"] = "reports@noesis.local"
+    os.environ["BASE_URL"] = "http://localhost:8000"
+
+    # ----------------------------------------------------------- subscription
+    _section("2/5  Creating test subscription")
+    from src.reports.subscriptions import create_subscription, delete_subscription
+
+    sub = create_subscription(args.to, args.topic, args.freq, args.fmt)
+    sub_id = sub["id"]
+    print(f"  id:        {sub_id}")
+    print(f"  email:     {sub['email']}")
+    print(f"  topic:     {sub['topic']}")
+    print(f"  frequency: {sub['frequency']}")
+    print(f"  format:    {sub['format']}")
+
+    # ----------------------------------------------------------- delivery
+    _section("3/5  Firing delivery")
+    from src.reports.scheduler import _deliver_subscriptions
+
+    try:
+        _deliver_subscriptions(args.freq)
+        print(f"  Delivery function completed for frequency='{args.freq}'")
+    except Exception as exc:
+        print(f"  ERROR during delivery: {exc}")
+        delete_subscription(sub_id)
+        stop_sink()
+        return 1
+
+    # ----------------------------------------------------------- capture
+    _section("4/5  Waiting for SMTP message")
+    msg = wait_for_message(timeout=args.timeout)
+    if msg is None:
+        print(f"  TIMEOUT — no message received within {args.timeout}s")
+        delete_subscription(sub_id)
+        stop_sink()
+        return 1
+
+    print(f"  Message received!  ({len(msg['raw_data'])} raw bytes)")
+    print()
+    _parse_email_summary(msg["raw_data"])
+
+    # ----------------------------------------------------------- cleanup
+    _section("5/5  Cleanup")
+    delete_subscription(sub_id)
+    stop_sink()
+    print(f"  Subscription {sub_id} deleted")
+    print(f"  SMTP sink stopped")
+
+    print()
+    print("  RESULT: PASS — email delivered end-to-end via SMTP")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/smtp-test/smtp-test.sh
+++ b/.claude/skills/smtp-test/smtp-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# smtp-test: smoke-test the scheduled report email delivery path.
+#
+# Starts a local SMTP sink, creates a test subscription, fires the weekly
+# delivery job, captures the email, and cleans up — no real SMTP server or
+# API server required.
+#
+# Usage:
+#   bash .claude/skills/smtp-test/smtp-test.sh [--to EMAIL] [--topic TOPIC] [--freq weekly|monthly] [--format pdf|csv]
+#
+# All args are forwarded to run_test.py. Defaults: --to test@noesis.local --topic AI --freq weekly --format pdf
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+exec python3 "$SCRIPT_DIR/run_test.py" "$@"

--- a/.claude/skills/smtp-test/smtp_sink.py
+++ b/.claude/skills/smtp-test/smtp_sink.py
@@ -1,0 +1,154 @@
+"""
+Minimal async SMTP sink server.
+
+Handles just enough of the SMTP protocol to accept a full message from
+smtplib (EHLO, MAIL FROM, RCPT TO, DATA, QUIT). Captured messages are
+stored in `MESSAGES` as dicts with keys: mail_from, rcpt_to, raw_data.
+
+Usage (standalone):
+    import asyncio, threading
+    from smtp_sink import start_sink, MESSAGES, stop_sink
+    port = start_sink()          # starts server in background thread
+    # ... send mail to localhost:port ...
+    msg = wait_for_message(timeout=10)
+    stop_sink()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+
+MESSAGES: List[Dict[str, Any]] = []
+_server: Optional[asyncio.Server] = None
+_loop: Optional[asyncio.AbstractEventLoop] = None
+_thread: Optional[threading.Thread] = None
+
+
+class _SMTPHandler(asyncio.Protocol):
+    def __init__(self) -> None:
+        self._buf = b""
+        self._state = "greeting"
+        self._mail_from = ""
+        self._rcpt_to: List[str] = []
+        self._in_data = False
+        self._data_lines: List[bytes] = []
+        self._transport: Optional[asyncio.Transport] = None
+
+    def connection_made(self, transport: asyncio.Transport) -> None:  # type: ignore[override]
+        self._transport = transport
+        self._send(b"220 smtp-sink ESMTP ready\r\n")
+
+    def _send(self, data: bytes) -> None:
+        if self._transport:
+            self._transport.write(data)
+
+    def data_received(self, data: bytes) -> None:
+        self._buf += data
+        while b"\r\n" in self._buf:
+            line, self._buf = self._buf.split(b"\r\n", 1)
+            self._handle_line(line)
+
+    def _handle_line(self, line: bytes) -> None:
+        if self._in_data:
+            if line == b".":
+                self._in_data = False
+                raw = b"\r\n".join(self._data_lines)
+                MESSAGES.append({
+                    "mail_from": self._mail_from,
+                    "rcpt_to": list(self._rcpt_to),
+                    "raw_data": raw.decode("utf-8", errors="replace"),
+                })
+                self._send(b"250 OK\r\n")
+            else:
+                # Unstuff leading dots
+                self._data_lines.append(line[1:] if line.startswith(b"..") else line)
+            return
+
+        cmd = line[:4].upper()
+        if cmd in (b"EHLO", b"HELO"):
+            self._send(b"250-smtp-sink\r\n250-8BITMIME\r\n250 OK\r\n")
+        elif cmd == b"MAIL":
+            self._mail_from = line.decode(errors="replace")
+            self._rcpt_to = []
+            self._send(b"250 OK\r\n")
+        elif cmd == b"RCPT":
+            self._rcpt_to.append(line.decode(errors="replace"))
+            self._send(b"250 OK\r\n")
+        elif cmd == b"DATA":
+            self._in_data = True
+            self._data_lines = []
+            self._send(b"354 End data with <CR><LF>.<CR><LF>\r\n")
+        elif cmd == b"QUIT":
+            self._send(b"221 Bye\r\n")
+            if self._transport:
+                self._transport.close()
+        elif cmd == b"RSET":
+            self._mail_from = ""
+            self._rcpt_to = []
+            self._data_lines = []
+            self._in_data = False
+            self._send(b"250 OK\r\n")
+        elif cmd == b"NOOP":
+            self._send(b"250 OK\r\n")
+        else:
+            self._send(b"500 Unrecognised command\r\n")
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:  # noqa: U100
+        pass
+
+
+def start_sink(host: str = "127.0.0.1", port: int = 0) -> int:
+    """
+    Start the SMTP sink in a daemon thread.
+    Returns the actual port it bound to (useful when port=0).
+    """
+    global _loop, _thread
+    import socket
+
+    # Find a free port if port=0
+    if port == 0:
+        with socket.socket() as s:
+            s.bind((host, 0))
+            port = s.getsockname()[1]
+
+    _loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    actual_port: List[int] = []
+
+    def _run() -> None:
+        asyncio.set_event_loop(_loop)
+
+        async def _main() -> None:
+            global _server
+            _server = await _loop.create_server(lambda: _SMTPHandler(), host, port)
+            actual_port.append(_server.sockets[0].getsockname()[1])
+            ready.set()
+            async with _server:
+                await _server.serve_forever()
+
+        _loop.run_until_complete(_main())
+
+    _thread = threading.Thread(target=_run, daemon=True)
+    _thread.start()
+    ready.wait(timeout=5)
+    return actual_port[0] if actual_port else port
+
+
+def stop_sink() -> None:
+    global _loop, _server
+    if _loop and _server:
+        _loop.call_soon_threadsafe(_server.close)
+
+
+def wait_for_message(timeout: float = 10.0) -> Optional[Dict[str, Any]]:
+    """Block until a message arrives or timeout. Returns the message or None."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if MESSAGES:
+            return MESSAGES[-1]
+        time.sleep(0.1)
+    return None

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -234,12 +234,19 @@ def try_import_document_routes():
 
 
 def try_import_report_routes():
-    """Try to import report generation routes (issue #51)."""
+    """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
     try:
         from src.api.routes import report_routes
         _imported_modules['report_routes'] = report_routes
         REPORT_ROUTES_AVAILABLE = True
+        # Start the background scheduler for scheduled email delivery (#52)
+        try:
+            from src.reports.scheduler import start_scheduler
+            start_scheduler()
+        except Exception:
+            import logging
+            logging.getLogger(__name__).warning("Report scheduler could not be started", exc_info=True)
         return True
     except ImportError:
         REPORT_ROUTES_AVAILABLE = False

--- a/src/api/routes/report_routes.py
+++ b/src/api/routes/report_routes.py
@@ -1,21 +1,22 @@
 """
-Report generation routes (Issue #51).
+Report generation and scheduled delivery routes (Issues #51, #52).
 
-GET /api/v1/reports/generate
-    ?topic=AI+Ethics
-    &period=last_30_days   (last_7_days | last_30_days | last_90_days | last_24_hours)
-    &format=json           (json | csv | pdf)
-
-JSON returns headline stats + first-page article list.
-CSV / PDF stream the file as a download.
+GET  /api/v1/reports/generate              — on-demand report (json | csv | pdf)
+POST /api/v1/reports/subscribe             — create a scheduled email subscription
+GET  /api/v1/reports/subscriptions         — list subscriptions (?email=...)
+GET  /api/v1/reports/subscriptions/{id}    — single subscription + delivery stats
+DELETE /api/v1/reports/subscriptions/{id}  — unsubscribe
+POST /api/v1/reports/trigger/{frequency}   — manually fire weekly|monthly delivery
+GET  /api/v1/reports/track/open/{token}    — 1×1 tracking pixel (open event)
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
+from pydantic import BaseModel, field_validator
 
 router = APIRouter(prefix="/api/v1/reports", tags=["reports"])
 
@@ -101,3 +102,135 @@ async def generate_report(
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Report generation failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Subscription request model
+# ---------------------------------------------------------------------------
+
+_VALID_FREQUENCIES = {"weekly", "monthly"}
+_VALID_FORMATS = {"pdf", "csv"}
+
+
+class SubscribeRequest(BaseModel):
+    email: str
+    topic: str
+    frequency: str = "weekly"
+    format: str = "pdf"
+
+    @field_validator("frequency")
+    @classmethod
+    def check_frequency(cls, v: str) -> str:
+        if v not in _VALID_FREQUENCIES:
+            raise ValueError(f"frequency must be one of {sorted(_VALID_FREQUENCIES)}")
+        return v
+
+    @field_validator("format")
+    @classmethod
+    def check_format(cls, v: str) -> str:
+        if v not in _VALID_FORMATS:
+            raise ValueError(f"format must be one of {sorted(_VALID_FORMATS)}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Subscription endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/subscribe", status_code=201)
+async def subscribe(body: SubscribeRequest) -> Dict[str, Any]:
+    """Subscribe an email address to periodic report delivery."""
+    try:
+        from src.reports.subscriptions import create_subscription
+        sub = create_subscription(body.email, body.topic, body.frequency, body.format)
+        return {"status": "created", "subscription": sub}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/subscriptions")
+async def list_subscriptions(
+    email: Optional[str] = Query(None, description="Filter by subscriber email"),
+) -> Dict[str, Any]:
+    """List all subscriptions, optionally filtered by email."""
+    try:
+        from src.reports.subscriptions import list_subscriptions as _list
+        return {"subscriptions": _list(email)}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/subscriptions/{sub_id}")
+async def get_subscription(sub_id: str) -> Dict[str, Any]:
+    """Get a single subscription and its delivery stats."""
+    try:
+        from src.reports.subscriptions import get_subscription as _get, delivery_stats
+        sub = _get(sub_id)
+        if sub is None:
+            raise HTTPException(status_code=404, detail=f"Subscription '{sub_id}' not found")
+        return {"subscription": sub, "delivery_stats": delivery_stats(sub_id)}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/subscriptions/{sub_id}", status_code=200)
+async def unsubscribe(sub_id: str) -> Dict[str, Any]:
+    """Remove a subscription."""
+    try:
+        from src.reports.subscriptions import get_subscription as _get, delete_subscription
+        if _get(sub_id) is None:
+            raise HTTPException(status_code=404, detail=f"Subscription '{sub_id}' not found")
+        delete_subscription(sub_id)
+        return {"status": "deleted", "id": sub_id}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Manual trigger (for testing / admin use)
+# ---------------------------------------------------------------------------
+
+@router.post("/trigger/{frequency}")
+async def trigger_delivery(frequency: str) -> Dict[str, Any]:
+    """Manually fire a delivery run (weekly | monthly). For testing only."""
+    if frequency not in _VALID_FREQUENCIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"frequency must be one of {sorted(_VALID_FREQUENCIES)}",
+        )
+    try:
+        from src.reports.scheduler import trigger_now
+        count = trigger_now(frequency)
+        return {"status": "triggered", "frequency": frequency, "subscriptions_processed": count}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Open tracking pixel
+# ---------------------------------------------------------------------------
+
+_TRACKING_PIXEL = (
+    b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff"
+    b"\x00\x00\x00\x21\xf9\x04\x00\x00\x00\x00\x00\x2c\x00\x00\x00\x00"
+    b"\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b"
+)
+
+
+@router.get("/track/open/{token}", include_in_schema=False)
+async def track_open(token: str) -> Response:
+    """Record an email open event and return a 1×1 transparent GIF."""
+    try:
+        from src.reports.subscriptions import record_open
+        record_open(token)
+    except Exception:
+        pass  # never fail a tracking request
+    return Response(
+        content=_TRACKING_PIXEL,
+        media_type="image/gif",
+        headers={"Cache-Control": "no-store, no-cache"},
+    )

--- a/src/reports/email_sender.py
+++ b/src/reports/email_sender.py
@@ -1,0 +1,121 @@
+"""
+SMTP email delivery for scheduled reports.
+
+Configuration via environment variables:
+
+    SMTP_HOST      SMTP server hostname          (default: localhost)
+    SMTP_PORT      SMTP port                     (default: 587)
+    SMTP_USER      SMTP username / API key login (optional)
+    SMTP_PASSWORD  SMTP password / API key       (optional)
+    SMTP_FROM      Sender address                (default: reports@noesis.local)
+    SMTP_TLS       Use STARTTLS                  (default: true)
+    SMTP_SSL       Use SMTP_SSL instead          (default: false)
+    BASE_URL       Public API base for tracking pixel (default: http://localhost:8000)
+
+Provider quick-start
+--------------------
+SendGrid:   SMTP_HOST=smtp.sendgrid.net SMTP_PORT=587 SMTP_USER=apikey SMTP_PASSWORD=<key>
+Mailgun:    SMTP_HOST=smtp.mailgun.org  SMTP_PORT=587 SMTP_USER=<login> SMTP_PASSWORD=<key>
+Postfix:    SMTP_HOST=localhost SMTP_PORT=25  (no auth, SMTP_TLS=false)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import smtplib
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+logger = logging.getLogger(__name__)
+
+
+def _cfg(key: str, default: str = "") -> str:
+    return os.getenv(key, default).strip()
+
+
+def _send_raw(msg: MIMEMultipart) -> None:
+    host = _cfg("SMTP_HOST", "localhost")
+    port = int(_cfg("SMTP_PORT", "587"))
+    user = _cfg("SMTP_USER")
+    password = _cfg("SMTP_PASSWORD")
+    use_ssl = _cfg("SMTP_SSL", "false").lower() == "true"
+    use_tls = _cfg("SMTP_TLS", "true").lower() == "true" and not use_ssl
+
+    cls = smtplib.SMTP_SSL if use_ssl else smtplib.SMTP
+    with cls(host, port) as server:
+        if use_tls:
+            server.starttls()
+        if user and password:
+            server.login(user, password)
+        server.send_message(msg)
+
+
+def send_report_email(
+    *,
+    to: str,
+    topic: str,
+    period: str,
+    frequency: str,
+    fmt: str,
+    report_bytes: bytes,
+    tracking_token: str,
+) -> None:
+    """
+    Send a report email with the report attached.
+
+    fmt must be 'pdf' or 'csv'. tracking_token is embedded as a 1×1 pixel
+    in the HTML body so open events can be recorded.
+    """
+    from_addr = _cfg("SMTP_FROM", "reports@noesis.local")
+    base_url = _cfg("BASE_URL", "http://localhost:8000")
+    tracking_url = f"{base_url}/api/v1/reports/track/open/{tracking_token}"
+
+    subject = f"[Noesis] {frequency.capitalize()} report: {topic} ({period.replace('_', ' ')})"
+
+    html = f"""
+<html><body style="font-family:sans-serif;color:#222;max-width:600px;margin:auto">
+  <h2 style="color:#3B6EEA">Noesis Report: {topic}</h2>
+  <p>Your <strong>{frequency}</strong> report for <em>{topic}</em>
+     covering <em>{period.replace('_', ' ')}</em> is attached.</p>
+  <p style="color:#666;font-size:12px">
+    To unsubscribe, contact your Noesis administrator.<br>
+    Powered by <a href="{base_url}">Noesis Knowledge Engine</a>
+  </p>
+  <img src="{tracking_url}" width="1" height="1" alt="" style="display:none">
+</body></html>
+"""
+    text = (
+        f"Noesis Report: {topic}\n\n"
+        f"Your {frequency} report for '{topic}' covering {period.replace('_', ' ')} is attached.\n"
+    )
+
+    msg = MIMEMultipart("mixed")
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to
+
+    alt = MIMEMultipart("alternative")
+    alt.attach(MIMEText(text, "plain"))
+    alt.attach(MIMEText(html, "html"))
+    msg.attach(alt)
+
+    # Attach report file
+    if fmt == "pdf":
+        mime_type, ext = "application/pdf", "pdf"
+    else:
+        mime_type, ext = "text/csv", "csv"
+
+    slug = topic.lower().replace(" ", "_")
+    filename = f"noesis_report_{slug}_{period}.{ext}"
+
+    part = MIMEBase(*mime_type.split("/"))
+    part.set_payload(report_bytes)
+    encoders.encode_base64(part)
+    part.add_header("Content-Disposition", f'attachment; filename="{filename}"')
+    msg.attach(part)
+
+    _send_raw(msg)
+    logger.info("Report email sent to %s (topic=%s token=%s)", to, topic, tracking_token)

--- a/src/reports/scheduler.py
+++ b/src/reports/scheduler.py
@@ -1,0 +1,106 @@
+"""
+APScheduler-based report delivery scheduler.
+
+Jobs
+----
+weekly_reports   — every Monday at 08:00 UTC
+monthly_reports  — 1st of each month at 08:00 UTC
+
+Start/stop
+----------
+Call start_scheduler() once at app startup (idempotent).
+Call stop_scheduler() at shutdown (no-op if not started).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_scheduler: Optional[object] = None
+
+
+def _deliver_subscriptions(frequency: str) -> None:
+    """Fetch all subscriptions matching frequency, generate and email each."""
+    from src.reports.subscriptions import list_subscriptions, mark_sent
+    from src.reports.email_sender import send_report_email
+    from src.reports.generate_report import generate_pdf, generate_csv
+
+    subs = list_subscriptions()
+    matching = [s for s in subs if s["frequency"] == frequency]
+    logger.info("Scheduler: delivering %s reports (%d subscriptions)", frequency, len(matching))
+
+    for sub in matching:
+        try:
+            fmt = sub["format"]
+            topic = sub["topic"]
+            period = "last_7_days" if frequency == "weekly" else "last_30_days"
+
+            report_bytes = generate_pdf(topic, period) if fmt == "pdf" else generate_csv(topic, period)
+            token = mark_sent(sub["id"])
+            send_report_email(
+                to=sub["email"],
+                topic=topic,
+                period=period,
+                frequency=frequency,
+                fmt=fmt,
+                report_bytes=report_bytes,
+                tracking_token=token,
+            )
+        except Exception:
+            logger.exception("Failed to deliver report to %s (sub_id=%s)", sub["email"], sub["id"])
+
+
+def _weekly_job() -> None:
+    _deliver_subscriptions("weekly")
+
+
+def _monthly_job() -> None:
+    _deliver_subscriptions("monthly")
+
+
+def start_scheduler() -> None:
+    """Start the background scheduler (idempotent)."""
+    global _scheduler
+    if _scheduler is not None:
+        return
+
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.cron import CronTrigger
+    except ImportError:
+        logger.warning("apscheduler not installed — scheduled report delivery disabled")
+        return
+
+    sched = BackgroundScheduler(timezone="UTC")
+    # Every Monday at 08:00 UTC
+    sched.add_job(_weekly_job, CronTrigger(day_of_week="mon", hour=8, minute=0), id="weekly_reports")
+    # 1st of each month at 08:00 UTC
+    sched.add_job(_monthly_job, CronTrigger(day=1, hour=8, minute=0), id="monthly_reports")
+
+    sched.start()
+    _scheduler = sched
+    logger.info("Report scheduler started (weekly=Mon 08:00, monthly=1st 08:00 UTC)")
+
+
+def stop_scheduler() -> None:
+    """Shut down the scheduler gracefully."""
+    global _scheduler
+    if _scheduler is None:
+        return
+    try:
+        _scheduler.shutdown(wait=False)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    _scheduler = None
+    logger.info("Report scheduler stopped")
+
+
+def trigger_now(frequency: str) -> int:
+    """Manually fire a delivery run (for testing). Returns subscription count processed."""
+    from src.reports.subscriptions import list_subscriptions
+    subs = [s for s in list_subscriptions() if s["frequency"] == frequency]
+    _deliver_subscriptions(frequency)
+    return len(subs)

--- a/src/reports/subscriptions.py
+++ b/src/reports/subscriptions.py
@@ -1,0 +1,187 @@
+"""
+Report subscription store backed by DuckDB.
+
+Tables
+------
+report_subscriptions  — one row per active subscription
+report_deliveries     — one row per email sent (open tracking)
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from src.database.local_analytics_connector import get_shared_connection, _LOCK
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS report_subscriptions (
+    id          VARCHAR PRIMARY KEY,
+    email       VARCHAR NOT NULL,
+    topic       VARCHAR NOT NULL,
+    frequency   VARCHAR NOT NULL,   -- 'weekly' | 'monthly'
+    format      VARCHAR NOT NULL,   -- 'pdf' | 'csv'
+    created_at  TIMESTAMP NOT NULL,
+    last_sent   TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS report_deliveries (
+    token       VARCHAR PRIMARY KEY,
+    sub_id      VARCHAR NOT NULL,
+    sent_at     TIMESTAMP NOT NULL,
+    opened_at   TIMESTAMP,
+    open_count  INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def _ensure_schema() -> None:
+    conn = get_shared_connection()
+    with _LOCK:
+        for stmt in _SCHEMA.strip().split(";"):
+            stmt = stmt.strip()
+            if stmt:
+                conn.execute(stmt)
+
+
+_schema_done = False
+_schema_lock = threading.Lock()
+
+
+def _init():
+    global _schema_done
+    if _schema_done:
+        return
+    with _schema_lock:
+        if not _schema_done:
+            _ensure_schema()
+            _schema_done = True
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions
+# ---------------------------------------------------------------------------
+
+def create_subscription(email: str, topic: str, frequency: str, fmt: str) -> Dict[str, Any]:
+    _init()
+    sub_id = secrets.token_hex(8)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            """
+            INSERT INTO report_subscriptions (id, email, topic, frequency, format, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [sub_id, email, topic, frequency, fmt, now],
+        )
+    return _row_to_dict(sub_id, email, topic, frequency, fmt, now, None)
+
+
+def list_subscriptions(email: Optional[str] = None) -> List[Dict[str, Any]]:
+    _init()
+    conn = get_shared_connection()
+    if email:
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT id, email, topic, frequency, format, created_at, last_sent FROM report_subscriptions WHERE email = ? ORDER BY created_at DESC",
+                [email],
+            ).fetchall()
+    else:
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT id, email, topic, frequency, format, created_at, last_sent FROM report_subscriptions ORDER BY created_at DESC"
+            ).fetchall()
+    return [_row_to_dict(r[0], r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
+
+
+def get_subscription(sub_id: str) -> Optional[Dict[str, Any]]:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        row = conn.execute(
+            "SELECT id, email, topic, frequency, format, created_at, last_sent FROM report_subscriptions WHERE id = ?",
+            [sub_id],
+        ).fetchone()
+    if not row:
+        return None
+    return _row_to_dict(row[0], row[1], row[2], row[3], row[4], row[5], row[6])
+
+
+def delete_subscription(sub_id: str) -> bool:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute("DELETE FROM report_subscriptions WHERE id = ?", [sub_id])
+        conn.execute("DELETE FROM report_deliveries WHERE sub_id = ?", [sub_id])
+    return True
+
+
+def mark_sent(sub_id: str) -> str:
+    """Record a delivery; return the tracking token."""
+    _init()
+    token = secrets.token_urlsafe(16)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            "INSERT INTO report_deliveries (token, sub_id, sent_at) VALUES (?, ?, ?)",
+            [token, sub_id, now],
+        )
+        conn.execute(
+            "UPDATE report_subscriptions SET last_sent = ? WHERE id = ?",
+            [now, sub_id],
+        )
+    return token
+
+
+def record_open(token: str) -> bool:
+    """Increment open count for a delivery token. Returns True if token found."""
+    _init()
+    conn = get_shared_connection()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    with _LOCK:
+        row = conn.execute(
+            "SELECT token FROM report_deliveries WHERE token = ?", [token]
+        ).fetchone()
+        if not row:
+            return False
+        conn.execute(
+            "UPDATE report_deliveries SET open_count = open_count + 1, opened_at = ? WHERE token = ?",
+            [now, token],
+        )
+    return True
+
+
+def delivery_stats(sub_id: str) -> Dict[str, Any]:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        rows = conn.execute(
+            "SELECT COUNT(*), SUM(open_count), MAX(opened_at) FROM report_deliveries WHERE sub_id = ?",
+            [sub_id],
+        ).fetchone()
+    # COUNT(*) always returns a row; guard satisfies type checker
+    total_sent = int(rows[0]) if rows else 0
+    total_opens = int(rows[1] or 0) if rows else 0
+    last_opened = str(rows[2]) if (rows and rows[2]) else None
+    return {
+        "total_sent": total_sent,
+        "total_opens": total_opens,
+        "open_rate": round(total_opens / total_sent, 3) if total_sent else 0.0,
+        "last_opened": last_opened,
+    }
+
+
+def _row_to_dict(id, email, topic, frequency, fmt, created_at, last_sent) -> Dict[str, Any]:
+    return {
+        "id": id,
+        "email": email,
+        "topic": topic,
+        "frequency": frequency,
+        "format": fmt,
+        "created_at": str(created_at),
+        "last_sent": str(last_sent) if last_sent else None,
+    }


### PR DESCRIPTION
## Summary

- **Subscription store** (`src/reports/subscriptions.py`): DuckDB-backed `report_subscriptions` + `report_deliveries` tables; full CRUD, per-delivery open tracking via unique tokens
- **SMTP email sender** (`src/reports/email_sender.py`): `smtplib`-based, provider-agnostic (SendGrid/Mailgun/Postfix); HTML + plain text multipart; PDF/CSV attachment; tracking pixel embedded in HTML body; configured via `SMTP_HOST/PORT/USER/PASSWORD/FROM/TLS` env vars
- **APScheduler** (`src/reports/scheduler.py`): `BackgroundScheduler` with weekly (Mon 08:00 UTC) and monthly (1st 08:00 UTC) cron jobs; `trigger_now()` for manual firing; started automatically at API boot inside `try_import_report_routes()`
- **6 new API endpoints** (`report_routes.py`): `POST /subscribe`, `GET /subscriptions[?email]`, `GET /subscriptions/{id}` (with delivery stats), `DELETE /subscriptions/{id}`, `POST /trigger/{weekly|monthly}`, `GET /track/open/{token}` (1×1 GIF open tracking pixel)
- **`smtp-test` skill** (`.claude/skills/smtp-test/`): end-to-end delivery smoke test; pure-Python async SMTP sink on a random port; no API server or real SMTP provider needed; runs in ~5s

## Test plan

- [ ] `POST /api/v1/reports/subscribe` creates a subscription (201)
- [ ] `GET /api/v1/reports/subscriptions` lists it; `?email=` filter works
- [ ] `GET /api/v1/reports/subscriptions/{id}` returns delivery stats `{total_sent:0, open_rate:0}`
- [ ] `POST /api/v1/reports/trigger/weekly` returns `{subscriptions_processed: N}`
- [ ] `GET /api/v1/reports/track/open/{token}` returns a 1×1 GIF (image/gif)
- [ ] `DELETE /api/v1/reports/subscriptions/{id}` removes it; subsequent GET returns 404
- [ ] `bash .claude/skills/smtp-test/smtp-test.sh --topic Iran` exits 0 and prints `RESULT: PASS`
- [ ] `bash .claude/skills/smtp-test/smtp-test.sh --format csv --topic Trump` sends CSV attachment