### PR TITLE
feat(mcp): list_hooks + list_mock_exports in noesis-schema server

### DIFF
--- a/tools/schema_mcp/server.py
+++ b/tools/schema_mcp/server.py
@@ -2,13 +2,16 @@
 Noesis schema server — MCP server.
 
 Token-efficient shortcuts to project structure so Claude doesn't need to
-read large source files just to check a column name or API path.
+read large source files just to check a column name, API path, or
+frontend query hook.
 
 Tools:
   list_tables()         -> table names + column summary from the DuckDB schema
   get_schema(table)     -> CREATE TABLE DDL + structured column list
   list_routes()         -> verb + path + source file for every API endpoint
   get_route(path)       -> parameters + query params for one endpoint
+  list_hooks()          -> every useX() hook: cache key + mock fallback name
+  list_mock_exports()   -> every mockX export: name + inferred TS type
 
 Design: regex parsing over the live source files — always reflects the
 current state of the repo without any import side-effects.
@@ -24,6 +27,8 @@ from fastmcp import FastMCP
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SEED_FILE = REPO_ROOT / "src" / "database" / "local_warehouse_seed.py"
 ROUTES_DIR = REPO_ROOT / "src" / "api" / "routes"
+QUERIES_FILE = REPO_ROOT / "apps" / "web" / "src" / "lib" / "queries.ts"
+MOCK_FILE    = REPO_ROOT / "apps" / "web" / "src" / "data" / "mock.ts"
 
 mcp = FastMCP("noesis-schema")
 
@@ -323,6 +328,175 @@ def get_route(path: str) -> dict[str, Any]:
             body_preview = "(handler not resolved)"
         results.append({**r, "body_preview": body_preview})
     return {"matches": results, "count": len(results)}
