### PR TITLE
feat(alerts): real-time alerts — Slack, Telegram, Email, SSE stream (#53)

### DIFF
--- a/src/alerts/channels.py
+++ b/src/alerts/channels.py
@@ -1,0 +1,163 @@
+"""
+Alert delivery channels: Email, Slack, Telegram.
+
+Each channel reads its config from env vars and fails soft — a delivery
+error is logged but never raises, so one bad channel never blocks others.
+
+Email
+-----
+    Reuses SMTP env vars from src/reports/email_sender.py:
+    SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_FROM, SMTP_TLS
+    ALERT_EMAIL_FROM  (overrides SMTP_FROM for alerts; optional)
+
+Slack
+-----
+    SLACK_WEBHOOK_URL   Incoming Webhook URL from api.slack.com/apps
+
+Telegram
+--------
+    TELEGRAM_BOT_TOKEN  Bot token from @BotFather
+    TELEGRAM_CHAT_ID    Target chat/channel ID
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import smtplib
+import urllib.request
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+def _smtp_cfg(key: str, default: str = "") -> str:
+    return os.getenv(key, default).strip()
+
+
+def send_email_alert(*, to: str, title: str, body: str) -> bool:
+    from_addr = _smtp_cfg("ALERT_EMAIL_FROM") or _smtp_cfg("SMTP_FROM", "alerts@noesis.local")
+    host = _smtp_cfg("SMTP_HOST", "localhost")
+    port = int(_smtp_cfg("SMTP_PORT", "587"))
+    user = _smtp_cfg("SMTP_USER")
+    password = _smtp_cfg("SMTP_PASSWORD")
+    use_ssl = _smtp_cfg("SMTP_SSL", "false").lower() == "true"
+    use_tls = _smtp_cfg("SMTP_TLS", "true").lower() == "true" and not use_ssl
+
+    html = f"""<html><body style="font-family:sans-serif;color:#222;max-width:600px;margin:auto">
+  <h2 style="color:#e25c3a">&#9888; Noesis Alert</h2>
+  <h3>{title}</h3>
+  <p style="white-space:pre-wrap">{body}</p>
+  <hr><p style="color:#999;font-size:11px">Noesis Knowledge Engine</p>
+</body></html>"""
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"[Noesis Alert] {title}"
+    msg["From"] = from_addr
+    msg["To"] = to
+    msg.attach(MIMEText(body, "plain"))
+    msg.attach(MIMEText(html, "html"))
+
+    try:
+        cls = smtplib.SMTP_SSL if use_ssl else smtplib.SMTP
+        with cls(host, port) as server:
+            if use_tls:
+                server.starttls()
+            if user and password:
+                server.login(user, password)
+            server.send_message(msg)
+        logger.info("Alert email sent to %s: %s", to, title)
+        return True
+    except Exception:
+        logger.exception("Failed to send alert email to %s", to)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Slack
+# ---------------------------------------------------------------------------
+
+def send_slack_alert(*, title: str, body: str) -> bool:
+    webhook = os.getenv("SLACK_WEBHOOK_URL", "").strip()
+    if not webhook:
+        logger.warning("SLACK_WEBHOOK_URL not set — skipping Slack alert")
+        return False
+
+    payload = {
+        "text": f"*[Noesis Alert] {title}*",
+        "blocks": [
+            {"type": "header", "text": {"type": "plain_text", "text": f"Noesis Alert: {title}"}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": body}},
+        ],
+    }
+    try:
+        req = urllib.request.Request(
+            webhook,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10):
+            pass
+        logger.info("Alert sent to Slack: %s", title)
+        return True
+    except Exception:
+        logger.exception("Failed to send Slack alert")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Telegram
+# ---------------------------------------------------------------------------
+
+def send_telegram_alert(*, title: str, body: str) -> bool:
+    token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = os.getenv("TELEGRAM_CHAT_ID", "").strip()
+    if not token or not chat_id:
+        logger.warning("TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID not set — skipping Telegram alert")
+        return False
+
+    text = f"*⚠️ Noesis Alert*\n*{title}*\n\n{body}"
+    payload = {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10):
+            pass
+        logger.info("Alert sent to Telegram chat %s: %s", chat_id, title)
+        return True
+    except Exception:
+        logger.exception("Failed to send Telegram alert")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch to a list of channels
+# ---------------------------------------------------------------------------
+
+def dispatch(channels: List[str], title: str, body: str, email: str | None = None) -> dict:
+    results: dict = {}
+    for ch in channels:
+        if ch == "email":
+            if email:
+                results["email"] = send_email_alert(to=email, title=title, body=body)
+            else:
+                logger.warning("Email channel requested but no email address on rule")
+                results["email"] = False
+        elif ch == "slack":
+            results["slack"] = send_slack_alert(title=title, body=body)
+        elif ch == "telegram":
+            results["telegram"] = send_telegram_alert(title=title, body=body)
+    return results

--- a/src/alerts/detector.py
+++ b/src/alerts/detector.py
@@ -1,0 +1,139 @@
+"""
+Alert condition detection against the local DuckDB warehouse.
+
+Three condition types
+---------------------
+breaking_news    — articles matching the topic published in the last 15 min
+                   with negative or strongly negative sentiment
+sentiment_shift  — avg sentiment over last 1h vs previous 1h exceeds threshold
+new_event        — at least 3 new articles on the same source in the last 30 min
+                   (proxy for a breaking cluster forming)
+
+Each check returns a dict with keys: triggered (bool), title, body.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+from src.database.local_analytics_connector import get_shared_connection, _LOCK
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def check_breaking_news(topic: str) -> Dict[str, Any]:
+    """Articles matching topic published in the last 15 min with negative sentiment."""
+    cutoff = _now() - timedelta(minutes=15)
+    pattern = f"%{topic}%"
+    conn = get_shared_connection()
+    with _LOCK:
+        rows = conn.execute(
+            """SELECT title, source, sentiment_score
+               FROM news_articles
+               WHERE (title ILIKE ? OR category ILIKE ?)
+                 AND publish_date >= ?
+                 AND sentiment_score < -0.1
+               ORDER BY publish_date DESC LIMIT 5""",
+            [pattern, pattern, cutoff],
+        ).fetchall()
+
+    if not rows:
+        return {"triggered": False, "title": "", "body": ""}
+
+    headlines = "\n".join(f"• {r[0]} ({r[1]}, score {r[2]:+.2f})" for r in rows)
+    return {
+        "triggered": True,
+        "title": f"Breaking: {len(rows)} negative article(s) on '{topic}'",
+        "body": f"New negative coverage detected in the last 15 minutes:\n\n{headlines}",
+    }
+
+
+def check_sentiment_shift(topic: str, threshold: float = 0.15) -> Dict[str, Any]:
+    """Sentiment shifted by more than `threshold` between the last two 1-hour windows."""
+    now = _now()
+    h1_start = now - timedelta(hours=1)
+    h2_start = now - timedelta(hours=2)
+    pattern = f"%{topic}%"
+    conn = get_shared_connection()
+
+    with _LOCK:
+        r_recent = conn.execute(
+            """SELECT AVG(sentiment_score) FROM news_articles
+               WHERE (title ILIKE ? OR category ILIKE ?)
+                 AND publish_date >= ? AND publish_date < ?""",
+            [pattern, pattern, h1_start, now],
+        ).fetchone()
+        r_prev = conn.execute(
+            """SELECT AVG(sentiment_score) FROM news_articles
+               WHERE (title ILIKE ? OR category ILIKE ?)
+                 AND publish_date >= ? AND publish_date < ?""",
+            [pattern, pattern, h2_start, h1_start],
+        ).fetchone()
+
+    avg_recent = r_recent[0] if r_recent and r_recent[0] is not None else None
+    avg_prev = r_prev[0] if r_prev and r_prev[0] is not None else None
+
+    if avg_recent is None or avg_prev is None:
+        return {"triggered": False, "title": "", "body": ""}
+
+    delta = avg_recent - avg_prev
+    if abs(delta) < threshold:
+        return {"triggered": False, "title": "", "body": ""}
+
+    direction = "worsened" if delta < 0 else "improved"
+    return {
+        "triggered": True,
+        "title": f"Sentiment {direction} for '{topic}': {delta:+.3f}",
+        "body": (
+            f"Sentiment on '{topic}' has {direction} significantly.\n\n"
+            f"  Previous hour avg: {avg_prev:+.3f}\n"
+            f"  Last hour avg:     {avg_recent:+.3f}\n"
+            f"  Delta:             {delta:+.3f}"
+        ),
+    }
+
+
+def check_new_event(topic: str) -> Dict[str, Any]:
+    """3+ articles from the same source on the topic in the last 30 min — cluster forming."""
+    cutoff = _now() - timedelta(minutes=30)
+    pattern = f"%{topic}%"
+    conn = get_shared_connection()
+
+    with _LOCK:
+        rows = conn.execute(
+            """SELECT source, COUNT(*) AS n
+               FROM news_articles
+               WHERE (title ILIKE ? OR category ILIKE ?)
+                 AND publish_date >= ?
+               GROUP BY source HAVING COUNT(*) >= 3
+               ORDER BY n DESC LIMIT 3""",
+            [pattern, pattern, cutoff],
+        ).fetchall()
+
+    if not rows:
+        return {"triggered": False, "title": "", "body": ""}
+
+    sources = ", ".join(f"{r[0]} ({r[1]} articles)" for r in rows)
+    return {
+        "triggered": True,
+        "title": f"New event cluster forming: '{topic}'",
+        "body": (
+            f"Multiple sources are publishing rapidly on '{topic}':\n\n"
+            f"{sources}\n\n"
+            "This may indicate a breaking event or policy update."
+        ),
+    }
+
+
+def run_all_checks(topic: str, alert_type: str, threshold: float | None) -> Dict[str, Any]:
+    """Run the appropriate check for a rule's alert_type."""
+    if alert_type == "breaking_news":
+        return check_breaking_news(topic)
+    if alert_type == "sentiment_shift":
+        return check_sentiment_shift(topic, threshold=threshold or 0.15)
+    if alert_type == "new_event":
+        return check_new_event(topic)
+    return {"triggered": False, "title": "", "body": ""}

--- a/src/alerts/dispatcher.py
+++ b/src/alerts/dispatcher.py
@@ -1,0 +1,154 @@
+"""
+Alert dispatcher — ties store + detector + channels together.
+
+An APScheduler job calls `poll_and_dispatch()` every 5 minutes.
+Fired alerts are also pushed to an in-process SSE queue so the
+frontend stream endpoint can relay them in real time.
+
+SSE queue
+---------
+`get_sse_queue()` returns an asyncio.Queue per connected client.
+`register_sse_client()` / `unregister_sse_client()` manage the set.
+`_push_sse(event)` broadcasts to all registered queues.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SSE fan-out registry
+# ---------------------------------------------------------------------------
+
+_sse_clients: Set[asyncio.Queue] = set()
+
+
+def register_sse_client(q: asyncio.Queue) -> None:
+    _sse_clients.add(q)
+    logger.debug("SSE client registered (%d total)", len(_sse_clients))
+
+
+def unregister_sse_client(q: asyncio.Queue) -> None:
+    _sse_clients.discard(q)
+    logger.debug("SSE client disconnected (%d remaining)", len(_sse_clients))
+
+
+def _push_sse(event: Dict[str, Any]) -> None:
+    """Non-async fan-out: put on every registered queue, drop if full."""
+    for q in list(_sse_clients):
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Cooldown check
+# ---------------------------------------------------------------------------
+
+def _is_cooled_down(rule: Dict[str, Any]) -> bool:
+    last = rule.get("last_fired")
+    if not last:
+        return True
+    try:
+        last_dt = datetime.fromisoformat(str(last))
+    except ValueError:
+        return True
+    cooldown = timedelta(minutes=int(rule.get("cooldown_min", 60)))
+    return datetime.now(timezone.utc).replace(tzinfo=None) - last_dt >= cooldown
+
+
+# ---------------------------------------------------------------------------
+# Core dispatch
+# ---------------------------------------------------------------------------
+
+def poll_and_dispatch() -> List[Dict[str, Any]]:
+    """Check every active alert rule; fire channels for triggered ones."""
+    from src.alerts.store import list_rules, mark_fired, log_history
+    from src.alerts.detector import run_all_checks
+    from src.alerts.channels import dispatch
+
+    fired = []
+    rules = list_rules()
+
+    for rule in rules:
+        if not _is_cooled_down(rule):
+            continue
+
+        result = run_all_checks(rule["topic"], rule["alert_type"], rule.get("threshold"))
+        if not result["triggered"]:
+            continue
+
+        title = result["title"]
+        body = result["body"]
+        channels: List[str] = rule["channels"]
+        email: Optional[str] = rule.get("email")
+
+        # Dispatch to external channels (fail-soft per channel)
+        delivery = dispatch(channels, title, body, email=email)
+
+        # Record in history
+        hist_id = log_history(rule["id"], rule["alert_type"], title, body, channels)
+        mark_fired(rule["id"])
+
+        event = {
+            "id": hist_id,
+            "rule_id": rule["id"],
+            "rule_name": rule["name"],
+            "alert_type": rule["alert_type"],
+            "topic": rule["topic"],
+            "title": title,
+            "body": body,
+            "channels": channels,
+            "delivery": delivery,
+            "fired_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        # Push to SSE clients
+        _push_sse(event)
+        fired.append(event)
+        logger.info("Alert fired: %s (rule=%s)", title, rule["id"])
+
+    return fired
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+_scheduler: Optional[Any] = None
+
+
+def start_alert_scheduler() -> None:
+    """Start the background poll job (every 5 minutes). Idempotent."""
+    global _scheduler
+    if _scheduler is not None:
+        return
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.interval import IntervalTrigger
+    except ImportError:
+        logger.warning("apscheduler missing — real-time alert polling disabled")
+        return
+
+    sched = BackgroundScheduler(timezone="UTC")
+    sched.add_job(poll_and_dispatch, IntervalTrigger(minutes=5), id="alert_poll")
+    sched.start()
+    _scheduler = sched
+    logger.info("Alert scheduler started (polling every 5 min)")
+
+
+def stop_alert_scheduler() -> None:
+    global _scheduler
+    if _scheduler is None:
+        return
+    try:
+        _scheduler.shutdown(wait=False)
+    except Exception:
+        pass
+    _scheduler = None

--- a/src/alerts/store.py
+++ b/src/alerts/store.py
@@ -1,0 +1,179 @@
+"""
+DuckDB-backed alert rules and history store.
+
+Tables
+------
+alert_rules    — one row per user-defined alert rule
+alert_history  — one row per fired alert (for audit / dedup)
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from src.database.local_analytics_connector import get_shared_connection, _LOCK
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS alert_rules (
+    id           VARCHAR PRIMARY KEY,
+    name         VARCHAR NOT NULL,
+    topic        VARCHAR NOT NULL,
+    alert_type   VARCHAR NOT NULL,
+    threshold    DOUBLE,
+    channels     VARCHAR NOT NULL,
+    email        VARCHAR,
+    created_at   TIMESTAMP NOT NULL,
+    last_fired   TIMESTAMP,
+    cooldown_min INTEGER NOT NULL DEFAULT 60
+);
+
+CREATE TABLE IF NOT EXISTS alert_history (
+    id         VARCHAR PRIMARY KEY,
+    rule_id    VARCHAR NOT NULL,
+    alert_type VARCHAR NOT NULL,
+    title      VARCHAR NOT NULL,
+    body       VARCHAR NOT NULL,
+    channels   VARCHAR NOT NULL,
+    fired_at   TIMESTAMP NOT NULL
+);
+"""
+
+_VALID_TYPES = {"breaking_news", "sentiment_shift", "new_event"}
+_VALID_CHANNELS = {"email", "slack", "telegram"}
+
+_schema_done = False
+_schema_lock = threading.Lock()
+
+
+def _init() -> None:
+    global _schema_done
+    if _schema_done:
+        return
+    with _schema_lock:
+        if not _schema_done:
+            conn = get_shared_connection()
+            with _LOCK:
+                for stmt in _SCHEMA.strip().split(";"):
+                    s = stmt.strip()
+                    if s:
+                        conn.execute(s)
+            _schema_done = True
+
+
+# ---------------------------------------------------------------------------
+# Rules CRUD
+# ---------------------------------------------------------------------------
+
+def create_rule(
+    name: str,
+    topic: str,
+    alert_type: str,
+    channels: List[str],
+    email: Optional[str] = None,
+    threshold: Optional[float] = None,
+    cooldown_min: int = 60,
+) -> Dict[str, Any]:
+    _init()
+    rule_id = secrets.token_hex(8)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    channels_json = json.dumps(sorted(set(channels)))
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            """INSERT INTO alert_rules
+               (id, name, topic, alert_type, threshold, channels, email, created_at, cooldown_min)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [rule_id, name, topic, alert_type, threshold, channels_json, email, now, cooldown_min],
+        )
+    return _rule_row(rule_id, name, topic, alert_type, threshold, channels_json, email, now, None, cooldown_min)
+
+
+def list_rules() -> List[Dict[str, Any]]:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        rows = conn.execute(
+            "SELECT id,name,topic,alert_type,threshold,channels,email,created_at,last_fired,cooldown_min"
+            " FROM alert_rules ORDER BY created_at DESC"
+        ).fetchall()
+    return [_rule_row(*r) for r in rows]
+
+
+def get_rule(rule_id: str) -> Optional[Dict[str, Any]]:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        row = conn.execute(
+            "SELECT id,name,topic,alert_type,threshold,channels,email,created_at,last_fired,cooldown_min"
+            " FROM alert_rules WHERE id=?",
+            [rule_id],
+        ).fetchone()
+    if not row:
+        return None
+    return _rule_row(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9])
+
+
+def delete_rule(rule_id: str) -> None:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute("DELETE FROM alert_rules WHERE id=?", [rule_id])
+
+
+def mark_fired(rule_id: str) -> None:
+    _init()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute("UPDATE alert_rules SET last_fired=? WHERE id=?", [now, rule_id])
+
+
+def log_history(rule_id: str, alert_type: str, title: str, body: str, channels: List[str]) -> str:
+    _init()
+    hist_id = secrets.token_hex(8)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            "INSERT INTO alert_history (id,rule_id,alert_type,title,body,channels,fired_at)"
+            " VALUES (?,?,?,?,?,?,?)",
+            [hist_id, rule_id, alert_type, title, body, json.dumps(channels), now],
+        )
+    return hist_id
+
+
+def get_history(limit: int = 50) -> List[Dict[str, Any]]:
+    _init()
+    conn = get_shared_connection()
+    with _LOCK:
+        rows = conn.execute(
+            "SELECT id,rule_id,alert_type,title,body,channels,fired_at"
+            " FROM alert_history ORDER BY fired_at DESC LIMIT ?",
+            [limit],
+        ).fetchall()
+    return [
+        {
+            "id": r[0], "rule_id": r[1], "alert_type": r[2],
+            "title": r[3], "body": r[4],
+            "channels": json.loads(r[5]), "fired_at": str(r[6]),
+        }
+        for r in rows
+    ]
+
+
+def _rule_row(
+    id, name, topic, alert_type, threshold, channels_json, email, created_at, last_fired, cooldown_min
+) -> Dict[str, Any]:
+    return {
+        "id": id, "name": name, "topic": topic, "alert_type": alert_type,
+        "threshold": threshold,
+        "channels": json.loads(channels_json) if channels_json else [],
+        "email": email,
+        "created_at": str(created_at),
+        "last_fired": str(last_fired) if last_fired else None,
+        "cooldown_min": cooldown_min,
+    }

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -21,6 +21,7 @@ AUTH_AVAILABLE = False
 SEARCH_AVAILABLE = False
 DOCUMENT_ROUTES_AVAILABLE = False
 REPORT_ROUTES_AVAILABLE = False
