### PR TITLE
feat(argument-mining): actor & source metadata extraction (#114)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -289,6 +289,24 @@ export interface RawSourceStance {
   window_end: string | null;
 }
 
+export interface RawActor {
+  document_id: string;
+  source_type: string;
+  actor_name: string;
+  entity_id: string;
+  role: "speaker" | "subject" | "author";
+  confidence: number | null;
+  extracted_at: string | null;
+}
+
+export interface RawActorSummary {
+  actor_name: string;
+  entity_id: string;
+  role: "speaker" | "subject" | "author";
+  doc_count: number;
+  avg_confidence: number;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -356,4 +374,10 @@ export const api = {
 
   argumentFramesBySource: (params?: { source?: string; source_type?: string; topic?: string; date_range?: string; limit?: number }) =>
     request<{ sources: RawFrameSource[]; count: number }>("/api/v1/arguments/frames/source", params),
+
+  argumentActors: (params?: { document_id?: string; source_type?: string; role?: string; actor_name?: string; limit?: number }) =>
+    request<{ actors: RawActor[]; count: number }>("/api/v1/arguments/actors", params),
+
+  argumentActorsSummary: (params?: { source_type?: string; role?: string; limit?: number }) =>
+    request<{ actors: RawActorSummary[]; count: number }>("/api/v1/arguments/actors/summary", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -33,7 +33,7 @@ import {
   mockDriftEvents,
   mockFramesBySource,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActor, RawActorSummary } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -55,6 +55,8 @@ import type {
   ControversyGraph,
   SourceStance,
   StanceDriftEvent,
+  DocumentActor,
+  ActorSummary,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -419,6 +421,44 @@ export function useArgumentFramesBySource(params?: { source?: string; source_typ
     params?.source_type && params.source_type !== "all"
       ? mockFramesBySource.filter((s) => s.source_type === params.source_type)
       : mockFramesBySource,
+  );
+}
+
+export function useArgumentActors(params?: { document_id?: string; source_type?: string; role?: string; actor_name?: string; limit?: number }): Result<DocumentActor[]> {
+  const key = `argumentActors-${params?.document_id ?? ""}-${params?.source_type ?? "all"}-${params?.role ?? ""}-${params?.actor_name ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<DocumentActor[]> => {
+      const res = await api.argumentActors(params);
+      return res.actors.map((r: RawActor) => ({
+        document_id:  r.document_id,
+        source_type:  r.source_type as SourceType,
+        actor_name:   r.actor_name,
+        entity_id:    r.entity_id,
+        role:         r.role,
+        confidence:   r.confidence,
+        extracted_at: r.extracted_at,
+      }));
+    },
+    [],
+  );
+}
+
+export function useArgumentActorsSummary(params?: { source_type?: string; role?: string; limit?: number }): Result<ActorSummary[]> {
+  const key = `argumentActorsSummary-${params?.source_type ?? "all"}-${params?.role ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<ActorSummary[]> => {
+      const res = await api.argumentActorsSummary(params);
+      return res.actors.map((r: RawActorSummary) => ({
+        actor_name:     r.actor_name,
+        entity_id:      r.entity_id,
+        role:           r.role,
+        doc_count:      r.doc_count,
+        avg_confidence: r.avg_confidence,
+      }));
+    },
+    [],
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -296,6 +296,24 @@ export interface ControversyGraph {
 
 export type SourceType = "news" | "blog" | "paper" | "book" | "transcript" | "web" | "note";
 
+export interface DocumentActor {
+  document_id: string;
+  source_type: SourceType;
+  actor_name: string;
+  entity_id: string;
+  role: "speaker" | "subject" | "author";
+  confidence: number | null;
+  extracted_at: string | null;
+}
+
+export interface ActorSummary {
+  actor_name: string;
+  entity_id: string;
+  role: "speaker" | "subject" | "author";
+  doc_count: number;
+  avg_confidence: number;
+}
+
 export interface KnowledgeDocument {
   document_id: string;
   source_type: SourceType;

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -1813,3 +1813,214 @@ async def get_sources_ranking(
     ]
 
     return {"sources": sources, "count": len(sources)}
+
+
+# ---------------------------------------------------------------------------
+# Actor / source metadata endpoints (#114)
+# ---------------------------------------------------------------------------
+
+@router.get("/actors")
+async def get_actors(
+    document_id: Optional[str] = Query(None, description="Filter by document ID"),
+    source_type: Optional[str] = Query(None, description="Filter by content type"),
+    role: Optional[str] = Query(None, description="Filter by role: speaker|subject|author"),
+    actor_name: Optional[str] = Query(None, description="Partial name match (ILIKE)"),
+    limit: int = Query(100, ge=1, le=1000, description="Max results"),
+) -> Dict[str, Any]:
+    """
+    Query ``document_actors`` for extracted actor/source metadata.
+
+    Each record carries a stable ``entity_id`` (sha1 of the canonical name)
+    that joins to the entity graph without a separate entity table.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if document_id:
+        conditions.append("document_id = ?")
+        params.append(document_id)
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if role:
+        conditions.append("role = ?")
+        params.append(role)
+    if actor_name:
+        conditions.append("actor_name ILIKE ?")
+        params.append(f"%{actor_name}%")
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT document_id, source_type, actor_name, entity_id,
+                   role, confidence, extracted_at
+            FROM document_actors
+            {where}
+            ORDER BY confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    actors = [
+        {
+            "document_id":  r[0],
+            "source_type":  r[1],
+            "actor_name":   r[2],
+            "entity_id":    r[3],
+            "role":         r[4],
+            "confidence":   round(r[5], 4) if r[5] is not None else None,
+            "extracted_at": r[6],
+        }
+        for r in rows
+    ]
+    return {"actors": actors, "count": len(actors)}
+
+
+@router.post("/actors/extract")
+async def extract_actors_for_document(
+    document_id: str = Query(..., description="Document ID in news_articles"),
+    source_type: str = Query("news", description="Source type of the document"),
+) -> Dict[str, Any]:
+    """
+    Run actor extraction on a single stored document and persist results.
+
+    Uses spaCy NER when ``en_core_web_sm`` is installed; falls back to
+    regex heuristics automatically.
+    """
+    import threading, time
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.metadata import extract_actors, store_actors
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    with lock:
+        row = conn.execute(
+            "SELECT id, title, content, source FROM news_articles WHERE id = ? LIMIT 1",
+            [document_id],
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Document '{document_id}' not found")
+
+    from services.ingest.common.document_model import Document  # type: ignore[import]
+
+    doc = Document(
+        document_id=row[0],
+        source_type=source_type,
+        language="en",
+        ingested_at=int(time.time() * 1000),
+        source_id=row[3],
+        title=row[1],
+        content=row[2] or "",
+    )
+    records = extract_actors(doc)
+    if records:
+        with lock:
+            store_actors(records, conn)
+
+    return {
+        "document_id": document_id,
+        "source_type": source_type,
+        "actors_extracted": len(records),
+        "actors": [
+            {"actor_name": r.actor_name, "role": r.role,
+             "entity_id": r.entity_id, "confidence": round(r.confidence, 4)}
+            for r in records
+        ],
+    }
+
+
+@router.post("/actors/batch")
+async def run_actors_batch(
+    limit: int = Query(200, ge=1, le=2000,
+                       description="Max news_articles documents to process"),
+) -> Dict[str, Any]:
+    """
+    Extract actors for news_articles documents not yet in ``document_actors``.
+
+    Safe to call repeatedly — already-processed documents are skipped.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.metadata import run_actor_batch
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+    return run_actor_batch(conn, lock, limit=limit)
+
+
+@router.get("/actors/summary")
+async def get_actors_summary(
+    source_type: Optional[str] = Query(None, description="Filter by content type"),
+    role: Optional[str] = Query(None, description="Filter by role"),
+    limit: int = Query(30, ge=1, le=200, description="Top-N actors by document frequency"),
+) -> Dict[str, Any]:
+    """
+    Aggregate view: most frequent actors across all documents.
+
+    Returns top actors by document_count, broken down by role.  Useful for
+    feeding the stance detection and policy position pipelines with a
+    pre-ranked actor list.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if role:
+        conditions.append("role = ?")
+        params.append(role)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT actor_name, entity_id, role,
+                   COUNT(DISTINCT document_id) AS doc_count,
+                   ROUND(AVG(confidence), 4)   AS avg_confidence
+            FROM document_actors
+            {where}
+            GROUP BY actor_name, entity_id, role
+            ORDER BY doc_count DESC, avg_confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    return {
+        "actors": [
+            {
+                "actor_name":     r[0],
+                "entity_id":      r[1],
+                "role":           r[2],
+                "doc_count":      r[3],
+                "avg_confidence": float(r[4]) if r[4] is not None else 0.0,
+            }
+            for r in rows
+        ],
+        "count": len(rows),
+    }

--- a/src/argument_mining/__init__.py
+++ b/src/argument_mining/__init__.py
@@ -9,4 +9,5 @@ Entry points:
     from src.argument_mining.position_tracker import check_position_followthrough, run_followthrough_batch
     from src.argument_mining.conflict_graph import compute_claim_conflicts, build_conflict_graph, cosine_similarity
     from src.argument_mining.attribution import classify_attribution, run_attribution_batch
+    from src.argument_mining.metadata import extract_actors, store_actors, run_actor_batch
 """

--- a/src/argument_mining/metadata.py
+++ b/src/argument_mining/metadata.py
@@ -1,0 +1,465 @@
+"""
+Actor & source metadata extractor — issue #114.
+
+Extracts structured actor metadata (quoted speakers, attributed institutions,
+authors, publishers) from any Document regardless of source_type.
+
+spaCy ``en_core_web_sm`` is used for NER when installed; the module falls back
+to regex heuristics so no ML dependency is required for basic operation.
+
+Content-type specifics
+----------------------
+news / blog   — document.authors (byline), document.source_id (outlet),
+                PERSON/ORG entities from body text
+paper         — document.authors, APA-cited institutions, bracketed references
+transcript    — speaker labels from document.metadata["segments"] or "speakers",
+                PERSON NER on body text for named interviewees
+book          — document.authors, document.metadata["publisher"],
+                dialogue speaker labels ("SPEAKER: " prefix)
+note / upload — document.metadata["creator"] or document.authors
+
+Entity linking
+--------------
+Actors are linked to a stable entity_id derived from their canonical form:
+``ent-<sha1[:12] of lower-stripped name>``.  This is consistent with the
+``_extract_entities`` + ``_aggregate_entities`` approach in
+``local_warehouse_views``, so actor records can be joined to the entity graph
+without a separate entity table.
+
+Public API
+----------
+  extract_actors(document) -> List[ActorRecord]
+  store_actors(records, conn) -> None
+  run_actor_batch(conn, lock, limit?) -> {"processed": int, "actors": int, "skipped": int}
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Compiled patterns (heuristic fallback path)
+# ---------------------------------------------------------------------------
+
+# News "said/told/wrote" attribution — captures the speaker before the verb
+_SAID_RE = re.compile(
+    r"((?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})|(?:[A-Z]{2,}))"
+    r"\s+(?:said|told|wrote|stated|confirmed|noted|argued|added|explained"
+    r"|revealed|disclosed|warned|insisted|acknowledged|conceded|announced)",
+    re.M,
+)
+# Quoted speech intro: "…," Name said
+_QUOTE_SAID_RE = re.compile(
+    r'["“].{5,120}["”]\s*,?\s+'
+    r"((?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+"
+    r"(?:said|told|wrote|noted|added|explained)",
+    re.M,
+)
+# Transcript speaker label "Speaker Name: text"
+_TRANSCRIPT_SPEAKER_RE = re.compile(
+    r"^((?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})|(?:[A-Z]{2,}(?:\s+[A-Z]{2,})?))\s*:",
+    re.M,
+)
+# APA citation institution (after "at X" or "from X" inside parenthetical)
+_PAPER_INSTITUTION_RE = re.compile(
+    r"\b(?:at|from|of)\s+((?:[A-Z][a-z]+(?:\s+(?:of|and|for|the|University|Institute|College|School|Center|Centre|Lab(?:oratory)?|Department|Hospital)\b)?)*[A-Z][a-z]+)",
+)
+# Dialogue speaker in books "NAME: " or "Name said"
+_BOOK_SPEAKER_RE = re.compile(
+    r"^([A-Z][A-Z\s]{1,25}):\s",  # ALL-CAPS label
+    re.M,
+)
+# Org-like multi-word title-case sequences (fallback)
+_ORG_CAPS_RE = re.compile(
+    r"(?:^|\s)((?:[A-Z][a-z]{1,20}\s){1,4}(?:Inc|Corp|Ltd|LLC|LLP|Group|Bank|Fund|Agency|Commission|Committee|Department|Ministry|Authority|Association|Institute|Foundation|University|College|Hospital|Center|Centre|Lab|WHO|IMF|EU|UN|NATO|FBI|CIA|SEC|ECB|Fed)\b)",
+    re.M,
+)
+
+# Names to skip (sentence starters, filler)
+_SKIP_NAMES = frozenset({
+    "the", "a", "an", "this", "that", "it", "they", "he", "she", "we", "you",
+    "i", "my", "his", "her", "its", "our", "their", "as", "but", "and", "or",
+    "so", "yet", "for", "nor", "the", "said", "told", "wrote",
+})
+
+
+# ---------------------------------------------------------------------------
+# spaCy NER helper (optional)
+# ---------------------------------------------------------------------------
+
+_nlp = None
+_nlp_tried = False
+
+
+def _get_nlp():
+    global _nlp, _nlp_tried
+    if _nlp_tried:
+        return _nlp
+    _nlp_tried = True
+    try:
+        import spacy
+        _nlp = spacy.load("en_core_web_sm")
+        logger.info("metadata: spaCy en_core_web_sm loaded")
+    except Exception as e:
+        logger.debug("metadata: spaCy not available (%s) — using regex fallback", e)
+        _nlp = None
+    return _nlp
+
+
+def _ner_actors(text: str) -> List[Tuple[str, str]]:
+    """Return (name, spaCy_label) pairs for PERSON and ORG entities."""
+    nlp = _get_nlp()
+    if nlp is None or not text:
+        return []
+    try:
+        doc = nlp(text[:50_000])  # cap to avoid timeouts on large docs
+        return [
+            (ent.text.strip(), ent.label_)
+            for ent in doc.ents
+            if ent.label_ in ("PERSON", "ORG", "GPE", "FAC", "NORP")
+            and len(ent.text.strip()) >= 2
+        ]
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Entity-ID derivation
+# ---------------------------------------------------------------------------
+
+def _entity_id(name: str) -> str:
+    """Stable, reproducible entity ID derived from the canonical name."""
+    canonical = re.sub(r"\s+", " ", name.strip().lower())
+    return "ent-" + hashlib.sha1(canonical.encode()).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# ActorRecord
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ActorRecord:
+    document_id: str
+    source_type: str
+    actor_name: str
+    entity_id: str
+    role: str        # "speaker" | "subject" | "author"
+    confidence: float
+    extracted_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    @classmethod
+    def make(cls, document_id: str, source_type: str,
+             name: str, role: str, confidence: float) -> "ActorRecord":
+        return cls(
+            document_id=document_id,
+            source_type=source_type,
+            actor_name=name,
+            entity_id=_entity_id(name),
+            role=role,
+            confidence=confidence,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-type extractors
+# ---------------------------------------------------------------------------
+
+def _valid_name(name: str) -> bool:
+    name = name.strip()
+    if not name or len(name) < 2:
+        return False
+    if name.lower() in _SKIP_NAMES:
+        return False
+    words = name.split()
+    # Must start with a capital or be an acronym
+    if not (words[0][0].isupper() or words[0].isupper()):
+        return False
+    return True
+
+
+def _from_authors(document_id: str, source_type: str,
+                  authors: Sequence[str], role: str = "author") -> List[ActorRecord]:
+    return [
+        ActorRecord.make(document_id, source_type, a.strip(), role, 0.95)
+        for a in authors
+        if a and a.strip() and _valid_name(a.strip())
+    ]
+
+
+def _regex_speakers_from_text(document_id: str, source_type: str,
+                               text: str) -> List[ActorRecord]:
+    seen: Dict[str, ActorRecord] = {}
+    for pat, role, conf in [
+        (_SAID_RE, "speaker", 0.72),
+        (_QUOTE_SAID_RE, "speaker", 0.78),
+    ]:
+        for m in pat.finditer(text):
+            name = m.group(1).strip()
+            if _valid_name(name) and name not in seen:
+                seen[name] = ActorRecord.make(document_id, source_type, name, role, conf)
+    return list(seen.values())
+
+
+def _spacy_subjects(document_id: str, source_type: str, text: str,
+                    role: str = "subject") -> List[ActorRecord]:
+    pairs = _ner_actors(text)
+    seen: Dict[str, ActorRecord] = {}
+    for name, label in pairs:
+        if not _valid_name(name) or name in seen:
+            continue
+        r = "speaker" if label == "PERSON" else role
+        conf = 0.82 if label == "PERSON" else 0.75
+        seen[name] = ActorRecord.make(document_id, source_type, name, r, conf)
+    return list(seen.values())
+
+
+def _extract_news_blog(doc) -> List[ActorRecord]:
+    did, stype = doc.document_id, doc.source_type
+    out: List[ActorRecord] = []
+
+    # Byline / authors
+    out.extend(_from_authors(did, stype, doc.authors or [], role="author"))
+
+    # Outlet from source_id
+    if doc.source_id and _valid_name(doc.source_id):
+        out.append(ActorRecord.make(did, stype, doc.source_id, "subject", 0.90))
+
+    body = (doc.content or "")[:20_000]
+
+    # spaCy NER first, fall back to regex
+    if _get_nlp():
+        out.extend(_spacy_subjects(did, stype, body, role="subject"))
+    else:
+        out.extend(_regex_speakers_from_text(did, stype, body))
+        for m in _ORG_CAPS_RE.finditer(body):
+            name = m.group(1).strip()
+            if _valid_name(name):
+                out.append(ActorRecord.make(did, stype, name, "subject", 0.65))
+
+    return out
+
+
+def _extract_paper(doc) -> List[ActorRecord]:
+    did, stype = doc.document_id, doc.source_type
+    out: List[ActorRecord] = []
+    out.extend(_from_authors(did, stype, doc.authors or [], role="author"))
+
+    body = (doc.content or "")[:20_000]
+
+    if _get_nlp():
+        out.extend(_spacy_subjects(did, stype, body, role="subject"))
+    else:
+        for m in _PAPER_INSTITUTION_RE.finditer(body):
+            name = m.group(1).strip()
+            if _valid_name(name):
+                out.append(ActorRecord.make(did, stype, name, "subject", 0.65))
+
+    # Publisher from metadata
+    publisher = (doc.metadata or {}).get("publisher") or (doc.metadata or {}).get("journal")
+    if publisher and _valid_name(str(publisher)):
+        out.append(ActorRecord.make(did, stype, str(publisher), "subject", 0.88))
+
+    return out
+
+
+def _extract_transcript(doc) -> List[ActorRecord]:
+    did, stype = doc.document_id, doc.source_type
+    out: List[ActorRecord] = []
+    out.extend(_from_authors(did, stype, doc.authors or [], role="author"))
+
+    # Speaker segments from metadata (Whisper output or manual diarization)
+    meta = doc.metadata or {}
+    speakers_seen: set = set()
+
+    for key in ("segments", "diarization"):
+        for seg in meta.get(key, []):
+            sp = seg.get("speaker") or seg.get("label") or ""
+            if sp and _valid_name(sp) and sp not in speakers_seen:
+                speakers_seen.add(sp)
+                out.append(ActorRecord.make(did, stype, sp, "speaker", 0.90))
+
+    for sp in meta.get("speakers", []):
+        if isinstance(sp, dict):
+            name = sp.get("name") or sp.get("label") or ""
+        else:
+            name = str(sp)
+        if name and _valid_name(name) and name not in speakers_seen:
+            speakers_seen.add(name)
+            out.append(ActorRecord.make(did, stype, name, "speaker", 0.90))
+
+    # Body-text speaker labels ("Name: …")
+    body = (doc.content or "")[:20_000]
+    for m in _TRANSCRIPT_SPEAKER_RE.finditer(body):
+        name = m.group(1).strip()
+        if _valid_name(name) and name not in speakers_seen:
+            speakers_seen.add(name)
+            out.append(ActorRecord.make(did, stype, name, "speaker", 0.80))
+
+    # Named interviewees from NER
+    if _get_nlp():
+        for rec in _spacy_subjects(did, stype, body, role="subject"):
+            out.append(rec)
+
+    return out
+
+
+def _extract_book(doc) -> List[ActorRecord]:
+    did, stype = doc.document_id, doc.source_type
+    out: List[ActorRecord] = []
+    out.extend(_from_authors(did, stype, doc.authors or [], role="author"))
+
+    meta = doc.metadata or {}
+    publisher = meta.get("publisher")
+    if publisher and _valid_name(str(publisher)):
+        out.append(ActorRecord.make(did, stype, str(publisher), "subject", 0.88))
+
+    body = (doc.content or "")[:20_000]
+
+    # ALL-CAPS dialogue speakers
+    seen: set = set()
+    for m in _BOOK_SPEAKER_RE.finditer(body):
+        name = m.group(1).strip().title()
+        if _valid_name(name) and name not in seen:
+            seen.add(name)
+            out.append(ActorRecord.make(did, stype, name, "speaker", 0.75))
+
+    if _get_nlp():
+        out.extend(_spacy_subjects(did, stype, body, role="subject"))
+
+    return out
+
+
+def _extract_note_upload(doc) -> List[ActorRecord]:
+    did, stype = doc.document_id, doc.source_type
+    out: List[ActorRecord] = []
+    out.extend(_from_authors(did, stype, doc.authors or [], role="author"))
+
+    meta = doc.metadata or {}
+    for key in ("creator", "uploader", "owner", "uploaded_by"):
+        val = meta.get(key)
+        if val and _valid_name(str(val)):
+            out.append(ActorRecord.make(did, stype, str(val), "author", 0.92))
+            break
+
+    body = (doc.content or "")[:10_000]
+    if _get_nlp():
+        out.extend(_spacy_subjects(did, stype, body, role="subject"))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Dedup helper
+# ---------------------------------------------------------------------------
+
+def _dedup(records: List[ActorRecord]) -> List[ActorRecord]:
+    """Keep highest-confidence record per (actor_name, role) pair."""
+    best: Dict[Tuple[str, str], ActorRecord] = {}
+    for r in records:
+        key = (r.actor_name.lower(), r.role)
+        if key not in best or r.confidence > best[key].confidence:
+            best[key] = r
+    return list(best.values())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_EXTRACTORS = {
+    "news":       _extract_news_blog,
+    "blog":       _extract_news_blog,
+    "paper":      _extract_paper,
+    "transcript": _extract_transcript,
+    "book":       _extract_book,
+    "note":       _extract_note_upload,
+    "web":        _extract_news_blog,
+}
+
+
+def extract_actors(document) -> List[ActorRecord]:
+    """
+    Extract actor/source metadata from *document* (a Document instance).
+
+    Returns a deduplicated list of ActorRecord with roles:
+      ``author``  — byline, creator, uploader, publisher
+      ``speaker`` — quoted speaker, transcript label, dialogue character
+      ``subject`` — named organization or institution mentioned as an actor
+    """
+    fn = _EXTRACTORS.get(document.source_type, _extract_news_blog)
+    records = fn(document)
+    return _dedup(records)
+
+
+def store_actors(records: List[ActorRecord], conn) -> None:
+    """Persist actor records to ``document_actors`` (INSERT OR REPLACE)."""
+    for r in records:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO document_actors
+                (document_id, source_type, actor_name, entity_id,
+                 role, confidence, extracted_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [r.document_id, r.source_type, r.actor_name, r.entity_id,
+             r.role, r.confidence, r.extracted_at],
+        )
+
+
+def run_actor_batch(conn, lock, limit: int = 200) -> dict:
+    """
+    Extract actors for news_articles documents not yet in ``document_actors``.
+
+    Sweeps ``news_articles`` for documents whose ``id`` is absent from
+    ``document_actors``, extracts actors, and persists them.  Safe to call
+    repeatedly.
+    """
+    from services.ingest.common.document_model import Document  # type: ignore[import]
+
+    try:
+        with lock:
+            rows = conn.execute(
+                """
+                SELECT id, title, content, source, category
+                FROM news_articles
+                WHERE id NOT IN (SELECT DISTINCT document_id FROM document_actors)
+                LIMIT ?
+                """,
+                [limit],
+            ).fetchall()
+    except Exception as e:
+        return {"error": str(e), "processed": 0, "actors": 0, "skipped": 0}
+
+    processed = actors_total = skipped = 0
+    import time
+
+    for doc_id, title, content, source, _category in rows:
+        try:
+            doc = Document(
+                document_id=doc_id,
+                source_type="news",
+                language="en",
+                ingested_at=int(time.time() * 1000),
+                source_id=source,
+                title=title,
+                content=content or "",
+            )
+            records = extract_actors(doc)
+            if records:
+                with lock:
+                    store_actors(records, conn)
+            actors_total += len(records)
+            processed += 1
+        except Exception:
+            skipped += 1
+
+    return {"processed": processed, "actors": actors_total, "skipped": skipped}

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -121,6 +121,17 @@ CREATE TABLE IF NOT EXISTS claim_conflicts (
     computed_at     VARCHAR,
     PRIMARY KEY (claim_id_a, claim_id_b)
 );
+
+CREATE TABLE IF NOT EXISTS document_actors (
+    document_id  VARCHAR NOT NULL,
+    source_type  VARCHAR NOT NULL,
+    actor_name   VARCHAR NOT NULL,
+    entity_id    VARCHAR,
+    role         VARCHAR NOT NULL,
+    confidence   DOUBLE,
+    extracted_at VARCHAR,
+    PRIMARY KEY (document_id, actor_name, role)
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -14,6 +14,14 @@ Tools (non-overlapping with pipeline_mcp which owns positions/conflicts):
                     limit?)
   claim_evidence_pairs(claim_id?,         -> claim-to-claim evidence pairs
                        relation?, limit?)
+  list_unsourced_claims(source_type?,     -> unattributed claim records
+                        limit?)
+  trigger_attribution_batch(limit?)       -> classify unattributed claims (RW)
+  list_actors(document_id?, source_type?, -> actor/source metadata rows
+              role?, actor_name?, limit?)
+  actor_summary(source_type?, role?,      -> top actors by document frequency
+                limit?)
+  trigger_actor_batch(limit?)             -> extract actors from news_articles (RW)
 
 Design constraints (same as pipeline_mcp):
   * Lazy imports inside each tool — top-level imports are stdlib + fastmcp only.
@@ -511,6 +519,184 @@ def trigger_attribution_batch(limit: int = 500) -> dict:
     try:
         rw_conn = duckdb.connect(db_path, read_only=False)
         result = run_attribution_batch(rw_conn, lock, limit=limit)
+        rw_conn.close()
+        return result
+    except Exception as e:
+        return {"error": f"write connection failed — warehouse may be locked: {e}"}
+
+
+@mcp.tool
+def list_actors(
+    document_id: Optional[str] = None,
+    source_type: Optional[str] = None,
+    role: Optional[str] = None,
+    actor_name: Optional[str] = None,
+    limit: int = MAX_LIST,
+) -> dict:
+    """
+    Query extracted actor/source metadata from ``document_actors``.
+
+    Filter by any combination of document_id, source_type, role
+    (speaker|subject|author), or partial actor_name.
+
+    Returns compact rows with entity_id, role, and confidence.
+
+    Args:
+        document_id: Restrict to one document.
+        source_type: news|blog|paper|transcript|book|note|web.
+        role:        speaker, subject, or author.
+        actor_name:  Substring match (case-insensitive).
+        limit:       Max rows (default 50).
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+
+    conditions: list[str] = []
+    params: list = []
+
+    if document_id:
+        conditions.append("document_id = ?")
+        params.append(document_id)
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if role:
+        conditions.append("role = ?")
+        params.append(role)
+    if actor_name:
+        conditions.append("lower(actor_name) LIKE ?")
+        params.append(f"%{actor_name.lower()}%")
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT document_id, source_type, actor_name, entity_id,
+                   role, confidence, extracted_at
+            FROM document_actors
+            {where}
+            ORDER BY confidence DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {
+        "count": len(rows),
+        "actors": [
+            {
+                "document_id":  r[0],
+                "source_type":  r[1],
+                "actor_name":   r[2],
+                "entity_id":    r[3],
+                "role":         r[4],
+                "confidence":   round(r[5], 3) if r[5] is not None else None,
+                "extracted_at": r[6],
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool
+def actor_summary(
+    source_type: Optional[str] = None,
+    role: Optional[str] = None,
+    limit: int = 30,
+) -> dict:
+    """
+    Top actors by document frequency across all ingested content.
+
+    Useful for seeding stance-detection and policy-position pipelines with a
+    pre-ranked actor list without scanning full article text.
+
+    Args:
+        source_type: Filter by content type.
+        role:        Filter by role (speaker|subject|author).
+        limit:       Top-N (default 30).
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+
+    conditions: list[str] = []
+    params: list = []
+
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if role:
+        conditions.append("role = ?")
+        params.append(role)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT actor_name, entity_id, role,
+                   COUNT(DISTINCT document_id) AS doc_count,
+                   ROUND(AVG(confidence), 4)   AS avg_confidence
+            FROM document_actors
+            {where}
+            GROUP BY actor_name, entity_id, role
+            ORDER BY doc_count DESC, avg_confidence DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {
+        "count": len(rows),
+        "actors": [
+            {
+                "actor_name":     r[0],
+                "entity_id":      r[1],
+                "role":           r[2],
+                "doc_count":      r[3],
+                "avg_confidence": float(r[4]) if r[4] is not None else 0.0,
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool
+def trigger_actor_batch(limit: int = 200) -> dict:
+    """
+    Extract actors for news_articles documents not yet in ``document_actors``.
+
+    Calls ``run_actor_batch`` from ``src.argument_mining.metadata``.
+    Safe to call repeatedly — already-processed documents are skipped.
+
+    Args:
+        limit: Max documents per call (default 200).
+
+    Returns {"processed": int, "actors": int, "skipped": int}.
+    """
+    import os, threading, duckdb
+
+    try:
+        from src.argument_mining.metadata import run_actor_batch  # type: ignore[import]
+    except ImportError as e:
+        return {"error": f"metadata module unavailable: {e}"}
+
+    db_path = os.environ.get(
+        "NEURONEWS_DB_PATH",
+        str(REPO_ROOT / "data" / "local_warehouse.duckdb"),
+    )
+    try:
+        rw_conn = duckdb.connect(db_path, read_only=False)
+        lock = threading.Lock()
+        result = run_actor_batch(rw_conn, lock, limit=limit)
         rw_conn.close()
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `src/argument_mining/metadata.py` with content-type-aware `extract_actors(document)` — spaCy NER when `en_core_web_sm` is installed, regex heuristics otherwise (byline/author fields, transcript speaker labels, org-cap patterns, APA institutions, diarization metadata segments)
- Creates `document_actors` DuckDB table via idempotent migration in `local_warehouse_seed.py`; uses stable `sha1[:12]`-based `entity_id` matching the existing entity-graph convention
- Adds four REST endpoints under `/api/v1/arguments/actors`: `GET /actors`, `POST /actors/extract`, `POST /actors/batch`, `GET /actors/summary`
- Extends `neuronews-arguments` MCP server with `list_actors`, `actor_summary`, `trigger_actor_batch` tools for token-efficient warehouse inspection
- Frontend: `RawActor`/`RawActorSummary` API types, `DocumentActor`/`ActorSummary` view-model types, `useArgumentActors`/`useArgumentActorsSummary` React Query hooks

## Test plan

- [x] `python .claude/skills/verify-argument-mining/verify.py` — PASS (all 6 source types)
- [x] `python -c "import ast, pathlib; ast.parse(pathlib.Path('src/argument_mining/metadata.py').read_text())"` — clean
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — no errors
- [ ] Manual: `POST /api/v1/arguments/actors/extract?document_id=<id>` returns actor list with roles
- [ ] Manual: `POST /api/v1/arguments/actors/batch` sweeps existing articles
- [ ] Manual: MCP `trigger_actor_batch()` via `neuronews-arguments` server

Closes #114