### PR TITLE
feat(arguments): interactive force-directed controversy graph (#96)

### DIFF
--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -19,6 +19,7 @@ import type {
   FrameDistribution,
   ActorPosition,
   ConflictPair,
+  ControversyGraph,
 } from "../types";
 
 const NOW = Date.now();
@@ -313,3 +314,34 @@ export const mockConflicts: ConflictPair[] = [
   { actor_a: "WHO",              actor_b: "Pharma Industry",  topic: "Drug Pricing",               intensity: 0.47, source_count: 7  },
   { actor_a: "BIS",              actor_b: "Goldman Sachs",    topic: "Central Bank Independence",  intensity: 0.61, source_count: 9  },
 ];
+
+export const mockControversyGraph: ControversyGraph = {
+  node_count: 10,
+  edge_count: 12,
+  nodes: [
+    { id: "c1",  label: "Reuters",        source: "Reuters",        source_type: "news",       topic: "AI Regulation",        date: "2024-11-12", claim_text: "AI systems require mandatory pre-deployment safety audits before any commercial release.", confidence: 0.89, document_id: "doc-n-01" },
+    { id: "c2",  label: "EU Commission",  source: "EU Commission",  source_type: "paper",      topic: "AI Regulation",        date: "2024-11-15", claim_text: "Current AI systems do not yet pose an existential safety risk requiring immediate regulatory intervention.", confidence: 0.76, document_id: "doc-p-01" },
+    { id: "c3",  label: "Bloomberg",      source: "Bloomberg",      source_type: "news",       topic: "Interest Rate Policy", date: "2024-10-08", claim_text: "The Federal Reserve will cut rates by 50 basis points before year-end to stimulate economic growth.", confidence: 0.82, document_id: "doc-n-02" },
+    { id: "c4",  label: "WSJ Editorial",  source: "WSJ Editorial",  source_type: "blog",       topic: "Interest Rate Policy", date: "2024-10-14", claim_text: "Premature rate cuts risk reigniting inflation that has not yet been durably subdued.", confidence: 0.71, document_id: "doc-b-01" },
+    { id: "c5",  label: "OPEC Report",    source: "OPEC Report",    source_type: "paper",      topic: "Oil Production",       date: "2024-09-05", claim_text: "Global oil demand will peak no earlier than 2030, supporting continued upstream investment.", confidence: 0.93, document_id: "doc-p-02" },
+    { id: "c6",  label: "IEA",            source: "IEA",            source_type: "paper",      topic: "Oil Production",       date: "2024-09-10", claim_text: "Oil demand is set to peak well before 2030 as EV adoption and renewable capacity accelerate.", confidence: 0.88, document_id: "doc-p-03" },
+    { id: "c7",  label: "FT",             source: "FT",             source_type: "news",       topic: "Trade Tariffs",        date: "2024-08-22", claim_text: "Broad tariffs on Chinese imports will reduce the US trade deficit and protect domestic manufacturing.", confidence: 0.67, document_id: "doc-n-03" },
+    { id: "c8",  label: "IMF Report",     source: "IMF Report",     source_type: "paper",      topic: "Trade Tariffs",        date: "2024-08-28", claim_text: "Tariff escalation will reduce global GDP by 0.7% and primarily harm the economies imposing them.", confidence: 0.91, document_id: "doc-p-04" },
+    { id: "c9",  label: "Nature Podcast", source: "Nature Podcast", source_type: "transcript", topic: "Drug Pricing",         date: "2024-07-11", claim_text: "Price controls on pharmaceuticals will stifle R&D investment and reduce long-term innovation.", confidence: 0.74, document_id: "doc-t-01" },
+    { id: "c10", label: "WHO",            source: "WHO",            source_type: "paper",      topic: "Drug Pricing",         date: "2024-07-20", claim_text: "Excessive drug pricing by pharmaceutical companies is the primary barrier to equitable global healthcare access.", confidence: 0.85, document_id: "doc-p-05" },
+  ],
+  edges: [
+    { source: "c1",  target: "c2",  severity: 0.87, relation: "contradicts" },
+    { source: "c2",  target: "c1",  severity: 0.82, relation: "contradicts" },
+    { source: "c3",  target: "c4",  severity: 0.78, relation: "contradicts" },
+    { source: "c4",  target: "c3",  severity: 0.74, relation: "contradicts" },
+    { source: "c5",  target: "c6",  severity: 0.93, relation: "contradicts" },
+    { source: "c6",  target: "c5",  severity: 0.91, relation: "contradicts" },
+    { source: "c7",  target: "c8",  severity: 0.83, relation: "contradicts" },
+    { source: "c8",  target: "c7",  severity: 0.86, relation: "contradicts" },
+    { source: "c9",  target: "c10", severity: 0.72, relation: "contradicts" },
+    { source: "c10", target: "c9",  severity: 0.79, relation: "contradicts" },
+    { source: "c1",  target: "c7",  severity: 0.55, relation: "contradicts" },
+    { source: "c3",  target: "c5",  severity: 0.48, relation: "contradicts" },
+  ],
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -208,6 +208,25 @@ export interface RawConflictPair {
   source_count: number;
 }
 
+export interface RawControversyNode {
+  id: string;
+  label: string;
+  source: string;
+  source_type: string;
+  topic: string;
+  date: string | null;
+  claim_text: string;
+  confidence: number;
+  document_id: string;
+}
+
+export interface RawControversyEdge {
+  source: string;
+  target: string;
+  severity: number;
+  relation: string;
+}
+
 export interface RawSourceRanking {
   source: string;
   source_type: string;
@@ -268,6 +287,9 @@ export const api = {
 
   argumentControversy: (params?: { topic?: string; source_type?: string; date_range?: string; limit?: number }) =>
     request<{ conflicts: RawConflictPair[]; count: number }>("/api/v1/arguments/controversy", params),
+
+  argumentControversyGraph: (params?: { topic?: string; source_type?: string; date_range?: string; limit?: number }) =>
+    request<{ nodes: RawControversyNode[]; edges: RawControversyEdge[]; node_count: number; edge_count: number }>("/api/v1/arguments/controversy/graph", params),
 
   argumentSourcesRanking: (params?: { source_type?: string; limit?: number }) =>
     request<{ sources: RawSourceRanking[]; count: number }>("/api/v1/arguments/sources/ranking", params),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -28,6 +28,7 @@ import {
   mockPositions,
   mockConflicts,
   mockFrameDistribution,
+  mockControversyGraph,
 } from "../data/mock";
 import type { RawClaim, RawStanceSummary, RawActorPosition } from "./api";
 import { palette, ACCENT } from "../theme";
@@ -46,6 +47,7 @@ import type {
   ConflictPair,
   FrameDistribution,
   SourceType,
+  ControversyGraph,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -314,6 +316,19 @@ export function useArgumentControversy(params?: { topic?: string; source_type?: 
       return res.conflicts;
     },
     mockConflicts,
+  );
+}
+
+export function useArgumentControversyGraph(params?: { topic?: string; source_type?: string; date_range?: string }): Result<ControversyGraph> {
+  const key = `argumentControversyGraph-${params?.source_type ?? "all"}-${params?.topic ?? ""}-${params?.date_range ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<ControversyGraph> => {
+      const res = await api.argumentControversyGraph(params);
+      if (!res.nodes.length) throw new Error("empty");
+      return res;
+    },
+    mockControversyGraph,
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -213,6 +213,32 @@ export interface ConflictPair {
   source_count: number;
 }
 
+export interface ControversyNode {
+  id: string;
+  label: string;
+  source: string;
+  source_type: string;
+  topic: string;
+  date: string | null;
+  claim_text: string;
+  confidence: number;
+  document_id: string;
+}
+
+export interface ControversyEdge {
+  source: string;
+  target: string;
+  severity: number;
+  relation: string;
+}
+
+export interface ControversyGraph {
+  nodes: ControversyNode[];
+  edges: ControversyEdge[];
+  node_count: number;
+  edge_count: number;
+}
+
 export type SourceType = "news" | "blog" | "paper" | "book" | "transcript" | "web" | "note";
 
 export interface KnowledgeDocument {

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
-import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy } from "../lib/queries";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph } from "../lib/queries";
 import { mockFramesBySourceType } from "../data/mock";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
-import type { ArgumentTab, SourceType, StanceSummary } from "../types";
+import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge } from "../types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -461,58 +461,377 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
 
 // ─── Controversy panel ────────────────────────────────────────────────────────
 
+const ST_COLORS: Record<string, string> = {
+  news: palette.blue, blog: palette.teal, paper: palette.violet,
+  transcript: palette.amber, book: palette.pos, note: palette.dim,
+};
+
+interface SimNode extends ControversyNode {
+  x: number; y: number; vx: number; vy: number;
+}
+
+function useForceSimulation(
+  nodes: ControversyNode[],
+  edges: ControversyEdge[],
+  width: number,
+  height: number,
+) {
+  const simRef = useRef<SimNode[]>([]);
+  const rafRef = useRef<number>(0);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    cancelAnimationFrame(rafRef.current);
+    simRef.current = nodes.map((n, i) => ({
+      ...n,
+      x: width / 2 + Math.cos((i / nodes.length) * Math.PI * 2) * 160,
+      y: height / 2 + Math.sin((i / nodes.length) * Math.PI * 2) * 120,
+      vx: 0, vy: 0,
+    }));
+    let iter = 0;
+
+    function step() {
+      const sim = simRef.current;
+      const alpha = Math.max(0.01, 0.8 * Math.pow(0.975, iter));
+      const cx = width / 2, cy = height / 2;
+      const R = 18;
+
+      for (let i = 0; i < sim.length; i++) {
+        sim[i].vx += (cx - sim[i].x) * 0.012 * alpha;
+        sim[i].vy += (cy - sim[i].y) * 0.012 * alpha;
+        for (let j = i + 1; j < sim.length; j++) {
+          const dx = sim[i].x - sim[j].x;
+          const dy = sim[i].y - sim[j].y;
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+          const force = (alpha * 3200) / (dist * dist);
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          sim[i].vx += fx; sim[i].vy += fy;
+          sim[j].vx -= fx; sim[j].vy -= fy;
+        }
+      }
+
+      for (const e of edges) {
+        const a = sim.find((n) => n.id === e.source);
+        const b = sim.find((n) => n.id === e.target);
+        if (!a || !b) continue;
+        const dx = b.x - a.x, dy = b.y - a.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        const restLen = 120;
+        const force = ((dist - restLen) / dist) * alpha * 0.35 * e.severity;
+        const fx = dx * force, fy = dy * force;
+        a.vx += fx; a.vy += fy;
+        b.vx -= fx; b.vy -= fy;
+      }
+
+      for (const n of sim) {
+        n.vx *= 0.72; n.vy *= 0.72;
+        n.x = Math.max(R, Math.min(width - R, n.x + n.vx));
+        n.y = Math.max(R, Math.min(height - R, n.y + n.vy));
+      }
+
+      iter++;
+      setTick((t) => t + 1);
+      if (iter < 220) rafRef.current = requestAnimationFrame(step);
+    }
+
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [nodes, edges, width, height]);
+
+  return { sim: simRef.current, tick };
+}
+
+function ConflictGraph({
+  nodes,
+  edges,
+  selectedId,
+  onSelect,
+}: {
+  nodes: ControversyNode[];
+  edges: ControversyEdge[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  const W = 740, H = 420;
+  const { sim } = useForceSimulation(nodes, edges, W, H);
+
+  const posMap = new Map(sim.map((n) => [n.id, { x: n.x, y: n.y }]));
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ display: "block", background: colors.cardInner, borderRadius: 8 }}
+      onClick={() => onSelect(null)}
+    >
+      <defs>
+        <marker id="arr" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill={`${palette.neg}88`} />
+        </marker>
+      </defs>
+
+      {/* Edges */}
+      {edges.map((e, i) => {
+        const a = posMap.get(e.source);
+        const b = posMap.get(e.target);
+        if (!a || !b) return null;
+        const w = 1 + e.severity * 3.5;
+        const opacity = selectedId
+          ? e.source === selectedId || e.target === selectedId ? 0.85 : 0.12
+          : 0.45;
+        return (
+          <line key={i}
+            x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+            stroke={palette.neg}
+            strokeWidth={w}
+            strokeOpacity={opacity}
+            markerEnd="url(#arr)"
+          />
+        );
+      })}
+
+      {/* Nodes */}
+      {sim.map((n) => {
+        const color = ST_COLORS[n.source_type] ?? palette.dim;
+        const isSelected = n.id === selectedId;
+        const dimmed = selectedId !== null && !isSelected &&
+          !edges.some((e) => e.source === selectedId && e.target === n.id || e.target === selectedId && e.source === n.id);
+        return (
+          <g key={n.id} transform={`translate(${n.x},${n.y})`}
+            style={{ cursor: "pointer" }}
+            onClick={(ev) => { ev.stopPropagation(); onSelect(isSelected ? null : n.id); }}
+          >
+            <circle r={isSelected ? 20 : 14}
+              fill={`${color}22`}
+              stroke={isSelected ? color : `${color}88`}
+              strokeWidth={isSelected ? 2.5 : 1.5}
+              opacity={dimmed ? 0.2 : 1}
+            />
+            <text
+              textAnchor="middle" dominantBaseline="middle"
+              fontSize={9} fill={color}
+              opacity={dimmed ? 0.2 : 1}
+              style={{ pointerEvents: "none", userSelect: "none", fontFamily: fonts.mono }}
+            >
+              {n.label.length > 10 ? n.label.slice(0, 9) + "…" : n.label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function NodeDetail({
+  node,
+  edges,
+  nodes,
+  onClose,
+}: {
+  node: ControversyNode;
+  edges: ControversyEdge[];
+  nodes: ControversyNode[];
+  onClose: () => void;
+}) {
+  const color = ST_COLORS[node.source_type] ?? palette.dim;
+  const linked = edges
+    .filter((e) => e.source === node.id || e.target === node.id)
+    .map((e) => {
+      const peerId = e.source === node.id ? e.target : e.source;
+      const peer = nodes.find((n) => n.id === peerId);
+      return peer ? { peer, edge: e } : null;
+    })
+    .filter(Boolean) as { peer: ControversyNode; edge: ControversyEdge }[];
+
+  return (
+    <div style={{ ...card, padding: "16px 18px", borderLeft: `3px solid ${color}` }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+        <div>
+          <span style={{ fontWeight: 600, fontSize: 13 }}>{node.source}</span>
+          <SourceTypePill type={node.source_type} />
+          <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.faint, marginLeft: 8 }}>
+            {node.date ?? "—"} · {node.topic}
+          </span>
+        </div>
+        <button onClick={onClose} style={{ background: "none", border: "none", color: palette.dim, cursor: "pointer", fontSize: 16, lineHeight: 1 }}>
+          ✕
+        </button>
+      </div>
+      <div style={{ marginTop: 10, fontSize: 13, lineHeight: 1.6, color: colors.text }}>
+        "{node.claim_text}"
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <div style={{ ...mono10, marginBottom: 6 }}>confidence</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ flex: 1, height: 4, background: colors.cardInner, borderRadius: 2 }}>
+            <div style={{ width: `${node.confidence * 100}%`, height: "100%", borderRadius: 2, background: color }} />
+          </div>
+          <span style={{ fontFamily: fonts.mono, fontSize: 10, color }}>{Math.round(node.confidence * 100)}%</span>
+        </div>
+      </div>
+      {linked.length > 0 && (
+        <div style={{ marginTop: 14 }}>
+          <div style={{ ...mono10, marginBottom: 8 }}>conflicting with ({linked.length})</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {linked.map(({ peer, edge }) => {
+              const pcolor = ST_COLORS[peer.source_type] ?? palette.dim;
+              const sev = Math.round(edge.severity * 100);
+              return (
+                <div key={peer.id} style={{ background: colors.cardInner, borderRadius: 6, padding: "8px 12px", display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10 }}>
+                  <div style={{ flex: 1 }}>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10, color: pcolor, marginRight: 6 }}>{peer.source}</span>
+                    <span style={{ fontSize: 11.5, color: colors.textMuted }}>"{peer.claim_text.slice(0, 90)}{peer.claim_text.length > 90 ? "…" : ""}"</span>
+                  </div>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9, color: sev >= 75 ? palette.neg : palette.amber, background: `${sev >= 75 ? palette.neg : palette.amber}18`, border: `1px solid ${sev >= 75 ? palette.neg : palette.amber}40`, borderRadius: 4, padding: "2px 6px", flexShrink: 0 }}>
+                    {sev}% sev
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ControversyPanel({ sourceType }: { sourceType: string }) {
-  const { data: conflicts, source, isLoading } = useArgumentControversy(
+  const [topic, setTopicFilter] = useState<string | null>(null);
+  const [dateRange, setDateRange] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { data: conflicts, source: listSource, isLoading: listLoading } = useArgumentControversy(
     sourceType !== "all" ? { source_type: sourceType } : undefined,
   );
-  const sorted = [...conflicts].sort((a, b) => b.intensity - a.intensity);
+  const params: { topic?: string; source_type?: string; date_range?: string } = {};
+  if (sourceType !== "all") params.source_type = sourceType;
+  if (topic) params.topic = topic;
+  if (dateRange) params.date_range = dateRange;
+  const { data: graph, source: graphSource, isLoading: graphLoading } = useArgumentControversyGraph(
+    Object.keys(params).length ? params : undefined,
+  );
+
+  const allTopics = Array.from(new Set([
+    ...graph.nodes.map((n) => n.topic),
+    ...conflicts.map((c) => c.topic),
+  ])).sort();
+
+  const filteredNodes = topic ? graph.nodes.filter((n) => n.topic === topic) : graph.nodes;
+  const filteredNodeIds = new Set(filteredNodes.map((n) => n.id));
+  const filteredEdges = graph.edges.filter((e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target));
+
+  const selectedNode = selectedId ? filteredNodes.find((n) => n.id === selectedId) ?? null : null;
+
+  const onSelect = useCallback((id: string | null) => {
+    setSelectedId(id);
+  }, []);
+
+  const DATE_RANGES = [
+    { key: null, label: "All time" },
+    { key: "7d",  label: "7 days" },
+    { key: "30d", label: "30 days" },
+    { key: "90d", label: "90 days" },
+  ];
 
   return (
     <div>
+      {/* Header */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
-        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Conflict Map</span>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Conflict Graph</span>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.blue, background: `${palette.blue}14`, border: `1px solid ${palette.blue}40`, borderRadius: 5, padding: "3px 8px", letterSpacing: "0.1em" }}>
-            GRAPH IN #96
+          <SourceBadge source={graphSource} isLoading={graphLoading} />
+        </div>
+      </div>
+
+      {/* Filters row */}
+      <div style={{ display: "flex", gap: 16, marginBottom: 14, flexWrap: "wrap", alignItems: "center" }}>
+        {/* Topic picker */}
+        <div style={{ display: "flex", gap: 5, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={{ ...mono10, marginRight: 4 }}>Topic</span>
+          {[{ key: null, label: "All" }, ...allTopics.map((t) => ({ key: t, label: t }))].map(({ key, label }) => (
+            <button key={label} onClick={() => { setTopicFilter(key); setSelectedId(null); }}
+              style={{
+                fontFamily: fonts.mono, fontSize: 10, padding: "3px 9px", borderRadius: 5, cursor: "pointer",
+                border: topic === key ? `1px solid ${accentBorder(ACCENT)}` : `1px solid ${colors.border2}`,
+                background: topic === key ? accentSoft(ACCENT) : "transparent",
+                color: topic === key ? ACCENT : palette.dim,
+              }}
+            >{label}</button>
+          ))}
+        </div>
+        {/* Date range */}
+        <div style={{ display: "flex", gap: 5, alignItems: "center" }}>
+          <span style={{ ...mono10, marginRight: 4 }}>Period</span>
+          {DATE_RANGES.map(({ key, label }) => (
+            <button key={label} onClick={() => setDateRange(key)}
+              style={{
+                fontFamily: fonts.mono, fontSize: 10, padding: "3px 9px", borderRadius: 5, cursor: "pointer",
+                border: dateRange === key ? `1px solid ${accentBorder(ACCENT)}` : `1px solid ${colors.border2}`,
+                background: dateRange === key ? accentSoft(ACCENT) : "transparent",
+                color: dateRange === key ? ACCENT : palette.dim,
+              }}
+            >{label}</button>
+          ))}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div style={{ display: "flex", gap: 14, marginBottom: 12, flexWrap: "wrap" }}>
+        {Object.entries(ST_COLORS).map(([type, color]) => (
+          <span key={type} style={{ display: "flex", alignItems: "center", gap: 4, fontFamily: fonts.mono, fontSize: 9.5, color }}>
+            <span style={{ width: 8, height: 8, borderRadius: "50%", background: color, display: "inline-block" }} />
+            {type}
           </span>
-          <SourceBadge source={source} isLoading={isLoading} />
-        </div>
+        ))}
+        <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.faint, marginLeft: 8 }}>
+          edge thickness = conflict severity · click node for details
+        </span>
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {sorted.map((c) => {
-          const intPct = Math.round(c.intensity * 100);
-          const color = c.intensity > 0.75 ? palette.neg : c.intensity > 0.5 ? palette.amber : palette.neu;
-          return (
-            <div key={`${c.actor_a}-${c.actor_b}`} style={{ ...card, padding: "14px 18px" }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-                {/* Actor A */}
-                <span style={{ fontWeight: 600, fontSize: 13, flex: 1, textAlign: "right" }}>{c.actor_a}</span>
-                {/* Conflict indicator */}
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, flexShrink: 0, minWidth: 80 }}>
-                  <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color, letterSpacing: "0.1em" }}>
-                    {intPct}% intensity
-                  </span>
-                  <div style={{ width: 80, height: 6, background: colors.cardInner, borderRadius: 3 }}>
-                    <div style={{ width: `${intPct}%`, height: "100%", borderRadius: 3, background: color }} />
+      {/* Graph */}
+      <div style={{ ...card, padding: 12, marginBottom: 14 }}>
+        {filteredNodes.length === 0 ? (
+          <div style={{ height: 200, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: fonts.mono, fontSize: 12, color: palette.faint }}>
+            No conflict data for selected filters.
+          </div>
+        ) : (
+          <ConflictGraph nodes={filteredNodes} edges={filteredEdges} selectedId={selectedId} onSelect={onSelect} />
+        )}
+      </div>
+
+      {/* Node detail panel */}
+      {selectedNode && (
+        <div style={{ marginBottom: 14 }}>
+          <NodeDetail node={selectedNode} edges={filteredEdges} nodes={filteredNodes} onClose={() => setSelectedId(null)} />
+        </div>
+      )}
+
+      {/* Conflict list (collapsed summary) */}
+      <div style={{ marginTop: 4 }}>
+        <div style={{ ...mono10, marginBottom: 8 }}>Top conflicts by intensity</div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {[...conflicts].sort((a, b) => b.intensity - a.intensity).slice(0, 5).map((c) => {
+            const intPct = Math.round(c.intensity * 100);
+            const color = c.intensity > 0.75 ? palette.neg : c.intensity > 0.5 ? palette.amber : palette.neu;
+            return (
+              <div key={`${c.actor_a}-${c.actor_b}`} style={{ ...card, padding: "10px 14px", display: "flex", alignItems: "center", gap: 10 }}>
+                <span style={{ fontWeight: 600, fontSize: 12, flex: 1, textAlign: "right", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.actor_a}</span>
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3, flexShrink: 0, minWidth: 70 }}>
+                  <div style={{ width: 70, height: 4, background: colors.cardInner, borderRadius: 2 }}>
+                    <div style={{ width: `${intPct}%`, height: "100%", borderRadius: 2, background: color }} />
                   </div>
-                  <span style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.faint }}>{c.source_count} sources</span>
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9, color, letterSpacing: "0.08em" }}>{intPct}%</span>
                 </div>
-                {/* Actor B */}
-                <span style={{ fontWeight: 600, fontSize: 13, flex: 1 }}>{c.actor_b}</span>
+                <span style={{ fontWeight: 600, fontSize: 12, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.actor_b}</span>
               </div>
-              <div style={{ marginTop: 8, textAlign: "center", fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint }}>
-                {c.topic}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
 
-      <div style={{ marginTop: 20, ...card, padding: "14px 18px", borderColor: `${palette.blue}44`, background: `${palette.blue}08` }}>
-        <div style={{ fontFamily: fonts.mono, fontSize: 11, color: palette.blue }}>
-          ◈ Interactive force-directed conflict graph with source_type colour coding on nodes ships in issue #96.
-        </div>
+      {/* List source badge */}
+      <div style={{ marginTop: 10, display: "flex", justifyContent: "flex-end" }}>
+        <SourceBadge source={listSource} isLoading={listLoading} />
       </div>
     </div>
   );

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -1,5 +1,5 @@
 """
-Argument Mining API routes (Issues #90, #93, #95).
+Argument Mining API routes (Issues #90, #93, #95, #96).
 
 GET  /api/v1/arguments/frames                    — aggregate frame distribution
 GET  /api/v1/arguments/frames?document_id=       — frames for a specific document
@@ -15,6 +15,7 @@ GET  /api/v1/arguments/stance                    — stance distribution across 
 GET  /api/v1/arguments/stance/drift              — 7-bucket supportive-ratio time series
 GET  /api/v1/arguments/positions                 — actor positions derived from claims
 GET  /api/v1/arguments/controversy               — conflict pairs ranked by contradiction count
+GET  /api/v1/arguments/controversy/graph         — force-directed graph: nodes=claims, edges=contradictions (#96)
 GET  /api/v1/arguments/sources/ranking           — sources ranked by claim quality
 """
 from __future__ import annotations
@@ -927,6 +928,126 @@ async def get_controversy(
     ]
 
     return {"conflicts": conflicts, "count": len(conflicts)}
+
+
+# ---------------------------------------------------------------------------
+# Controversy graph endpoint (#96)
+# ---------------------------------------------------------------------------
+
+@router.get("/controversy/graph")
+async def get_controversy_graph(
+    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    source_type: Optional[str] = Query(None, description="Filter by source type"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
+    limit: int = Query(60, ge=1, le=300),
+) -> Dict[str, Any]:
+    """
+    Return a force-directed graph of contested claims.
+
+    Nodes are individual claims involved in cross-source contradictions.
+    Edges are claim_evidence rows where relation='contradicts' and the two
+    claims come from different source outlets.
+
+    Node fields:  id, label, source, source_type, topic, date, claim_text, confidence
+    Edge fields:  source, target, severity (similarity_score ∈ [0,1]), relation
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    cutoff = _parse_date_cutoff(date_range)
+    conditions: list[str] = [
+        "e.relation = 'contradicts'",
+        "n1.source IS NOT NULL",
+        "n2.source IS NOT NULL",
+        "n1.source != n2.source",
+    ]
+    params: list[Any] = []
+
+    if source_type:
+        conditions.append("(c1.source_type = ? OR c2.source_type = ?)")
+        params.extend([source_type, source_type])
+    if topic:
+        conditions.append("(n1.category ILIKE ? OR n2.category ILIKE ?)")
+        params.extend([f"%{topic}%", f"%{topic}%"])
+    if cutoff:
+        conditions.append("(n1.publish_date >= ? OR n2.publish_date >= ?)")
+        params.extend([cutoff, cutoff])
+
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT
+                c1.claim_id                          AS claim_id_a,
+                c1.claim_text                        AS text_a,
+                c1.source_type                       AS source_type_a,
+                c1.confidence                        AS confidence_a,
+                c1.extracted_at                      AS date_a,
+                COALESCE(n1.source, c1.source_type)  AS source_a,
+                COALESCE(n1.category, 'general')     AS topic_a,
+                c1.document_id                       AS doc_id_a,
+                c2.claim_id                          AS claim_id_b,
+                c2.claim_text                        AS text_b,
+                c2.source_type                       AS source_type_b,
+                c2.confidence                        AS confidence_b,
+                c2.extracted_at                      AS date_b,
+                COALESCE(n2.source, c2.source_type)  AS source_b,
+                COALESCE(n2.category, 'general')     AS topic_b,
+                c2.document_id                       AS doc_id_b,
+                COALESCE(e.similarity_score, 0.5)    AS severity
+            FROM claim_evidence e
+            JOIN argument_claims c1 ON e.claim_id             = c1.claim_id
+            JOIN argument_claims c2 ON e.evidence_document_id = c2.document_id
+            LEFT JOIN news_articles n1 ON c1.document_id       = n1.id
+            LEFT JOIN news_articles n2 ON c2.document_id       = n2.id
+            WHERE {' AND '.join(conditions)}
+            ORDER BY severity DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    nodes: dict[str, Any] = {}
+    edges: list[dict[str, Any]] = []
+
+    for r in rows:
+        (
+            cid_a, txt_a, stype_a, conf_a, date_a, src_a, topic_a, doc_a,
+            cid_b, txt_b, stype_b, conf_b, date_b, src_b, topic_b, doc_b,
+            severity,
+        ) = r
+        if cid_a not in nodes:
+            nodes[cid_a] = {
+                "id": cid_a, "label": src_a, "source": src_a,
+                "source_type": stype_a, "topic": topic_a,
+                "date": str(date_a) if date_a else None,
+                "claim_text": txt_a,
+                "confidence": float(conf_a) if conf_a is not None else 0.5,
+                "document_id": doc_a,
+            }
+        if cid_b not in nodes:
+            nodes[cid_b] = {
+                "id": cid_b, "label": src_b, "source": src_b,
+                "source_type": stype_b, "topic": topic_b,
+                "date": str(date_b) if date_b else None,
+                "claim_text": txt_b,
+                "confidence": float(conf_b) if conf_b is not None else 0.5,
+                "document_id": doc_b,
+            }
+        edges.append({
+            "source": cid_a,
+            "target": cid_b,
+            "severity": round(float(severity), 3),
+            "relation": "contradicts",
+        })
+
+    node_list = list(nodes.values())
+    return {"nodes": node_list, "edges": edges, "node_count": len(node_list), "edge_count": len(edges)}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New `GET /api/v1/arguments/controversy/graph` endpoint — returns `{nodes, edges}` from `claim_evidence` contradictions between different source outlets; nodes carry claim text, source, source_type, topic, date and confidence; edges carry severity (similarity_score)
- Pure-React SVG force simulation (no new dependencies) — Verlet integration with repulsion, spring attraction along edges, centering and damping; 220-iteration settle then stops
- Node colour encodes `source_type` (news=blue, blog=teal, paper=violet, transcript=amber, book=green, note=grey); edge thickness encodes conflict severity; directional arrowheads
- Clicking a node: node enlarges and highlights its edges, all others dim; inline detail panel opens below the graph showing claim text, confidence bar, and all conflicting claims with severity badges
- Topic picker pills filter graph and re-fetch from backend; period pills (7d / 30d / 90d / All time) filter by `date_range`
- Top-5 conflict intensity list preserved below the graph (backed by existing `/controversy` endpoint)
- `ControversyGraph`, `ControversyNode`, `ControversyEdge` types added; `mockControversyGraph` (10 nodes, 12 edges across 5 topics) added for demo mode

## Files changed

| File | Change |
|---|---|
| `src/api/routes/argument_routes.py` | +100 lines — `GET /controversy/graph` |
| `apps/web/src/types.ts` | +25 lines — `ControversyGraph/Node/Edge` |
| `apps/web/src/data/mock.ts` | +35 lines — `mockControversyGraph` |
| `apps/web/src/lib/api.ts` | +25 lines — `RawControversyNode/Edge`, `argumentControversyGraph()` |
| `apps/web/src/lib/queries.ts` | +15 lines — `useArgumentControversyGraph` |
| `apps/web/src/views/Arguments.tsx` | +375 lines — `ConflictGraph`, `NodeDetail`, full `ControversyPanel` rewrite |

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] Controversy tab renders force-directed graph in demo mode
- [x] Clicking a node highlights its edges and shows detail panel with claim text + linked conflicts
- [x] Topic filter pills correctly subset nodes and edges
- [x] Period filter pills wire through to `date_range` param
- [x] Unselected nodes dim correctly; clicking background deselects
- [ ] With live backend: verify `/controversy/graph` returns nodes/edges from real `claim_evidence` data

Closes #96 