### PR TITLE
feat(arguments): stance drift detection per source & topic (#102)

### DIFF
--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -21,6 +21,7 @@ import type {
   ConflictPair,
   ControversyGraph,
   SourceStance,
+  StanceDriftEvent,
 } from "../types";
 
 const NOW = Date.now();
@@ -338,6 +339,17 @@ export const mockSourceStances: SourceStance[] = [
   // Paper / journal
   { source: "Nature Climate Change", source_type: "paper", topic: "Energy",     supportive: 18, critical:  4, neutral:  6, ambiguous: 2, total: 30, confidence: 0.82, document_count: 30, window_start: "2026-06-19", window_end: "2026-06-26" },
   { source: "Nature Climate Change", source_type: "paper", topic: "Policy",     supportive: 14, critical:  6, neutral:  5, ambiguous: 3, total: 28, confidence: 0.81, document_count: 28, window_start: "2026-06-19", window_end: "2026-06-26" },
+];
+
+export const mockDriftEvents: StanceDriftEvent[] = [
+  { source: "Reuters",         source_type: "news",  topic: "Economy",    from_stance: "neutral",    to_stance: "critical",   confidence_delta: 0.23, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-05:2026-06-12" },
+  { source: "Reuters",         source_type: "news",  topic: "Economy",    from_stance: "critical",   to_stance: "supportive", confidence_delta: 0.31, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-12:2026-06-19" },
+  { source: "Reuters",         source_type: "news",  topic: "Energy",     from_stance: "neutral",    to_stance: "critical",   confidence_delta: 0.25, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-05:2026-06-12" },
+  { source: "Bloomberg",       source_type: "news",  topic: "Economy",    from_stance: "supportive", to_stance: "neutral",    confidence_delta: 0.22, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-05:2026-06-12" },
+  { source: "Bloomberg",       source_type: "news",  topic: "Technology", from_stance: "neutral",    to_stance: "supportive", confidence_delta: 0.28, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-12:2026-06-19" },
+  { source: "Financial Times", source_type: "news",  topic: "Policy",     from_stance: "neutral",    to_stance: "critical",   confidence_delta: 0.21, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-05:2026-06-12" },
+  { source: "The Guardian",    source_type: "news",  topic: "Energy",     from_stance: "critical",   to_stance: "ambiguous",  confidence_delta: 0.19, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-12:2026-06-19" },
+  { source: "energy-transition.blog", source_type: "blog", topic: "Energy", from_stance: "supportive", to_stance: "critical", confidence_delta: 0.34, detected_at: "2026-06-19T03:00:00Z", window_pair: "2026-06-05:2026-06-12" },
 ];
 
 export const mockControversyGraph: ControversyGraph = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -193,6 +193,17 @@ export interface RawStanceSummary {
   by_source: Record<string, { supportive: number; critical: number; neutral: number; ambiguous: number }>;
 }
 
+export interface RawDriftEvent {
+  source: string;
+  source_type: string;
+  topic: string;
+  from_stance: string;
+  to_stance: string;
+  confidence_delta: number | null;
+  detected_at: string | null;
+  window_pair: string | null;
+}
+
 export interface RawActorPosition {
   actor: string;
   position: string;
@@ -314,4 +325,7 @@ export const api = {
 
   argumentStanceSources: (params?: { topic?: string; source?: string; source_type?: string; date_range?: string; limit?: number }) =>
     request<{ sources: RawSourceStance[]; count: number }>("/api/v1/arguments/stance/sources", params),
+
+  argumentStanceDrift: (params?: { source?: string; source_type?: string; topic?: string; limit?: number }) =>
+    request<{ events: RawDriftEvent[]; drift: number[]; periods: string[]; count: number }>("/api/v1/arguments/stance/drift", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -30,8 +30,9 @@ import {
   mockFrameDistribution,
   mockControversyGraph,
   mockSourceStances,
+  mockDriftEvents,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawSourceStance } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition, RawSourceStance, RawDriftEvent } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -50,6 +51,7 @@ import type {
   SourceType,
   ControversyGraph,
   SourceStance,
+  StanceDriftEvent,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -358,6 +360,28 @@ export function useArgumentStanceSources(params?: { topic?: string; source?: str
       }));
     },
     mockSourceStances,
+  );
+}
+
+export function useArgumentStanceDrift(params?: { source?: string; source_type?: string; topic?: string }): Result<StanceDriftEvent[]> {
+  const key = `argumentStanceDrift-${params?.source ?? ""}-${params?.source_type ?? "all"}-${params?.topic ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<StanceDriftEvent[]> => {
+      const res = await api.argumentStanceDrift(params);
+      if (!res.events || res.events.length === 0) throw new Error("empty");
+      return res.events.map((r: RawDriftEvent) => ({
+        source: r.source,
+        source_type: r.source_type as SourceType,
+        topic: r.topic,
+        from_stance: r.from_stance as StanceDriftEvent["from_stance"],
+        to_stance: r.to_stance as StanceDriftEvent["to_stance"],
+        confidence_delta: r.confidence_delta,
+        detected_at: r.detected_at,
+        window_pair: r.window_pair,
+      }));
+    },
+    mockDriftEvents,
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -166,6 +166,17 @@ export type ViewKey =
 
 export type ArgumentTab = "claims" | "stance" | "frames" | "positions" | "controversy" | "sources";
 
+export interface StanceDriftEvent {
+  source: string;
+  source_type: SourceType;
+  topic: string;
+  from_stance: "supportive" | "critical" | "neutral" | "ambiguous";
+  to_stance: "supportive" | "critical" | "neutral" | "ambiguous";
+  confidence_delta: number | null;
+  detected_at: string | null;
+  window_pair: string | null;
+}
+
 export interface ClaimResult {
   document_id: string;
   source_type: SourceType;

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
-import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources } from "../lib/queries";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources, useArgumentStanceDrift } from "../lib/queries";
 import { mockFramesBySourceType } from "../data/mock";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
-import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance } from "../types";
+import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent } from "../types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -902,8 +902,82 @@ function StanceBar({ s }: { s: SourceStance }) {
   );
 }
 
+// ─── Drift timeline ───────────────────────────────────────────────────────────
+
+function DriftTimeline({ source, sourceType }: { source: string; sourceType: string }) {
+  const params = {
+    source,
+    ...(sourceType !== "all" ? { source_type: sourceType } : {}),
+  };
+  const { data: events, source: dataSource } = useArgumentStanceDrift(params);
+
+  const filtered = events.filter((e: StanceDriftEvent) => e.source === source);
+
+  function windowLabel(pair: string | null): string {
+    if (!pair) return "—";
+    const [a, b] = pair.split(":");
+    return `${a} → ${b}`;
+  }
+
+  return (
+    <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${colors.border}` }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+        <span style={{ ...mono10 }}>Drift timeline</span>
+        <span style={{
+          fontFamily: fonts.mono, fontSize: 9, letterSpacing: "0.07em",
+          color: dataSource === "live" ? palette.pos : palette.dim,
+          background: `${dataSource === "live" ? palette.pos : palette.dim}18`,
+          border: `1px solid ${dataSource === "live" ? palette.pos : palette.dim}40`,
+          borderRadius: 4, padding: "1px 6px", textTransform: "uppercase",
+        }}>{dataSource}</span>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div style={{ fontFamily: fonts.mono, fontSize: 11, color: palette.dim, padding: "8px 0" }}>
+          No drift events detected for this source.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {filtered.map((e: StanceDriftEvent, i: number) => {
+            const fromColor = STANCE_COLORS[e.from_stance];
+            const toColor   = STANCE_COLORS[e.to_stance];
+            const delta = e.confidence_delta != null ? `Δ${(e.confidence_delta * 100).toFixed(0)}%` : null;
+            return (
+              <div key={i} style={{
+                display: "flex", alignItems: "center", gap: 10,
+                padding: "7px 10px", borderRadius: 7,
+                background: colors.cardInner, border: `1px solid ${colors.border2}`,
+              }}>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim, width: 170, flexShrink: 0 }}>
+                  {windowLabel(e.window_pair)}
+                </span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, fontWeight: 600, color: fromColor }}>{e.from_stance}</span>
+                <span style={{ color: palette.dim, fontSize: 12 }}>→</span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 10, fontWeight: 600, color: toColor }}>{e.to_stance}</span>
+                {e.topic && (
+                  <span style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.dim, marginLeft: "auto", flexShrink: 0 }}>{e.topic}</span>
+                )}
+                {delta && (
+                  <span style={{
+                    fontFamily: fonts.mono, fontSize: 9, color: palette.amber,
+                    background: `${palette.amber}18`, border: `1px solid ${palette.amber}40`,
+                    borderRadius: 4, padding: "1px 5px", flexShrink: 0,
+                  }}>{delta}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Sources panel ────────────────────────────────────────────────────────────
+
 function SourcesPanel({ sourceType }: { sourceType: string }) {
   const [selectedTopic, setSelectedTopic] = useState<string>("all");
+  const [expandedSource, setExpandedSource] = useState<string | null>(null);
   const params = sourceType !== "all" ? { source_type: sourceType } : undefined;
   const { data: stances, source, isLoading } = useArgumentStanceSources(params);
 
@@ -966,6 +1040,7 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           {sorted.map(([src, { source_type, sup, crit, neu, amb, total }]) => {
             const color = ST_COLORS_SHARED[source_type] ?? palette.dim;
+            const isExpanded = expandedSource === src;
             const row: SourceStance = {
               source: src, source_type: source_type as SourceType,
               topic: selectedTopic === "all" ? "all" : selectedTopic,
@@ -975,7 +1050,10 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
             };
             return (
               <div key={src} style={{ ...card, padding: "10px 14px" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+                <div
+                  style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8, cursor: "pointer" }}
+                  onClick={() => setExpandedSource(isExpanded ? null : src)}
+                >
                   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                     <div style={{ width: 6, height: 6, borderRadius: "50%", background: color, flexShrink: 0 }} />
                     <span style={{ fontFamily: fonts.mono, fontSize: 12, color: colors.text }}>{src}</span>
@@ -985,9 +1063,13 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
                       borderRadius: 4, padding: "1px 5px", flexShrink: 0, textTransform: "uppercase",
                     }}>{source_type}</span>
                   </div>
-                  <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>{total} docs</span>
+                  <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>{total} docs</span>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>{isExpanded ? "▲" : "▼"}</span>
+                  </div>
                 </div>
                 <StanceBar s={row} />
+                {isExpanded && <DriftTimeline source={src} sourceType={sourceType} />}
               </div>
             );
           })}
@@ -1048,7 +1130,7 @@ export default function Arguments() {
     <div>
       <PageHeader
         title="Argument Mining"
-        subtitle="Claims · stance · sources · frames · positions · controversy — across all content types"
+        subtitle="Claims · stance · sources · drift · frames · positions · controversy — across all content types"
         right={
           <FilterPills value={sourceType} onChange={setSourceType} />
         }

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -261,6 +261,19 @@ def try_import_argument_routes():
         from src.api.routes import argument_routes
         _imported_modules['argument_routes'] = argument_routes
         ARGUMENT_ROUTES_AVAILABLE = True
+        try:
+            from src.argument_mining.stance_aggregator import schedule_stance_job
+            from src.argument_mining.drift_detector import schedule_drift_job
+            from apscheduler.schedulers.background import BackgroundScheduler
+            _sched = BackgroundScheduler()
+            schedule_stance_job(_sched, hour=3)
+            schedule_drift_job(_sched, hour=4)
+            _sched.start()
+        except Exception:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Argument mining schedulers could not be started", exc_info=True
+            )
         return True
     except ImportError:
         ARGUMENT_ROUTES_AVAILABLE = False

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -13,7 +13,7 @@ GET  /api/v1/arguments/claims/{id}               — single claim with evidence 
 GET  /api/v1/arguments/claims/{id}/evidence      — evidence for a claim
 POST /api/v1/arguments/claims/{id}/factcheck     — trigger on-demand fact-check (#97)
 GET  /api/v1/arguments/stance/sources            — stance per (source, topic) from source_stances table (#99)
-GET  /api/v1/arguments/stance/drift              — 7-bucket supportive-ratio time series
+GET  /api/v1/arguments/stance/drift              — structured drift events + 7-bucket time series (#102)
 GET  /api/v1/arguments/stance                    — stance distribution across topics
 GET  /api/v1/arguments/positions                 — actor positions derived from claims
 GET  /api/v1/arguments/controversy               — conflict pairs ranked by contradiction count
@@ -777,8 +777,17 @@ async def get_stance_drift(
     source: Optional[str] = Query(None, description="Filter by publication source name"),
     source_type: Optional[str] = Query(None, description="Filter by source type"),
     topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    limit: int = Query(50, ge=1, le=500),
 ) -> Dict[str, Any]:
-    """Return a 7-bucket time-series of the supportive-claim ratio."""
+    """
+    Return stance drift data for (source, topic).
+
+    Primary response: structured drift events from `stance_drift_events` (populated
+    nightly by the drift detection job — issue #102).
+
+    Also returns a 7-bucket supportive-ratio time series derived from claim rows
+    for the sparkline in the Stance panel (backward compat).
+    """
     import threading
     from datetime import datetime
 
@@ -787,6 +796,11 @@ async def get_stance_drift(
     conn = get_shared_connection()
     lock = getattr(conn, "_lock", None) or threading.Lock()
 
+    # ── Structured drift events from the dedicated table ─────────────────────
+    events = _load_drift_events(conn, lock, source=source, source_type=source_type,
+                                topic=topic, limit=limit)
+
+    # ── Legacy 7-bucket time-series (sparkline) ───────────────────────────────
     rows = _load_claim_stance_rows(conn, lock, source_type, source, topic, cutoff=None)
 
     def _parse_ts(s: str) -> Optional[datetime]:
@@ -796,45 +810,98 @@ async def get_stance_drift(
             return None
 
     timed = [(r[3], r[2], int(r[4]), int(r[5])) for r in rows if r[3]]
-    if not timed:
-        return {"drift": [], "periods": [], "topic": topic, "source": source, "source_type": source_type, "count": 0}
+    drift: list[float] = []
+    periods: list[str] = []
 
-    ts_objs = [_parse_ts(r[0]) for r in timed]
-    valid = [(ts, r[1], r[2], r[3]) for ts, r in zip(ts_objs, timed) if ts is not None]
-    if not valid:
-        return {"drift": [], "periods": [], "topic": topic, "source": source, "source_type": source_type, "count": 0}
-
-    t_min = min(v[0] for v in valid)
-    t_max = max(v[0] for v in valid)
-    span = max((t_max - t_min).total_seconds(), 1)
-    n_buckets = 7
-
-    buckets: list[dict] = [{"supportive": 0, "total": 0} for _ in range(n_buckets)]
-    periods = [
-        (t_min + (t_max - t_min) * (i / n_buckets)).strftime("%Y-%m-%d")
-        for i in range(n_buckets)
-    ]
-
-    for ts, confidence, sup, con in valid:
-        frac = (ts - t_min).total_seconds() / span
-        idx = min(n_buckets - 1, int(frac * n_buckets))
-        buckets[idx]["total"] += 1
-        if _classify_stance(sup, con, float(confidence or 0)) == "supportive":
-            buckets[idx]["supportive"] += 1
-
-    drift = [
-        round(b["supportive"] / b["total"], 3) if b["total"] > 0 else 0.0
-        for b in buckets
-    ]
+    if timed:
+        ts_objs = [_parse_ts(r[0]) for r in timed]
+        valid = [(ts, r[1], r[2], r[3]) for ts, r in zip(ts_objs, timed) if ts is not None]
+        if valid:
+            t_min = min(v[0] for v in valid)
+            t_max = max(v[0] for v in valid)
+            span = max((t_max - t_min).total_seconds(), 1)
+            n_buckets = 7
+            buckets: list[dict] = [{"supportive": 0, "total": 0} for _ in range(n_buckets)]
+            periods = [
+                (t_min + (t_max - t_min) * (i / n_buckets)).strftime("%Y-%m-%d")
+                for i in range(n_buckets)
+            ]
+            for ts, confidence, sup, con in valid:
+                frac = (ts - t_min).total_seconds() / span
+                idx = min(n_buckets - 1, int(frac * n_buckets))
+                buckets[idx]["total"] += 1
+                if _classify_stance(sup, con, float(confidence or 0)) == "supportive":
+                    buckets[idx]["supportive"] += 1
+            drift = [
+                round(b["supportive"] / b["total"], 3) if b["total"] > 0 else 0.0
+                for b in buckets
+            ]
 
     return {
+        "events": events,
         "drift": drift,
         "periods": periods,
         "topic": topic,
         "source": source,
         "source_type": source_type,
-        "count": len(valid),
+        "count": len(events),
     }
+
+
+def _load_drift_events(
+    conn,
+    lock,
+    *,
+    source: Optional[str],
+    source_type: Optional[str],
+    topic: Optional[str],
+    limit: int,
+) -> list[dict]:
+    """Query stance_drift_events filtered by source/source_type/topic."""
+    conditions = []
+    params: list = []
+    if source:
+        conditions.append("source = ?")
+        params.append(source)
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if topic:
+        conditions.append("topic = ?")
+        params.append(topic)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    try:
+        with lock:
+            rows = conn.execute(
+                f"""
+                SELECT source, source_type, topic, from_stance, to_stance,
+                       confidence_delta, detected_at, window_pair
+                FROM stance_drift_events
+                {where}
+                ORDER BY window_pair DESC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+    except Exception:
+        return []
+
+    return [
+        {
+            "source": r[0],
+            "source_type": r[1],
+            "topic": r[2],
+            "from_stance": r[3],
+            "to_stance": r[4],
+            "confidence_delta": r[5],
+            "detected_at": r[6],
+            "window_pair": r[7],
+        }
+        for r in rows
+    ]
 
 
 @router.get("/stance")

--- a/src/argument_mining/drift_detector.py
+++ b/src/argument_mining/drift_detector.py
@@ -1,0 +1,121 @@
+"""
+Detect stance drift between consecutive weekly windows per (source, topic).
+
+Reads the `source_stances` table populated by the nightly stance aggregation
+job and writes `stance_drift_events` rows when either:
+  - the dominant stance changes across consecutive windows, OR
+  - the average confidence delta exceeds CONF_DELTA_THRESHOLD.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+CONF_DELTA_THRESHOLD = 0.2
+
+
+def _dominant(window_data: dict) -> tuple[str, float]:
+    """Return (dominant_stance, avg_confidence) for a single window bucket."""
+    best = max(window_data, key=lambda s: window_data[s]["count"])
+    total = sum(d["count"] for d in window_data.values()) or 1
+    avg_conf = sum(d["conf_sum"] for d in window_data.values()) / total
+    return best, avg_conf
+
+
+def run_drift_detection(conn, lock: threading.Lock) -> dict:
+    """
+    Compare consecutive weekly windows in `source_stances` and write
+    `stance_drift_events` rows for detected pivots.
+
+    Returns {"events_written": n}.
+    """
+    with lock:
+        rows = conn.execute(
+            """
+            SELECT source, source_type, topic, stance, document_count, confidence, window_start
+            FROM source_stances
+            ORDER BY source, source_type, topic, window_start
+            """
+        ).fetchall()
+
+    if not rows:
+        logger.info("drift_detector: source_stances is empty — nothing to compare")
+        return {"events_written": 0}
+
+    # groups[(src, src_type, topic)][window_start][stance] = {count, conf_sum}
+    groups: dict = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {"count": 0, "conf_sum": 0.0})))
+
+    for source, source_type, topic, stance, doc_count, conf, window_start in rows:
+        if not window_start or not stance:
+            continue
+        key = (source, source_type, topic)
+        bucket = groups[key][window_start][stance]
+        bucket["count"] += doc_count or 0
+        bucket["conf_sum"] += (conf or 0.0) * (doc_count or 0)
+
+    events_written = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    for (source, source_type, topic), windows in groups.items():
+        sorted_windows = sorted(windows.keys())
+        for i in range(len(sorted_windows) - 1):
+            w_a = sorted_windows[i]
+            w_b = sorted_windows[i + 1]
+
+            stance_a, conf_a = _dominant(windows[w_a])
+            stance_b, conf_b = _dominant(windows[w_b])
+            conf_delta = abs(conf_b - conf_a)
+
+            if stance_a == stance_b and conf_delta <= CONF_DELTA_THRESHOLD:
+                continue
+
+            window_pair = f"{w_a}:{w_b}"
+            with lock:
+                conn.execute(
+                    """
+                    DELETE FROM stance_drift_events
+                    WHERE source = ? AND source_type = ? AND topic = ? AND window_pair = ?
+                    """,
+                    [source, source_type, topic, window_pair],
+                )
+                conn.execute(
+                    """
+                    INSERT INTO stance_drift_events
+                        (source, source_type, topic, from_stance, to_stance,
+                         confidence_delta, detected_at, window_pair)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [source, source_type, topic, stance_a, stance_b,
+                     round(conf_delta, 4), now, window_pair],
+                )
+            events_written += 1
+
+    logger.info("drift_detector: detected %d drift events", events_written)
+    return {"events_written": events_written}
+
+
+def run_once() -> None:
+    """Entry point for scheduled execution."""
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+    result = run_drift_detection(conn, lock)
+    logger.info("Drift detection complete: %s", result)
+
+
+def schedule_drift_job(scheduler, *, hour: int = 4) -> None:
+    """Register a nightly 04:00 UTC drift detection job (runs after stance aggregation)."""
+    from apscheduler.triggers.cron import CronTrigger
+
+    scheduler.add_job(
+        run_once,
+        CronTrigger(hour=hour, minute=0),
+        id="stance_drift_detection",
+        replace_existing=True,
+    )
+    logger.info("Stance drift detection scheduled at %02d:00 UTC", hour)

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -76,6 +76,17 @@ CREATE TABLE IF NOT EXISTS source_stances (
     window_end     VARCHAR,
     computed_at    VARCHAR
 );
+
+CREATE TABLE IF NOT EXISTS stance_drift_events (
+    source           VARCHAR NOT NULL,
+    source_type      VARCHAR NOT NULL,
+    topic            VARCHAR NOT NULL,
+    from_stance      VARCHAR NOT NULL,
+    to_stance        VARCHAR NOT NULL,
+    confidence_delta DOUBLE,
+    detected_at      VARCHAR,
+    window_pair      VARCHAR
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tests/unit/argument_mining/test_drift_detector.py
+++ b/tests/unit/argument_mining/test_drift_detector.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for src/argument_mining/drift_detector.py (#102).
+
+All DB interactions are mocked so these run offline.
+"""
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock, call
+
+
+def _make_conn(rows=None):
+    conn = MagicMock()
+    conn._lock = threading.Lock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows or []
+    conn.execute.return_value = cursor
+    return conn
+
+
+def _row(source="Reuters", source_type="news", topic="Economy", stance="supportive",
+         doc_count=10, conf=0.75, window_start="2026-06-01"):
+    return (source, source_type, topic, stance, doc_count, conf, window_start)
+
+
+class TestRunDriftDetectionEmpty(unittest.TestCase):
+    def test_returns_zero_when_no_rows(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        conn = _make_conn(rows=[])
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result, {"events_written": 0})
+
+    def test_returns_zero_when_only_one_window(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        conn = _make_conn(rows=[_row(window_start="2026-06-01")])
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result, {"events_written": 0})
+
+
+class TestRunDriftDetectionNoDrift(unittest.TestCase):
+    def test_no_event_when_same_stance_small_delta(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="supportive", conf=0.70, window_start="2026-06-01"),
+            _row(stance="supportive", conf=0.75, window_start="2026-06-08"),
+        ]
+        conn = _make_conn(rows=rows)
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result["events_written"], 0)
+        sql_calls = [str(c.args[0]) for c in conn.execute.call_args_list if c.args]
+        self.assertFalse(any("INSERT" in s for s in sql_calls))
+
+
+class TestRunDriftDetectionWithDrift(unittest.TestCase):
+    def test_event_written_when_dominant_stance_changes(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="supportive", conf=0.80, window_start="2026-06-01", doc_count=10),
+            _row(stance="critical",   conf=0.75, window_start="2026-06-01", doc_count=1),
+            _row(stance="critical",   conf=0.80, window_start="2026-06-08", doc_count=10),
+            _row(stance="supportive", conf=0.75, window_start="2026-06-08", doc_count=1),
+        ]
+        conn = _make_conn(rows=rows)
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result["events_written"], 1)
+
+    def test_event_written_when_confidence_delta_exceeds_threshold(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="supportive", conf=0.90, window_start="2026-06-01"),
+            _row(stance="supportive", conf=0.60, window_start="2026-06-08"),
+        ]
+        conn = _make_conn(rows=rows)
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result["events_written"], 1)
+
+    def test_delete_before_insert(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="supportive", window_start="2026-06-01"),
+            _row(stance="critical",   window_start="2026-06-08"),
+        ]
+        conn = _make_conn(rows=rows)
+        run_drift_detection(conn, threading.Lock())
+
+        sql_calls = [str(c.args[0]) for c in conn.execute.call_args_list if c.args]
+        deletes = [i for i, s in enumerate(sql_calls) if "DELETE" in s]
+        inserts = [i for i, s in enumerate(sql_calls) if "INSERT" in s]
+        self.assertTrue(deletes, "Expected at least one DELETE")
+        self.assertTrue(inserts, "Expected at least one INSERT")
+        self.assertLess(deletes[0], inserts[0])
+
+    def test_insert_contains_correct_stances(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="neutral",  conf=0.70, window_start="2026-06-01", doc_count=8),
+            _row(stance="critical", conf=0.70, window_start="2026-06-08", doc_count=8),
+        ]
+        conn = _make_conn(rows=rows)
+        run_drift_detection(conn, threading.Lock())
+
+        insert_calls = [c for c in conn.execute.call_args_list if "INSERT" in str(c.args[0] if c.args else "")]
+        self.assertTrue(insert_calls)
+        insert_params = insert_calls[0].args[1]
+        # from_stance=neutral, to_stance=critical
+        self.assertEqual(insert_params[3], "neutral")
+        self.assertEqual(insert_params[4], "critical")
+
+    def test_multiple_source_topic_pairs_produce_independent_events(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            # Reuters / Economy: stance flip
+            ("Reuters", "news", "Economy", "supportive", 10, 0.80, "2026-06-01"),
+            ("Reuters", "news", "Economy", "critical",   10, 0.80, "2026-06-08"),
+            # Bloomberg / Tech: no change
+            ("Bloomberg", "news", "Tech", "neutral", 10, 0.70, "2026-06-01"),
+            ("Bloomberg", "news", "Tech", "neutral", 10, 0.72, "2026-06-08"),
+        ]
+        conn = _make_conn(rows=rows)
+        result = run_drift_detection(conn, threading.Lock())
+        self.assertEqual(result["events_written"], 1)
+
+    def test_window_pair_format(self):
+        from src.argument_mining.drift_detector import run_drift_detection
+
+        rows = [
+            _row(stance="supportive", window_start="2026-06-01"),
+            _row(stance="critical",   window_start="2026-06-08"),
+        ]
+        conn = _make_conn(rows=rows)
+        run_drift_detection(conn, threading.Lock())
+
+        insert_calls = [c for c in conn.execute.call_args_list if "INSERT" in str(c.args[0] if c.args else "")]
+        insert_params = insert_calls[0].args[1]
+        self.assertEqual(insert_params[7], "2026-06-01:2026-06-08")
+
+
+class TestScheduleDriftJob(unittest.TestCase):
+    def test_registers_job_with_scheduler(self):
+        from src.argument_mining.drift_detector import schedule_drift_job
+
+        scheduler = MagicMock()
+        schedule_drift_job(scheduler, hour=4)
+        scheduler.add_job.assert_called_once()
+        kwargs = scheduler.add_job.call_args[1]
+        self.assertEqual(kwargs.get("id"), "stance_drift_detection")
+
+    def test_replace_existing_true(self):
+        from src.argument_mining.drift_detector import schedule_drift_job
+
+        scheduler = MagicMock()
+        schedule_drift_job(scheduler)
+        kwargs = scheduler.add_job.call_args[1]
+        self.assertTrue(kwargs.get("replace_existing"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `stance_drift_events` DuckDB table: stores pivot events per `(source, source_type, topic, window_pair)`
- `src/argument_mining/drift_detector.py`: compares consecutive weekly windows from `source_stances`; flags drift when dominant stance changes or confidence delta > 0.2; DELETE+INSERT upsert per window pair
- Nightly scheduler wired in `try_import_argument_routes()` — stance aggregation at 03:00 UTC, drift detection at 04:00 UTC
- `GET /api/v1/arguments/stance/drift` enhanced to return structured `events` array alongside the existing 7-bucket time series (backward compat)
- Sources panel: each outlet card is now clickable and expands a **Drift Timeline** showing window pairs, stance transitions with colour coding, topic labels, and Δ confidence badges
- 11 unit tests (all pass), TypeScript typecheck clean

## Test plan

- [ ] `python -m pytest tests/unit/argument_mining/test_drift_detector.py -v` — 11 passed
- [ ] `npm run typecheck` in `apps/web/` — exit 0
- [ ] Open Arguments → Sources tab, click any outlet card → drift timeline expands with mock events
- [ ] `GET /api/v1/arguments/stance/drift?source=Reuters` — response contains `events` key