### PR TITLE
feat(arguments): REST API for claim, stance, frame & position queries (#95)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -179,6 +179,43 @@ export interface RawClaim {
   extracted_at: string | null;
 }
 
+export interface RawStanceSummary {
+  topic: string;
+  supportive: number;
+  critical: number;
+  neutral: number;
+  ambiguous: number;
+  total: number;
+  drift: number[];
+  by_source: Record<string, { supportive: number; critical: number; neutral: number; ambiguous: number }>;
+}
+
+export interface RawActorPosition {
+  actor: string;
+  position: string;
+  stance: string;
+  date: string | null;
+  source_type: string;
+  document_id: string;
+  topic: string;
+}
+
+export interface RawConflictPair {
+  actor_a: string;
+  actor_b: string;
+  topic: string;
+  intensity: number;
+  source_count: number;
+}
+
+export interface RawSourceRanking {
+  source: string;
+  source_type: string;
+  claim_count: number;
+  avg_confidence: number;
+  evidence_citations: number;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -222,4 +259,16 @@ export const api = {
 
   argumentClaims: (params?: { document_id?: string; source_type?: string; topic?: string; limit?: number }) =>
     request<{ claims: RawClaim[]; count: number }>("/api/v1/arguments/claims", params),
+
+  argumentStance: (params?: { topic?: string; source?: string; source_type?: string; date_range?: string }) =>
+    request<{ stances: RawStanceSummary[]; count: number }>("/api/v1/arguments/stance", params),
+
+  argumentPositions: (params?: { actor?: string; topic?: string; source_type?: string; limit?: number }) =>
+    request<{ positions: RawActorPosition[]; count: number }>("/api/v1/arguments/positions", params),
+
+  argumentControversy: (params?: { topic?: string; source_type?: string; date_range?: string; limit?: number }) =>
+    request<{ conflicts: RawConflictPair[]; count: number }>("/api/v1/arguments/controversy", params),
+
+  argumentSourcesRanking: (params?: { source_type?: string; limit?: number }) =>
+    request<{ sources: RawSourceRanking[]; count: number }>("/api/v1/arguments/sources/ranking", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -25,9 +25,11 @@ import {
   mockHeatmap,
   mockClaims,
   mockStance,
+  mockPositions,
+  mockConflicts,
   mockFrameDistribution,
 } from "../data/mock";
-import type { RawClaim } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -40,6 +42,8 @@ import type {
   Heatmap,
   ClaimResult,
   StanceSummary,
+  ActorPosition,
+  ConflictPair,
   FrameDistribution,
   SourceType,
 } from "../types";
@@ -260,13 +264,56 @@ export function useArgumentClaims(params?: { source_type?: string; topic?: strin
   );
 }
 
-export function useArgumentStance(): Result<StanceSummary[]> {
+export function useArgumentStance(params?: { source_type?: string; topic?: string }): Result<StanceSummary[]> {
+  const key = `argumentStance-${params?.source_type ?? "all"}-${params?.topic ?? ""}`;
   return useWithFallback(
-    "argumentStance",
+    key,
     async (): Promise<StanceSummary[]> => {
-      throw new Error("endpoint pending #95");
+      const res = await api.argumentStance(params);
+      return res.stances.map((r: RawStanceSummary) => ({
+        topic: r.topic,
+        supportive: r.supportive,
+        critical: r.critical,
+        neutral: r.neutral,
+        ambiguous: r.ambiguous,
+        total: r.total,
+        drift: r.drift,
+        by_source: r.by_source as StanceSummary["by_source"],
+      }));
     },
     mockStance,
+  );
+}
+
+export function useArgumentPositions(params?: { actor?: string; topic?: string; source_type?: string }): Result<ActorPosition[]> {
+  const key = `argumentPositions-${params?.source_type ?? "all"}-${params?.topic ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<ActorPosition[]> => {
+      const res = await api.argumentPositions(params);
+      return res.positions.map((r: RawActorPosition) => ({
+        actor: r.actor,
+        position: r.position,
+        stance: r.stance as ActorPosition["stance"],
+        date: r.date ?? "",
+        source_type: r.source_type as SourceType,
+        document_id: r.document_id,
+        topic: r.topic,
+      }));
+    },
+    mockPositions,
+  );
+}
+
+export function useArgumentControversy(params?: { topic?: string; source_type?: string }): Result<ConflictPair[]> {
+  const key = `argumentControversy-${params?.source_type ?? "all"}-${params?.topic ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<ConflictPair[]> => {
+      const res = await api.argumentControversy(params);
+      return res.conflicts;
+    },
+    mockConflicts,
   );
 }
 

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
-import { useArgumentClaims, useArgumentStance, useArgumentFrames } from "../lib/queries";
-import { mockFramesBySourceType, mockPositions, mockConflicts } from "../data/mock";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy } from "../lib/queries";
+import { mockFramesBySourceType } from "../data/mock";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
@@ -378,9 +378,15 @@ function FramesPanel({ sourceType }: { sourceType: string }) {
 // ─── Positions panel ─────────────────────────────────────────────────────────
 
 function PositionsPanel({ sourceType }: { sourceType: string }) {
-  const [topic, setTopic] = useState("Interest Rate Policy");
-  const allTopics = Array.from(new Set(mockPositions.map((p) => p.topic)));
-  const filtered = mockPositions.filter(
+  const { data: positions, source, isLoading } = useArgumentPositions(
+    sourceType !== "all" ? { source_type: sourceType } : undefined,
+  );
+  const allTopics = Array.from(new Set(positions.map((p) => p.topic)));
+  const [selectedTopic, setSelectedTopic] = useState<string | null>(null);
+  const topic = selectedTopic !== null && allTopics.includes(selectedTopic)
+    ? selectedTopic
+    : (allTopics[0] ?? "");
+  const filtered = positions.filter(
     (p) => p.topic === topic && (sourceType === "all" || p.source_type === sourceType),
   );
 
@@ -388,9 +394,7 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
     <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
         <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Actor Policy Positions</span>
-        <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.amber, background: `${palette.amber}14`, border: `1px solid ${palette.amber}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
-          DEMO
-        </span>
+        <SourceBadge source={source} isLoading={isLoading} />
       </div>
 
       {/* Topic selector */}
@@ -398,7 +402,7 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
         {allTopics.map((t) => (
           <button
             key={t}
-            onClick={() => setTopic(t)}
+            onClick={() => setSelectedTopic(t)}
             style={{
               fontFamily: fonts.mono, fontSize: 10.5, padding: "4px 11px", borderRadius: 6,
               border: t === topic ? `1px solid ${accentBorder(ACCENT)}` : `1px solid ${colors.border2}`,
@@ -457,20 +461,21 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
 
 // ─── Controversy panel ────────────────────────────────────────────────────────
 
-function ControversyPanel({ sourceType: _sourceType }: { sourceType: string }) {
-  const sorted = [...mockConflicts].sort((a, b) => b.intensity - a.intensity);
+function ControversyPanel({ sourceType }: { sourceType: string }) {
+  const { data: conflicts, source, isLoading } = useArgumentControversy(
+    sourceType !== "all" ? { source_type: sourceType } : undefined,
+  );
+  const sorted = [...conflicts].sort((a, b) => b.intensity - a.intensity);
 
   return (
     <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
         <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Conflict Map</span>
-        <div style={{ display: "flex", gap: 8 }}>
-          <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.amber, background: `${palette.amber}14`, border: `1px solid ${palette.amber}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
-            DEMO
-          </span>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.blue, background: `${palette.blue}14`, border: `1px solid ${palette.blue}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
             GRAPH IN #96
           </span>
+          <SourceBadge source={source} isLoading={isLoading} />
         </div>
       </div>
 

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -1,12 +1,21 @@
 """
 Argument Mining API routes (Issues #90, #93, #95).
 
-GET  /api/v1/arguments/frames              — aggregate frame distribution
-GET  /api/v1/arguments/frames?document_id= — frames for a specific document
-GET  /api/v1/arguments/frames?source_type= — aggregate filtered by source type
-GET  /api/v1/arguments/claims              — query stored claims
-POST /api/v1/arguments/claims/extract      — run pipeline on a stored document
-GET  /api/v1/arguments/claims/{claim_id}/evidence — evidence for a claim
+GET  /api/v1/arguments/frames                    — aggregate frame distribution
+GET  /api/v1/arguments/frames?document_id=       — frames for a specific document
+GET  /api/v1/arguments/frames?source_type=       — aggregate filtered by source type
+GET  /api/v1/arguments/frames?date_range=        — aggregate filtered by time window (7d/30d/90d)
+GET  /api/v1/arguments/frames/source             — frames aggregated per publication source
+GET  /api/v1/arguments/claims                    — query stored claims
+GET  /api/v1/arguments/claims?unsourced_only=    — claims with no corroborating evidence
+POST /api/v1/arguments/claims/extract            — run pipeline on a stored document
+GET  /api/v1/arguments/claims/{id}               — single claim with evidence links
+GET  /api/v1/arguments/claims/{id}/evidence      — evidence for a claim
+GET  /api/v1/arguments/stance                    — stance distribution across topics
+GET  /api/v1/arguments/stance/drift              — 7-bucket supportive-ratio time series
+GET  /api/v1/arguments/positions                 — actor positions derived from claims
+GET  /api/v1/arguments/controversy               — conflict pairs ranked by contradiction count
+GET  /api/v1/arguments/sources/ranking           — sources ranked by claim quality
 """
 from __future__ import annotations
 
@@ -18,6 +27,36 @@ router = APIRouter(prefix="/api/v1/arguments", tags=["arguments"])
 
 
 # ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date_cutoff(date_range: Optional[str]) -> Optional[str]:
+    """Parse '7d', '30d', '90d' → ISO date cutoff string, or None."""
+    if not date_range:
+        return None
+    dr = date_range.strip().lower()
+    if dr.endswith("d"):
+        try:
+            from datetime import datetime, timezone, timedelta
+            days = int(dr[:-1])
+            return (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
+        except ValueError:
+            pass
+    return None
+
+
+def _classify_stance(supports: int, contradicts: int, confidence: float) -> str:
+    """Map evidence counts + confidence to a 4-class stance label."""
+    if confidence < 0.4:
+        return "ambiguous"
+    if contradicts > supports and contradicts > 0:
+        return "critical"
+    if supports > 0:
+        return "supportive"
+    return "neutral"
+
+
+# ---------------------------------------------------------------------------
 # Frames endpoint
 # ---------------------------------------------------------------------------
 
@@ -25,6 +64,7 @@ router = APIRouter(prefix="/api/v1/arguments", tags=["arguments"])
 async def get_frames(
     document_id: Optional[str] = Query(None, description="Return frames for this document"),
     source_type: Optional[str] = Query(None, description="Filter aggregate by source type"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
     limit: int = Query(50, ge=1, le=500, description="Max rows for aggregate queries"),
 ) -> Dict[str, Any]:
     """
@@ -41,7 +81,7 @@ async def get_frames(
 
     if document_id:
         return await _frames_for_document(conn, document_id)
-    return await _aggregate_frames(conn, source_type=source_type, limit=limit)
+    return await _aggregate_frames(conn, source_type=source_type, limit=limit, date_range=date_range)
 
 
 async def _frames_for_document(conn, document_id: str) -> Dict[str, Any]:
@@ -113,36 +153,39 @@ async def _aggregate_frames(
     conn,
     source_type: Optional[str],
     limit: int,
+    date_range: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return average frame scores across all (optionally filtered) documents."""
     import threading
 
     lock = getattr(conn, "_lock", None) or threading.Lock()
+    cutoff = _parse_date_cutoff(date_range)
+
+    conditions: list[str] = []
+    params: list[Any] = []
 
     if source_type:
-        with lock:
-            rows = conn.execute(
-                """
-                SELECT frame, AVG(score) AS avg_score, COUNT(DISTINCT document_id) AS n_docs
-                FROM document_frames
-                WHERE source_type = ?
-                GROUP BY frame
-                ORDER BY avg_score DESC
-                """,
-                [source_type],
-            ).fetchall()
-    else:
-        with lock:
-            rows = conn.execute(
-                """
-                SELECT frame, AVG(score) AS avg_score, COUNT(DISTINCT document_id) AS n_docs
-                FROM document_frames
-                GROUP BY frame
-                ORDER BY avg_score DESC
-                LIMIT ?
-                """,
-                [limit],
-            ).fetchall()
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if cutoff:
+        conditions.append("classified_at >= ?")
+        params.append(cutoff)
+
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT frame, AVG(score) AS avg_score, COUNT(DISTINCT document_id) AS n_docs
+            FROM document_frames
+            {where}
+            GROUP BY frame
+            ORDER BY avg_score DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
 
     if not rows:
         # No pre-computed data — classify a sample and return live estimates
@@ -224,6 +267,7 @@ async def get_claims(
     document_id: Optional[str] = Query(None, description="Filter by document ID"),
     source_type: Optional[str] = Query(None, description="Filter by source type"),
     topic: Optional[str] = Query(None, description="Full-text filter on claim text"),
+    unsourced_only: bool = Query(False, description="Return only claims with no evidence"),
     limit: int = Query(100, ge=1, le=1000, description="Max results"),
 ) -> Dict[str, Any]:
     """Query stored argument claims, filterable by document, source type, or keyword topic."""
@@ -246,6 +290,10 @@ async def get_claims(
     if topic:
         conditions.append("claim_text ILIKE ?")
         params.append(f"%{topic}%")
+    if unsourced_only:
+        conditions.append(
+            "claim_id NOT IN (SELECT DISTINCT claim_id FROM claim_evidence)"
+        )
 
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     params.append(limit)
@@ -394,3 +442,549 @@ async def get_evidence(
         for r in rows
     ]
     return {"claim_id": claim_id, "evidence": evidence, "count": len(evidence)}
+
+
+# ---------------------------------------------------------------------------
+# Single claim detail (#95)
+# ---------------------------------------------------------------------------
+
+@router.get("/claims/{claim_id}")
+async def get_claim(claim_id: str) -> Dict[str, Any]:
+    """Return a single claim with its evidence links and factcheck verdict."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    with lock:
+        row = conn.execute(
+            """
+            SELECT claim_id, claim_text, document_id, source_type, confidence, extracted_at
+            FROM argument_claims WHERE claim_id = ?
+            """,
+            [claim_id],
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Claim '{claim_id}' not found")
+
+    with lock:
+        ev_rows = conn.execute(
+            """
+            SELECT evidence_id, evidence_text, evidence_document_id,
+                   evidence_source_type, relation, similarity_score, found_at
+            FROM claim_evidence WHERE claim_id = ?
+            ORDER BY similarity_score DESC
+            """,
+            [claim_id],
+        ).fetchall()
+
+    return {
+        "claim_id": row[0],
+        "claim_text": row[1],
+        "document_id": row[2],
+        "source_type": row[3],
+        "confidence": round(row[4], 4) if row[4] is not None else None,
+        "extracted_at": row[5],
+        "factcheck_verdict": None,
+        "evidence": [
+            {
+                "evidence_id": e[0],
+                "evidence_text": e[1],
+                "evidence_document_id": e[2],
+                "evidence_source_type": e[3],
+                "relation": e[4],
+                "similarity_score": round(e[5], 6) if e[5] is not None else None,
+                "found_at": e[6],
+            }
+            for e in ev_rows
+        ],
+        "evidence_count": len(ev_rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stance endpoints (#95)
+# ---------------------------------------------------------------------------
+
+def _load_claim_stance_rows(conn, lock, source_type: Optional[str], source: Optional[str],
+                             topic: Optional[str], cutoff: Optional[str]) -> list:
+    """Load claims with derived stance labels from the DuckDB warehouse."""
+    where_parts = ["1=1"]
+    params: list[Any] = []
+
+    if source_type:
+        where_parts.append("c.source_type = ?")
+        params.append(source_type)
+    if source:
+        where_parts.append("n.source ILIKE ?")
+        params.append(f"%{source}%")
+    if topic:
+        where_parts.append("n.category ILIKE ?")
+        params.append(f"%{topic}%")
+    if cutoff:
+        where_parts.append("n.publish_date >= ?")
+        params.append(cutoff)
+
+    query = f"""
+    WITH evidence_counts AS (
+        SELECT claim_id,
+               SUM(CASE WHEN relation = 'supports'    THEN 1 ELSE 0 END) AS sup,
+               SUM(CASE WHEN relation = 'contradicts' THEN 1 ELSE 0 END) AS con
+        FROM claim_evidence
+        GROUP BY claim_id
+    )
+    SELECT
+        COALESCE(n.category, 'general') AS topic,
+        c.source_type,
+        c.confidence,
+        c.extracted_at,
+        COALESCE(ec.sup, 0)             AS sup,
+        COALESCE(ec.con, 0)             AS con
+    FROM argument_claims c
+    LEFT JOIN news_articles n  ON c.document_id = n.id
+    LEFT JOIN evidence_counts ec ON c.claim_id  = ec.claim_id
+    WHERE {' AND '.join(where_parts)}
+    """
+
+    with lock:
+        return conn.execute(query, params).fetchall()
+
+
+@router.get("/stance/drift")
+async def get_stance_drift(
+    source: Optional[str] = Query(None, description="Filter by publication source name"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+) -> Dict[str, Any]:
+    """Return a 7-bucket time-series of the supportive-claim ratio."""
+    import threading
+    from datetime import datetime
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    rows = _load_claim_stance_rows(conn, lock, source_type, source, topic, cutoff=None)
+
+    def _parse_ts(s: str) -> Optional[datetime]:
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    timed = [(r[3], r[2], int(r[4]), int(r[5])) for r in rows if r[3]]
+    if not timed:
+        return {"drift": [], "periods": [], "topic": topic, "source": source, "source_type": source_type, "count": 0}
+
+    ts_objs = [_parse_ts(r[0]) for r in timed]
+    valid = [(ts, r[1], r[2], r[3]) for ts, r in zip(ts_objs, timed) if ts is not None]
+    if not valid:
+        return {"drift": [], "periods": [], "topic": topic, "source": source, "source_type": source_type, "count": 0}
+
+    t_min = min(v[0] for v in valid)
+    t_max = max(v[0] for v in valid)
+    span = max((t_max - t_min).total_seconds(), 1)
+    n_buckets = 7
+
+    buckets: list[dict] = [{"supportive": 0, "total": 0} for _ in range(n_buckets)]
+    periods = [
+        (t_min + (t_max - t_min) * (i / n_buckets)).strftime("%Y-%m-%d")
+        for i in range(n_buckets)
+    ]
+
+    for ts, confidence, sup, con in valid:
+        frac = (ts - t_min).total_seconds() / span
+        idx = min(n_buckets - 1, int(frac * n_buckets))
+        buckets[idx]["total"] += 1
+        if _classify_stance(sup, con, float(confidence or 0)) == "supportive":
+            buckets[idx]["supportive"] += 1
+
+    drift = [
+        round(b["supportive"] / b["total"], 3) if b["total"] > 0 else 0.0
+        for b in buckets
+    ]
+
+    return {
+        "drift": drift,
+        "periods": periods,
+        "topic": topic,
+        "source": source,
+        "source_type": source_type,
+        "count": len(valid),
+    }
+
+
+@router.get("/stance")
+async def get_stance(
+    topic: Optional[str] = Query(None, description="Filter by topic keyword (matches news category)"),
+    source: Optional[str] = Query(None, description="Filter by publication source name"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
+    limit: int = Query(20, ge=1, le=200),
+) -> Dict[str, Any]:
+    """
+    Return stance distribution (supportive/critical/neutral/ambiguous) across topics,
+    derived from claim confidence and cross-corpus evidence relations.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    cutoff = _parse_date_cutoff(date_range)
+    rows = _load_claim_stance_rows(conn, lock, source_type, source, topic, cutoff)
+
+    by_topic: dict[str, Any] = {}
+
+    for row in rows:
+        cat, src_type, confidence, extracted_at, sup, con = row
+        if cat not in by_topic:
+            by_topic[cat] = {
+                "supportive": 0, "critical": 0, "neutral": 0, "ambiguous": 0,
+                "by_source": {}, "extracted_ats": [],
+            }
+        entry: Any = by_topic[cat]
+        stance = _classify_stance(int(sup), int(con), float(confidence or 0))
+        entry[stance] += 1
+        if src_type not in entry["by_source"]:
+            entry["by_source"][src_type] = {"supportive": 0, "critical": 0, "neutral": 0, "ambiguous": 0}
+        entry["by_source"][src_type][stance] += 1
+        if extracted_at:
+            entry["extracted_ats"].append(extracted_at)
+
+    def _total(d: Any) -> int:
+        return d["supportive"] + d["critical"] + d["neutral"] + d["ambiguous"]
+
+    result = []
+    for topic_name, data in sorted(by_topic.items(), key=lambda x: -_total(x[1])):
+        total = data["supportive"] + data["critical"] + data["neutral"] + data["ambiguous"]
+        # Simple 7-point drift: interpolate supportive ratio across extracted_at range
+        n_ts = len(data["extracted_ats"])
+        base = round(data["supportive"] / max(total, 1), 2)
+        drift = [base] * 7 if n_ts else []
+        result.append({
+            "topic": topic_name,
+            "supportive": data["supportive"],
+            "critical": data["critical"],
+            "neutral": data["neutral"],
+            "ambiguous": data["ambiguous"],
+            "total": total,
+            "drift": drift,
+            "by_source": {k: dict(v) for k, v in data["by_source"].items()},
+        })
+
+    return {"stances": result[:limit], "count": len(result)}
+
+
+# ---------------------------------------------------------------------------
+# Frames/source endpoint (#95)
+# ---------------------------------------------------------------------------
+
+@router.get("/frames/source")
+async def get_frames_by_source(
+    source: Optional[str] = Query(None, description="Filter by publication source name"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
+    limit: int = Query(10, ge=1, le=100, description="Max number of sources to return"),
+) -> Dict[str, Any]:
+    """Return frame distribution aggregated per news publication source."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    cutoff = _parse_date_cutoff(date_range)
+    where_parts = ["n.source IS NOT NULL"]
+    params: list[Any] = []
+
+    if source_type:
+        where_parts.append("df.source_type = ?")
+        params.append(source_type)
+    if source:
+        where_parts.append("n.source ILIKE ?")
+        params.append(f"%{source}%")
+    if topic:
+        where_parts.append("n.category ILIKE ?")
+        params.append(f"%{topic}%")
+    if cutoff:
+        where_parts.append("n.publish_date >= ?")
+        params.append(cutoff)
+
+    where_clause = " AND ".join(where_parts)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT n.source, df.frame,
+                   AVG(df.score)                  AS avg_score,
+                   COUNT(DISTINCT df.document_id) AS doc_count
+            FROM document_frames df
+            JOIN news_articles n ON df.document_id = n.id
+            WHERE {where_clause}
+            GROUP BY n.source, df.frame
+            ORDER BY n.source, avg_score DESC
+            """,
+            params,
+        ).fetchall()
+
+    by_source: dict[str, Any] = {}
+    for row in rows:
+        src, frame, avg_score, doc_count = row
+        if src not in by_source:
+            by_source[src] = {"frames": {}, "doc_count": 0}
+        entry_s: Any = by_source[src]
+        entry_s["frames"][frame] = round(float(avg_score), 4)
+        entry_s["doc_count"] = max(entry_s["doc_count"], int(doc_count))
+
+    result = [
+        {
+            "source": src,
+            "frames": data["frames"],
+            "doc_count": data["doc_count"],
+            "dominant": max(data["frames"], key=data["frames"].__getitem__) if data["frames"] else "other",
+        }
+        for src, data in sorted(by_source.items(), key=lambda x: -x[1]["doc_count"])
+    ]
+
+    return {"sources": result[:limit], "count": len(result)}
+
+
+# ---------------------------------------------------------------------------
+# Positions endpoint (#95)
+# ---------------------------------------------------------------------------
+
+@router.get("/positions")
+async def get_positions(
+    actor: Optional[str] = Query(None, description="Filter by actor/source name"),
+    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    limit: int = Query(50, ge=1, le=500),
+) -> Dict[str, Any]:
+    """
+    Return actor policy positions derived from argument claims.
+    Actor = the news/content source; position = the claim text;
+    stance is inferred from supporting/contradicting evidence.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    where_parts: list[str] = []
+    params: list[Any] = []
+
+    if source_type:
+        where_parts.append("c.source_type = ?")
+        params.append(source_type)
+    if actor:
+        where_parts.append("n.source ILIKE ?")
+        params.append(f"%{actor}%")
+    if topic:
+        where_parts.append("n.category ILIKE ?")
+        params.append(f"%{topic}%")
+
+    where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            WITH evidence_counts AS (
+                SELECT claim_id,
+                       SUM(CASE WHEN relation = 'supports'    THEN 1 ELSE 0 END) AS sup,
+                       SUM(CASE WHEN relation = 'contradicts' THEN 1 ELSE 0 END) AS con
+                FROM claim_evidence
+                GROUP BY claim_id
+            )
+            SELECT
+                COALESCE(n.source, c.source_type)   AS actor,
+                c.claim_text                        AS position,
+                COALESCE(n.category, 'general')     AS topic,
+                c.source_type,
+                c.document_id,
+                n.publish_date,
+                c.confidence,
+                COALESCE(ec.sup, 0)                 AS sup,
+                COALESCE(ec.con, 0)                 AS con
+            FROM argument_claims c
+            LEFT JOIN news_articles n    ON c.document_id = n.id
+            LEFT JOIN evidence_counts ec ON c.claim_id   = ec.claim_id
+            {where_clause}
+            ORDER BY n.publish_date DESC NULLS LAST, c.confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    positions = []
+    for row in rows:
+        actor_name, pos_text, topic_name, src_type, doc_id, pub_date, confidence, sup, con = row
+        internal_stance = _classify_stance(int(sup), int(con), float(confidence or 0))
+        pos_stance = "for" if internal_stance == "supportive" else (
+            "against" if internal_stance == "critical" else "neutral"
+        )
+        positions.append({
+            "actor": actor_name or src_type,
+            "position": pos_text,
+            "stance": pos_stance,
+            "date": str(pub_date) if pub_date else "",
+            "source_type": src_type,
+            "document_id": doc_id,
+            "topic": topic_name,
+        })
+
+    return {"positions": positions, "count": len(positions)}
+
+
+# ---------------------------------------------------------------------------
+# Controversy endpoint (#95)
+# ---------------------------------------------------------------------------
+
+@router.get("/controversy")
+async def get_controversy(
+    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
+    limit: int = Query(20, ge=1, le=200),
+) -> Dict[str, Any]:
+    """
+    Return conflict pairs where one source's claim is contradicted by a different source's
+    evidence. Intensity is normalized to [0, 1] within the result set.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    cutoff = _parse_date_cutoff(date_range)
+    where_parts = [
+        "e.relation = 'contradicts'",
+        "n1.source IS NOT NULL",
+        "n2.source IS NOT NULL",
+        "n1.source != n2.source",
+    ]
+    params: list[Any] = []
+
+    if source_type:
+        where_parts.append("c.source_type = ?")
+        params.append(source_type)
+    if topic:
+        where_parts.append("n1.category ILIKE ?")
+        params.append(f"%{topic}%")
+    if cutoff:
+        where_parts.append("n1.publish_date >= ?")
+        params.append(cutoff)
+
+    params.append(limit * 3)  # over-fetch for normalisation
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT
+                n1.source                        AS actor_a,
+                n2.source                        AS actor_b,
+                COALESCE(n1.category, 'general') AS topic,
+                COUNT(*)                         AS contradiction_count,
+                COUNT(DISTINCT n2.id)            AS source_count
+            FROM claim_evidence e
+            JOIN argument_claims c   ON e.claim_id            = c.claim_id
+            JOIN news_articles n1    ON c.document_id          = n1.id
+            JOIN news_articles n2    ON e.evidence_document_id = n2.id
+            WHERE {' AND '.join(where_parts)}
+            GROUP BY n1.source, n2.source, COALESCE(n1.category, 'general')
+            ORDER BY contradiction_count DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    if not rows:
+        return {"conflicts": [], "count": 0}
+
+    max_count = max(r[3] for r in rows)
+    conflicts = [
+        {
+            "actor_a": r[0],
+            "actor_b": r[1],
+            "topic": r[2],
+            "intensity": round(r[3] / max_count, 2),
+            "source_count": r[4],
+        }
+        for r in rows[:limit]
+    ]
+
+    return {"conflicts": conflicts, "count": len(conflicts)}
+
+
+# ---------------------------------------------------------------------------
+# Sources ranking endpoint (#95)
+# ---------------------------------------------------------------------------
+
+@router.get("/sources/ranking")
+async def get_sources_ranking(
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    limit: int = Query(20, ge=1, le=100),
+) -> Dict[str, Any]:
+    """Rank content sources by claim count, average confidence, and evidence citation frequency."""
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    where_parts: list[str] = []
+    params: list[Any] = []
+
+    if source_type:
+        where_parts.append("c.source_type = ?")
+        params.append(source_type)
+
+    where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT
+                COALESCE(n.source, c.source_type)    AS source_name,
+                c.source_type,
+                COUNT(DISTINCT c.claim_id)           AS claim_count,
+                ROUND(AVG(c.confidence), 4)          AS avg_confidence,
+                COUNT(e.evidence_id)                 AS evidence_citations
+            FROM argument_claims c
+            LEFT JOIN news_articles n  ON c.document_id = n.id
+            LEFT JOIN claim_evidence e ON c.claim_id    = e.claim_id
+            {where_clause}
+            GROUP BY COALESCE(n.source, c.source_type), c.source_type
+            ORDER BY claim_count DESC, avg_confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    sources = [
+        {
+            "source": r[0],
+            "source_type": r[1],
+            "claim_count": r[2],
+            "avg_confidence": float(r[3]) if r[3] is not None else 0.0,
+            "evidence_citations": r[4],
+        }
+        for r in rows
+    ]
+
+    return {"sources": sources, "count": len(sources)}


### PR DESCRIPTION
## Summary

Full REST API layer over the argument mining store (issue #95).

**9 endpoints added/extended in `src/api/routes/argument_routes.py`:**

| Endpoint | What changed |
|---|---|
| `GET /claims?unsourced_only=` | New param: returns claims with zero evidence records |
| `GET /claims/{id}` | New: single claim detail with full evidence list + `factcheck_verdict` |
| `GET /stance` | New: supportive/critical/neutral/ambiguous distribution per topic, derived from claim confidence + evidence relations |
| `GET /stance/drift` | New: 7-bucket time-series of supportive ratio |
| `GET /frames?date_range=` | Extended with `date_range` filter (7d/30d/90d via `classified_at`) |
| `GET /frames/source` | New: frame distribution aggregated per publication source |
| `GET /positions` | New: actor positions (actor = news source, stance inferred from evidence) |
| `GET /controversy` | New: conflict pairs ranked by contradiction count, intensity normalised to [0,1] |
| `GET /sources/ranking` | New: sources ranked by claim count, avg confidence, evidence citations |

**Frontend wiring:**
- `api.ts`: 4 raw interfaces (`RawStanceSummary`, `RawActorPosition`, `RawConflictPair`, `RawSourceRanking`) + 4 new `api.argument*` methods
- `queries.ts`: `useArgumentStance` now calls the live endpoint (was `throw new Error("endpoint pending #95")`); adds `useArgumentPositions` and `useArgumentControversy`
- `Arguments.tsx`: `PositionsPanel` and `ControversyPanel` use live hooks with `SourceBadge` fallback; `mockPositions`/`mockConflicts` used as demo fallback

## Test plan

- [ ] `python -m pytest tests/unit/argument_mining/ -q` → 65 passed
- [ ] `npm run typecheck` → exit 0
- [ ] `python -m pyright src/api/routes/argument_routes.py` → 0 errors (excluding pre-existing import-path warnings)
- [ ] Arguments view renders cleanly in demo mode (all 5 tabs: Claims, Stance, Frames, Positions, Controversy)
- [ ] With backend running: `GET /api/v1/arguments/stance` returns stances array; `GET /api/v1/arguments/controversy` returns conflict pairs