+
+
+# ---------------------------------------------------------------------------
+# Frontend parsing
+# ---------------------------------------------------------------------------
+
+# Matches: export function useFoo(...): Result<Bar> { ... }
+#   or:    export function useFoo(...): { ... } { ... }
+_HOOK_DEF_RE = re.compile(
+    r"export\s+function\s+(use\w+)\s*\(([^)]*)\)\s*:\s*Result<([^>]+)>",
+    re.MULTILINE,
+)
+
+# useWithFallback("cacheKey", ..., mockFallback)  — cache key may be a string or template literal
+_WITH_FALLBACK_RE = re.compile(
+    r'useWithFallback\(\s*(?:`([^`]+)`|["\']([^"\']+)["\'])',
+    re.MULTILINE,
+)
+
+# export const mockFoo: SomeType[] = ...   or   export const mockFoo = [...]
+_MOCK_EXPORT_RE = re.compile(
+    r"^export\s+const\s+(mock\w+)\s*(?::\s*([^=]+?))?\s*=",
+    re.MULTILINE,
+)
+
+
+def _parse_hooks() -> list[dict]:
+    """Parse queries.ts for every exported useX() hook."""
+    if not QUERIES_FILE.exists():
+        return []
+    src = QUERIES_FILE.read_text()
+    hooks = []
+
+    # Find each exported hook function
+    for m in _HOOK_DEF_RE.finditer(src):
+        name = m.group(1)
+        params_raw = m.group(2).strip()
+        result_type = m.group(3).strip()
+
+        # Parse param names (reuse top-level splitter logic inline)
+        params: list[str] = []
+        if params_raw:
+            for part in _top_level_split(params_raw):
+                pm = re.match(r"\*{0,2}(\w+)", part.strip())
+                if pm and pm.group(1) not in ("self", "cls"):
+                    params.append(pm.group(1))
+
+        # Find the cache key used in useWithFallback inside this function body
+        # — scan from the match position to the next exported function
+        body_start = m.end()
+        next_export = src.find("\nexport function use", body_start)
+        body = src[body_start: next_export if next_export != -1 else len(src)]
+
+        cache_key: str | None = None
+        wf = _WITH_FALLBACK_RE.search(body)
+        if wf:
+            cache_key = wf.group(1) or wf.group(2)  # group 1 = backtick, group 2 = quote
+
+        # Find mock fallback — last bare identifier argument on the useWithFallback line
+        mock_name: str | None = None
+        if wf:
+            # The fallback is the third positional arg to useWithFallback(key, fn, fallback)
+            # Find the opening paren of the useWithFallback call and extract top-level args
+            call_start = body.find("useWithFallback(", wf.start())
+            if call_start != -1:
+                paren_open = body.index("(", call_start)
+                depth = 0
+                i = paren_open
+                call_chars: list[str] = []
+                while i < len(body):
+                    ch = body[i]
+                    if ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0:
+                            break
+                    call_chars.append(ch)
+                    i += 1
+                call_inner = "".join(call_chars[1:])  # strip leading (
+                top_args = _top_level_split(call_inner)
+                if len(top_args) >= 3:
+                    fallback_expr = top_args[2].strip()
+                    # If it's a simple identifier (not an object/array literal), use it
+                    if re.match(r"^[A-Za-z_]\w*$", fallback_expr):
+                        mock_name = fallback_expr
+
+        hooks.append({
+            "name": name,
+            "params": params,
+            "returns": f"Result<{result_type}>",
+            "cache_key": cache_key,
+            "mock_fallback": mock_name,
+        })
+    return hooks
+
+
+def _parse_mock_exports() -> list[dict]:
+    """Parse mock.ts for every exported const mockX."""
+    if not MOCK_FILE.exists():
+        return []
+    src = MOCK_FILE.read_text()
+    exports = []
+    for m in _MOCK_EXPORT_RE.finditer(src):
+        name = m.group(1)
+        declared_type = m.group(2).strip() if m.group(2) else None
+
+        # Infer type from the value if not declared
+        inferred: str | None = None
+        val_start = m.end()
+        # Peek at first non-whitespace character of the value
+        stripped = src[val_start:].lstrip()
+        if stripped.startswith("["):
+            inferred = "array"
+        elif stripped.startswith("{"):
+            inferred = "object"
+        elif stripped.startswith('"') or stripped.startswith("'") or stripped.startswith("`"):
+            inferred = "string"
+
+        exports.append({
+            "name": name,
+            "type": declared_type or inferred or "unknown",
+        })
+    return exports
+
+
+# ---------------------------------------------------------------------------
+# Frontend tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def list_hooks() -> dict:
+    """List every React Query hook exported from apps/web/src/lib/queries.ts.
+
+    Returns the hook name, its parameters, the Result<T> return type, the
+    React Query cache key, and the mock fallback constant name.
+
+    Avoids reading queries.ts (200+ lines) just to find where to append a
+    new hook or what cache key an existing one uses.
+    """
+    if not QUERIES_FILE.exists():
+        return {"error": f"queries.ts not found at {QUERIES_FILE}"}
+    hooks = _parse_hooks()
+    return {
+        "hooks": hooks,
+        "count": len(hooks),
+        "source": str(QUERIES_FILE.relative_to(REPO_ROOT)),
+        "hint": "append new hooks after the last entry; use a unique cache_key",
+    }
+
+
+@mcp.tool
+def list_mock_exports() -> dict:
+    """List every exported mock constant from apps/web/src/data/mock.ts.
+
+    Returns name and TypeScript type for each export so you know what mock
+    data already exists before adding new entries.
+
+    Avoids reading mock.ts (~350+ lines) just to check what's already there.
+    """
+    if not MOCK_FILE.exists():
+        return {"error": f"mock.ts not found at {MOCK_FILE}"}
+    exports = _parse_mock_exports()
+    return {
+        "exports": exports,
+        "count": len(exports),
+        "source": str(MOCK_FILE.relative_to(REPO_ROOT)),
+        "hint": "append new mocks after the last export; import the type in the file header",
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two new tools added to the existing `noesis-schema` MCP server (`tools/schema_mcp/server.py`) for the frontend data-wiring workflow.

### `list_hooks()`
Every exported `useX()` hook from `apps/web/src/lib/queries.ts`:
- param names (top-level aware, no `Query()` internals)
- `Result<T>` return type
- React Query cache key — handles both plain strings and template literals (e.g. `` `argumentFrames-${sourceType ?? "all"}` ``)
- mock fallback constant name extracted from the third `useWithFallback(key, fn, fallback)` argument

### `list_mock_exports()`
Every `export const mockX` from `apps/web/src/data/mock.ts`:
- declared TypeScript type annotation when present (e.g. `ClaimResult[]`, `Record<string, WorkspaceDetail>`)
- inferred shape (`array` / `object` / `string`) when unannotated

### Why
Adding a new API/data flow currently requires reading `queries.ts` (~270 lines) to find where to append and what cache keys exist, and `mock.ts` (~350 lines) to check what mock data already exists. These two tools reduce that to one cheap MCP call each.

## Test plan

- [ ] `python3 tools/schema_mcp/server.py` starts cleanly (stdio)
- [ ] `list_hooks()` returns 12 hooks including `useArgumentFrames` with cache key `` `argumentFrames-${sourceType ?? "all"}` ``
- [ ] `list_mock_exports()` returns 19 exports including `mockClaims: ClaimResult[]`
