### PR TITLE
feat(argument-mining): claim & evidence extraction pipeline (#93)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -170,6 +170,15 @@ export interface RawFrameDistribution {
   source: string;
 }
 
+export interface RawClaim {
+  claim_id: string;
+  claim_text: string;
+  document_id: string;
+  source_type: string;
+  confidence: number | null;
+  extracted_at: string | null;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -210,4 +219,7 @@ export const api = {
 
   argumentFrames: (params?: { source_type?: string; document_id?: string; limit?: number }) =>
     request<RawFrameDistribution>("/api/v1/arguments/frames", params),
+
+  argumentClaims: (params?: { document_id?: string; source_type?: string; topic?: string; limit?: number }) =>
+    request<{ claims: RawClaim[]; count: number }>("/api/v1/arguments/claims", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -27,6 +27,7 @@ import {
   mockStance,
   mockFrameDistribution,
 } from "../data/mock";
+import type { RawClaim } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -40,6 +41,7 @@ import type {
   ClaimResult,
   StanceSummary,
   FrameDistribution,
+  SourceType,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -238,11 +240,21 @@ export function useTicker(): Result<string> {
 
 // ─── Argument Mining ─────────────────────────────────────────────────────────
 
-export function useArgumentClaims(): Result<ClaimResult[]> {
+export function useArgumentClaims(params?: { source_type?: string; topic?: string }): Result<ClaimResult[]> {
+  const key = `argumentClaims-${params?.source_type ?? "all"}-${params?.topic ?? ""}`;
   return useWithFallback(
-    "argumentClaims",
+    key,
     async (): Promise<ClaimResult[]> => {
-      throw new Error("endpoint pending #95");
+      const res = await api.argumentClaims(params);
+      return res.claims.map((r: RawClaim) => ({
+        document_id: r.document_id,
+        source_type: r.source_type as SourceType,
+        text: r.claim_text,
+        is_claim: true,
+        confidence: r.confidence ?? 0,
+        factcheck_verdict: null,
+        title: "",
+      }));
     },
     mockClaims,
   );

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -1,9 +1,12 @@
 """
-Argument Mining API routes (Issue #90, #95).
+Argument Mining API routes (Issues #90, #93, #95).
 
 GET  /api/v1/arguments/frames              — aggregate frame distribution
 GET  /api/v1/arguments/frames?document_id= — frames for a specific document
 GET  /api/v1/arguments/frames?source_type= — aggregate filtered by source type
+GET  /api/v1/arguments/claims              — query stored claims
+POST /api/v1/arguments/claims/extract      — run pipeline on a stored document
+GET  /api/v1/arguments/claims/{claim_id}/evidence — evidence for a claim
 """
 from __future__ import annotations
 
@@ -210,3 +213,184 @@ async def _aggregate_live(conn, source_type: Optional[str]) -> Dict[str, Any]:
         }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Live frame classification failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Claims endpoints (#93)
+# ---------------------------------------------------------------------------
+
+@router.get("/claims")
+async def get_claims(
+    document_id: Optional[str] = Query(None, description="Filter by document ID"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    topic: Optional[str] = Query(None, description="Full-text filter on claim text"),
+    limit: int = Query(100, ge=1, le=1000, description="Max results"),
+) -> Dict[str, Any]:
+    """Query stored argument claims, filterable by document, source type, or keyword topic."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if document_id:
+        conditions.append("document_id = ?")
+        params.append(document_id)
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if topic:
+        conditions.append("claim_text ILIKE ?")
+        params.append(f"%{topic}%")
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT claim_id, claim_text, document_id, source_type, confidence, extracted_at
+            FROM argument_claims
+            {where}
+            ORDER BY confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    claims = [
+        {
+            "claim_id": r[0],
+            "claim_text": r[1],
+            "document_id": r[2],
+            "source_type": r[3],
+            "confidence": round(r[4], 4) if r[4] is not None else None,
+            "extracted_at": r[5],
+        }
+        for r in rows
+    ]
+    return {"claims": claims, "count": len(claims)}
+
+
+@router.post("/claims/extract")
+async def extract_claims_for_document(
+    document_id: str = Query(..., description="ID of a document already in news_articles"),
+    source_type: str = Query("news", description="Source type label"),
+) -> Dict[str, Any]:
+    """Run the claim+evidence pipeline on a stored document and persist results."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    with lock:
+        row = conn.execute(
+            "SELECT id, title, content FROM news_articles WHERE id = ? LIMIT 1",
+            [document_id],
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Document '{document_id}' not found")
+
+    doc_id, title, content = row[0], row[1], row[2]
+    if not content:
+        raise HTTPException(status_code=422, detail="Document has no content to process")
+
+    try:
+        import time
+        from services.ingest.common.document_model import Document
+        from src.argument_mining.evidence import run_pipeline
+
+        doc = Document(
+            document_id=doc_id,
+            source_type=source_type,
+            language="en",
+            ingested_at=int(time.time() * 1000),
+            title=title,
+            content=content,
+        )
+        claims, evidence = run_pipeline(doc, conn)
+        return {
+            "document_id": doc_id,
+            "source_type": source_type,
+            "claims_extracted": len(claims),
+            "evidence_found": len(evidence),
+            "claims": [
+                {
+                    "claim_id": c.claim_id,
+                    "claim_text": c.claim_text,
+                    "confidence": round(c.confidence, 4),
+                }
+                for c in claims
+            ],
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Pipeline failed: {exc}")
+
+
+@router.get("/claims/{claim_id}/evidence")
+async def get_evidence(
+    claim_id: str,
+    relation: Optional[str] = Query(None, description="Filter by 'supports' or 'contradicts'"),
+    limit: int = Query(20, ge=1, le=200),
+) -> Dict[str, Any]:
+    """Return stored evidence records for a given claim."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions = ["claim_id = ?"]
+    params: list[Any] = [claim_id]
+
+    if relation:
+        if relation not in ("supports", "contradicts"):
+            raise HTTPException(status_code=422, detail="relation must be 'supports' or 'contradicts'")
+        conditions.append("relation = ?")
+        params.append(relation)
+
+    params.append(limit)
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT evidence_id, evidence_text, evidence_document_id,
+                   evidence_source_type, relation, similarity_score, found_at
+            FROM claim_evidence
+            WHERE {' AND '.join(conditions)}
+            ORDER BY similarity_score DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    # Verify the claim exists (return 404 rather than empty list for unknown IDs)
+    if not rows:
+        with lock:
+            exists = conn.execute(
+                "SELECT 1 FROM argument_claims WHERE claim_id = ? LIMIT 1",
+                [claim_id],
+            ).fetchone()
+        if not exists:
+            raise HTTPException(status_code=404, detail=f"Claim '{claim_id}' not found")
+
+    evidence = [
+        {
+            "evidence_id": r[0],
+            "evidence_text": r[1],
+            "evidence_document_id": r[2],
+            "evidence_source_type": r[3],
+            "relation": r[4],
+            "similarity_score": round(r[5], 6) if r[5] is not None else None,
+            "found_at": r[6],
+        }
+        for r in rows
+    ]
+    return {"claim_id": claim_id, "evidence": evidence, "count": len(evidence)}

--- a/src/argument_mining/evidence.py
+++ b/src/argument_mining/evidence.py
@@ -1,0 +1,296 @@
+"""
+Claim & Evidence Extraction Pipeline.
+
+Two-stage pipeline:
+  1. extract_claims(document)   — run ClaimDetector over any Document,
+                                   return ClaimRecord list
+  2. find_evidence(claim, corpus) — TF-IDF cosine search over a sentence
+                                    corpus; classify each match as
+                                    "supports" or "contradicts"
+
+run_pipeline(document, conn) wires both stages and persists results to
+the DuckDB tables argument_claims / claim_evidence.
+
+No trained model is required — ClaimDetector falls back to its heuristic
+and the evidence search is sklearn TF-IDF + cosine.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Tuple
+
+from services.ingest.common.document_model import Document
+from src.argument_mining.models import get_claim_detector
+
+logger = logging.getLogger(__name__)
+
+# Minimum cosine similarity to consider a sentence as evidence
+SIMILARITY_THRESHOLD = 0.20
+# Maximum evidence sentences returned per claim
+MAX_EVIDENCE = 10
+
+# ---------------------------------------------------------------------------
+# Contradiction signals
+# ---------------------------------------------------------------------------
+
+_CONTRADICTION_SIGNALS = frozenset({
+    "not", "no", "never", "neither", "nor",
+    "didn't", "doesn't", "don't", "won't", "wasn't", "weren't", "hasn't",
+    "haven't", "wouldn't", "couldn't", "shouldn't", "cannot", "can't",
+    "refute", "refutes", "refuted", "dispute", "disputes", "disputed",
+    "contradict", "contradicts", "contradicted",
+    "deny", "denies", "denied", "reject", "rejects", "rejected",
+    "challenge", "challenges", "challenged", "debunk", "debunks", "debunked",
+    "false", "incorrect", "wrong", "inaccurate", "misleading", "untrue",
+    "contrary", "despite", "however", "though", "although",
+    "but", "yet", "while", "whereas", "nevertheless",
+})
+
+_CONTRADICTION_THRESHOLD = 2  # signals needed to flip to "contradicts"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ClaimRecord:
+    claim_id: str
+    claim_text: str
+    document_id: str
+    source_type: str
+    confidence: float
+    extracted_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass
+class EvidenceRecord:
+    evidence_id: str
+    claim_id: str
+    evidence_text: str
+    evidence_document_id: str
+    evidence_source_type: str
+    relation: str   # "supports" | "contradicts"
+    similarity_score: float
+    found_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+# Corpus entry: (sentence_text, document_id, source_type)
+CorpusEntry = Tuple[str, str, str]
+
+
+# ---------------------------------------------------------------------------
+# ID helpers
+# ---------------------------------------------------------------------------
+
+def _claim_id(document_id: str, sentence_idx: int) -> str:
+    raw = f"{document_id}::{sentence_idx}"
+    return "cl-" + hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+def _evidence_id(claim_id: str, evidence_document_id: str, evidence_text: str) -> str:
+    raw = f"{claim_id}::{evidence_document_id}::{evidence_text[:64]}"
+    return "ev-" + hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Similarity + relation detection
+# ---------------------------------------------------------------------------
+
+def _contradiction_score(text: str) -> int:
+    """Count contradiction signals present in a sentence."""
+    words = set(re.findall(r"\b\w+\b", text.lower()))
+    return len(words & _CONTRADICTION_SIGNALS)
+
+
+def _cosine_similarities(claim_text: str, corpus_texts: List[str]) -> List[float]:
+    """TF-IDF cosine similarity between claim and each corpus sentence."""
+    try:
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        from sklearn.metrics.pairwise import cosine_similarity as sk_cosine
+    except ImportError:
+        logger.warning("sklearn not available — evidence search disabled")
+        return [0.0] * len(corpus_texts)
+
+    if not corpus_texts:
+        return []
+
+    all_texts = [claim_text] + corpus_texts
+    try:
+        vec = TfidfVectorizer(min_df=1, ngram_range=(1, 2), sublinear_tf=True)
+        tfidf = vec.fit_transform(all_texts)
+        sims = sk_cosine(tfidf[0:1], tfidf[1:]).flatten()
+        return sims.tolist()
+    except Exception as exc:
+        logger.warning("TF-IDF similarity failed: %s", exc)
+        return [0.0] * len(corpus_texts)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def extract_claims(document: Document) -> List[ClaimRecord]:
+    """Run ClaimDetector over `document`; return only sentences classified as claims."""
+    detector = get_claim_detector()
+    predictions = detector.predict(document)
+    records = []
+    for pred in predictions:
+        if not pred.is_claim:
+            continue
+        records.append(ClaimRecord(
+            claim_id=_claim_id(document.document_id, pred.sentence_idx),
+            claim_text=pred.text,
+            document_id=document.document_id,
+            source_type=document.source_type,
+            confidence=pred.confidence,
+        ))
+    return records
+
+
+def find_evidence(
+    claim: ClaimRecord,
+    corpus: List[CorpusEntry],
+    threshold: float = SIMILARITY_THRESHOLD,
+    max_results: int = MAX_EVIDENCE,
+) -> List[EvidenceRecord]:
+    """Search `corpus` for sentences that support or contradict `claim`.
+
+    Args:
+        claim:      the claim to search evidence for
+        corpus:     list of (sentence_text, document_id, source_type) tuples;
+                    sentences from the same document as the claim are skipped
+        threshold:  minimum cosine similarity to qualify as evidence
+        max_results: cap on number of evidence records returned
+    """
+    # Exclude same-document sentences to avoid circular evidence
+    candidates = [e for e in corpus if e[1] != claim.document_id]
+    if not candidates:
+        return []
+
+    texts = [e[0] for e in candidates]
+    scores = _cosine_similarities(claim.claim_text, texts)
+
+    # Collect matches above threshold, sorted by descending score
+    indexed = sorted(
+        ((s, i) for i, s in enumerate(scores) if s >= threshold),
+        key=lambda x: -x[0],
+    )
+
+    evidence: List[EvidenceRecord] = []
+    seen_doc_ids: set = set()
+    for score, idx in indexed[:max_results]:
+        ev_text, ev_doc_id, ev_source_type = candidates[idx]
+        # Deduplicate same document_id (keep highest-score sentence only)
+        if ev_doc_id in seen_doc_ids:
+            continue
+        seen_doc_ids.add(ev_doc_id)
+
+        cscore = _contradiction_score(ev_text)
+        relation = "contradicts" if cscore >= _CONTRADICTION_THRESHOLD else "supports"
+
+        evidence.append(EvidenceRecord(
+            evidence_id=_evidence_id(claim.claim_id, ev_doc_id, ev_text),
+            claim_id=claim.claim_id,
+            evidence_text=ev_text,
+            evidence_document_id=ev_doc_id,
+            evidence_source_type=ev_source_type,
+            relation=relation,
+            similarity_score=round(score, 6),
+        ))
+    return evidence
+
+
+# ---------------------------------------------------------------------------
+# DuckDB persistence
+# ---------------------------------------------------------------------------
+
+def store_claim(record: ClaimRecord, conn) -> None:
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO argument_claims
+            (claim_id, claim_text, document_id, source_type, confidence, extracted_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        [record.claim_id, record.claim_text, record.document_id,
+         record.source_type, record.confidence, record.extracted_at],
+    )
+
+
+def store_evidence(record: EvidenceRecord, conn) -> None:
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO claim_evidence
+            (evidence_id, claim_id, evidence_text, evidence_document_id,
+             evidence_source_type, relation, similarity_score, found_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [record.evidence_id, record.claim_id, record.evidence_text,
+         record.evidence_document_id, record.evidence_source_type,
+         record.relation, record.similarity_score, record.found_at],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    document: Document,
+    conn,
+    corpus_fn: Optional[Callable[[], List[CorpusEntry]]] = None,
+) -> Tuple[List[ClaimRecord], List[EvidenceRecord]]:
+    """Extract claims from `document`, find cross-corpus evidence, persist both.
+
+    Args:
+        document:   any Document across all source types
+        conn:       DuckDB connection (argument_claims + claim_evidence must exist)
+        corpus_fn:  callable returning [(sentence, doc_id, source_type), ...];
+                    defaults to loading all news_articles content from DuckDB
+    """
+    claims = extract_claims(document)
+    if not claims:
+        return [], []
+
+    corpus = corpus_fn() if corpus_fn else _default_corpus(conn, document.document_id)
+
+    all_evidence: List[EvidenceRecord] = []
+    for claim in claims:
+        store_claim(claim, conn)
+        evidence = find_evidence(claim, corpus)
+        for ev in evidence:
+            store_evidence(ev, conn)
+        all_evidence.extend(evidence)
+
+    logger.info(
+        "run_pipeline: doc=%s source=%s claims=%d evidence=%d",
+        document.document_id, document.source_type, len(claims), len(all_evidence),
+    )
+    return claims, all_evidence
+
+
+def _default_corpus(conn, exclude_document_id: str) -> List[CorpusEntry]:
+    """Load all content from news_articles as a sentence corpus."""
+    try:
+        rows = conn.execute(
+            "SELECT id, content FROM news_articles WHERE id != ? AND content IS NOT NULL LIMIT 500",
+            [exclude_document_id],
+        ).fetchall()
+    except Exception as exc:
+        logger.warning("Could not load corpus from news_articles: %s", exc)
+        return []
+
+    corpus: List[CorpusEntry] = []
+    sent_re = re.compile(r"(?<=[.!?])\s+")
+    for doc_id, content in rows:
+        if not content:
+            continue
+        for sentence in sent_re.split(content.strip()):
+            sentence = sentence.strip()
+            if len(sentence) >= 20:
+                corpus.append((sentence, doc_id, "news"))
+    return corpus

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -40,6 +40,26 @@ CREATE TABLE IF NOT EXISTS document_frames (
     classified_at VARCHAR,
     PRIMARY KEY (document_id, frame)
 );
+
+CREATE TABLE IF NOT EXISTS argument_claims (
+    claim_id      VARCHAR PRIMARY KEY,
+    claim_text    VARCHAR NOT NULL,
+    document_id   VARCHAR NOT NULL,
+    source_type   VARCHAR NOT NULL,
+    confidence    DOUBLE,
+    extracted_at  VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS claim_evidence (
+    evidence_id          VARCHAR PRIMARY KEY,
+    claim_id             VARCHAR NOT NULL,
+    evidence_text        VARCHAR,
+    evidence_document_id VARCHAR NOT NULL,
+    evidence_source_type VARCHAR NOT NULL,
+    relation             VARCHAR NOT NULL,
+    similarity_score     DOUBLE,
+    found_at             VARCHAR
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tests/unit/argument_mining/test_evidence.py
+++ b/tests/unit/argument_mining/test_evidence.py
@@ -1,0 +1,405 @@
+"""
+Unit tests for the Claim & Evidence Extraction Pipeline (Issue #93).
+
+Fixtures cover the three required cross-source scenarios:
+  - news  ↔ blog cross-reference  (corroboration → "supports")
+  - paper ↔ news contradiction    (dispute       → "contradicts")
+  - transcript with no match      (no evidence found)
+
+All tests run fully offline — no DuckDB, no trained model, no network.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repo root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from src.argument_mining.evidence import (
+    ClaimRecord,
+    EvidenceRecord,
+    _claim_id,
+    _contradiction_score,
+    extract_claims,
+    find_evidence,
+    run_pipeline,
+    store_claim,
+    store_evidence,
+)
+from services.ingest.common.document_model import Document
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _doc(document_id: str, source_type: str, content: str) -> Document:
+    return Document(
+        document_id=document_id,
+        source_type=source_type,
+        language="en",
+        ingested_at=0,
+        content=content,
+    )
+
+
+def _claim(claim_id: str, claim_text: str, document_id: str, source_type: str) -> ClaimRecord:
+    return ClaimRecord(
+        claim_id=claim_id,
+        claim_text=claim_text,
+        document_id=document_id,
+        source_type=source_type,
+        confidence=0.75,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ID helpers
+# ---------------------------------------------------------------------------
+
+def test_claim_id_is_deterministic():
+    a = _claim_id("doc-1", 0)
+    b = _claim_id("doc-1", 0)
+    assert a == b
+    assert a.startswith("cl-")
+
+
+def test_claim_id_differs_across_documents():
+    assert _claim_id("doc-1", 0) != _claim_id("doc-2", 0)
+
+
+# ---------------------------------------------------------------------------
+# Contradiction score
+# ---------------------------------------------------------------------------
+
+def test_contradiction_score_clean_sentence():
+    assert _contradiction_score("The GDP rose by 3.2% in the third quarter.") == 0
+
+
+def test_contradiction_score_negation():
+    score = _contradiction_score("The report is false and researchers dispute the findings.")
+    assert score >= 2
+
+
+def test_contradiction_score_hedge_words():
+    score = _contradiction_score("Critics say the claims are wrong, however the data shows otherwise.")
+    assert score >= 2
+
+
+# ---------------------------------------------------------------------------
+# extract_claims
+# ---------------------------------------------------------------------------
+
+def test_extract_claims_returns_claim_records():
+    doc = _doc(
+        "news-001",
+        "news",
+        "The Federal Reserve raised interest rates by 0.5% in March 2024. "
+        "This decision reflects ongoing concerns about inflation.",
+    )
+    records = extract_claims(doc)
+    # The first sentence has strong claim signals (measurement + date)
+    assert any(r.document_id == "news-001" for r in records)
+    for r in records:
+        assert r.source_type == "news"
+        assert 0 < r.confidence <= 1.0
+        assert r.claim_id.startswith("cl-")
+
+
+def test_extract_claims_filters_non_claims():
+    doc = _doc(
+        "note-001",
+        "note",
+        "I might believe this could perhaps work out. "
+        "Do you think we should consider it?",
+    )
+    records = extract_claims(doc)
+    # Hedged opinion + question — heuristic should return no claims or very few
+    for r in records:
+        assert r.confidence < 0.9  # no high-confidence claims in pure opinion text
+
+
+def test_extract_claims_empty_document():
+    doc = _doc("empty-001", "news", "")
+    records = extract_claims(doc)
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: news ↔ blog cross-reference (corroboration)
+# ---------------------------------------------------------------------------
+
+def test_news_blog_cross_reference():
+    """A blog post corroborates a news claim → relation='supports'."""
+    news_claim = _claim(
+        "cl-news-01",
+        "The European Central Bank raised interest rates by 50 basis points.",
+        "news-ecb-001",
+        "news",
+    )
+    # Blog sentence that closely mirrors the claim
+    blog_corpus = [
+        (
+            "The ECB increased interest rates by 50 basis points in its latest decision.",
+            "blog-finance-007",
+            "blog",
+        ),
+        ("Markets reacted positively to the announcement.", "blog-finance-007", "blog"),
+        ("Unrelated content about cooking recipes and weekend plans.", "blog-life-099", "blog"),
+    ]
+    evidence = find_evidence(news_claim, blog_corpus, threshold=0.15)
+
+    assert len(evidence) > 0, "Expected corroborating evidence from blog"
+    top = evidence[0]
+    assert top.evidence_source_type == "blog"
+    assert top.relation == "supports"
+    assert top.similarity_score > 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: paper ↔ news contradiction
+# ---------------------------------------------------------------------------
+
+def test_paper_news_contradiction():
+    """A news article disputes a research paper's claim → relation='contradicts'."""
+    paper_claim = _claim(
+        "cl-paper-01",
+        "The vaccine efficacy rate reached 95% in clinical trials.",
+        "paper-vax-001",
+        "paper",
+    )
+    # News sentence that contradicts: "not", "dispute", "false"
+    news_corpus = [
+        (
+            "Critics dispute the reported efficacy rate, calling the 95% figure false and incorrect.",
+            "news-health-042",
+            "news",
+        ),
+        (
+            "The clinical study reported vaccine efficacy of 95 percent in trial participants.",
+            "news-science-003",
+            "news",
+        ),
+    ]
+    evidence = find_evidence(paper_claim, news_corpus, threshold=0.10)
+
+    assert len(evidence) > 0, "Expected evidence from news corpus"
+    relations = {e.relation for e in evidence}
+    assert "contradicts" in relations, f"Expected a contradiction but got: {relations}"
+
+    # The contradiction sentence should have higher _contradiction_score
+    contradicting = [e for e in evidence if e.relation == "contradicts"]
+    assert len(contradicting) >= 1
+    assert contradicting[0].evidence_source_type == "news"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: transcript claim with no evidence match
+# ---------------------------------------------------------------------------
+
+def test_transcript_no_evidence_match():
+    """A transcript claim with no similar text in corpus → empty evidence list."""
+    transcript_claim = _claim(
+        "cl-trans-01",
+        "Senator Williams announced a new bipartisan infrastructure framework.",
+        "transcript-senate-001",
+        "transcript",
+    )
+    # Completely unrelated corpus
+    unrelated_corpus = [
+        ("The price of crude oil fell by 2 dollars per barrel.", "news-energy-001", "news"),
+        ("Scientists discovered a new species of deep-sea fish.", "blog-science-002", "blog"),
+        ("The quarterly earnings report exceeded analyst expectations.", "news-finance-003", "news"),
+    ]
+    evidence = find_evidence(transcript_claim, unrelated_corpus, threshold=0.20)
+    assert evidence == [], f"Expected no evidence but got {len(evidence)} results"
+
+
+# ---------------------------------------------------------------------------
+# find_evidence: same-document filtering
+# ---------------------------------------------------------------------------
+
+def test_find_evidence_excludes_same_document():
+    """Sentences from the claim's own document must never appear as evidence."""
+    claim = _claim("cl-1", "The bank raised rates by 25 basis points.", "doc-001", "news")
+    corpus = [
+        # Same document — must be skipped
+        ("The bank raised its benchmark interest rate by 25 basis points.", "doc-001", "news"),
+        # Different document — eligible
+        ("Central bank increased interest rates by 25 basis points today.", "doc-002", "blog"),
+    ]
+    evidence = find_evidence(claim, corpus, threshold=0.15)
+    doc_ids = {e.evidence_document_id for e in evidence}
+    assert "doc-001" not in doc_ids, "Same-document sentence leaked into evidence"
+
+
+def test_find_evidence_empty_corpus():
+    claim = _claim("cl-1", "GDP grew 3%.", "doc-001", "news")
+    assert find_evidence(claim, []) == []
+
+
+def test_find_evidence_deduplicates_same_document_id():
+    """Only the highest-scoring sentence from each evidence document is kept."""
+    claim = _claim("cl-1", "The unemployment rate fell to 3.5%.", "doc-x", "news")
+    corpus = [
+        ("The unemployment rate dropped to 3.5 percent last month.", "doc-y", "blog"),
+        ("Unemployment fell sharply to 3.5% according to the labor bureau.", "doc-y", "blog"),
+    ]
+    evidence = find_evidence(claim, corpus, threshold=0.10)
+    ev_docs = [e.evidence_document_id for e in evidence]
+    assert ev_docs.count("doc-y") <= 1, "Duplicate document ID in evidence"
+
+
+# ---------------------------------------------------------------------------
+# DuckDB persistence
+# ---------------------------------------------------------------------------
+
+def _make_conn():
+    """In-memory DuckDB with both claim tables."""
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE argument_claims (
+            claim_id VARCHAR PRIMARY KEY,
+            claim_text VARCHAR NOT NULL,
+            document_id VARCHAR NOT NULL,
+            source_type VARCHAR NOT NULL,
+            confidence DOUBLE,
+            extracted_at VARCHAR
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE claim_evidence (
+            evidence_id VARCHAR PRIMARY KEY,
+            claim_id VARCHAR NOT NULL,
+            evidence_text VARCHAR,
+            evidence_document_id VARCHAR NOT NULL,
+            evidence_source_type VARCHAR NOT NULL,
+            relation VARCHAR NOT NULL,
+            similarity_score DOUBLE,
+            found_at VARCHAR
+        )
+    """)
+    return conn
+
+
+def test_store_claim_roundtrip():
+    conn = _make_conn()
+    record = ClaimRecord(
+        claim_id="cl-abc123",
+        claim_text="GDP grew 3.2% in 2024.",
+        document_id="doc-001",
+        source_type="news",
+        confidence=0.82,
+    )
+    store_claim(record, conn)
+    row = conn.execute(
+        "SELECT claim_text, source_type, confidence FROM argument_claims WHERE claim_id = ?",
+        ["cl-abc123"],
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "GDP grew 3.2% in 2024."
+    assert row[1] == "news"
+    assert abs(row[2] - 0.82) < 1e-6
+
+
+def test_store_evidence_roundtrip():
+    conn = _make_conn()
+    claim = ClaimRecord(
+        claim_id="cl-base",
+        claim_text="Rates rose 0.5%.",
+        document_id="doc-a",
+        source_type="news",
+        confidence=0.70,
+    )
+    store_claim(claim, conn)
+
+    ev = EvidenceRecord(
+        evidence_id="ev-xyz",
+        claim_id="cl-base",
+        evidence_text="Interest rates increased by half a percentage point.",
+        evidence_document_id="doc-b",
+        evidence_source_type="blog",
+        relation="supports",
+        similarity_score=0.61,
+    )
+    store_evidence(ev, conn)
+
+    row = conn.execute(
+        "SELECT relation, similarity_score FROM claim_evidence WHERE evidence_id = ?",
+        ["ev-xyz"],
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "supports"
+    assert abs(row[1] - 0.61) < 1e-6
+
+
+def test_store_claim_is_idempotent():
+    conn = _make_conn()
+    record = ClaimRecord(
+        claim_id="cl-idem",
+        claim_text="Original claim.",
+        document_id="doc-1",
+        source_type="news",
+        confidence=0.60,
+    )
+    store_claim(record, conn)
+    # Re-store with updated confidence — should not raise
+    record.confidence = 0.80
+    store_claim(record, conn)
+    row = conn.execute(
+        "SELECT COUNT(*) FROM argument_claims WHERE claim_id = 'cl-idem'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_pipeline integration
+# ---------------------------------------------------------------------------
+
+def test_run_pipeline_end_to_end():
+    """Full pipeline with an in-memory DB and injected corpus."""
+    conn = _make_conn()
+    doc = _doc(
+        "pipe-doc-001",
+        "blog",
+        "The central bank raised interest rates by 0.75% in its June meeting. "
+        "This represents the largest single increase in 28 years.",
+    )
+    corpus = [
+        ("The Fed raised rates by 75 basis points, the biggest hike in decades.", "news-fed-001", "news"),
+        ("Unrelated: best pasta recipes for summer evenings.", "blog-food-002", "blog"),
+    ]
+    claims, _ = run_pipeline(doc, conn, corpus_fn=lambda: corpus)
+
+    # At least the measurement sentence should be a claim
+    assert len(claims) >= 1
+    for c in claims:
+        assert c.document_id == "pipe-doc-001"
+        assert c.source_type == "blog"
+
+    # Verify persistence
+    row = conn.execute(
+        "SELECT COUNT(*) FROM argument_claims WHERE document_id = 'pipe-doc-001'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == len(claims)
+
+
+def test_run_pipeline_no_claims_returns_empty():
+    """Documents with only hedged opinions produce no claims or evidence."""
+    conn = _make_conn()
+    doc = _doc(
+        "hedge-doc-001",
+        "note",
+        "I might think this could perhaps be interesting. Maybe?",
+    )
+    claims, all_evidence = run_pipeline(doc, conn, corpus_fn=lambda: [])
+    # Either zero claims or claims persist correctly (no error)
+    row = conn.execute("SELECT COUNT(*) FROM argument_claims").fetchone()
+    assert row is not None
+    assert row[0] == len(claims)
+    assert all_evidence == []


### PR DESCRIPTION
## Summary

- **`src/argument_mining/evidence.py`** — two-stage pipeline: `extract_claims(doc)` runs `ClaimDetector` over any `Document`; `find_evidence(claim, corpus)` uses TF-IDF cosine similarity to find corroborating / contradicting evidence across the corpus; relation is detected by counting negation/contradiction signals (threshold ≥ 2 → `contradicts`); `run_pipeline()` wires both stages and persists to DuckDB via `INSERT OR REPLACE`
- **`src/database/local_warehouse_seed.py`** — adds `argument_claims` and `claim_evidence` tables to the DuckDB schema
- **`src/api/routes/argument_routes.py`** — three new endpoints: `GET /api/v1/arguments/claims` (filter by doc/source_type/topic), `POST /api/v1/arguments/claims/extract` (run pipeline on a stored document), `GET /api/v1/arguments/claims/{claim_id}/evidence` (stored evidence with relation filter)
- **`apps/web/src/lib/api.ts`** — `RawClaim` interface + `argumentClaims()` endpoint call
- **`apps/web/src/lib/queries.ts`** — `useArgumentClaims()` now hits the live endpoint (falls back to `mockClaims` on error/empty)
- **`tests/unit/argument_mining/test_evidence.py`** — 19 tests, all passing; covers all three AC scenarios (news↔blog corroboration, paper↔news contradiction, transcript with no match), DuckDB roundtrips, deduplication, same-doc exclusion, full pipeline e2e

## Test plan

- [x] `python -m pytest tests/unit/argument_mining/ -v` → 65/65 passed
- [x] `npm run typecheck` (apps/web) → clean
- [ ] Start backend and `POST /api/v1/arguments/claims/extract?document_id=<id>` to verify live pipeline
- [ ] `GET /api/v1/arguments/claims?source_type=news` returns stored claims
- [ ] `GET /api/v1/arguments/claims/<id>/evidence` returns evidence records

Closes #93