### PR TITLE
feat(reports): customizable report filters and scheduling (#54)

### DIFF
--- a/src/api/routes/report_routes.py
+++ b/src/api/routes/report_routes.py
@@ -1,18 +1,22 @@
 """
-Report generation and scheduled delivery routes (Issues #51, #52).
+Report generation and scheduled delivery routes (Issues #51, #52, #54).
 
 GET  /api/v1/reports/generate              — on-demand report (json | csv | pdf)
+GET  /api/v1/reports/custom_report         — customisable report (entity, date_range, sentiment …)
 POST /api/v1/reports/subscribe             — create a scheduled email subscription
 GET  /api/v1/reports/subscriptions         — list subscriptions (?email=...)
 GET  /api/v1/reports/subscriptions/{id}    — single subscription + delivery stats
 DELETE /api/v1/reports/subscriptions/{id}  — unsubscribe
+POST /api/v1/reports/schedules             — create a custom scheduled report
+GET  /api/v1/reports/schedules             — list custom schedules (?email=...)
+DELETE /api/v1/reports/schedules/{id}      — delete a custom schedule
 POST /api/v1/reports/trigger/{frequency}   — manually fire weekly|monthly delivery
 GET  /api/v1/reports/track/open/{token}    — 1×1 tracking pixel (open event)
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
@@ -206,6 +210,248 @@ async def trigger_delivery(frequency: str) -> Dict[str, Any]:
         from src.reports.scheduler import trigger_now
         count = trigger_now(frequency)
         return {"status": "triggered", "frequency": frequency, "subscriptions_processed": count}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Open tracking pixel
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Custom report endpoint (issue #54)
+# ---------------------------------------------------------------------------
+
+_VALID_SENTIMENTS = {"positive", "negative", "neutral", "all"}
+_VALID_PERIODS_EXT = {"last_24_hours", "last_7_days", "last_30_days", "last_60_days", "last_90_days"}
+
+
+@router.get("/custom_report")
+async def custom_report(
+    entity: Optional[str] = Query(None, description="Primary entity/keyword (alias for keywords[0])"),
+    keywords: Optional[str] = Query(None, description="Comma-separated additional keywords"),
+    date_range: Optional[str] = Query(None, description="Preset: last_7_days | last_30_days | last_60_days | last_90_days | last_24_hours"),
+    date_from: Optional[str] = Query(None, description="ISO date start, e.g. 2026-01-01"),
+    date_to: Optional[str] = Query(None, description="ISO date end, e.g. 2026-06-30"),
+    sentiment: Optional[str] = Query(None, description="positive | negative | neutral | all"),
+    sentiment_min: Optional[float] = Query(None, ge=-1.0, le=1.0, description="Min sentiment score"),
+    sentiment_max: Optional[float] = Query(None, ge=-1.0, le=1.0, description="Max sentiment score"),
+    source: Optional[str] = Query(None, description="Filter by source name (ILIKE)"),
+    category: Optional[str] = Query(None, description="Filter by category (ILIKE)"),
+    format: str = Query("json", description="json | csv | pdf"),
+    limit: int = Query(200, ge=1, le=1000),
+    title: Optional[str] = Query(None, description="Custom report title"),
+) -> Any:
+    """
+    Fully customisable report with entity/keyword, date range, and sentiment filters.
+
+    Example: /api/v1/reports/custom_report?entity=Tesla&date_range=last_60_days&sentiment=negative
+    """
+    # Build keyword list
+    kw_list: List[str] = []
+    if entity:
+        kw_list.append(entity)
+    if keywords:
+        kw_list.extend([k.strip() for k in keywords.split(",") if k.strip()])
+    if not kw_list:
+        raise HTTPException(status_code=422, detail="Provide at least one of: entity, keywords")
+
+    if date_range and date_range not in _VALID_PERIODS_EXT:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid date_range. Valid: {sorted(_VALID_PERIODS_EXT)}",
+        )
+    if sentiment and sentiment not in _VALID_SENTIMENTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid sentiment. Valid: {sorted(_VALID_SENTIMENTS)}",
+        )
+    if format not in ("json", "csv", "pdf"):
+        raise HTTPException(status_code=422, detail="format must be json | csv | pdf")
+
+    try:
+        from src.reports.generate_report import (
+            CustomReportFilter, fetch_custom_report_data,
+            generate_custom_csv, generate_custom_pdf,
+        )
+
+        filt = CustomReportFilter(
+            keywords=kw_list,
+            period=date_range,
+            date_from=date_from,
+            date_to=date_to,
+            sentiment=sentiment if sentiment != "all" else None,
+            sentiment_min=sentiment_min,
+            sentiment_max=sentiment_max,
+            source=source,
+            category=category,
+            limit=limit,
+            report_title=title or "",
+        )
+
+        slug = "_".join(kw_list[:2]).lower().replace(" ", "_")
+
+        if format == "csv":
+            data = generate_custom_csv(filt)
+            filename = f"custom_report_{slug}.csv"
+            return Response(
+                content=data, media_type="text/csv",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+
+        if format == "pdf":
+            data = generate_custom_pdf(filt)
+            filename = f"custom_report_{slug}.pdf"
+            return Response(
+                content=data, media_type="application/pdf",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+
+        report = fetch_custom_report_data(filt)
+        return {
+            "topic": report.topic,
+            "period": report.period,
+            "generated_at": report.generated_at,
+            "filters_applied": {
+                "keywords": kw_list,
+                "date_range": date_range,
+                "date_from": date_from,
+                "date_to": date_to,
+                "sentiment": sentiment,
+                "sentiment_min": sentiment_min,
+                "sentiment_max": sentiment_max,
+                "source": source,
+                "category": category,
+                "limit": limit,
+            },
+            "stats": {
+                "total_articles": report.total_articles,
+                "avg_sentiment": report.avg_sentiment,
+                "positive_pct": report.positive_pct,
+                "negative_pct": report.negative_pct,
+                "neutral_pct": report.neutral_pct,
+                "top_sources": report.top_sources,
+            },
+            "articles": [
+                {
+                    "article_id": a.article_id,
+                    "title": a.title,
+                    "source": a.source,
+                    "category": a.category,
+                    "publish_date": a.publish_date,
+                    "sentiment_label": a.sentiment_label,
+                    "sentiment_score": a.sentiment_score,
+                    "url": a.url,
+                }
+                for a in report.articles
+            ],
+        }
+
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Custom report failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Custom schedule endpoints (issue #54)
+# ---------------------------------------------------------------------------
+
+_VALID_FREQUENCIES = {"weekly", "monthly"}
+_VALID_FORMATS = {"pdf", "csv"}
+
+
+class CustomScheduleRequest(BaseModel):
+    name: str
+    email: str
+    frequency: str = "weekly"
+    format: str = "pdf"
+    keywords: List[str]
+    date_range: Optional[str] = None
+    sentiment: Optional[str] = None
+    sentiment_min: Optional[float] = None
+    sentiment_max: Optional[float] = None
+    source: Optional[str] = None
+    category: Optional[str] = None
+    limit: int = 200
+
+    @field_validator("frequency")
+    @classmethod
+    def check_freq(cls, v: str) -> str:
+        if v not in _VALID_FREQUENCIES:
+            raise ValueError(f"frequency must be one of {sorted(_VALID_FREQUENCIES)}")
+        return v
+
+    @field_validator("format")
+    @classmethod
+    def check_fmt(cls, v: str) -> str:
+        if v not in _VALID_FORMATS:
+            raise ValueError(f"format must be one of {sorted(_VALID_FORMATS)}")
+        return v
+
+    @field_validator("keywords")
+    @classmethod
+    def check_keywords(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("At least one keyword required")
+        return v
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+CustomScheduleRequest.model_rebuild()
+
+
+@router.post("/schedules", status_code=201)
+async def create_schedule(body: CustomScheduleRequest) -> Dict[str, Any]:
+    """Create a custom scheduled report with filter configuration."""
+    try:
+        from src.reports.subscriptions import create_custom_schedule
+        filters = {
+            "keywords": body.keywords,
+            "period": body.date_range,
+            "sentiment": body.sentiment,
+            "sentiment_min": body.sentiment_min,
+            "sentiment_max": body.sentiment_max,
+            "source": body.source,
+            "category": body.category,
+            "limit": body.limit,
+        }
+        sched = create_custom_schedule(
+            name=body.name,
+            email=body.email,
+            frequency=body.frequency,
+            fmt=body.format,
+            filters=filters,
+        )
+        return {"status": "created", "schedule": sched}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/schedules")
+async def list_schedules(
+    email: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    """List custom report schedules."""
+    try:
+        from src.reports.subscriptions import list_custom_schedules
+        return {"schedules": list_custom_schedules(email)}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/schedules/{sched_id}")
+async def delete_schedule(sched_id: str) -> Dict[str, Any]:
+    """Delete a custom report schedule."""
+    try:
+        from src.reports.subscriptions import get_custom_schedule, delete_custom_schedule
+        if get_custom_schedule(sched_id) is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{sched_id}' not found")
+        delete_custom_schedule(sched_id)
+        return {"status": "deleted", "id": sched_id}
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/src/reports/generate_report.py
+++ b/src/reports/generate_report.py
@@ -16,7 +16,7 @@ import io
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import List
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +25,11 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _PERIOD_DAYS: dict[str, int] = {
+    "last_24_hours": 1,
     "last_7_days": 7,
     "last_30_days": 30,
+    "last_60_days": 60,
     "last_90_days": 90,
-    "last_24_hours": 1,
 }
 
 
@@ -182,18 +183,190 @@ def _latin1(text: str) -> str:
 
 def generate_pdf(topic: str, period: str) -> bytes:
     """Return PDF bytes for the report. Requires fpdf2."""
+    return _render_pdf(_fetch_report_data(topic, period))
+
+
+# ---------------------------------------------------------------------------
+# Custom filter report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CustomReportFilter:
+    """Full set of filter parameters for a customised report."""
+    keywords: List[str]                    # one or more keywords (OR-joined)
+    period: Optional[str] = None           # preset period name
+    date_from: Optional[str] = None        # ISO date, e.g. "2026-01-01"
+    date_to: Optional[str] = None          # ISO date, e.g. "2026-06-30"
+    sentiment: Optional[str] = None        # positive|negative|neutral|all
+    sentiment_min: Optional[float] = None  # e.g. -1.0
+    sentiment_max: Optional[float] = None  # e.g. 1.0
+    source: Optional[str] = None           # exact source name
+    category: Optional[str] = None        # exact category
+    limit: int = 200
+    report_title: str = ""
+
+
+def _resolve_date_range(f: CustomReportFilter):
+    """Return (cutoff_from, cutoff_to) naive datetimes."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    if f.date_from or f.date_to:
+        try:
+            dt_from = datetime.fromisoformat(f.date_from) if f.date_from else datetime(2000, 1, 1)
+            dt_to = datetime.fromisoformat(f.date_to) if f.date_to else now
+        except ValueError as exc:
+            raise ValueError(f"Invalid date format (use ISO 8601, e.g. 2026-01-01): {exc}") from exc
+        return dt_from, dt_to
+
+    period = f.period or "last_7_days"
+    days = _PERIOD_DAYS.get(period)
+    if days is None:
+        raise ValueError(f"Unknown period '{period}'. Supported: {sorted(_PERIOD_DAYS)}")
+    return now - timedelta(days=days), now
+
+
+def _build_custom_query(f: CustomReportFilter):
+    """Return (sql, params) for the custom filter."""
+    conditions: List[str] = []
+    params: List[object] = []
+
+    # Keywords — OR across title and category
+    if f.keywords:
+        kw_clauses = " OR ".join(
+            "(title ILIKE ? OR category ILIKE ?)" for _ in f.keywords
+        )
+        conditions.append(f"({kw_clauses})")
+        for kw in f.keywords:
+            params.extend([f"%{kw}%", f"%{kw}%"])
+
+    # Date range
+    dt_from, dt_to = _resolve_date_range(f)
+    conditions.append("publish_date >= ?")
+    params.append(dt_from)
+    conditions.append("publish_date <= ?")
+    params.append(dt_to)
+
+    # Sentiment label
+    if f.sentiment and f.sentiment != "all":
+        conditions.append("sentiment_label = ?")
+        params.append(f.sentiment)
+
+    # Sentiment score range
+    if f.sentiment_min is not None:
+        conditions.append("sentiment_score >= ?")
+        params.append(f.sentiment_min)
+    if f.sentiment_max is not None:
+        conditions.append("sentiment_score <= ?")
+        params.append(f.sentiment_max)
+
+    # Source / category exact match
+    if f.source:
+        conditions.append("source ILIKE ?")
+        params.append(f.source)
+    if f.category:
+        conditions.append("category ILIKE ?")
+        params.append(f.category)
+
+    where = " AND ".join(conditions) if conditions else "1=1"
+    sql = f"""
+        SELECT
+            id,
+            title,
+            COALESCE(url, '') AS url,
+            COALESCE(source, 'Unknown') AS source,
+            COALESCE(category, 'General') AS category,
+            STRFTIME(publish_date, '%Y-%m-%d %H:%M') AS publish_date,
+            COALESCE(sentiment_label, 'neutral') AS sentiment_label,
+            COALESCE(sentiment_score, 0.0) AS sentiment_score
+        FROM news_articles
+        WHERE {where}
+        ORDER BY publish_date DESC
+        LIMIT {int(f.limit)}
+    """
+    return sql, params
+
+
+def fetch_custom_report_data(f: CustomReportFilter) -> ReportData:
+    """Run a fully-filtered DuckDB query and return a ReportData."""
+    from src.database.local_analytics_connector import get_shared_connection, _LOCK
+
+    sql, params = _build_custom_query(f)
+    conn = get_shared_connection()
+    with _LOCK:
+        rows = conn.execute(sql, params).fetchall()
+
+    articles = [
+        ArticleRow(
+            article_id=r[0], title=r[1], url=r[2], source=r[3],
+            category=r[4], publish_date=r[5],
+            sentiment_label=r[6], sentiment_score=float(r[7]),
+        )
+        for r in rows
+    ]
+
+    total = len(articles)
+    avg_sent = sum(a.sentiment_score for a in articles) / total if total else 0.0
+    pos = sum(1 for a in articles if a.sentiment_label == "positive")
+    neg = sum(1 for a in articles if a.sentiment_label == "negative")
+    pct = lambda n: round(n / total * 100, 1) if total else 0.0
+    source_counts: dict[str, int] = {}
+    for a in articles:
+        source_counts[a.source] = source_counts.get(a.source, 0) + 1
+    top_sources = [s for s, _ in sorted(source_counts.items(), key=lambda x: -x[1])[:5]]
+
+    title = f.report_title or (", ".join(f.keywords[:3]) if f.keywords else "Custom Report")
+    period_label = f.period or (
+        f"{f.date_from or '...'} to {f.date_to or 'now'}"
+    )
+
+    return ReportData(
+        topic=title,
+        period=period_label,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        total_articles=total,
+        avg_sentiment=round(avg_sent, 4),
+        positive_pct=pct(pos),
+        negative_pct=pct(total - pos - (total - pos - neg)),
+        neutral_pct=pct(total - pos - neg),
+        top_sources=top_sources,
+        articles=articles,
+    )
+
+
+def generate_custom_csv(f: CustomReportFilter) -> bytes:
+    data = fetch_custom_report_data(f)
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow([
+        "article_id", "title", "source", "category",
+        "publish_date", "sentiment_label", "sentiment_score", "url",
+    ])
+    for a in data.articles:
+        writer.writerow([
+            a.article_id, a.title, a.source, a.category,
+            a.publish_date, a.sentiment_label, a.sentiment_score, a.url,
+        ])
+    return buf.getvalue().encode("utf-8")
+
+
+def generate_custom_pdf(f: CustomReportFilter) -> bytes:
+    """PDF using the same renderer as generate_pdf but from a CustomReportFilter."""
+    data = fetch_custom_report_data(f)
+    # Reuse the PDF renderer by temporarily aliasing the data
+    return _render_pdf(data)
+
+
+def _render_pdf(data: ReportData) -> bytes:
+    """Internal PDF renderer shared by generate_pdf and generate_custom_pdf."""
     try:
         from fpdf import FPDF
     except ImportError as exc:
         raise RuntimeError("fpdf2 is required: pip install fpdf2") from exc
 
-    data = _fetch_report_data(topic, period)
-
     pdf = FPDF()
     pdf.set_auto_page_break(auto=True, margin=14)
     pdf.add_page()
 
-    # Title block
     pdf.set_font("Helvetica", "B", 18)
     pdf.cell(0, 10, _latin1(f"Noesis Report: {data.topic}"), ln=True)
     pdf.set_font("Helvetica", "", 10)
@@ -205,11 +378,9 @@ def generate_pdf(topic: str, period: str) -> bytes:
     pdf.line(10, pdf.get_y(), 200, pdf.get_y())
     pdf.ln(5)
 
-    # Summary stats
     pdf.set_text_color(0, 0, 0)
     pdf.set_font("Helvetica", "B", 12)
     pdf.cell(0, 8, "Summary", ln=True)
-    pdf.set_font("Helvetica", "", 10)
 
     stats = [
         ("Total articles", str(data.total_articles)),
@@ -230,7 +401,6 @@ def generate_pdf(topic: str, period: str) -> bytes:
     pdf.line(10, pdf.get_y(), 200, pdf.get_y())
     pdf.ln(5)
 
-    # Article listing
     pdf.set_font("Helvetica", "B", 12)
     pdf.cell(0, 8, f"Articles ({data.total_articles})", ln=True)
     pdf.ln(2)
@@ -252,8 +422,8 @@ def generate_pdf(topic: str, period: str) -> bytes:
 
         pdf.set_text_color(0, 0, 0)
         pdf.set_font("Helvetica", "", 9)
-        title = a.title if len(a.title) <= 90 else a.title[:87] + "..."
-        pdf.cell(0, 6, _latin1(title), ln=True)
+        title_text = a.title if len(a.title) <= 90 else a.title[:87] + "..."
+        pdf.cell(0, 6, _latin1(title_text), ln=True)
 
         pdf.set_text_color(140, 140, 140)
         pdf.set_font("Helvetica", "", 8)

--- a/src/reports/scheduler.py
+++ b/src/reports/scheduler.py
@@ -55,10 +55,12 @@ def _deliver_subscriptions(frequency: str) -> None:
 
 def _weekly_job() -> None:
     _deliver_subscriptions("weekly")
+    _deliver_custom_schedules("weekly")
 
 
 def _monthly_job() -> None:
     _deliver_subscriptions("monthly")
+    _deliver_custom_schedules("monthly")
 
 
 def start_scheduler() -> None:
@@ -98,9 +100,62 @@ def stop_scheduler() -> None:
     logger.info("Report scheduler stopped")
 
 
+def _deliver_custom_schedules(frequency: str) -> None:
+    """Generate and email custom-filter scheduled reports."""
+    from src.reports.subscriptions import list_custom_schedules, mark_custom_sent
+    from src.reports.email_sender import send_report_email
+    from src.reports.generate_report import (
+        CustomReportFilter, generate_custom_pdf, generate_custom_csv,
+    )
+
+    schedules = [s for s in list_custom_schedules() if s["frequency"] == frequency]
+    logger.info("Custom scheduler: %d schedules for frequency=%s", len(schedules), frequency)
+
+    for sched in schedules:
+        try:
+            f_dict = sched["filters"]
+            filt = CustomReportFilter(
+                keywords=f_dict.get("keywords", [sched.get("name", "report")]),
+                period=f_dict.get("period"),
+                date_from=f_dict.get("date_from"),
+                date_to=f_dict.get("date_to"),
+                sentiment=f_dict.get("sentiment"),
+                sentiment_min=f_dict.get("sentiment_min"),
+                sentiment_max=f_dict.get("sentiment_max"),
+                source=f_dict.get("source"),
+                category=f_dict.get("category"),
+                limit=f_dict.get("limit", 200),
+                report_title=sched["name"],
+            )
+            fmt = sched["format"]
+            report_bytes = generate_custom_pdf(filt) if fmt == "pdf" else generate_custom_csv(filt)
+
+            # Reuse the report subscription token mechanism
+            from src.reports.subscriptions import mark_sent, create_subscription, delete_subscription
+            # Create ephemeral subscription entry just to get a tracking token
+            tmp = create_subscription(sched["email"], sched["name"], frequency, fmt)
+            token = mark_sent(tmp["id"])
+            delete_subscription(tmp["id"])
+
+            send_report_email(
+                to=sched["email"],
+                topic=sched["name"],
+                period=filt.period or "custom",
+                frequency=frequency,
+                fmt=fmt,
+                report_bytes=report_bytes,
+                tracking_token=token,
+            )
+            mark_custom_sent(sched["id"])
+        except Exception:
+            logger.exception("Failed to deliver custom report to %s (id=%s)", sched["email"], sched["id"])
+
+
 def trigger_now(frequency: str) -> int:
     """Manually fire a delivery run (for testing). Returns subscription count processed."""
-    from src.reports.subscriptions import list_subscriptions
+    from src.reports.subscriptions import list_subscriptions, list_custom_schedules
     subs = [s for s in list_subscriptions() if s["frequency"] == frequency]
+    custom = [s for s in list_custom_schedules() if s["frequency"] == frequency]
     _deliver_subscriptions(frequency)
-    return len(subs)
+    _deliver_custom_schedules(frequency)
+    return len(subs) + len(custom)

--- a/src/reports/subscriptions.py
+++ b/src/reports/subscriptions.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, List, Optional
 
 from src.database.local_analytics_connector import get_shared_connection, _LOCK
 
+import json
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS report_subscriptions (
     id          VARCHAR PRIMARY KEY,
@@ -182,6 +184,125 @@ def _row_to_dict(id, email, topic, frequency, fmt, created_at, last_sent) -> Dic
         "topic": topic,
         "frequency": frequency,
         "format": fmt,
+        "created_at": str(created_at),
+        "last_sent": str(last_sent) if last_sent else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Custom report schedules (issue #54)
+# ---------------------------------------------------------------------------
+
+_CUSTOM_SCHEMA = """
+CREATE TABLE IF NOT EXISTS custom_report_schedules (
+    id           VARCHAR PRIMARY KEY,
+    name         VARCHAR NOT NULL,
+    email        VARCHAR NOT NULL,
+    frequency    VARCHAR NOT NULL,
+    format       VARCHAR NOT NULL,
+    filters_json VARCHAR NOT NULL,
+    created_at   TIMESTAMP NOT NULL,
+    last_sent    TIMESTAMP
+);
+"""
+
+_custom_schema_done = False
+_custom_schema_lock = threading.Lock()
+
+
+def _init_custom() -> None:
+    global _custom_schema_done
+    if _custom_schema_done:
+        return
+    with _custom_schema_lock:
+        if not _custom_schema_done:
+            conn = get_shared_connection()
+            with _LOCK:
+                conn.execute(_CUSTOM_SCHEMA)
+            _custom_schema_done = True
+
+
+def create_custom_schedule(
+    name: str,
+    email: str,
+    frequency: str,
+    fmt: str,
+    filters: Dict[str, Any],
+) -> Dict[str, Any]:
+    _init_custom()
+    sched_id = secrets.token_hex(8)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    filters_json = json.dumps(filters)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            """INSERT INTO custom_report_schedules
+               (id, name, email, frequency, format, filters_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            [sched_id, name, email, frequency, fmt, filters_json, now],
+        )
+    return _custom_row(sched_id, name, email, frequency, fmt, filters_json, now, None)
+
+
+def list_custom_schedules(email: Optional[str] = None) -> List[Dict[str, Any]]:
+    _init_custom()
+    conn = get_shared_connection()
+    if email:
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT id,name,email,frequency,format,filters_json,created_at,last_sent"
+                " FROM custom_report_schedules WHERE email=? ORDER BY created_at DESC",
+                [email],
+            ).fetchall()
+    else:
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT id,name,email,frequency,format,filters_json,created_at,last_sent"
+                " FROM custom_report_schedules ORDER BY created_at DESC"
+            ).fetchall()
+    return [_custom_row(*r) for r in rows]
+
+
+def get_custom_schedule(sched_id: str) -> Optional[Dict[str, Any]]:
+    _init_custom()
+    conn = get_shared_connection()
+    with _LOCK:
+        row = conn.execute(
+            "SELECT id,name,email,frequency,format,filters_json,created_at,last_sent"
+            " FROM custom_report_schedules WHERE id=?",
+            [sched_id],
+        ).fetchone()
+    if not row:
+        return None
+    return _custom_row(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7])
+
+
+def delete_custom_schedule(sched_id: str) -> None:
+    _init_custom()
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute("DELETE FROM custom_report_schedules WHERE id=?", [sched_id])
+
+
+def mark_custom_sent(sched_id: str) -> None:
+    _init_custom()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = get_shared_connection()
+    with _LOCK:
+        conn.execute(
+            "UPDATE custom_report_schedules SET last_sent=? WHERE id=?",
+            [now, sched_id],
+        )
+
+
+def _custom_row(id, name, email, frequency, fmt, filters_json, created_at, last_sent) -> Dict[str, Any]:
+    return {
+        "id": id,
+        "name": name,
+        "email": email,
+        "frequency": frequency,
+        "format": fmt,
+        "filters": json.loads(filters_json) if filters_json else {},
         "created_at": str(created_at),
         "last_sent": str(last_sent) if last_sent else None,
     }


### PR DESCRIPTION
## Summary

- **`GET /api/v1/reports/custom_report`** — on-demand report with full filter set: `entity`, `keywords` (comma-separated, OR-joined), `date_range` preset OR explicit `date_from`/`date_to`, `sentiment` label, `sentiment_min`/`sentiment_max` score range, `source`, `category`, `format` (json|csv|pdf), `limit`
- **`POST/GET/DELETE /api/v1/reports/schedules`** — persist custom filter configs as weekly/monthly delivery schedules; integrated into the APScheduler cron jobs alongside the existing subscription scheduler
- Shared `_render_pdf()` renderer (no duplication between `generate_pdf` and `generate_custom_pdf`); `_build_custom_query()` assembles parameterised DuckDB WHERE clauses dynamically
- `custom_report_schedules` DuckDB table with CRUD helpers in `subscriptions.py`

## Test plan

- [ ] `GET /api/v1/reports/custom_report?entity=Tesla&date_range=last_60_days` returns JSON with `stats` and `articles`
- [ ] `?format=csv` returns CSV attachment, `?format=pdf` returns PDF attachment
- [ ] Missing `entity` and `keywords` → 422
- [ ] Unknown `date_range` or `sentiment` value → 422
- [ ] `POST /api/v1/reports/schedules` with valid body → 201 with schedule id
- [ ] `GET /api/v1/reports/schedules` lists created schedules
- [ ] `DELETE /api/v1/reports/schedules/{id}` removes schedule; DELETE of unknown id → 404
- [ ] `POST /api/v1/reports/trigger/weekly` fires both regular subscriptions and custom schedules

Closes #54