### PR TITLE
feat(argument-mining): position follow-through tracker & Policy Tracker UI (#111)

### DIFF
--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -297,15 +297,84 @@ export const mockFramesBySourceType: Record<string, Record<string, number>> = {
 };
 
 export const mockPositions: ActorPosition[] = [
-  { actor: "Federal Reserve",  topic: "Interest Rate Policy",   position: "Hold at 5.25%; monitor inflation before cutting",  stance: "neutral",  date: "2026-06-20", source_type: "news",       document_id: "doc-news-001" },
-  { actor: "IMF",              topic: "Interest Rate Policy",   position: "Advocates gradual cuts to prevent recession",       stance: "for",      date: "2026-06-18", source_type: "paper",      document_id: "doc-paper-002" },
-  { actor: "Goldman Sachs",    topic: "Interest Rate Policy",   position: "Expects two cuts in H2; overweight equities",       stance: "for",      date: "2026-06-15", source_type: "transcript", document_id: "doc-transcript-001" },
-  { actor: "Senator Warren",   topic: "Interest Rate Policy",   position: "Criticises Fed; calls for political oversight",     stance: "against",  date: "2026-06-12", source_type: "news",       document_id: "doc-news-003" },
-  { actor: "BIS",              topic: "Interest Rate Policy",   position: "Warns premature cuts risk wage-price spiral",       stance: "against",  date: "2026-06-10", source_type: "paper",      document_id: "doc-paper-003" },
-  { actor: "ECB",              topic: "Interest Rate Policy",   position: "Diverging from Fed; began cutting cycle in June",   stance: "for",      date: "2026-06-08", source_type: "news",       document_id: "doc-news-004" },
-  { actor: "EU Commission",    topic: "AI Regulation",          position: "Mandatory risk assessment for frontier models",     stance: "for",      date: "2026-06-19", source_type: "news",       document_id: "doc-news-005" },
-  { actor: "Tech Industry",    topic: "AI Regulation",          position: "Self-regulation preferred; opposes hard limits",    stance: "against",  date: "2026-06-17", source_type: "blog",       document_id: "doc-blog-002" },
-  { actor: "UN AI Advisory",   topic: "AI Regulation",          position: "International treaty with binding safety norms",    stance: "for",      date: "2026-06-14", source_type: "paper",      document_id: "doc-paper-004" },
+  {
+    actor: "Federal Reserve", topic: "Interest Rate Policy",
+    position: "Hold at 5.25%; monitor inflation before cutting",
+    stance: "neutral", date: "2026-06-20", source_type: "news", document_id: "doc-news-001",
+    position_id: "pos-mock-001",
+    updates: [
+      { update_id: "upd-mock-001a", article_id: "doc-news-101", update_type: "reaffirmed", evidence_text: "The Federal Reserve maintained its position on interest rates, reiterating its intention to hold until inflation data improves.", confidence: 0.82, detected_at: "2026-06-23T08:00:00Z" },
+      { update_id: "upd-mock-001b", article_id: "doc-news-102", update_type: "updated",    evidence_text: "Federal Reserve minutes suggest the timeline for the first cut has been extended into Q4.", confidence: 0.68, detected_at: "2026-06-25T14:30:00Z" },
+    ],
+  },
+  {
+    actor: "IMF", topic: "Interest Rate Policy",
+    position: "Advocates gradual cuts to prevent recession",
+    stance: "for", date: "2026-06-18", source_type: "paper", document_id: "doc-paper-002",
+    position_id: "pos-mock-002",
+    updates: [
+      { update_id: "upd-mock-002a", article_id: "doc-news-103", update_type: "reaffirmed", evidence_text: "IMF reiterated its call for gradual monetary easing at the G7 finance ministers meeting.", confidence: 0.76, detected_at: "2026-06-22T10:00:00Z" },
+    ],
+  },
+  {
+    actor: "Goldman Sachs", topic: "Interest Rate Policy",
+    position: "Expects two cuts in H2; overweight equities",
+    stance: "for", date: "2026-06-15", source_type: "transcript", document_id: "doc-transcript-001",
+    position_id: "pos-mock-003",
+    updates: [
+      { update_id: "upd-mock-003a", article_id: "doc-news-104", update_type: "reversed",   evidence_text: "Goldman Sachs revised its forecast, no longer expecting two cuts; analysts backed away from the overweight equities call amid renewed inflation data.", confidence: 0.83, detected_at: "2026-06-24T09:15:00Z" },
+    ],
+  },
+  {
+    actor: "Senator Warren", topic: "Interest Rate Policy",
+    position: "Criticises Fed; calls for political oversight",
+    stance: "against", date: "2026-06-12", source_type: "news", document_id: "doc-news-003",
+    position_id: "pos-mock-004",
+    updates: [],
+  },
+  {
+    actor: "BIS", topic: "Interest Rate Policy",
+    position: "Warns premature cuts risk wage-price spiral",
+    stance: "against", date: "2026-06-10", source_type: "paper", document_id: "doc-paper-003",
+    position_id: "pos-mock-005",
+    updates: [
+      { update_id: "upd-mock-005a", article_id: "doc-news-105", update_type: "reaffirmed", evidence_text: "BIS general manager doubled down on warnings against premature rate cuts, citing persistent services inflation.", confidence: 0.79, detected_at: "2026-06-21T11:00:00Z" },
+    ],
+  },
+  {
+    actor: "ECB", topic: "Interest Rate Policy",
+    position: "Diverging from Fed; began cutting cycle in June",
+    stance: "for", date: "2026-06-08", source_type: "news", document_id: "doc-news-004",
+    position_id: "pos-mock-006",
+    updates: [
+      { update_id: "upd-mock-006a", article_id: "doc-news-106", update_type: "updated",    evidence_text: "ECB adjusted its forward guidance, narrowing the expected pace of cuts from quarterly to semi-annual.", confidence: 0.65, detected_at: "2026-06-20T15:00:00Z" },
+    ],
+  },
+  {
+    actor: "EU Commission", topic: "AI Regulation",
+    position: "Mandatory risk assessment for frontier models",
+    stance: "for", date: "2026-06-19", source_type: "news", document_id: "doc-news-005",
+    position_id: "pos-mock-007",
+    updates: [
+      { update_id: "upd-mock-007a", article_id: "doc-news-107", update_type: "updated",    evidence_text: "EU Commission expanded the scope of mandatory assessments to include open-weight models above 10B parameters.", confidence: 0.71, detected_at: "2026-06-24T13:00:00Z" },
+    ],
+  },
+  {
+    actor: "Tech Industry", topic: "AI Regulation",
+    position: "Self-regulation preferred; opposes hard limits",
+    stance: "against", date: "2026-06-17", source_type: "blog", document_id: "doc-blog-002",
+    position_id: "pos-mock-008",
+    updates: [],
+  },
+  {
+    actor: "UN AI Advisory", topic: "AI Regulation",
+    position: "International treaty with binding safety norms",
+    stance: "for", date: "2026-06-14", source_type: "paper", document_id: "doc-paper-004",
+    position_id: "pos-mock-009",
+    updates: [
+      { update_id: "upd-mock-009a", article_id: "doc-news-108", update_type: "reaffirmed", evidence_text: "UN AI advisory panel reiterated its stance on binding safety norms at the Vienna AI governance forum.", confidence: 0.74, detected_at: "2026-06-23T16:00:00Z" },
+    ],
+  },
 ];
 
 export const mockConflicts: ConflictPair[] = [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -214,6 +214,15 @@ export interface RawDriftEvent {
   window_pair: string | null;
 }
 
+export interface RawPositionUpdate {
+  update_id: string;
+  article_id: string;
+  update_type: string;
+  evidence_text: string;
+  confidence: number;
+  detected_at: string;
+}
+
 export interface RawActorPosition {
   actor: string;
   position: string;
@@ -222,6 +231,8 @@ export interface RawActorPosition {
   source_type: string;
   document_id: string;
   topic: string;
+  position_id?: string;
+  updates?: RawPositionUpdate[];
 }
 
 export interface RawConflictPair {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -33,7 +33,7 @@ import {
   mockDriftEvents,
   mockFramesBySource,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawSourceStance, RawDriftEvent, RawFrameSource } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -47,6 +47,7 @@ import type {
   ClaimResult,
   StanceSummary,
   ActorPosition,
+  PositionUpdate,
   ConflictPair,
   FrameDistribution,
   FrameSource,
@@ -309,6 +310,15 @@ export function useArgumentPositions(params?: { actor?: string; topic?: string; 
         source_type: r.source_type as SourceType,
         document_id: r.document_id,
         topic: r.topic,
+        position_id: r.position_id,
+        updates: (r.updates ?? []).map((u: RawPositionUpdate): PositionUpdate => ({
+          update_id:     u.update_id,
+          article_id:    u.article_id,
+          update_type:   u.update_type as PositionUpdate["update_type"],
+          evidence_text: u.evidence_text,
+          confidence:    u.confidence,
+          detected_at:   u.detected_at,
+        })),
       }));
     },
     mockPositions,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -233,6 +233,17 @@ export interface FrameDistribution {
   source: string;
 }
 
+export type UpdateType = "reaffirmed" | "reversed" | "updated" | "no_signal";
+
+export interface PositionUpdate {
+  update_id: string;
+  article_id: string;
+  update_type: UpdateType;
+  evidence_text: string;
+  confidence: number;
+  detected_at: string;
+}
+
 export interface ActorPosition {
   actor: string;
   position: string;
@@ -241,6 +252,8 @@ export interface ActorPosition {
   source_type: SourceType;
   document_id: string;
   topic: string;
+  position_id?: string;
+  updates?: PositionUpdate[];
 }
 
 export interface ConflictPair {

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -4,7 +4,7 @@ import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPos
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
-import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource } from "../types";
+import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource, PositionUpdate, UpdateType } from "../types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -61,6 +61,20 @@ const VERDICT_LABELS: Record<string, string> = {
 };
 
 const POSITION_COLORS: Record<string, string> = { for: palette.pos, against: palette.neg, neutral: palette.neu };
+
+const UPDATE_TYPE_COLORS: Record<UpdateType, string> = {
+  reaffirmed: palette.pos,
+  reversed:   palette.neg,
+  updated:    palette.amber,
+  no_signal:  palette.dim,
+};
+
+const UPDATE_TYPE_LABELS: Record<UpdateType, string> = {
+  reaffirmed: "REAFFIRMED",
+  reversed:   "REVERSED",
+  updated:    "UPDATED",
+  no_signal:  "NO SIGNAL",
+};
 
 // ─── Shared style tokens ─────────────────────────────────────────────────────
 
@@ -505,12 +519,69 @@ function FramesPanel({ sourceType }: { sourceType: string }) {
 
 // ─── Positions panel ─────────────────────────────────────────────────────────
 
+function UpdateBadge({ type }: { type: UpdateType }) {
+  const color = UPDATE_TYPE_COLORS[type];
+  return (
+    <span style={{
+      fontFamily: fonts.mono, fontSize: 9, letterSpacing: "0.08em",
+      color, background: `${color}18`, border: `1px solid ${color}40`,
+      borderRadius: 4, padding: "1px 6px", flexShrink: 0,
+    }}>
+      {UPDATE_TYPE_LABELS[type]}
+    </span>
+  );
+}
+
+function UpdateTimeline({ updates }: { updates: PositionUpdate[] }) {
+  const visible = updates.filter((u) => u.update_type !== "no_signal");
+  if (visible.length === 0) return (
+    <div style={{ marginTop: 8, fontFamily: fonts.mono, fontSize: 11, color: palette.faint }}>
+      No follow-through updates detected yet.
+    </div>
+  );
+
+  return (
+    <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ ...mono10, marginBottom: 4 }}>Follow-through</div>
+      {visible.map((u, i) => {
+        const color = UPDATE_TYPE_COLORS[u.update_type as UpdateType];
+        const isLast = i === visible.length - 1;
+        return (
+          <div key={u.update_id} style={{ display: "flex", gap: 10 }}>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, width: 14 }}>
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: color, flexShrink: 0, marginTop: 4 }} />
+              {!isLast && <div style={{ width: 1, flex: 1, background: colors.border, margin: "2px 0" }} />}
+            </div>
+            <div style={{ flex: 1, paddingBottom: 4 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 3 }}>
+                <UpdateBadge type={u.update_type as UpdateType} />
+                <span style={{ fontFamily: fonts.mono, fontSize: 9.5, color: palette.faint }}>
+                  {u.detected_at ? u.detected_at.slice(0, 10) : "—"}
+                </span>
+                <span style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.dim }}>
+                  {Math.round(u.confidence * 100)}% conf
+                </span>
+              </div>
+              {u.evidence_text && (
+                <div style={{ fontSize: 11.5, color: colors.textMuted, lineHeight: 1.5, fontStyle: "italic" }}>
+                  "{u.evidence_text.length > 140 ? u.evidence_text.slice(0, 137) + "…" : u.evidence_text}"
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function PositionsPanel({ sourceType }: { sourceType: string }) {
   const { data: positions, source, isLoading } = useArgumentPositions(
     sourceType !== "all" ? { source_type: sourceType } : undefined,
   );
   const allTopics = Array.from(new Set(positions.map((p) => p.topic)));
   const [selectedTopic, setSelectedTopic] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const topic = selectedTopic !== null && allTopics.includes(selectedTopic)
     ? selectedTopic
     : (allTopics[0] ?? "");
@@ -518,10 +589,20 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
     (p) => p.topic === topic && (sourceType === "all" || p.source_type === sourceType),
   );
 
+  const latestUpdateType = (updates: PositionUpdate[] | undefined): UpdateType | null => {
+    if (!updates?.length) return null;
+    const visible = updates.filter((u) => u.update_type !== "no_signal");
+    if (!visible.length) return null;
+    return visible[visible.length - 1].update_type as UpdateType;
+  };
+
   return (
     <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
-        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Actor Policy Positions</span>
+        <div>
+          <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Actor Policy Positions</span>
+          <span style={{ ...mono10, marginLeft: 10 }}>click a position to see follow-through history</span>
+        </div>
         <SourceBadge source={source} isLoading={isLoading} />
       </div>
 
@@ -543,6 +624,16 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
         ))}
       </div>
 
+      {/* Legend */}
+      <div style={{ display: "flex", gap: 14, marginBottom: 12, flexWrap: "wrap" }}>
+        {(["reaffirmed", "updated", "reversed"] as UpdateType[]).map((t) => (
+          <span key={t} style={{ display: "flex", alignItems: "center", gap: 4, fontFamily: fonts.mono, fontSize: 9.5, color: UPDATE_TYPE_COLORS[t] }}>
+            <span style={{ width: 7, height: 7, borderRadius: "50%", background: UPDATE_TYPE_COLORS[t], display: "inline-block" }} />
+            {UPDATE_TYPE_LABELS[t]}
+          </span>
+        ))}
+      </div>
+
       <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
         {filtered.length === 0 && (
           <div style={{ fontFamily: fonts.mono, fontSize: 12, color: palette.faint, padding: "20px 0", textAlign: "center" }}>
@@ -552,32 +643,62 @@ function PositionsPanel({ sourceType }: { sourceType: string }) {
         {filtered.map((pos, i) => {
           const stanceColor = POSITION_COLORS[pos.stance];
           const isLast = i === filtered.length - 1;
+          const posKey = pos.position_id ?? `${pos.actor}-${pos.date}`;
+          const isExpanded = expandedId === posKey;
+          const latest = latestUpdateType(pos.updates);
+          const latestColor = latest ? UPDATE_TYPE_COLORS[latest] : null;
+
           return (
-            <div key={`${pos.actor}-${pos.date}`} style={{ display: "flex", gap: 16 }}>
+            <div key={posKey} style={{ display: "flex", gap: 16 }}>
               {/* Timeline spine */}
               <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, width: 20 }}>
                 <div style={{ width: 10, height: 10, borderRadius: "50%", background: stanceColor, border: `2px solid ${colors.bg}`, flexShrink: 0, marginTop: 12 }} />
                 {!isLast && <div style={{ width: 1, flex: 1, background: colors.border, margin: "2px 0" }} />}
               </div>
               {/* Content */}
-              <div style={{ ...card, padding: "12px 14px", marginBottom: 8, flex: 1 }}>
+              <div
+                style={{ ...card, padding: "12px 14px", marginBottom: 8, flex: 1, cursor: "pointer" }}
+                onClick={() => setExpandedId(isExpanded ? null : posKey)}
+              >
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-                  <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                     <span style={{ fontWeight: 600, fontSize: 13 }}>{pos.actor}</span>
                     <span style={{
-                      marginLeft: 8, fontFamily: fonts.mono, fontSize: 9.5, letterSpacing: "0.08em",
+                      fontFamily: fonts.mono, fontSize: 9.5, letterSpacing: "0.08em",
                       color: stanceColor, background: `${stanceColor}18`, border: `1px solid ${stanceColor}40`,
                       borderRadius: 4, padding: "1px 6px",
                     }}>
                       {pos.stance.toUpperCase()}
                     </span>
+                    {latest && latestColor && (
+                      <UpdateBadge type={latest} />
+                    )}
                   </div>
-                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <div style={{ display: "flex", gap: 8, alignItems: "center", flexShrink: 0 }}>
                     <SourceTypePill type={pos.source_type} />
                     <span style={{ fontFamily: fonts.mono, fontSize: 10.5, color: palette.faint }}>{pos.date}</span>
+                    <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>{isExpanded ? "▲" : "▼"}</span>
                   </div>
                 </div>
                 <div style={{ marginTop: 6, fontSize: 12.5, color: colors.textMuted, lineHeight: 1.5 }}>{pos.position}</div>
+
+                {/* Update count pill when collapsed */}
+                {!isExpanded && pos.updates && pos.updates.filter((u) => u.update_type !== "no_signal").length > 0 && (
+                  <div style={{ marginTop: 6 }}>
+                    <span style={{
+                      fontFamily: fonts.mono, fontSize: 9, color: palette.dim,
+                      background: `${palette.dim}18`, border: `1px solid ${palette.dim}30`,
+                      borderRadius: 4, padding: "1px 7px",
+                    }}>
+                      {pos.updates.filter((u) => u.update_type !== "no_signal").length} follow-through update{pos.updates.filter((u) => u.update_type !== "no_signal").length !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                )}
+
+                {/* Update timeline — expanded */}
+                {isExpanded && (
+                  <UpdateTimeline updates={pos.updates ?? []} />
+                )}
               </div>
             </div>
           );

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -1,5 +1,5 @@
 """
-Argument Mining API routes (Issues #90, #93, #95, #96, #97, #99, #102, #105).
+Argument Mining API routes (Issues #90, #93, #95, #96, #97, #99, #102, #105, #110, #111).
 
 GET  /api/v1/arguments/frames                    — aggregate frame distribution
 GET  /api/v1/arguments/frames?document_id=       — frames for a specific document
@@ -15,8 +15,9 @@ POST /api/v1/arguments/claims/{id}/factcheck     — trigger on-demand fact-chec
 GET  /api/v1/arguments/stance/sources            — stance per (source, topic) from source_stances table (#99)
 GET  /api/v1/arguments/stance/drift              — structured drift events + 7-bucket time series (#102)
 GET  /api/v1/arguments/stance                    — stance distribution across topics
-GET  /api/v1/arguments/positions                 — actor policy positions from policy_positions table (#110)
+GET  /api/v1/arguments/positions                 — actor policy positions with follow-through history (#110, #111)
 POST /api/v1/arguments/positions/extract         — run position extraction on a stored document (#110)
+POST /api/v1/arguments/positions/{id}/check      — trigger follow-through check for one position (#111)
 GET  /api/v1/arguments/controversy               — conflict pairs ranked by contradiction count
 GET  /api/v1/arguments/controversy/graph         — force-directed graph: nodes=claims, edges=contradictions (#96)
 GET  /api/v1/arguments/sources/ranking           — sources ranked by claim quality
@@ -1219,6 +1220,7 @@ async def get_positions(
                             "document_id": r[5],
                             "date": str(r[6]) if r[6] else "",
                             "confidence": round(float(r[7] or 0), 4),
+                            "updates": [],
                             "_source": "claims_fallback",
                         }
                         for r in fb_rows
@@ -1229,16 +1231,47 @@ async def get_positions(
             except Exception:
                 return {"positions": [], "count": 0}
 
+        # Fetch follow-through updates for all returned positions
+        position_ids = [r[0] for r in rows]
+        placeholders = ", ".join("?" * len(position_ids))
+        try:
+            update_rows = conn.execute(
+                f"""
+                SELECT update_id, position_id, article_id, update_type,
+                       evidence_text, confidence, detected_at
+                FROM position_updates
+                WHERE position_id IN ({placeholders})
+                ORDER BY detected_at ASC
+                """,
+                position_ids,
+            ).fetchall()
+        except Exception:
+            update_rows = []
+
+    # Group updates by position_id
+    updates_by_pos: dict[str, list] = {}
+    for u in update_rows:
+        pid = u[1]
+        updates_by_pos.setdefault(pid, []).append({
+            "update_id":     u[0],
+            "article_id":    u[2],
+            "update_type":   u[3],
+            "evidence_text": u[4] or "",
+            "confidence":    round(float(u[5] or 0), 4),
+            "detected_at":   u[6] or "",
+        })
+
     positions = [
         {
             "position_id": row[0],
-            "actor": row[1],
-            "topic": row[2],
-            "position": row[3],
-            "source_type": row[4],
-            "document_id": row[5],
-            "date": row[6] or "",
-            "confidence": round(float(row[7] or 0), 4),
+            "actor":        row[1],
+            "topic":        row[2],
+            "position":     row[3],
+            "source_type":  row[4],
+            "document_id":  row[5],
+            "date":         row[6] or "",
+            "confidence":   round(float(row[7] or 0), 4),
+            "updates":      updates_by_pos.get(row[0], []),
         }
         for row in rows
     ]
@@ -1328,6 +1361,85 @@ async def extract_positions_for_document(
         }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Extraction failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Position follow-through check (#111)
+# ---------------------------------------------------------------------------
+
+@router.post("/positions/{position_id}/check")
+async def check_position_followthrough(
+    position_id: str,
+    limit: int = Query(100, ge=1, le=500, description="Max articles to scan"),
+) -> Dict[str, Any]:
+    """
+    Trigger an on-demand follow-through check for a single position (#111).
+
+    Scans recent articles for references to the same (actor, topic) pair and
+    classifies each reference as reaffirmed / reversed / updated / no_signal.
+    Results are stored in ``position_updates`` and returned immediately.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.position_tracker import (
+        check_position_followthrough as _check,
+        store_followthrough,
+    )
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    with lock:
+        pos_row = conn.execute(
+            "SELECT actor, topic, extracted_at FROM policy_positions WHERE position_id = ? LIMIT 1",
+            [position_id],
+        ).fetchone()
+
+    if not pos_row:
+        raise HTTPException(status_code=404, detail=f"Position '{position_id}' not found")
+
+    actor, topic, extracted_at = pos_row
+    since = (extracted_at or "1970-01-01")[:10]
+
+    with lock:
+        articles = conn.execute(
+            "SELECT id, content, publish_date FROM news_articles "
+            "WHERE CAST(publish_date AS VARCHAR) > ? LIMIT ?",
+            [since, limit],
+        ).fetchall()
+
+    try:
+        records = _check(position_id, actor, topic, articles)
+        if records:
+            with lock:
+                store_followthrough(records, conn)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Follow-through check failed: {exc}")
+
+    summary: Dict[str, int] = {}
+    for r in records:
+        summary[r.update_type] = summary.get(r.update_type, 0) + 1
+
+    return {
+        "position_id": position_id,
+        "actor": actor,
+        "topic": topic,
+        "articles_scanned": len(articles),
+        "updates_found": len(records),
+        "summary": summary,
+        "updates": [
+            {
+                "update_id":     r.update_id,
+                "article_id":    r.article_id,
+                "update_type":   r.update_type,
+                "evidence_text": r.evidence_text,
+                "confidence":    r.confidence,
+                "detected_at":   r.detected_at,
+            }
+            for r in records
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/argument_mining/__init__.py
+++ b/src/argument_mining/__init__.py
@@ -1,8 +1,10 @@
 """
-Argument Mining — claim detection, stance classification, frame analysis, position extraction.
+Argument Mining — claim detection, stance classification, frame analysis, position extraction,
+and position follow-through tracking.
 
 Entry points:
     from src.argument_mining.models import predict_claims, predict_stance
     from src.argument_mining.frames import predict_frames
     from src.argument_mining.positions import extract_positions, run_position_pipeline
+    from src.argument_mining.position_tracker import check_position_followthrough, run_followthrough_batch
 """

--- a/src/argument_mining/followthrough_scheduler.py
+++ b/src/argument_mining/followthrough_scheduler.py
@@ -1,0 +1,45 @@
+"""
+Nightly follow-through batch runner for position tracking (issue #111).
+
+Run directly:
+    python -m src.argument_mining.followthrough_scheduler
+
+Or via APScheduler:
+    from src.argument_mining.followthrough_scheduler import schedule_followthrough_job
+"""
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def run_once(limit: int = 50) -> dict:
+    """Run one pass of the follow-through batch and return summary counts."""
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.position_tracker import run_followthrough_batch
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+    return run_followthrough_batch(conn, lock, limit=limit)
+
+
+def schedule_followthrough_job(scheduler: object, hour: int = 3) -> None:
+    """Register a nightly APScheduler job at *hour* UTC (defaults to 03:00)."""
+    from apscheduler.triggers.cron import CronTrigger  # type: ignore[import]
+
+    scheduler.add_job(  # type: ignore[attr-defined]
+        run_once,
+        trigger=CronTrigger(hour=hour, minute=0),
+        id="followthrough_nightly",
+        replace_existing=True,
+        max_instances=1,
+    )
+    logger.info("Scheduled nightly follow-through check at %02d:00 UTC", hour)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    summary = run_once()
+    print(f"Done: {summary}")

--- a/src/argument_mining/position_tracker.py
+++ b/src/argument_mining/position_tracker.py
@@ -1,0 +1,277 @@
+"""
+Position Follow-Through Tracker (issue #111).
+
+For each stored policy position, scans recent news articles for references
+to the same (actor, topic) pair and classifies each reference as:
+  - reaffirmed  : actor confirmed or doubled down on the original position
+  - reversed    : actor changed or abandoned the original position
+  - updated     : actor modified or adjusted the original position
+  - no_signal   : actor+topic mentioned but no clear follow-through signal
+
+Results are stored in ``position_updates`` and attached to each position
+returned by ``GET /api/v1/arguments/positions``.
+
+Run standalone:
+    python -m src.argument_mining.position_tracker
+
+Or via the nightly scheduler:
+    from src.argument_mining.followthrough_scheduler import schedule_followthrough_job
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Signal patterns
+# ---------------------------------------------------------------------------
+
+_REVERSAL_SIGNALS = re.compile(
+    r"\b("
+    r"reversed?|abandoned|dropped|scrapped|u-turn|walked\s+back|flip-flop(?:ped)?|"
+    r"backtracked?|no\s+longer|retracted|rescinded|cancelled|annulled|"
+    r"overturned|retreats?\s+from|changed\s+course|changed\s+(?:their\s+)?position|"
+    r"reneged|backed\s+away\s+from|broke\s+(?:his|her|their)\s+promise|"
+    r"ditched|shelved|withdrew|stepping\s+back|pulling\s+back"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_UPDATE_SIGNALS = re.compile(
+    r"\b("
+    r"updated?|modified?|adjusted?|expanded?|extended?|narrowed?|strengthened?|"
+    r"weakened?|amended?|revised?|refined?|shifted?|evolved?|softened?|"
+    r"hardened?|scaled\s+(?:back|up)|paused?|delayed?|postponed?"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_REAFFIRM_SIGNALS = re.compile(
+    r"\b("
+    r"reaffirmed?|reiterates?|doubled\s+down|confirmed?|remained?\s+committed|"
+    r"maintained?|stood\s+by|upheld|renewed?|insists?|continues?\s+to|"
+    r"still\s+plans?|standing\s+firm|held\s+(?:firm|course)|"
+    r"reiterated?|restated?|repeated?|re-confirmed?"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FollowthroughRecord:
+    update_id: str
+    position_id: str
+    article_id: str
+    update_type: str        # reaffirmed | reversed | updated | no_signal
+    evidence_text: str
+    confidence: float
+    detected_at: str        # ISO UTC timestamp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _update_id(position_id: str, article_id: str) -> str:
+    """Deterministic ID keyed on (position_id, article_id)."""
+    h = hashlib.sha1(f"{position_id}|{article_id}".encode()).hexdigest()[:32]
+    return f"upd-{h}"
+
+
+def _split_sentences(text: str) -> List[str]:
+    """Split raw text into sentences (mirrors sentences_from_document)."""
+    parts = re.split(r"(?<=[.!?])\s+|\n{2,}", text.strip())
+    return [p.strip() for p in parts if len(p.strip()) >= 20]
+
+
+def _actor_mentioned(text: str, actor: str) -> bool:
+    """Return True if any ≥4-char word from the actor name appears in the text."""
+    words = [w for w in actor.split() if len(w) >= 4]
+    if not words:
+        return actor.lower() in text.lower()
+    low = text.lower()
+    return any(w.lower() in low for w in words)
+
+
+def _topic_mentioned(text: str, keywords: frozenset) -> bool:
+    """Return True if any topic keyword appears in the text."""
+    low = text.lower()
+    return any(kw in low for kw in keywords)
+
+
+def _classify_sentence(sentence: str) -> Tuple[str, float]:
+    """Map a sentence to (update_type, confidence).
+
+    Priority: reversal beats reaffirmation; mixed signals → updated.
+    """
+    has_reversal = bool(_REVERSAL_SIGNALS.search(sentence))
+    has_reaffirm = bool(_REAFFIRM_SIGNALS.search(sentence))
+    has_update   = bool(_UPDATE_SIGNALS.search(sentence))
+
+    if has_reversal and not has_reaffirm:
+        return "reversed",   0.80
+    if has_reaffirm and not has_reversal:
+        return "reaffirmed", 0.75
+    if has_reversal and has_reaffirm:
+        return "updated",    0.50
+    if has_update:
+        return "updated",    0.65
+    return "no_signal", 0.30
+
+
+def _topic_keywords(topic: str) -> frozenset:
+    """Return the keyword frozenset for a topic label from the taxonomy."""
+    from src.argument_mining.positions import _TOPIC_TAXONOMY
+    for label, kw in _TOPIC_TAXONOMY:
+        if label == topic:
+            return kw
+    return frozenset({topic.lower()})
+
+
+# ---------------------------------------------------------------------------
+# Core follow-through check
+# ---------------------------------------------------------------------------
+
+
+def check_position_followthrough(
+    position_id: str,
+    actor: str,
+    topic: str,
+    articles: List[Tuple],  # (article_id, content, publish_date)
+) -> List[FollowthroughRecord]:
+    """Check one position against a list of (article_id, content, publish_date) tuples.
+
+    Returns at most one FollowthroughRecord per article — the sentence with the
+    highest-confidence signal wins.  ``no_signal`` records are produced only when
+    the actor+topic are both referenced so we have a traceable mention.
+    """
+    topic_kw = _topic_keywords(topic)
+    records: List[FollowthroughRecord] = []
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    for article_id, content, _pub_date in articles:
+        if not content:
+            continue
+        if not _actor_mentioned(content, actor):
+            continue
+        if not _topic_mentioned(content, topic_kw):
+            continue
+
+        best_type = "no_signal"
+        best_conf = 0.30
+        best_sent = ""
+
+        for sent in _split_sentences(content):
+            if not _actor_mentioned(sent, actor):
+                continue
+            utype, conf = _classify_sentence(sent)
+            if conf > best_conf:
+                best_type = utype
+                best_conf = conf
+                best_sent = sent
+
+        records.append(FollowthroughRecord(
+            update_id=_update_id(position_id, article_id),
+            position_id=position_id,
+            article_id=article_id,
+            update_type=best_type,
+            evidence_text=(best_sent or content[:200])[:500],
+            confidence=round(best_conf, 4),
+            detected_at=now_iso,
+        ))
+
+    return records
+
+
+def store_followthrough(records: List[FollowthroughRecord], conn) -> None:
+    """Persist FollowthroughRecord list to position_updates. Idempotent (INSERT OR REPLACE)."""
+    if not records:
+        return
+    conn.executemany(
+        """
+        INSERT OR REPLACE INTO position_updates
+            (update_id, position_id, article_id, update_type,
+             evidence_text, confidence, detected_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (r.update_id, r.position_id, r.article_id, r.update_type,
+             r.evidence_text, r.confidence, r.detected_at)
+            for r in records
+        ],
+    )
+
+
+def run_followthrough_batch(conn, lock, limit: int = 50) -> dict:
+    """Nightly batch: check all stored positions against new articles.
+
+    For each position (up to *limit*), queries articles published after the
+    position's ``extracted_at`` timestamp and classifies any relevant mentions.
+
+    Returns:
+        {"checked": int, "matched": int, "stored": int}
+    """
+    with lock:
+        positions = conn.execute(
+            """
+            SELECT position_id, actor, topic, extracted_at
+            FROM policy_positions
+            ORDER BY extracted_at ASC
+            LIMIT ?
+            """,
+            [limit],
+        ).fetchall()
+
+    counts: dict = {"checked": 0, "matched": 0, "stored": 0}
+
+    for position_id, actor, topic, extracted_at in positions:
+        counts["checked"] += 1
+        since = (extracted_at or "1970-01-01")[:10]
+
+        with lock:
+            articles = conn.execute(
+                """
+                SELECT id, content, publish_date
+                FROM news_articles
+                WHERE CAST(publish_date AS VARCHAR) > ?
+                LIMIT 200
+                """,
+                [since],
+            ).fetchall()
+
+        if not articles:
+            continue
+
+        records = check_position_followthrough(position_id, actor, topic, articles)
+        if not records:
+            continue
+
+        counts["matched"] += len(records)
+        with lock:
+            store_followthrough(records, conn)
+        counts["stored"] += len(records)
+
+    logger.info("run_followthrough_batch: %s", counts)
+    return counts
+
+
+if __name__ == "__main__":
+    import threading
+    logging.basicConfig(level=logging.INFO)
+    from src.database.local_analytics_connector import get_shared_connection
+
+    _conn = get_shared_connection()
+    _lock = getattr(_conn, "_lock", None) or threading.Lock()
+    result = run_followthrough_batch(_conn, _lock)
+    print(f"Done: {result}")

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -99,6 +99,16 @@ CREATE TABLE IF NOT EXISTS policy_positions (
     confidence     DOUBLE,
     extracted_at   VARCHAR
 );
+
+CREATE TABLE IF NOT EXISTS position_updates (
+    update_id      VARCHAR PRIMARY KEY,
+    position_id    VARCHAR NOT NULL,
+    article_id     VARCHAR NOT NULL,
+    update_type    VARCHAR NOT NULL,
+    evidence_text  VARCHAR,
+    confidence     DOUBLE,
+    detected_at    VARCHAR
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -14,9 +14,11 @@ Tools:
                 query?)                   source = RSS feed name OR a source_type from
                                           list_connector_types(); query = JSON list of paths/
                                           IDs passed to that connector's discover().
-  run_stage(stage, input_ref?, ...)    -> run one named stage: fetch|sentiment|store|ingest|positions
-  trace_article(id)                    -> where an article exists across warehouse / vector / s3
-  query_positions(actor?, topic?, ...) -> query policy_positions table for actor commitments (#110)
+  run_stage(stage, input_ref?, ...)         -> run one named stage: fetch|sentiment|store|ingest|positions
+  trace_article(id)                         -> where an article exists across warehouse / vector / s3
+  query_positions(actor?, topic?, ...)      -> query policy_positions table for actor commitments (#110)
+  query_position_updates(position_id?, ...) -> query position_updates follow-through events (#111)
+  trigger_followthrough_check(limit?)       -> run nightly follow-through batch on-demand (#111)
 
 Design constraints (learned the hard way in this repo):
   * Lazy imports inside tools. The top of this module imports only stdlib +
@@ -689,6 +691,119 @@ def query_positions(
             for r in rows
         ],
     }
+
+
+@mcp.tool
+def query_position_updates(
+    position_id: Optional[str] = None,
+    actor: Optional[str] = None,
+    topic: Optional[str] = None,
+    update_type: Optional[str] = None,
+    limit: int = 15,
+) -> dict:
+    """Query ``position_updates`` for follow-through events (#111).
+
+    Returns compact update summaries (evidence truncated to 120 chars).
+    Filter by position, actor name, topic, or update_type
+    (reaffirmed / reversed / updated / no_signal).
+
+    Args:
+        position_id: exact position ID to look up.
+        actor:       ILIKE filter on the actor name (joined from policy_positions).
+        topic:       ILIKE filter on topic (joined from policy_positions).
+        update_type: exact filter — reaffirmed | reversed | updated | no_signal.
+        limit:       max rows (capped at 25).
+    """
+    limit = max(1, min(int(limit), MAX_LIST))
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": f"warehouse unavailable: {exc}"}
+
+    join = "LEFT JOIN policy_positions p ON u.position_id = p.position_id"
+    where_parts: list[str] = []
+    params: list[Any] = []
+
+    if position_id:
+        where_parts.append("u.position_id = ?")
+        params.append(position_id)
+    if actor:
+        where_parts.append("p.actor ILIKE ?")
+        params.append(f"%{actor}%")
+    if topic:
+        where_parts.append("p.topic ILIKE ?")
+        params.append(f"%{topic}%")
+    if update_type:
+        where_parts.append("u.update_type = ?")
+        params.append(update_type)
+    where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    params.append(limit)
+
+    try:
+        rows = con.execute(
+            f"""
+            SELECT u.update_id, u.position_id, p.actor, p.topic,
+                   u.article_id, u.update_type, u.confidence, u.detected_at,
+                   LEFT(u.evidence_text, 120) AS evidence_preview
+            FROM position_updates u
+            {join}
+            {where_clause}
+            ORDER BY u.detected_at DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        con.close()
+    except Exception as exc:
+        con.close()
+        return {"error": f"query failed: {exc}"}
+
+    return {
+        "filters": {k: v for k, v in {
+            "position_id": position_id, "actor": actor,
+            "topic": topic, "update_type": update_type,
+        }.items() if v},
+        "count": len(rows),
+        "updates": [
+            {
+                "update_id":       r[0],
+                "position_id":     r[1],
+                "actor":           r[2] or "",
+                "topic":           r[3] or "",
+                "article_id":      r[4],
+                "update_type":     r[5],
+                "confidence":      round(float(r[6] or 0), 4),
+                "detected_at":     r[7] or "",
+                "evidence_preview": r[8] or "",
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool
+def trigger_followthrough_check(limit: int = 50) -> dict:
+    """Run one pass of the nightly follow-through batch on-demand (#111).
+
+    Checks up to ``limit`` stored positions against recent warehouse articles
+    and stores classified update events (reaffirmed/reversed/updated/no_signal)
+    in ``position_updates``.  Use ``query_position_updates()`` to read results.
+
+    Args:
+        limit: max positions to process (capped at 200).
+    """
+    limit = max(1, min(int(limit), 200))
+    try:
+        import threading
+        from src.argument_mining.position_tracker import run_followthrough_batch
+
+        con = _warehouse_rw()
+        lock = threading.Lock()
+        counts = run_followthrough_batch(con, lock, limit=limit)
+        con.close()
+        return {"status": "ok", **counts}
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **`src/argument_mining/position_tracker.py`** — core follow-through detection: `check_position_followthrough()` scans articles for (actor, topic) mentions and classifies each as `reaffirmed / reversed / updated / no_signal` using regex signal patterns; `run_followthrough_batch()` sweeps all stored positions nightly
- **`src/argument_mining/followthrough_scheduler.py`** — APScheduler wrapper at 03:00 UTC, mirrors `factcheck_scheduler.py`
- **`position_updates` table** — added to `local_warehouse_seed.py`; columns: `update_id (PK)`, `position_id`, `article_id`, `update_type`, `evidence_text`, `confidence`, `detected_at`
- **API** — `GET /positions` now joins `position_updates` and attaches `updates[]` to each position; new `POST /positions/{id}/check` triggers on-demand follow-through for a single position
- **Policy Tracker panel** — Positions tab shows the latest follow-through badge inline (green REAFFIRMED / amber UPDATED / red REVERSED); clicking a card expands an `UpdateTimeline` with dated evidence snippets and confidence scores
- **Pipeline MCP** — `query_position_updates(actor?, topic?, update_type?)` and `trigger_followthrough_check(limit?)` added for token-efficient position tracking without raw SQL

### Classification logic (no trained model needed)

For each article mentioning both the actor and topic keywords:
1. Scan every sentence that mentions the actor
2. Apply three regex pattern sets (reversal verbs, update verbs, reaffirmation verbs)
3. Highest-confidence match across all sentences = the article's classification
4. One `FollowthroughRecord` per article, stored idempotently

Reversal beats reaffirmation when both fire; mixed signals → `updated`.

## Test plan

- [ ] `python3 -c "from src.argument_mining.position_tracker import check_position_followthrough; print('ok')"` — clean import
- [ ] Classification: `_classify_sentence("The minister reversed course")` → `("reversed", 0.80)`
- [ ] DB: `run_followthrough_batch(conn, lock)` on seeded warehouse produces `position_updates` rows
- [ ] API: `GET /api/v1/arguments/positions` → each position carries `updates` list (empty if no data yet)
- [ ] API: `POST /api/v1/arguments/positions/{id}/check` → returns `updates_found`, `summary` dict
- [ ] UI: Arguments → Positions tab shows REAFFIRMED/UPDATED/REVERSED badges; click expands timeline
- [ ] MCP: `query_position_updates(actor="Goldman")` returns matching updates
- [ ] MCP: `trigger_followthrough_check(limit=10)` returns `{checked, matched, stored}` counts