+ALERT_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -233,6 +234,25 @@ def try_import_document_routes():
         return False
 
 
+def try_import_alert_routes():
+    """Try to import real-time alert routes (issue #53)."""
+    global ALERT_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import alert_routes
+        _imported_modules['alert_routes'] = alert_routes
+        ALERT_ROUTES_AVAILABLE = True
+        try:
+            from src.alerts.dispatcher import start_alert_scheduler
+            start_alert_scheduler()
+        except Exception:
+            import logging
+            logging.getLogger(__name__).warning("Alert scheduler could not be started", exc_info=True)
+        return True
+    except ImportError:
+        ALERT_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -281,6 +301,7 @@ def check_all_imports():
     try_import_search_routes()
     try_import_document_routes()
     try_import_report_routes()
+    try_import_alert_routes()
     _load_domain_packs()
 
 
@@ -537,6 +558,13 @@ def include_optional_routers(app):
         search_routes = _imported_modules.get('search_routes')
         if search_routes:
             app.include_router(search_routes.router, prefix="/api/v1/search", tags=["Search"])
+            routers_included += 1
+
+    # Include real-time alert routes (issue #53)
+    if ALERT_ROUTES_AVAILABLE:
+        alert_routes = _imported_modules.get('alert_routes')
+        if alert_routes:
+            app.include_router(alert_routes.router)
             routers_included += 1
 
     # Include report generation routes (issue #51)

