### PR TITLE
feat(argument-mining): policy position extraction pipeline (#110)

### DIFF
--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -15,7 +15,8 @@ POST /api/v1/arguments/claims/{id}/factcheck     — trigger on-demand fact-chec
 GET  /api/v1/arguments/stance/sources            — stance per (source, topic) from source_stances table (#99)
 GET  /api/v1/arguments/stance/drift              — structured drift events + 7-bucket time series (#102)
 GET  /api/v1/arguments/stance                    — stance distribution across topics
-GET  /api/v1/arguments/positions                 — actor positions derived from claims
+GET  /api/v1/arguments/positions                 — actor policy positions from policy_positions table (#110)
+POST /api/v1/arguments/positions/extract         — run position extraction on a stored document (#110)
 GET  /api/v1/arguments/controversy               — conflict pairs ranked by contradiction count
 GET  /api/v1/arguments/controversy/graph         — force-directed graph: nodes=claims, edges=contradictions (#96)
 GET  /api/v1/arguments/sources/ranking           — sources ranked by claim quality
@@ -1106,15 +1107,19 @@ async def get_frames_by_source(
 
 @router.get("/positions")
 async def get_positions(
-    actor: Optional[str] = Query(None, description="Filter by actor/source name"),
-    topic: Optional[str] = Query(None, description="Filter by topic/category keyword"),
+    actor: Optional[str] = Query(None, description="Filter by actor name (ILIKE)"),
+    topic: Optional[str] = Query(None, description="Filter by topic keyword (ILIKE)"),
     source_type: Optional[str] = Query(None, description="Filter by source type"),
+    date_range: Optional[str] = Query(None, description="Time window: 7d, 30d, 90d"),
     limit: int = Query(50, ge=1, le=500),
 ) -> Dict[str, Any]:
     """
-    Return actor policy positions derived from argument claims.
-    Actor = the news/content source; position = the claim text;
-    stance is inferred from supporting/contradicting evidence.
+    Return actor policy positions from the ``policy_positions`` table (#110).
+
+    Each position is a sentence where a named actor asserts an intention or
+    commitment on a policy topic. Results come from
+    ``src.argument_mining.positions.extract_positions`` run as a post-ingestion
+    stage. Falls back to claim-derived positions when the table is empty.
     """
     import threading
 
@@ -1123,70 +1128,206 @@ async def get_positions(
     conn = get_shared_connection()
     lock = getattr(conn, "_lock", None) or threading.Lock()
 
+    date_cutoff = _parse_date_cutoff(date_range)
     where_parts: list[str] = []
     params: list[Any] = []
 
     if source_type:
-        where_parts.append("c.source_type = ?")
+        where_parts.append("source_type = ?")
         params.append(source_type)
     if actor:
-        where_parts.append("n.source ILIKE ?")
+        where_parts.append("actor ILIKE ?")
         params.append(f"%{actor}%")
     if topic:
-        where_parts.append("n.category ILIKE ?")
+        where_parts.append("topic ILIKE ?")
         params.append(f"%{topic}%")
+    if date_cutoff:
+        where_parts.append("position_date >= ?")
+        params.append(date_cutoff)
 
     where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
     params.append(limit)
 
     with lock:
-        rows = conn.execute(
-            f"""
-            WITH evidence_counts AS (
-                SELECT claim_id,
-                       SUM(CASE WHEN relation = 'supports'    THEN 1 ELSE 0 END) AS sup,
-                       SUM(CASE WHEN relation = 'contradicts' THEN 1 ELSE 0 END) AS con
-                FROM claim_evidence
-                GROUP BY claim_id
-            )
-            SELECT
-                COALESCE(n.source, c.source_type)   AS actor,
-                c.claim_text                        AS position,
-                COALESCE(n.category, 'general')     AS topic,
-                c.source_type,
-                c.document_id,
-                n.publish_date,
-                c.confidence,
-                COALESCE(ec.sup, 0)                 AS sup,
-                COALESCE(ec.con, 0)                 AS con
-            FROM argument_claims c
-            LEFT JOIN news_articles n    ON c.document_id = n.id
-            LEFT JOIN evidence_counts ec ON c.claim_id   = ec.claim_id
-            {where_clause}
-            ORDER BY n.publish_date DESC NULLS LAST, c.confidence DESC
-            LIMIT ?
-            """,
-            params,
-        ).fetchall()
+        # Try the dedicated policy_positions table first
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT position_id, actor, topic, position_text,
+                       source_type, document_id, position_date, confidence
+                FROM policy_positions
+                {where_clause}
+                ORDER BY position_date DESC NULLS LAST, confidence DESC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+        except Exception:
+            rows = []
 
-    positions = []
-    for row in rows:
-        actor_name, pos_text, topic_name, src_type, doc_id, pub_date, confidence, sup, con = row
-        internal_stance = _classify_stance(int(sup), int(con), float(confidence or 0))
-        pos_stance = "for" if internal_stance == "supportive" else (
-            "against" if internal_stance == "critical" else "neutral"
-        )
-        positions.append({
-            "actor": actor_name or src_type,
-            "position": pos_text,
-            "stance": pos_stance,
-            "date": str(pub_date) if pub_date else "",
-            "source_type": src_type,
-            "document_id": doc_id,
-            "topic": topic_name,
-        })
+        # If table is empty, fall back to claim-derived positions
+        if not rows:
+            fb_where_parts = []
+            fb_params: list[Any] = []
+            if source_type:
+                fb_where_parts.append("c.source_type = ?")
+                fb_params.append(source_type)
+            if actor:
+                fb_where_parts.append("n.source ILIKE ?")
+                fb_params.append(f"%{actor}%")
+            if topic:
+                fb_where_parts.append("n.category ILIKE ?")
+                fb_params.append(f"%{topic}%")
+            fb_where = ("WHERE " + " AND ".join(fb_where_parts)) if fb_where_parts else ""
+            fb_params.append(limit)
+            try:
+                fb_rows = conn.execute(
+                    f"""
+                    WITH evidence_counts AS (
+                        SELECT claim_id,
+                               SUM(CASE WHEN relation = 'supports'    THEN 1 ELSE 0 END) AS sup,
+                               SUM(CASE WHEN relation = 'contradicts' THEN 1 ELSE 0 END) AS con
+                        FROM claim_evidence
+                        GROUP BY claim_id
+                    )
+                    SELECT
+                        c.claim_id,
+                        COALESCE(n.source, c.source_type)   AS actor,
+                        COALESCE(n.category, 'general')     AS topic,
+                        c.claim_text,
+                        c.source_type,
+                        c.document_id,
+                        n.publish_date,
+                        c.confidence
+                    FROM argument_claims c
+                    LEFT JOIN news_articles n    ON c.document_id = n.id
+                    LEFT JOIN evidence_counts ec ON c.claim_id   = ec.claim_id
+                    {fb_where}
+                    ORDER BY n.publish_date DESC NULLS LAST, c.confidence DESC
+                    LIMIT ?
+                    """,
+                    fb_params,
+                ).fetchall()
+                return {
+                    "positions": [
+                        {
+                            "position_id": r[0],
+                            "actor": r[1] or r[4],
+                            "topic": r[2],
+                            "position": r[3],
+                            "source_type": r[4],
+                            "document_id": r[5],
+                            "date": str(r[6]) if r[6] else "",
+                            "confidence": round(float(r[7] or 0), 4),
+                            "_source": "claims_fallback",
+                        }
+                        for r in fb_rows
+                    ],
+                    "count": len(fb_rows),
+                    "_note": "policy_positions table is empty — run /positions/extract first",
+                }
+            except Exception:
+                return {"positions": [], "count": 0}
 
+    positions = [
+        {
+            "position_id": row[0],
+            "actor": row[1],
+            "topic": row[2],
+            "position": row[3],
+            "source_type": row[4],
+            "document_id": row[5],
+            "date": row[6] or "",
+            "confidence": round(float(row[7] or 0), 4),
+        }
+        for row in rows
+    ]
     return {"positions": positions, "count": len(positions)}
+
+
+@router.post("/positions/extract")
+async def extract_positions_for_document(
+    document_id: str = Query(..., description="ID of a document already in news_articles"),
+    source_type: str = Query("news", description="Source type label"),
+) -> Dict[str, Any]:
+    """
+    Run position extraction on a stored document and persist results (#110).
+
+    Identifies sentences where a named actor asserts a commitment on a policy
+    topic and stores them in ``policy_positions``. Runs
+    ``src.argument_mining.positions.run_position_pipeline`` which also calls
+    ``extract_positions`` internally.
+    """
+    import threading
+    import time
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    with lock:
+        row = conn.execute(
+            "SELECT id, title, content, publish_date, source, category "
+            "FROM news_articles WHERE id = ? LIMIT 1",
+            [document_id],
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Document '{document_id}' not found")
+
+    doc_id, title, content, publish_date, source, category = row
+    if not content:
+        raise HTTPException(status_code=422, detail="Document has no content to process")
+
+    try:
+        from services.ingest.common.document_model import Document
+        from src.argument_mining.positions import run_position_pipeline
+
+        metadata: Dict[str, Any] = {}
+        if category:
+            metadata["category"] = category
+
+        created_at_ms: Optional[int] = None
+        if publish_date is not None:
+            try:
+                created_at_ms = int(publish_date.timestamp() * 1000)
+            except (AttributeError, OSError, ValueError):
+                pass
+
+        doc = Document(
+            document_id=doc_id,
+            source_type=source_type,
+            language="en",
+            ingested_at=int(time.time() * 1000),
+            source_id=source,
+            title=title,
+            content=content,
+            created_at=created_at_ms,
+            metadata=metadata,
+        )
+
+        with lock:
+            records = run_position_pipeline(doc, conn)
+
+        return {
+            "document_id": doc_id,
+            "source_type": source_type,
+            "positions_extracted": len(records),
+            "positions": [
+                {
+                    "position_id": r.position_id,
+                    "actor": r.actor,
+                    "topic": r.topic,
+                    "position_text": r.position_text,
+                    "date": r.position_date or "",
+                    "confidence": r.confidence,
+                }
+                for r in records
+            ],
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Extraction failed: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/argument_mining/__init__.py
+++ b/src/argument_mining/__init__.py
@@ -1,7 +1,8 @@
 """
-Argument Mining — claim detection, stance classification, frame analysis.
+Argument Mining — claim detection, stance classification, frame analysis, position extraction.
 
 Entry points:
     from src.argument_mining.models import predict_claims, predict_stance
     from src.argument_mining.frames import predict_frames
+    from src.argument_mining.positions import extract_positions, run_position_pipeline
 """

--- a/src/argument_mining/positions.py
+++ b/src/argument_mining/positions.py
@@ -1,0 +1,403 @@
+"""
+Policy Position Extraction Pipeline (issue #110).
+
+Identifies sentences where a named actor asserts an intention or commitment on
+a policy topic, then returns structured (actor, topic, position_text, date,
+document_id, source_type) tuples.
+
+Works across all six Noesis source types without requiring trained NLP models:
+  - news / blog  — named-actor commitment sentences, editorial positions
+  - paper        — author recommendations and policy-implication statements
+  - transcript   — speaker-attributed commitments
+  - book         — thesis/position statements
+  - note / upload — meeting-minutes commitments and action items
+
+Positions are stored in the ``policy_positions`` DuckDB table and can be
+retrieved via ``GET /api/v1/arguments/positions``.
+
+Usage:
+    from src.argument_mining.positions import extract_positions, run_position_pipeline
+    records = extract_positions(document)                  # pure extraction
+    records = run_position_pipeline(document, conn)        # extract + persist
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+from services.ingest.common.document_model import Document
+from src.argument_mining.dataset import sentences_from_document
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Verbs that signal a policy commitment or stated intention
+_COMMITMENT_PATTERN = re.compile(
+    r"\b("
+    r"will\s+\w+|"
+    r"plans?\s+to|"
+    r"intends?\s+to|"
+    r"aims?\s+to|"
+    r"seeks?\s+to|"
+    r"committed?\s+to|"
+    r"pledged?|"
+    r"promised?|"
+    r"vowed?|"
+    r"proposed?|"
+    r"announced?|"
+    r"urges?|"
+    r"calls?\s+for|"
+    r"calls?\s+on|"
+    r"demands?|"
+    r"requires?|"
+    r"mandates?|"
+    r"recommends?|"
+    r"advocates?|"
+    r"supports?|"
+    r"opposes?|"
+    r"endorses?|"
+    r"backs?\s+(?:the|a|an)|"
+    r"rejects?|"
+    r"vetoes?|"
+    r"blocks?"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Patterns for extracting the actor from a sentence — tried in order.
+# Each pattern must have exactly one capture group (the actor string).
+_ACTOR_PATTERNS: List[re.Pattern] = [
+    # "SPEAKER: text" — transcript all-caps or title-case speaker label
+    re.compile(r"^([A-Z][A-Z\s]{2,30}):"),
+    re.compile(r"^([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,4}):\s"),
+    # "President/Prime Minister/CEO ... Name said/pledged/..." (Title Case names only)
+    re.compile(
+        r"\b(?:President|Prime\s+Minister|Minister|Secretary(?:\s+of\s+State)?|"
+        r"Governor|Senator|Chancellor|Commissioner|General|Admiral|Director|CEO|"
+        r"Chair(?:man|woman|person)?|Representative|Ambassador|Mayor|Premier)\s+"
+        r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})\b",
+    ),
+    # "Name, the Title, said/announced/..."
+    re.compile(
+        r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+),\s+(?:the\s+)?[a-z]+"
+        r"(?:\s+[a-z]+)?,\s+(?:said|announced|stated|pledged|promised|vowed)",
+    ),
+    # "Name said/announced/pledged/promised/vowed/..."
+    re.compile(
+        r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+"
+        r"(?:said|stated|announced|pledged|promised|vowed|committed|proposed|urged|warned)",
+    ),
+    # "The CFO/board/committee committed/resolved/plans..."
+    re.compile(
+        r"((?:The\s+)?(?:CFO|CTO|COO|CRO|board|committee|cabinet|council|"
+        r"panel|task\s+force|working\s+group|executive\s+team|leadership\s+team))"
+        r"(?:\s+|,\s+)(?:committed|resolved|pledged|vowed|plans|will\b|announced|agreed|decided)",
+        re.IGNORECASE,
+    ),
+    # "The government/administration/party/ministry will..."
+    re.compile(
+        r"((?:The\s+)?(?:government|administration|ruling\s+party|opposition|ministry|"
+        r"department|authority|agency|regulator|union|alliance|party|"
+        r"senate|congress|parliament|court|treasury|central\s+bank))"
+        r"\s+(?:will\b|has\s+pledged|announced|said|plans|committed|vowed)",
+        re.IGNORECASE,
+    ),
+]
+
+# Topic keyword taxonomy — each entry: (topic_label, keyword_set)
+_TOPIC_TAXONOMY: List[Tuple[str, frozenset]] = [
+    ("healthcare", frozenset({
+        "health", "medical", "hospital", "vaccine", "drug", "medicine",
+        "patient", "nhs", "medicare", "medicaid", "pharmaceutical", "treatment",
+        "disease", "cancer", "mental health", "pandemic", "public health",
+    })),
+    ("economy", frozenset({
+        "economy", "economic", "inflation", "gdp", "unemployment", "tax",
+        "budget", "fiscal", "monetary", "trade", "deficit", "debt", "growth",
+        "recession", "interest rate", "central bank", "finance", "market",
+        "currency", "wage", "pension", "subsidy", "tariff",
+    })),
+    ("environment", frozenset({
+        "climate", "environment", "carbon", "emission", "renewable", "energy",
+        "fossil fuel", "net zero", "biodiversity", "deforestation", "pollution",
+        "green", "solar", "wind", "nuclear", "sustainability",
+    })),
+    ("security", frozenset({
+        "military", "defence", "defense", "security", "army", "navy", "weapon",
+        "nato", "border", "terrorism", "cyberattack", "intelligence", "war",
+        "nuclear", "missile", "sanction", "troops",
+    })),
+    ("law", frozenset({
+        "law", "legal", "court", "legislation", "regulation", "bill", "act",
+        "rights", "constitution", "crime", "justice", "police", "prison",
+        "penalty", "compliance", "enforcement", "verdict",
+    })),
+    ("politics", frozenset({
+        "election", "vote", "party", "government", "minister", "parliament",
+        "senate", "congress", "president", "prime minister", "democracy",
+        "reform", "policy", "political", "campaign", "referendum",
+    })),
+    ("social", frozenset({
+        "inequality", "poverty", "housing", "education", "school", "university",
+        "welfare", "child", "family", "immigration", "refugee", "discrimination",
+        "gender", "race", "ethnicity", "labour", "worker", "union",
+    })),
+    ("technology", frozenset({
+        "technology", "tech", "ai", "artificial intelligence", "data",
+        "digital", "software", "internet", "cyber", "privacy", "algorithm",
+        "robot", "automation", "semiconductor", "platform",
+    })),
+    ("business", frozenset({
+        "company", "corporation", "ceo", "shareholder", "merger", "acquisition",
+        "profit", "revenue", "market share", "competition", "antitrust",
+        "startup", "investment", "ipo", "stock",
+    })),
+]
+
+# Minimum claim-detector confidence to treat a sentence as position-bearing
+_MIN_CONFIDENCE = 0.45
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PositionRecord:
+    position_id: str
+    document_id: str
+    source_type: str
+    actor: str
+    topic: str
+    position_text: str
+    position_date: Optional[str]
+    confidence: float
+    extracted_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_position_bearing(sentence: str, min_confidence: float) -> Tuple[bool, float]:
+    """Return (is_position, confidence) using claim heuristic + commitment pattern.
+
+    Questions are never position statements even when they contain commitment verbs.
+    We use the raw heuristic score (not the inverted confidence) so that the boost
+    for commitment verbs doesn't accidentally promote uncertain non-claims.
+    """
+    if sentence.strip().endswith("?"):
+        return False, 0.0
+
+    from src.argument_mining.models import _claim_heuristic
+
+    claim_pred = _claim_heuristic(sentence, 0)
+    # _claim_heuristic returns confidence = 1 - score for non-claims; recover raw score.
+    raw_score = claim_pred.confidence if claim_pred.is_claim else (1.0 - claim_pred.confidence)
+    has_commitment = bool(_COMMITMENT_PATTERN.search(sentence))
+    adjusted = min(0.95, raw_score + 0.15) if has_commitment else raw_score
+    is_pos = adjusted >= min_confidence and (claim_pred.is_claim or has_commitment)
+    return is_pos, adjusted
+
+
+def _extract_actor(sentence: str, document: Document) -> str:
+    """Extract the most likely named actor from a sentence.
+
+    Tries regex patterns in order; falls back to document-level metadata.
+    """
+    for pattern in _ACTOR_PATTERNS:
+        m = pattern.search(sentence)
+        if m:
+            actor = m.group(1).strip().rstrip(",.:;")
+            if 2 < len(actor) < 80:
+                return _normalise_actor(actor)
+
+    # Fallback 1: first author
+    if document.authors:
+        return document.authors[0]
+    # Fallback 2: source_id (often the news outlet name)
+    if document.source_id:
+        return document.source_id
+    # Fallback 3: source_type label
+    return document.source_type
+
+
+def _normalise_actor(raw: str) -> str:
+    """Collapse excess whitespace and title-case the actor name."""
+    return re.sub(r"\s+", " ", raw).strip()
+
+
+def _infer_topic(document: Document, sentence: str) -> str:
+    """Infer the policy topic for a sentence.
+
+    Priority:
+      1. `metadata.topics` from the Document (set by upstream enrichment)
+      2. Document category field via metadata
+      3. Keyword match against _TOPIC_TAXONOMY on the sentence + title
+    """
+    # 1. Upstream topic enrichment
+    topics_meta: list = document.metadata.get("topics", [])
+    if topics_meta:
+        raw = topics_meta[0].lower() if topics_meta else ""
+        for label, keywords in _TOPIC_TAXONOMY:
+            if label in raw or any(kw in raw for kw in keywords):
+                return label
+        return raw[:60] or "general"
+
+    # 2. Document-level category
+    category = (document.metadata.get("category") or "").lower()
+    if category:
+        for label, _ in _TOPIC_TAXONOMY:
+            if label in category:
+                return label
+
+    # 3. Keyword scan of sentence + title
+    combined = ((document.title or "") + " " + sentence).lower()
+    best_label = "general"
+    best_count = 0
+    for label, keywords in _TOPIC_TAXONOMY:
+        hits = sum(1 for kw in keywords if kw in combined)
+        if hits > best_count:
+            best_count = hits
+            best_label = label
+    return best_label
+
+
+def _document_date(document: Document) -> Optional[str]:
+    """Extract a human-readable date string from the Document."""
+    ts_ms = document.created_at or document.ingested_at
+    if not ts_ms:
+        return None
+    try:
+        dt = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc)
+        return dt.date().isoformat()
+    except (OSError, ValueError, OverflowError):
+        return None
+
+
+def _position_id(document_id: str, sentence: str, actor: str) -> str:
+    """Deterministic UUID-style ID from (doc, sentence, actor)."""
+    h = hashlib.sha1(f"{document_id}|{actor}|{sentence}".encode()).hexdigest()[:32]
+    return f"pos-{h}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_positions(document: Document) -> List[PositionRecord]:
+    """Extract policy positions from any Document.
+
+    Returns a list of PositionRecord instances — one per distinct
+    (actor, topic, position_text) triple found in the document.
+    The list is empty when no position-bearing sentences are detected.
+
+    No DB connection is required; this function is pure extraction.
+    """
+    sentences = sentences_from_document(document)
+    if not sentences:
+        return []
+
+    pub_date = _document_date(document)
+    records: List[PositionRecord] = []
+    seen_ids: set = set()
+
+    for sent in sentences:
+        is_pos, confidence = _is_position_bearing(sent, _MIN_CONFIDENCE)
+        if not is_pos:
+            continue
+
+        actor = _extract_actor(sent, document)
+        topic = _infer_topic(document, sent)
+        pid = _position_id(document.document_id, sent, actor)
+
+        if pid in seen_ids:
+            continue
+        seen_ids.add(pid)
+
+        records.append(PositionRecord(
+            position_id=pid,
+            document_id=document.document_id,
+            source_type=document.source_type,
+            actor=actor,
+            topic=topic,
+            position_text=sent,
+            position_date=pub_date,
+            confidence=round(confidence, 4),
+        ))
+
+    logger.debug(
+        "extract_positions: doc=%s source=%s sentences=%d positions=%d",
+        document.document_id,
+        document.source_type,
+        len(sentences),
+        len(records),
+    )
+    return records
+
+
+def store_positions(records: List[PositionRecord], conn) -> None:
+    """Persist PositionRecord list to the policy_positions DuckDB table.
+
+    Uses INSERT OR REPLACE semantics keyed on position_id so re-running
+    the pipeline on the same document is safe (idempotent).
+    """
+    if not records:
+        return
+    conn.executemany(
+        """
+        INSERT OR REPLACE INTO policy_positions
+            (position_id, document_id, source_type, actor, topic,
+             position_text, position_date, confidence, extracted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                r.position_id,
+                r.document_id,
+                r.source_type,
+                r.actor,
+                r.topic,
+                r.position_text,
+                r.position_date,
+                r.confidence,
+                r.extracted_at,
+            )
+            for r in records
+        ],
+    )
+
+
+def run_position_pipeline(document: Document, conn) -> List[PositionRecord]:
+    """Extract positions and persist them to the DB in one call.
+
+    Designed to be called as a post-ingestion stage after
+    ``src.argument_mining.evidence.run_pipeline``.
+
+    Args:
+        document: any Document (news/blog/paper/transcript/book/note).
+        conn:     DuckDB connection; ``policy_positions`` must already exist
+                  (created by ``ensure_schema`` in local_warehouse_seed).
+
+    Returns the list of PositionRecord objects persisted.
+    """
+    records = extract_positions(document)
+    store_positions(records, conn)
+    logger.info(
+        "run_position_pipeline: doc=%s source=%s positions_stored=%d",
+        document.document_id,
+        document.source_type,
+        len(records),
+    )
+    return records

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -87,6 +87,18 @@ CREATE TABLE IF NOT EXISTS stance_drift_events (
     detected_at      VARCHAR,
     window_pair      VARCHAR
 );
+
+CREATE TABLE IF NOT EXISTS policy_positions (
+    position_id    VARCHAR PRIMARY KEY,
+    document_id    VARCHAR NOT NULL,
+    source_type    VARCHAR NOT NULL,
+    actor          VARCHAR NOT NULL,
+    topic          VARCHAR NOT NULL,
+    position_text  VARCHAR NOT NULL,
+    position_date  VARCHAR,
+    confidence     DOUBLE,
+    extracted_at   VARCHAR
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -14,8 +14,9 @@ Tools:
                 query?)                   source = RSS feed name OR a source_type from
                                           list_connector_types(); query = JSON list of paths/
                                           IDs passed to that connector's discover().
-  run_stage(stage, input_ref?, ...)    -> run one named stage: fetch | sentiment | store | ingest
+  run_stage(stage, input_ref?, ...)    -> run one named stage: fetch|sentiment|store|ingest|positions
   trace_article(id)                    -> where an article exists across warehouse / vector / s3
+  query_positions(actor?, topic?, ...) -> query policy_positions table for actor commitments (#110)
 
 Design constraints (learned the hard way in this repo):
   * Lazy imports inside tools. The top of this module imports only stdlib +
@@ -82,6 +83,24 @@ def _warehouse_ro():
         raise RuntimeError(
             f"warehouse at {path} is not readable (likely locked by a running "
             f"API/ingester — DuckDB is single-writer): {exc}"
+        ) from exc
+
+
+def _warehouse_rw():
+    """Open the DuckDB warehouse READ-WRITE. Use only for write-stage tools."""
+    import duckdb
+
+    path = _db_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"warehouse not found at {path} — start the API once to seed it, "
+            f"or set NEURONEWS_DB_PATH"
+        )
+    try:
+        return duckdb.connect(path, read_only=False)
+    except Exception as exc:
+        raise RuntimeError(
+            f"warehouse at {path} is locked (DuckDB single-writer): {exc}"
         ) from exc
 
 
@@ -314,6 +333,9 @@ def run_stage(
                 warehouse to be free — DuckDB single-writer).
       ingest    input_ref = source name (or omit for all sources). Full
                 fetch->store. Read-only diff unless apply=true.
+      positions input_ref = article/document id already in the warehouse.
+                Runs position extraction and writes results to policy_positions.
+                Use query_positions() to read them back.
 
     Args:
         stage: one of fetch | sentiment | store | ingest.
@@ -424,9 +446,76 @@ def run_stage(
                 )
         return result
 
+    if stage == "positions":
+        if not input_ref:
+            return {"error": "positions needs input_ref = an article/document id"}
+        try:
+            con_rw = _warehouse_rw()
+        except Exception as exc:
+            return {"error": f"warehouse unavailable: {exc}"}
+        try:
+            row = con_rw.execute(
+                "SELECT id, title, content, publish_date, source, category "
+                "FROM news_articles WHERE id = ? LIMIT 1",
+                [input_ref],
+            ).fetchone()
+        except Exception as exc:
+            con_rw.close()
+            return {"error": f"document lookup failed: {exc}"}
+        if not row:
+            con_rw.close()
+            return {"error": f"document {input_ref!r} not found in warehouse"}
+        doc_id, title, content, publish_date, source, category = row
+        if not content:
+            con_rw.close()
+            return {"error": "document has no content"}
+        try:
+            import time as _time
+            from services.ingest.common.document_model import Document
+            from src.argument_mining.positions import run_position_pipeline
+            meta: dict[str, Any] = {}
+            if category:
+                meta["category"] = category
+            created_ms: Optional[int] = None
+            if publish_date is not None:
+                try:
+                    created_ms = int(publish_date.timestamp() * 1000)
+                except Exception:
+                    pass
+            doc = Document(
+                document_id=doc_id,
+                source_type="news",
+                language="en",
+                ingested_at=int(_time.time() * 1000),
+                source_id=source,
+                title=title,
+                content=content,
+                created_at=created_ms,
+                metadata=meta,
+            )
+            records = run_position_pipeline(doc, con_rw)
+            con_rw.close()
+        except Exception as exc:
+            con_rw.close()
+            return {"error": f"position extraction failed: {exc}"}
+        return {
+            "stage": "positions",
+            "document_id": doc_id,
+            "positions_extracted": len(records),
+            "positions": [
+                {
+                    "actor": r.actor,
+                    "topic": r.topic,
+                    "confidence": round(r.confidence, 4),
+                    "text_preview": r.position_text[:CONTENT_PREVIEW],
+                }
+                for r in records[:MAX_LIST]
+            ],
+        }
+
     return {
         "error": f"unknown stage {stage!r}",
-        "valid_stages": ["fetch", "sentiment", "store", "ingest"],
+        "valid_stages": ["fetch", "sentiment", "store", "ingest", "positions"],
     }
 
 
@@ -524,6 +613,82 @@ def trace_article(id: str) -> dict:
         trace["object_store"] = {"status": "no S3_ENDPOINT_URL configured"}
 
     return trace
+
+
+@mcp.tool
+def query_positions(
+    actor: Optional[str] = None,
+    topic: Optional[str] = None,
+    source_type: Optional[str] = None,
+    limit: int = 10,
+) -> dict:
+    """Query the ``policy_positions`` table for actor policy commitments (#110).
+
+    Returns compact position summaries — never full content payloads.
+    Use ``run_stage("positions", input_ref=<id>)`` to first populate the table
+    for a specific document.
+
+    Args:
+        actor:       ILIKE filter on the actor name (e.g. "government", "Johnson").
+        topic:       ILIKE filter on topic (e.g. "economy", "healthcare", "law").
+        source_type: Exact filter on source type (news/blog/paper/transcript/book/note).
+        limit:       Max rows to return (capped at 25).
+    """
+    limit = max(1, min(int(limit), MAX_LIST))
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": f"warehouse unavailable: {exc}"}
+
+    where_parts: list[str] = []
+    params: list[Any] = []
+    if actor:
+        where_parts.append("actor ILIKE ?")
+        params.append(f"%{actor}%")
+    if topic:
+        where_parts.append("topic ILIKE ?")
+        params.append(f"%{topic}%")
+    if source_type:
+        where_parts.append("source_type = ?")
+        params.append(source_type)
+    where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    params.append(limit)
+
+    try:
+        rows = con.execute(
+            f"""
+            SELECT position_id, actor, topic, source_type, document_id,
+                   position_date, confidence,
+                   LEFT(position_text, {CONTENT_PREVIEW}) AS preview
+            FROM policy_positions
+            {where_clause}
+            ORDER BY position_date DESC NULLS LAST, confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        con.close()
+    except Exception as exc:
+        con.close()
+        return {"error": f"query failed: {exc}", "hint": "table may not exist yet — run ensure_schema"}
+
+    return {
+        "filters": {k: v for k, v in {"actor": actor, "topic": topic, "source_type": source_type}.items() if v},
+        "count": len(rows),
+        "positions": [
+            {
+                "position_id": r[0],
+                "actor": r[1],
+                "topic": r[2],
+                "source_type": r[3],
+                "document_id": r[4],
+                "date": r[5] or "",
+                "confidence": round(float(r[6] or 0), 4),
+                "text_preview": r[7],
+            }
+            for r in rows
+        ],
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **`src/argument_mining/positions.py`** — new module implementing the full position extraction pipeline: `extract_positions(document)` (pure, no DB) and `run_position_pipeline(document, conn)` (extract + persist)
- **`policy_positions` DuckDB table** — added to schema in `local_warehouse_seed.py`; columns: `position_id`, `document_id`, `source_type`, `actor`, `topic`, `position_text`, `position_date`, `confidence`, `extracted_at`
- **API updates** — `GET /api/v1/arguments/positions` now queries `policy_positions` directly with actor/topic/source_type/date_range filters; falls back to claim-derived positions for backwards compatibility. New `POST /positions/extract` triggers extraction on any stored document
- **Pipeline MCP** — `run_stage("positions", input_ref=<id>)` and new `query_positions(actor?, topic?)` tool for token-efficient position inspection without raw SQL

### How extraction works (no trained model required)

For each sentence: (1) run `_claim_heuristic` for base confidence; (2) check for commitment verbs (`will X`, `pledged`, `vowed`, `plans to`, `recommends`, etc.); (3) extract actor via 8 ordered regex patterns (transcript speaker labels → titled persons → named persons + verb → institutional roles). Topic is inferred from document metadata, then category, then keyword scan. Questions are excluded.

Covers all six source types: news, blog, paper, transcript, book, note.

## Test plan

- [ ] `python3 -c "from src.argument_mining.positions import extract_positions, run_position_pipeline; print('ok')"` — clean import
- [ ] Unit smoke: `extract_positions(doc)` returns PositionRecord list for each source type
- [ ] DB integration: `run_position_pipeline(doc, conn)` writes to `policy_positions` with correct schema
- [ ] API: `POST /api/v1/arguments/positions/extract?document_id=art-0001` → returns extracted positions
- [ ] API: `GET /api/v1/arguments/positions?actor=government` → queries table with filter
- [ ] MCP: `run_stage("positions", input_ref="art-0001")` returns position summaries
- [ ] MCP: `query_positions(topic="economy")` returns matching rows
- [ ] Pre-existing `test_influence_score_calculation` failure confirmed unrelated