### PR TITLE
feat(web): Argument Mining panel (#91)

### DIFF
--- a/apps/web/.claude/skills/run-web/driver.mjs
+++ b/apps/web/.claude/skills/run-web/driver.mjs
@@ -89,6 +89,7 @@ const VIEWS = [
   ["Workspaces", "workspaces"],
   ["Watchlists", "watchlists"],
   ["Story Timeline", "timeline"],
+  ["Arguments", "arguments"],
 ];
 
 function parseArgs(argv) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import Trending from "./views/Trending";
 import Workspaces from "./views/Workspaces";
 import Watchlists from "./views/Watchlists";
 import Timeline from "./views/Timeline";
+import Arguments from "./views/Arguments";
 
 export default function App() {
   const [view, setView] = useState<ViewKey>("dashboard");
@@ -48,6 +49,7 @@ export default function App() {
           {view === "workspaces" && <Workspaces />}
           {view === "watchlists" && <Watchlists />}
           {view === "timeline" && <Timeline />}
+          {view === "arguments" && <Arguments />}
         </main>
       </div>
     </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -19,7 +19,8 @@ const coreNav: NavDef[] = [
 ];
 
 const researchNav: NavDef[] = [
-  { key: "workspaces", label: "Workspaces", glyph: "◳", badge: "4" },
+  { key: "workspaces",  label: "Workspaces",       glyph: "◳", badge: "4" },
+  { key: "arguments",   label: "Arguments",         glyph: "◫" },
 ];
 
 const newsOnlyNav: NavDef[] = [

--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -14,6 +14,11 @@ import type {
   Story,
   TimelineEvent,
   KnowledgeDocument,
+  ClaimResult,
+  StanceSummary,
+  FrameDistribution,
+  ActorPosition,
+  ConflictPair,
 } from "../types";
 
 const NOW = Date.now();
@@ -242,3 +247,69 @@ export const mockTopicSentiment: TopicSentiment[] = [
 
 export const mockTickerText =
   "  ●  Fed signals rate pause as core PCE eases  ●  Nvidia Blackwell Ultra claims 4x inference gain  ●  EU opens cloud antitrust probe  ●  Fusion experiment sustains net energy gain  ●  Oil slips below $74 on OPEC+ uncertainty  ●  Alzheimer’s drug clears late-stage trial  ";
+
+// ─── Argument Mining ─────────────────────────────────────────────────────────
+
+export const mockClaims: ClaimResult[] = [
+  { document_id: "doc-news-001", source_type: "news", title: "Federal Reserve signals pause on rate hikes", text: "The unemployment rate fell to 3.8% in March, the lowest level in two decades.", is_claim: true, confidence: 0.85, factcheck_verdict: "verified" },
+  { document_id: "doc-news-001", source_type: "news", title: "Federal Reserve signals pause on rate hikes", text: "Critics argue the government has not done enough to address the cost-of-living crisis.", is_claim: false, confidence: 0.72, factcheck_verdict: null },
+  { document_id: "doc-news-002", source_type: "news", title: "Nvidia Blackwell Ultra claims 4× inference gain", text: "Blackwell Ultra delivers 4× the inference throughput of its predecessor at equal power.", is_claim: true, confidence: 0.91, factcheck_verdict: "disputed" },
+  { document_id: "doc-blog-001", source_type: "blog", title: "Platform Changes Impact Analysis", text: "Engagement dropped 37% after the platform update.", is_claim: true, confidence: 0.78, factcheck_verdict: "disputed" },
+  { document_id: "doc-blog-001", source_type: "blog", title: "Platform Changes Impact Analysis", text: "The library added async support in version 3.2, released on 4 April 2024.", is_claim: true, confidence: 0.91, factcheck_verdict: "verified" },
+  { document_id: "doc-paper-001", source_type: "paper", title: "Sleep Duration and Cognitive Performance", text: "A statistically significant correlation between sleep duration and cognitive performance (r = 0.74, p < 0.001).", is_claim: true, confidence: 0.94, factcheck_verdict: "verified" },
+  { document_id: "doc-paper-001", source_type: "paper", title: "Sleep Duration and Cognitive Performance", text: "The cohort comprised 3,247 participants aged 18–65 recruited across six clinical sites.", is_claim: true, confidence: 0.88, factcheck_verdict: "unverified" },
+  { document_id: "doc-transcript-001", source_type: "transcript", title: "Q3 2026 Earnings Call", text: "We reported a 30% reduction in operating costs across all four divisions.", is_claim: true, confidence: 0.82, factcheck_verdict: "disputed" },
+  { document_id: "doc-transcript-001", source_type: "transcript", title: "Q3 2026 Earnings Call", text: "The committee chair confirmed the vote passed by nine votes to three.", is_claim: true, confidence: 0.89, factcheck_verdict: "verified" },
+  { document_id: "doc-book-001", source_type: "book", title: "The Long Siege: A History", text: "By 1943 the city had lost more than a third of its pre-war population to evacuation.", is_claim: true, confidence: 0.77, factcheck_verdict: "unverified" },
+  { document_id: "doc-book-001", source_type: "book", title: "The Long Siege: A History", text: "The treaty signed on 11 June 1919 transferred sovereignty over the territory to the new republic.", is_claim: true, confidence: 0.83, factcheck_verdict: "verified" },
+  { document_id: "doc-note-001", source_type: "note", title: "Project Alpha Status Note", text: "Board approved budget of $2.4M on 14 June; finance confirmed transfer completed same day.", is_claim: true, confidence: 0.76, factcheck_verdict: null },
+  { document_id: "doc-note-001", source_type: "note", title: "Project Alpha Status Note", text: "Security audit completed 10 June — 3 critical findings, all remediated by 12 June.", is_claim: true, confidence: 0.81, factcheck_verdict: null },
+];
+
+export const mockStance: StanceSummary[] = [
+  { topic: "Interest Rate Policy",       supportive: 24, critical: 31, neutral: 18, ambiguous: 7,  total: 80, drift: [0.3, 0.28, 0.35, 0.38, 0.31, 0.29, 0.32], by_source: { news: { supportive: 12, critical: 18, neutral: 8,  ambiguous: 3 }, blog: { supportive: 6, critical: 7, neutral: 5, ambiguous: 2 }, paper: { supportive: 4, critical: 4, neutral: 3, ambiguous: 1 }, transcript: { supportive: 2, critical: 2, neutral: 2, ambiguous: 1 } } },
+  { topic: "AI Regulation",              supportive: 38, critical: 19, neutral: 27, ambiguous: 12, total: 96, drift: [0.4, 0.42, 0.38, 0.44, 0.46, 0.41, 0.43], by_source: { news: { supportive: 18, critical: 9, neutral: 12, ambiguous: 5 }, blog: { supportive: 12, critical: 6, neutral: 8,  ambiguous: 4 }, paper: { supportive: 5, critical: 3, neutral: 5, ambiguous: 2 }, transcript: { supportive: 3, critical: 1, neutral: 2, ambiguous: 1 } } },
+  { topic: "Climate Policy",             supportive: 41, critical: 22, neutral: 14, ambiguous: 8,  total: 85, drift: [0.45, 0.48, 0.5, 0.47, 0.52, 0.49, 0.51], by_source: { news: { supportive: 20, critical: 11, neutral: 7,  ambiguous: 4 }, blog: { supportive: 10, critical: 5, neutral: 4,  ambiguous: 2 }, paper: { supportive: 8, critical: 4, neutral: 2, ambiguous: 1 }, transcript: { supportive: 3, critical: 2, neutral: 1, ambiguous: 1 } } },
+  { topic: "Healthcare Reform",          supportive: 29, critical: 34, neutral: 22, ambiguous: 10, total: 95, drift: [0.31, 0.29, 0.32, 0.27, 0.3, 0.28, 0.29], by_source: { news: { supportive: 14, critical: 17, neutral: 10, ambiguous: 5 }, blog: { supportive: 8, critical: 9, neutral: 6,  ambiguous: 3 }, paper: { supportive: 5, critical: 5, neutral: 4, ambiguous: 1 }, transcript: { supportive: 2, critical: 3, neutral: 2, ambiguous: 1 } } },
+  { topic: "Trade Tariffs",              supportive: 15, critical: 48, neutral: 19, ambiguous: 6,  total: 88, drift: [0.17, 0.19, 0.16, 0.14, 0.18, 0.15, 0.16], by_source: { news: { supportive: 7, critical: 24, neutral: 9,  ambiguous: 3 }, blog: { supportive: 4, critical: 12, neutral: 5,  ambiguous: 2 }, paper: { supportive: 2, critical: 8, neutral: 3, ambiguous: 0 }, transcript: { supportive: 2, critical: 4, neutral: 2, ambiguous: 1 } } },
+  { topic: "Central Bank Independence",  supportive: 33, critical: 12, neutral: 28, ambiguous: 5,  total: 78, drift: [0.42, 0.41, 0.44, 0.43, 0.45, 0.42, 0.44], by_source: { news: { supportive: 16, critical: 6, neutral: 14, ambiguous: 2 }, blog: { supportive: 9, critical: 3, neutral: 8,  ambiguous: 2 }, paper: { supportive: 6, critical: 2, neutral: 4, ambiguous: 1 }, transcript: { supportive: 2, critical: 1, neutral: 2, ambiguous: 0 } } },
+];
+
+export const mockFrameDistribution: FrameDistribution = {
+  distribution: { economic: 0.42, political: 0.35, security: 0.28, scientific: 0.22, humanitarian: 0.18, legal: 0.15, other: 0.08 },
+  dominant: "economic",
+  total_documents: 47,
+  source_type_filter: null,
+  source: "demo",
+};
+
+export const mockFramesBySourceType: Record<string, Record<string, number>> = {
+  news:       { economic: 0.58, political: 0.44, security: 0.32, scientific: 0.18, humanitarian: 0.21, legal: 0.19, other: 0.06 },
+  blog:       { economic: 0.28, political: 0.22, security: 0.14, scientific: 0.34, humanitarian: 0.12, legal: 0.08, other: 0.22 },
+  paper:      { economic: 0.15, political: 0.08, security: 0.10, scientific: 0.72, humanitarian: 0.18, legal: 0.12, other: 0.05 },
+  transcript: { economic: 0.48, political: 0.52, security: 0.24, scientific: 0.16, humanitarian: 0.20, legal: 0.22, other: 0.10 },
+  book:       { economic: 0.32, political: 0.38, security: 0.44, scientific: 0.12, humanitarian: 0.36, legal: 0.28, other: 0.14 },
+  note:       { economic: 0.38, political: 0.18, security: 0.24, scientific: 0.20, humanitarian: 0.10, legal: 0.34, other: 0.16 },
+};
+
+export const mockPositions: ActorPosition[] = [
+  { actor: "Federal Reserve",  topic: "Interest Rate Policy",   position: "Hold at 5.25%; monitor inflation before cutting",  stance: "neutral",  date: "2026-06-20", source_type: "news",       document_id: "doc-news-001" },
+  { actor: "IMF",              topic: "Interest Rate Policy",   position: "Advocates gradual cuts to prevent recession",       stance: "for",      date: "2026-06-18", source_type: "paper",      document_id: "doc-paper-002" },
+  { actor: "Goldman Sachs",    topic: "Interest Rate Policy",   position: "Expects two cuts in H2; overweight equities",       stance: "for",      date: "2026-06-15", source_type: "transcript", document_id: "doc-transcript-001" },
+  { actor: "Senator Warren",   topic: "Interest Rate Policy",   position: "Criticises Fed; calls for political oversight",     stance: "against",  date: "2026-06-12", source_type: "news",       document_id: "doc-news-003" },
+  { actor: "BIS",              topic: "Interest Rate Policy",   position: "Warns premature cuts risk wage-price spiral",       stance: "against",  date: "2026-06-10", source_type: "paper",      document_id: "doc-paper-003" },
+  { actor: "ECB",              topic: "Interest Rate Policy",   position: "Diverging from Fed; began cutting cycle in June",   stance: "for",      date: "2026-06-08", source_type: "news",       document_id: "doc-news-004" },
+  { actor: "EU Commission",    topic: "AI Regulation",          position: "Mandatory risk assessment for frontier models",     stance: "for",      date: "2026-06-19", source_type: "news",       document_id: "doc-news-005" },
+  { actor: "Tech Industry",    topic: "AI Regulation",          position: "Self-regulation preferred; opposes hard limits",    stance: "against",  date: "2026-06-17", source_type: "blog",       document_id: "doc-blog-002" },
+  { actor: "UN AI Advisory",   topic: "AI Regulation",          position: "International treaty with binding safety norms",    stance: "for",      date: "2026-06-14", source_type: "paper",      document_id: "doc-paper-004" },
+];
+
+export const mockConflicts: ConflictPair[] = [
+  { actor_a: "Federal Reserve",  actor_b: "Senator Warren",   topic: "Interest Rate Policy",      intensity: 0.78, source_count: 14 },
+  { actor_a: "Tech Industry",    actor_b: "EU Commission",    topic: "AI Regulation",              intensity: 0.91, source_count: 23 },
+  { actor_a: "OPEC",             actor_b: "US Energy Dept",   topic: "Oil Production",             intensity: 0.64, source_count: 11 },
+  { actor_a: "China",            actor_b: "WTO",              topic: "Trade Tariffs",              intensity: 0.83, source_count: 19 },
+  { actor_a: "US Treasury",      actor_b: "IMF",              topic: "Dollar Strength",            intensity: 0.52, source_count: 8  },
+  { actor_a: "WHO",              actor_b: "Pharma Industry",  topic: "Drug Pricing",               intensity: 0.47, source_count: 7  },
+  { actor_a: "BIS",              actor_b: "Goldman Sachs",    topic: "Central Bank Independence",  intensity: 0.61, source_count: 9  },
+];

--- a/apps/web/src/lib/adapters.ts
+++ b/apps/web/src/lib/adapters.ts
@@ -11,6 +11,7 @@ import type {
   TopicSentiment,
   LiveGraph,
   Heatmap,
+  FrameDistribution,
 } from "../types";
 import type {
   RawArticle,
@@ -21,6 +22,7 @@ import type {
   RawTopicSentiment,
   RawEntityGraph,
   RawHeatmap,
+  RawFrameDistribution,
 } from "./api";
 import type { KnowledgeDocument, SourceType } from "../types";
 
@@ -140,6 +142,16 @@ export function adaptDocuments(raw: RawDocument[]): KnowledgeDocument[] {
     authors: d.authors ?? [],
     metadata: d.metadata ?? {},
   }));
+}
+
+export function adaptFrameDistribution(raw: RawFrameDistribution): FrameDistribution {
+  return {
+    distribution: raw.distribution ?? {},
+    dominant: raw.dominant ?? "other",
+    total_documents: raw.total_documents ?? 0,
+    source_type_filter: raw.source_type_filter ?? null,
+    source: raw.source ?? "live",
+  };
 }
 
 export function adaptInfluencers(raw: RawInfluencer[]): TopEntity[] {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -162,6 +162,14 @@ export interface RawHeatmap {
   seed: number[][];
 }
 
+export interface RawFrameDistribution {
+  distribution: Record<string, number>;
+  dominant: string;
+  total_documents: number;
+  source_type_filter: string | null;
+  source: string;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -199,4 +207,7 @@ export const api = {
     request<RawDocument[]>("/api/v1/documents", params),
 
   packStatus: () => request<RawHealth>("/"),
+
+  argumentFrames: (params?: { source_type?: string; document_id?: string; limit?: number }) =>
+    request<RawFrameDistribution>("/api/v1/arguments/frames", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -13,6 +13,7 @@ import {
   adaptEntityGraph,
   adaptHeatmap,
   adaptDocuments,
+  adaptFrameDistribution,
 } from "./adapters";
 import {
   mockArticles,
@@ -22,6 +23,9 @@ import {
   mockTickerText,
   mockTopicSentiment,
   mockHeatmap,
+  mockClaims,
+  mockStance,
+  mockFrameDistribution,
 } from "../data/mock";
 import { palette, ACCENT } from "../theme";
 import type {
@@ -33,6 +37,9 @@ import type {
   TopicSentiment,
   LiveGraph,
   Heatmap,
+  ClaimResult,
+  StanceSummary,
+  FrameDistribution,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -226,5 +233,41 @@ export function useTicker(): Result<string> {
       return `  ●${text}  `;
     },
     mockTickerText,
+  );
+}
+
+// ─── Argument Mining ─────────────────────────────────────────────────────────
+
+export function useArgumentClaims(): Result<ClaimResult[]> {
+  return useWithFallback(
+    "argumentClaims",
+    async (): Promise<ClaimResult[]> => {
+      throw new Error("endpoint pending #95");
+    },
+    mockClaims,
+  );
+}
+
+export function useArgumentStance(): Result<StanceSummary[]> {
+  return useWithFallback(
+    "argumentStance",
+    async (): Promise<StanceSummary[]> => {
+      throw new Error("endpoint pending #95");
+    },
+    mockStance,
+  );
+}
+
+export function useArgumentFrames(sourceType?: string): Result<FrameDistribution> {
+  return useWithFallback(
+    `argumentFrames-${sourceType ?? "all"}`,
+    async () => {
+      const raw = await api.argumentFrames(sourceType ? { source_type: sourceType } : undefined);
+      if (!raw.distribution || Object.keys(raw.distribution).length === 0) throw new Error("empty");
+      return adaptFrameDistribution(raw);
+    },
+    sourceType && sourceType !== "all"
+      ? { ...mockFrameDistribution, distribution: mockFrameDistribution.distribution, source_type_filter: sourceType }
+      : mockFrameDistribution,
   );
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -161,7 +161,57 @@ export type ViewKey =
   | "trending"
   | "workspaces"
   | "watchlists"
-  | "timeline";
+  | "timeline"
+  | "arguments";
+
+export type ArgumentTab = "claims" | "stance" | "frames" | "positions" | "controversy";
+
+export interface ClaimResult {
+  document_id: string;
+  source_type: SourceType;
+  text: string;
+  is_claim: boolean;
+  confidence: number;
+  factcheck_verdict: "verified" | "disputed" | "unverified" | null;
+  title: string;
+}
+
+export interface StanceSummary {
+  topic: string;
+  supportive: number;
+  critical: number;
+  neutral: number;
+  ambiguous: number;
+  total: number;
+  by_source: Partial<Record<SourceType, { supportive: number; critical: number; neutral: number; ambiguous: number }>>;
+  drift: number[];
+}
+
+export interface FrameDistribution {
+  distribution: Record<string, number>;
+  dominant: string;
+  total_documents: number;
+  source_type_filter: string | null;
+  source: string;
+}
+
+export interface ActorPosition {
+  actor: string;
+  position: string;
+  stance: "for" | "against" | "neutral";
+  date: string;
+  source_type: SourceType;
+  document_id: string;
+  topic: string;
+}
+
+export interface ConflictPair {
+  actor_a: string;
+  actor_b: string;
+  topic: string;
+  intensity: number;
+  source_count: number;
+}
 
 export type SourceType = "news" | "blog" | "paper" | "book" | "transcript" | "web" | "note";
 

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,0 +1,582 @@
+import { useState, useEffect } from "react";
+import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames } from "../lib/queries";
+import { mockFramesBySourceType, mockPositions, mockConflicts } from "../data/mock";
+import PageHeader from "../components/PageHeader";
+import SourceBadge from "../components/SourceBadge";
+import Sparkline from "../components/charts/Sparkline";
+import type { ArgumentTab, SourceType, StanceSummary } from "../types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SOURCE_TYPES: Array<{ key: string; label: string }> = [
+  { key: "all",        label: "All" },
+  { key: "news",       label: "News" },
+  { key: "blog",       label: "Blog" },
+  { key: "paper",      label: "Paper" },
+  { key: "transcript", label: "Transcript" },
+  { key: "book",       label: "Book" },
+  { key: "note",       label: "Note" },
+];
+
+const TABS: Array<{ key: ArgumentTab; label: string; glyph: string }> = [
+  { key: "claims",      label: "Claims",      glyph: "◈" },
+  { key: "stance",      label: "Stance",      glyph: "◑" },
+  { key: "frames",      label: "Frames",      glyph: "⬡" },
+  { key: "positions",   label: "Positions",   glyph: "⤳" },
+  { key: "controversy", label: "Controversy", glyph: "⊗" },
+];
+
+const FRAME_LABELS = ["economic", "security", "humanitarian", "legal", "political", "scientific", "other"];
+
+const FRAME_COLORS: Record<string, string> = {
+  economic:     palette.pos,
+  security:     palette.neg,
+  humanitarian: palette.amber,
+  legal:        palette.teal,
+  political:    palette.violet,
+  scientific:   palette.blue,
+  other:        palette.dim,
+};
+
+const STANCE_COLORS = {
+  supportive: palette.pos,
+  critical:   palette.neg,
+  neutral:    palette.neu,
+  ambiguous:  palette.amber,
+};
+
+const VERDICT_COLORS: Record<string, string> = {
+  verified:   palette.pos,
+  disputed:   palette.neg,
+  unverified: palette.amber,
+};
+
+const POSITION_COLORS: Record<string, string> = { for: palette.pos, against: palette.neg, neutral: palette.neu };
+
+// ─── Shared style tokens ─────────────────────────────────────────────────────
+
+const card = { background: colors.card, border: `1px solid ${colors.border}`, borderRadius: 10 } as const;
+const mono10 = { fontFamily: fonts.mono, fontSize: 10, color: palette.dim, letterSpacing: "0.1em", textTransform: "uppercase" as const };
+
+// ─── URL param helpers ────────────────────────────────────────────────────────
+
+function readParam(key: string): string | null {
+  return new URLSearchParams(window.location.search).get(key);
+}
+
+function setParam(key: string, value: string) {
+  const p = new URLSearchParams(window.location.search);
+  p.set(key, value);
+  history.pushState({}, "", `?${p}`);
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function FilterPills({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+      {SOURCE_TYPES.map(({ key, label }) => {
+        const active = value === key;
+        return (
+          <button
+            key={key}
+            onClick={() => onChange(key)}
+            style={{
+              fontFamily: fonts.mono,
+              fontSize: 10.5,
+              padding: "3px 10px",
+              borderRadius: 6,
+              border: active ? `1px solid ${accentBorder(ACCENT)}` : `1px solid ${colors.border2}`,
+              background: active ? accentSoft(ACCENT) : "transparent",
+              color: active ? ACCENT : palette.dim,
+              cursor: "pointer",
+              letterSpacing: "0.06em",
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function TabBar({ active, onChange }: { active: ArgumentTab; onChange: (t: ArgumentTab) => void }) {
+  return (
+    <div style={{ display: "flex", gap: 2, borderBottom: `1px solid ${colors.border}`, marginBottom: 16 }}>
+      {TABS.map(({ key, label, glyph }) => {
+        const isActive = active === key;
+        return (
+          <button
+            key={key}
+            onClick={() => onChange(key)}
+            style={{
+              fontFamily: fonts.sans,
+              fontSize: 13,
+              fontWeight: 500,
+              padding: "9px 14px",
+              border: "none",
+              borderBottom: isActive ? `2px solid ${ACCENT}` : "2px solid transparent",
+              background: "transparent",
+              color: isActive ? ACCENT : palette.dim,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              marginBottom: -1,
+              transition: "color .12s",
+            }}
+          >
+            <span style={{ fontSize: 12 }}>{glyph}</span>
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Claims panel ─────────────────────────────────────────────────────────────
+
+function ClaimsPanel({ sourceType }: { sourceType: string }) {
+  const { data: claims, source, isLoading } = useArgumentClaims();
+  const filtered = sourceType === "all" ? claims : claims.filter((c) => c.source_type === sourceType);
+  const claimsOnly = filtered.filter((c) => c.is_claim);
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+        <div>
+          <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Detected Claims</span>
+          <span style={{ ...mono10, marginLeft: 10, fontFamily: fonts.mono, fontSize: 10 }}>{claimsOnly.length} of {filtered.length} sentences</span>
+        </div>
+        <SourceBadge source={source} isLoading={isLoading} />
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {filtered.map((c, i) => {
+          const verdict = c.factcheck_verdict;
+          const verdictColor = verdict ? VERDICT_COLORS[verdict] : palette.faint;
+          return (
+            <div
+              key={`${c.document_id}-${i}`}
+              style={{
+                ...card,
+                padding: "12px 16px",
+                borderLeft: `3px solid ${c.is_claim ? palette.blue : colors.border2}`,
+                opacity: c.is_claim ? 1 : 0.6,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500, color: colors.text, lineHeight: 1.5 }}>{c.text}</div>
+                  <div style={{ marginTop: 6, fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint }}>{c.title}</div>
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 6, flexShrink: 0 }}>
+                  <span style={{
+                    fontFamily: fonts.mono, fontSize: 9.5, fontWeight: 700, letterSpacing: "0.1em",
+                    color: c.is_claim ? palette.blue : palette.faint,
+                    background: `${c.is_claim ? palette.blue : palette.faint}18`,
+                    border: `1px solid ${c.is_claim ? palette.blue : palette.faint}40`,
+                    borderRadius: 5, padding: "2px 7px",
+                  }}>
+                    {c.is_claim ? "CLAIM" : "NON-CLAIM"}
+                  </span>
+
+                  <span style={{
+                    fontFamily: fonts.mono, fontSize: 9.5, letterSpacing: "0.08em",
+                    color: verdictColor, background: `${verdictColor}18`,
+                    border: `1px solid ${verdictColor}40`, borderRadius: 5, padding: "2px 7px",
+                  }}>
+                    {verdict ? verdict.toUpperCase() : "—"}
+                  </span>
+
+                  <SourceTypePill type={c.source_type} />
+                </div>
+              </div>
+
+              {/* Confidence bar */}
+              <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 8 }}>
+                <span style={{ ...mono10, width: 70 }}>Confidence</span>
+                <div style={{ flex: 1, height: 4, background: colors.cardInner, borderRadius: 2 }}>
+                  <div style={{ width: `${c.confidence * 100}%`, height: "100%", borderRadius: 2, background: c.is_claim ? palette.blue : palette.dim }} />
+                </div>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: palette.dim, width: 36, textAlign: "right" }}>
+                  {Math.round(c.confidence * 100)}%
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Stance panel ─────────────────────────────────────────────────────────────
+
+function StanceCounts({ s, sourceType }: { s: StanceSummary; sourceType: string }) {
+  const breakdown = sourceType !== "all" ? s.by_source[sourceType as SourceType] : null;
+  const counts = breakdown ?? { supportive: s.supportive, critical: s.critical, neutral: s.neutral, ambiguous: s.ambiguous };
+  const total = counts.supportive + counts.critical + counts.neutral + counts.ambiguous || 1;
+
+  return (
+    <div style={{ display: "flex", height: 8, borderRadius: 3, overflow: "hidden", flex: 1, margin: "0 12px" }}>
+      {(["supportive", "critical", "neutral", "ambiguous"] as const).map((key) => {
+        const pct = (counts[key] / total) * 100;
+        return pct > 0 ? (
+          <div key={key} title={`${key}: ${Math.round(pct)}%`}
+            style={{ width: `${pct}%`, background: STANCE_COLORS[key], transition: "width .3s" }} />
+        ) : null;
+      })}
+    </div>
+  );
+}
+
+function StancePanel({ sourceType }: { sourceType: string }) {
+  const { data: stances, source, isLoading } = useArgumentStance();
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Stance by Topic</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div style={{ display: "flex", gap: 10 }}>
+            {(["supportive", "critical", "neutral", "ambiguous"] as const).map((k) => (
+              <span key={k} style={{ fontFamily: fonts.mono, fontSize: 9.5, color: STANCE_COLORS[k], display: "flex", alignItems: "center", gap: 4 }}>
+                <span style={{ width: 7, height: 7, borderRadius: "50%", background: STANCE_COLORS[k], display: "inline-block" }} />
+                {k}
+              </span>
+            ))}
+          </div>
+          <SourceBadge source={source} isLoading={isLoading} />
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {stances.map((s) => (
+          <div key={s.topic} style={{ ...card, padding: "13px 16px" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ width: 180, fontWeight: 500, fontSize: 13, flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {s.topic}
+              </span>
+              <StanceCounts s={s} sourceType={sourceType} />
+              <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint, width: 56, textAlign: "right", flexShrink: 0 }}>
+                {s.total} docs
+              </span>
+              <div style={{ flexShrink: 0 }}>
+                <Sparkline values={s.drift} color={ACCENT} />
+              </div>
+            </div>
+
+            {/* Per-stance counts */}
+            <div style={{ marginTop: 8, display: "flex", gap: 16 }}>
+              {(["supportive", "critical", "neutral", "ambiguous"] as const).map((k) => {
+                const breakdown = sourceType !== "all" ? s.by_source[sourceType as SourceType] : null;
+                const v = breakdown ? breakdown[k] : s[k];
+                return (
+                  <span key={k} style={{ fontFamily: fonts.mono, fontSize: 10, color: STANCE_COLORS[k] }}>
+                    {v} {k}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Frames panel ─────────────────────────────────────────────────────────────
+
+function FramesPanel({ sourceType }: { sourceType: string }) {
+  const { data: frames, source, isLoading } = useArgumentFrames(sourceType === "all" ? undefined : sourceType);
+  const dist = frames.distribution;
+  const maxScore = Math.max(0.01, ...Object.values(dist));
+
+  const crossTypes = ["news", "blog", "paper", "transcript", "book", "note"];
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {/* Distribution chart */}
+      <div style={{ ...card, padding: "18px 20px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+          <div>
+            <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Frame Distribution</span>
+            <span style={{ ...mono10, marginLeft: 10 }}>
+              dominant: <span style={{ color: FRAME_COLORS[frames.dominant] ?? ACCENT }}>{frames.dominant}</span>
+              {frames.total_documents > 0 && ` · ${frames.total_documents} docs`}
+            </span>
+          </div>
+          <SourceBadge source={source} isLoading={isLoading} />
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {FRAME_LABELS.sort((a, b) => (dist[b] ?? 0) - (dist[a] ?? 0)).map((frame) => {
+            const score = dist[frame] ?? 0;
+            const pct = (score / maxScore) * 100;
+            const color = FRAME_COLORS[frame] ?? palette.dim;
+            return (
+              <div key={frame} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <span style={{ fontFamily: fonts.mono, fontSize: 11, color, width: 110, flexShrink: 0, textTransform: "capitalize" }}>{frame}</span>
+                <div style={{ flex: 1, height: 10, background: colors.cardInner, borderRadius: 3 }}>
+                  <div style={{ width: `${pct}%`, height: "100%", borderRadius: 3, background: color, transition: "width .4s" }} />
+                </div>
+                <span style={{ fontFamily: fonts.mono, fontSize: 11, color, width: 40, textAlign: "right" }}>
+                  {(score * 100).toFixed(0)}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Cross-format comparison table */}
+      <div style={{ ...card, padding: "18px 20px", overflowX: "auto" }}>
+        <div style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14, marginBottom: 14 }}>Cross-Format Comparison</div>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: fonts.mono, fontSize: 11 }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: "left", padding: "4px 10px 8px 0", color: palette.dim, fontWeight: 400, fontSize: 10, letterSpacing: "0.1em" }}>FRAME</th>
+              {crossTypes.map((st) => (
+                <th key={st} style={{ textAlign: "right", padding: "4px 8px 8px", color: palette.dim, fontWeight: 400, fontSize: 10, letterSpacing: "0.1em", textTransform: "uppercase" }}>{st}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {FRAME_LABELS.map((frame) => {
+              const color = FRAME_COLORS[frame] ?? palette.dim;
+              return (
+                <tr key={frame} style={{ borderTop: `1px solid ${colors.border}` }}>
+                  <td style={{ padding: "7px 10px 7px 0", color, textTransform: "capitalize" }}>{frame}</td>
+                  {crossTypes.map((st) => {
+                    const val = mockFramesBySourceType[st]?.[frame] ?? 0;
+                    const intensity = Math.round(val * 255).toString(16).padStart(2, "0");
+                    return (
+                      <td key={st} style={{ textAlign: "right", padding: "7px 8px", color: `${color}`, opacity: 0.4 + val * 0.6 }}>
+                        <span style={{
+                          display: "inline-block", padding: "2px 7px", borderRadius: 4,
+                          background: `${color}${intensity}`, color: val > 0.4 ? colors.bg : color,
+                        }}>
+                          {(val * 100).toFixed(0)}%
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Positions panel ─────────────────────────────────────────────────────────
+
+function PositionsPanel({ sourceType }: { sourceType: string }) {
+  const [topic, setTopic] = useState("Interest Rate Policy");
+  const allTopics = Array.from(new Set(mockPositions.map((p) => p.topic)));
+  const filtered = mockPositions.filter(
+    (p) => p.topic === topic && (sourceType === "all" || p.source_type === sourceType),
+  );
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Actor Policy Positions</span>
+        <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.amber, background: `${palette.amber}14`, border: `1px solid ${palette.amber}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
+          DEMO
+        </span>
+      </div>
+
+      {/* Topic selector */}
+      <div style={{ display: "flex", gap: 6, marginBottom: 16, flexWrap: "wrap" }}>
+        {allTopics.map((t) => (
+          <button
+            key={t}
+            onClick={() => setTopic(t)}
+            style={{
+              fontFamily: fonts.mono, fontSize: 10.5, padding: "4px 11px", borderRadius: 6,
+              border: t === topic ? `1px solid ${accentBorder(ACCENT)}` : `1px solid ${colors.border2}`,
+              background: t === topic ? accentSoft(ACCENT) : "transparent",
+              color: t === topic ? ACCENT : palette.dim, cursor: "pointer",
+            }}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        {filtered.length === 0 && (
+          <div style={{ fontFamily: fonts.mono, fontSize: 12, color: palette.faint, padding: "20px 0", textAlign: "center" }}>
+            No positions recorded for this topic / source type.
+          </div>
+        )}
+        {filtered.map((pos, i) => {
+          const stanceColor = POSITION_COLORS[pos.stance];
+          const isLast = i === filtered.length - 1;
+          return (
+            <div key={`${pos.actor}-${pos.date}`} style={{ display: "flex", gap: 16 }}>
+              {/* Timeline spine */}
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, width: 20 }}>
+                <div style={{ width: 10, height: 10, borderRadius: "50%", background: stanceColor, border: `2px solid ${colors.bg}`, flexShrink: 0, marginTop: 12 }} />
+                {!isLast && <div style={{ width: 1, flex: 1, background: colors.border, margin: "2px 0" }} />}
+              </div>
+              {/* Content */}
+              <div style={{ ...card, padding: "12px 14px", marginBottom: 8, flex: 1 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                  <div>
+                    <span style={{ fontWeight: 600, fontSize: 13 }}>{pos.actor}</span>
+                    <span style={{
+                      marginLeft: 8, fontFamily: fonts.mono, fontSize: 9.5, letterSpacing: "0.08em",
+                      color: stanceColor, background: `${stanceColor}18`, border: `1px solid ${stanceColor}40`,
+                      borderRadius: 4, padding: "1px 6px",
+                    }}>
+                      {pos.stance.toUpperCase()}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <SourceTypePill type={pos.source_type} />
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint }}>{pos.date}</span>
+                  </div>
+                </div>
+                <div style={{ marginTop: 6, fontSize: 12.5, color: colors.textMuted, lineHeight: 1.5 }}>{pos.position}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Controversy panel ────────────────────────────────────────────────────────
+
+function ControversyPanel({ sourceType: _sourceType }: { sourceType: string }) {
+  const sorted = [...mockConflicts].sort((a, b) => b.intensity - a.intensity);
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Conflict Map</span>
+        <div style={{ display: "flex", gap: 8 }}>
+          <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.amber, background: `${palette.amber}14`, border: `1px solid ${palette.amber}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
+            DEMO
+          </span>
+          <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.blue, background: `${palette.blue}14`, border: `1px solid ${palette.blue}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
+            GRAPH IN #96
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {sorted.map((c) => {
+          const intPct = Math.round(c.intensity * 100);
+          const color = c.intensity > 0.75 ? palette.neg : c.intensity > 0.5 ? palette.amber : palette.neu;
+          return (
+            <div key={`${c.actor_a}-${c.actor_b}`} style={{ ...card, padding: "14px 18px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                {/* Actor A */}
+                <span style={{ fontWeight: 600, fontSize: 13, flex: 1, textAlign: "right" }}>{c.actor_a}</span>
+                {/* Conflict indicator */}
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, flexShrink: 0, minWidth: 80 }}>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color, letterSpacing: "0.1em" }}>
+                    {intPct}% intensity
+                  </span>
+                  <div style={{ width: 80, height: 6, background: colors.cardInner, borderRadius: 3 }}>
+                    <div style={{ width: `${intPct}%`, height: "100%", borderRadius: 3, background: color }} />
+                  </div>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.faint }}>{c.source_count} sources</span>
+                </div>
+                {/* Actor B */}
+                <span style={{ fontWeight: 600, fontSize: 13, flex: 1 }}>{c.actor_b}</span>
+              </div>
+              <div style={{ marginTop: 8, textAlign: "center", fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint }}>
+                {c.topic}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 20, ...card, padding: "14px 18px", borderColor: `${palette.blue}44`, background: `${palette.blue}08` }}>
+        <div style={{ fontFamily: fonts.mono, fontSize: 11, color: palette.blue }}>
+          ◈ Interactive force-directed conflict graph with source_type colour coding on nodes ships in issue #96.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Source type pill ─────────────────────────────────────────────────────────
+
+function SourceTypePill({ type }: { type: string }) {
+  const ST_COLORS: Record<string, string> = {
+    news: palette.blue, blog: palette.teal, paper: palette.violet,
+    transcript: palette.amber, book: palette.pos, note: palette.dim,
+  };
+  const color = ST_COLORS[type] ?? palette.dim;
+  return (
+    <span style={{
+      fontFamily: fonts.mono, fontSize: 9, letterSpacing: "0.08em",
+      color, background: `${color}18`, border: `1px solid ${color}40`,
+      borderRadius: 4, padding: "1px 5px", flexShrink: 0, textTransform: "uppercase" as const,
+    }}>
+      {type}
+    </span>
+  );
+}
+
+// ─── Main view ────────────────────────────────────────────────────────────────
+
+export default function Arguments() {
+  const [tab, setTabRaw] = useState<ArgumentTab>(
+    (readParam("arg_tab") as ArgumentTab | null) ?? "claims",
+  );
+  const [sourceType, setSourceTypeRaw] = useState(readParam("source_type") ?? "all");
+
+  function setTab(t: ArgumentTab) {
+    setTabRaw(t);
+    setParam("arg_tab", t);
+  }
+
+  function setSourceType(v: string) {
+    setSourceTypeRaw(v);
+    setParam("source_type", v);
+  }
+
+  // Sync state if user navigates with browser Back/Forward
+  useEffect(() => {
+    function onPop() {
+      setTabRaw((readParam("arg_tab") as ArgumentTab | null) ?? "claims");
+      setSourceTypeRaw(readParam("source_type") ?? "all");
+    }
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="Argument Mining"
+        subtitle="Claims · stance · frames · positions · controversy — across all content types"
+        right={
+          <FilterPills value={sourceType} onChange={setSourceType} />
+        }
+      />
+
+      <TabBar active={tab} onChange={setTab} />
+
+      {tab === "claims"      && <ClaimsPanel      sourceType={sourceType} />}
+      {tab === "stance"      && <StancePanel       sourceType={sourceType} />}
+      {tab === "frames"      && <FramesPanel       sourceType={sourceType} />}
+      {tab === "positions"   && <PositionsPanel    sourceType={sourceType} />}
+      {tab === "controversy" && <ControversyPanel  sourceType={sourceType} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Five-tab **Argument Mining** view surfacing all argument layers across all six content types, accessible via the RESEARCH sidebar section.

### Panels

| Tab | What it shows |
|---|---|
| **Claims** | Sentence-level claim cards — CLAIM/NON-CLAIM label, factcheck verdict (VERIFIED/DISPUTED/UNVERIFIED), confidence bar, source_type badge, blue left border for claims |
| **Stance** | Per-topic stacked bars (supportive / critical / neutral / ambiguous) with 7-day drift sparkline; source_type filter switches from aggregate to per-source breakdown |
| **Frames** | Colour-coded horizontal bars for all 7 narrative frames; cross-format comparison heat table (frames × 6 source types) |
| **Positions** | Actor policy timeline filterable by topic and source_type; coloured spine (green=for, red=against, grey=neutral) with source badge and date |
| **Controversy** | Conflict pair table sorted by intensity; "GRAPH IN #96" badge marks where the interactive force-directed graph will land |

### Architecture

- **URL persistence** — `arg_tab=` and `source_type=` written to `URLSearchParams` via `pushState`; `popstate` listener keeps state in sync with browser Back/Forward — views are shareable links
- **Live data** — `useArgumentFrames` fetches from `GET /api/v1/arguments/frames` (implemented in #90) with DEMO fallback; `useArgumentClaims` / `useArgumentStance` fall back to DEMO until #95 ships
- **8 touch-points** — `ViewKey` union, 5 new types, mock data for all 5 panels, `RawFrameDistribution` + `api.argumentFrames`, `adaptFrameDistribution`, 3 query hooks, view component, Sidebar entry, App switch

## Test plan

- [ ] `npm run typecheck` exits 0 (zero errors)
- [ ] All 5 tabs render without console errors in DEMO mode
- [ ] source_type filter pills change stance breakdown and frame distribution
- [ ] Switching tabs updates the `?arg_tab=` URL param; Back/Forward restores state
- [ ] "Arguments" appears in sidebar under RESEARCH
- [ ] Frames tab live-fetches from `/api/v1/arguments/frames` when backend is up (shows LIVE badge)

Closes #91