--- a/src/api/routes/alert_routes.py
+++ b/src/api/routes/alert_routes.py
@@ -1,0 +1,226 @@
+"""
+Real-time alert routes (Issue #53).
+
+POST   /api/v1/alerts/rules             — create an alert rule
+GET    /api/v1/alerts/rules             — list all rules
+GET    /api/v1/alerts/rules/{id}        — get one rule
+DELETE /api/v1/alerts/rules/{id}        — delete a rule
+POST   /api/v1/alerts/poll              — manually trigger a poll cycle
+GET    /api/v1/alerts/history           — recent fired alerts
+GET    /api/v1/alerts/stream            — SSE stream of live alert events
+POST   /api/v1/alerts/test/{channel}    — send a test alert to one channel
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, field_validator
+
+router = APIRouter(prefix="/api/v1/alerts", tags=["alerts"])
+
+_VALID_TYPES = {"breaking_news", "sentiment_shift", "new_event"}
+_VALID_CHANNELS = {"email", "slack", "telegram"}
+
+
+# ---------------------------------------------------------------------------
+# Request model
+# ---------------------------------------------------------------------------
+
+class AlertRuleRequest(BaseModel):
+    name: str
+    topic: str
+    alert_type: str
+    channels: List[str]
+    email: Optional[str] = None
+    threshold: Optional[float] = None
+    cooldown_min: int = 60
+
+    @field_validator("alert_type")
+    @classmethod
+    def check_type(cls, v: str) -> str:
+        if v not in _VALID_TYPES:
+            raise ValueError(f"alert_type must be one of {sorted(_VALID_TYPES)}")
+        return v
+
+    @field_validator("channels")
+    @classmethod
+    def check_channels(cls, v: List[str]) -> List[str]:
+        bad = set(v) - _VALID_CHANNELS
+        if bad:
+            raise ValueError(f"Unknown channels: {sorted(bad)}. Valid: {sorted(_VALID_CHANNELS)}")
+        if not v:
+            raise ValueError("At least one channel required")
+        return v
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+AlertRuleRequest.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# Rules endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/rules", status_code=201)
+async def create_rule(body: AlertRuleRequest) -> Dict[str, Any]:
+    """Create a new alert rule."""
+    try:
+        from src.alerts.store import create_rule as _create
+        rule = _create(
+            name=body.name,
+            topic=body.topic,
+            alert_type=body.alert_type,
+            channels=body.channels,
+            email=body.email,
+            threshold=body.threshold,
+            cooldown_min=body.cooldown_min,
+        )
+        return {"status": "created", "rule": rule}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/rules")
+async def list_rules() -> Dict[str, Any]:
+    """List all alert rules."""
+    try:
+        from src.alerts.store import list_rules as _list
+        return {"rules": _list()}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/rules/{rule_id}")
+async def get_rule(rule_id: str) -> Dict[str, Any]:
+    """Get a single alert rule."""
+    try:
+        from src.alerts.store import get_rule as _get
+        rule = _get(rule_id)
+        if rule is None:
+            raise HTTPException(status_code=404, detail=f"Rule '{rule_id}' not found")
+        return {"rule": rule}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/rules/{rule_id}")
+async def delete_rule(rule_id: str) -> Dict[str, Any]:
+    """Delete an alert rule."""
+    try:
+        from src.alerts.store import get_rule as _get, delete_rule as _delete
+        if _get(rule_id) is None:
+            raise HTTPException(status_code=404, detail=f"Rule '{rule_id}' not found")
+        _delete(rule_id)
+        return {"status": "deleted", "id": rule_id}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Manual poll + history
+# ---------------------------------------------------------------------------
+
+@router.post("/poll")
+async def manual_poll() -> Dict[str, Any]:
+    """Manually trigger a poll cycle across all rules. Returns fired alerts."""
+    try:
+        from src.alerts.dispatcher import poll_and_dispatch
+        fired = poll_and_dispatch()
+        return {"alerts_fired": len(fired), "alerts": fired}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/history")
+async def get_history(
+    limit: int = Query(50, ge=1, le=500),
+) -> Dict[str, Any]:
+    """Get recently fired alert history."""
+    try:
+        from src.alerts.store import get_history as _hist
+        return {"history": _hist(limit=limit)}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# SSE stream
+# ---------------------------------------------------------------------------
+
+@router.get("/stream")
+async def alert_stream() -> StreamingResponse:
+    """
+    Server-Sent Events stream of live alerts.
+
+    Connect with:
+        const es = new EventSource('/api/v1/alerts/stream');
+        es.onmessage = e => console.log(JSON.parse(e.data));
+    """
+    from src.alerts.dispatcher import register_sse_client, unregister_sse_client
+
+    q: asyncio.Queue = asyncio.Queue(maxsize=100)
+    register_sse_client(q)
+
+    async def _generate():
+        try:
+            # Initial keep-alive comment
+            yield ": connected\n\n"
+            while True:
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=30.0)
+                    yield f"data: {json.dumps(event)}\n\n"
+                except asyncio.TimeoutError:
+                    # keep-alive ping
+                    yield ": ping\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            unregister_sse_client(q)
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Channel test
+# ---------------------------------------------------------------------------
+
+@router.post("/test/{channel}")
+async def test_channel(
+    channel: str,
+    email: Optional[str] = Query(None, description="Required when channel=email"),
+) -> Dict[str, Any]:
+    """Send a test alert to verify a channel is configured correctly."""
+    if channel not in _VALID_CHANNELS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"channel must be one of {sorted(_VALID_CHANNELS)}",
+        )
+    if channel == "email" and not email:
+        raise HTTPException(status_code=422, detail="?email= required for email channel test")
+
+    from src.alerts.channels import dispatch
+    results = dispatch(
+        [channel],
+        title="Noesis Alert Test",
+        body="This is a test alert from the Noesis real-time alert system. If you received this, the channel is configured correctly.",
+        email=email,
+    )
+    ok = results.get(channel, False)
+    return {"channel": channel, "delivered": ok, "note": "" if ok else "Check server logs and env vars"}


### PR DESCRIPTION
## Summary

- **`src/alerts/store.py`**: DuckDB `alert_rules` + `alert_history` tables; CRUD with per-rule cooldown tracking
- **`src/alerts/channels.py`**: Email (`smtplib`), Slack (Incoming Webhook), Telegram (Bot API) — all fail-soft; `SLACK_WEBHOOK_URL`, `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`, `SMTP_*` env vars
- **`src/alerts/detector.py`**: Three alert conditions queried from DuckDB:
  - `breaking_news` — negative articles matching topic in the last 15 min
  - `sentiment_shift` — avg sentiment delta between consecutive 1h windows exceeds threshold
  - `new_event` — 3+ articles from same source in 30 min (cluster forming / policy update)
- **`src/alerts/dispatcher.py`**: APScheduler polls every 5 min; SSE fan-out via per-client `asyncio.Queue`; `poll_and_dispatch()` for manual triggering
- **`src/api/routes/alert_routes.py`**: 7 endpoints — create/list/get/delete rules, manual poll, fired history, SSE stream, per-channel test

## Endpoints

| Method | Path | Description |
|---|---|---|
| POST | `/api/v1/alerts/rules` | Create alert rule |
| GET | `/api/v1/alerts/rules` | List all rules |
| GET | `/api/v1/alerts/rules/{id}` | Get one rule |
| DELETE | `/api/v1/alerts/rules/{id}` | Delete rule |
| POST | `/api/v1/alerts/poll` | Manually trigger poll cycle |
| GET | `/api/v1/alerts/history` | Recent fired alerts |
| GET | `/api/v1/alerts/stream` | SSE stream (`text/event-stream`) |
| POST | `/api/v1/alerts/test/{channel}` | Smoke-test email/slack/telegram |

## Test plan

- [ ] `POST /api/v1/alerts/rules` with `alert_type=breaking_news`, `channels=["slack"]` → 201
- [ ] `GET /api/v1/alerts/rules` lists it
- [ ] `POST /api/v1/alerts/test/slack` → `{"delivered": false, ...}` (no webhook set) — no crash
- [ ] `POST /api/v1/alerts/poll` returns `{"alerts_fired": N}`
- [ ] `GET /api/v1/alerts/stream` returns `text/event-stream` with `: connected` comment
- [ ] `POST /api/v1/alerts/test/email` without `?email=` → 422
- [ ] Bad `alert_type` / `channels` → 422