### PR TITLE
feat(argument-mining): outlet editorial-framing cluster analysis (#115)

### DIFF
--- a/.claude/skills/verify-outlet-clustering/SKILL.md
+++ b/.claude/skills/verify-outlet-clustering/SKILL.md
@@ -1,0 +1,48 @@
+# verify-outlet-clustering skill
+
+Smoke-tests the outlet editorial-framing cluster pipeline (#115) without
+needing a running API server or a populated warehouse.
+
+**All paths relative to repo root** (`/home/Ikey/NeuroNews`).
+
+## Usage
+
+```bash
+# Synthetic vectors (no warehouse required)
+python3 .claude/skills/verify-outlet-clustering/verify.py
+
+# Live warehouse (needs document_frames populated)
+python3 .claude/skills/verify-outlet-clustering/verify.py --live
+```
+
+## Example output
+
+```
+────────────────────────────────────────────────────────────────────────
+  Outlet Clustering — smoke-test
+────────────────────────────────────────────────────────────────────────
+  Mode: synthetic vectors
+
+  k=2  method=kmeans  silhouette=0.4302  outlets=10
+
+  Cluster 0 — economic-dominant  (dominant: economic)
+    [news        ] Bloomberg  (69 docs)
+    [news        ] Reuters  (64 docs)
+    ...
+
+  RESULT: PASS — clustering produced valid k-cluster assignment with PCA coords
+────────────────────────────────────────────────────────────────────────
+```
+
+## When to use
+
+| Scenario | Action |
+|---|---|
+| After editing `outlet_clustering.py` | Run synthetic mode to catch logic regressions |
+| After running frame extraction on new content | Run `--live` to see real cluster assignments |
+| Debugging silhouette score < 0 | Check for degenerate vectors (all-zero frames) |
+
+## Requirements
+
+- `numpy`, `scikit-learn` (already in project deps)
+- No trained models, no network, no warehouse (synthetic mode)

--- a/.claude/skills/verify-outlet-clustering/verify.py
+++ b/.claude/skills/verify-outlet-clustering/verify.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Smoke-test for the outlet editorial-framing cluster pipeline (#115).
+
+Runs against synthetic frame vectors (no warehouse required) and prints
+the cluster assignments + silhouette score.  Pass --live to query the real
+local_warehouse.duckdb instead.
+
+Exit 0 = PASS, 1 = FAIL.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+import numpy as np
+
+LINE = "─" * 72
+
+
+def run_synthetic():
+    from src.argument_mining.outlet_clustering import OutletVector, run_clustering, FRAME_LABELS  # type: ignore[import]
+
+    sources = [
+        ("Bloomberg",             "news",       {"economic":0.72,"security":0.24,"humanitarian":0.12,"legal":0.15,"political":0.35,"scientific":0.20,"other":0.04}, 69),
+        ("Reuters",               "news",       {"economic":0.61,"security":0.30,"humanitarian":0.18,"legal":0.19,"political":0.42,"scientific":0.16,"other":0.05}, 64),
+        ("Financial Times",       "news",       {"economic":0.58,"security":0.26,"humanitarian":0.21,"legal":0.23,"political":0.47,"scientific":0.18,"other":0.06}, 68),
+        ("The Guardian",          "news",       {"economic":0.34,"security":0.28,"humanitarian":0.46,"legal":0.24,"political":0.52,"scientific":0.22,"other":0.08}, 70),
+        ("STAT News",             "news",       {"economic":0.22,"security":0.12,"humanitarian":0.38,"legal":0.14,"political":0.18,"scientific":0.44,"other":0.06}, 35),
+        ("Wired",                 "news",       {"economic":0.30,"security":0.18,"humanitarian":0.14,"legal":0.12,"political":0.22,"scientific":0.55,"other":0.10}, 32),
+        ("energy-transition.blog","blog",       {"economic":0.28,"security":0.14,"humanitarian":0.30,"legal":0.10,"political":0.36,"scientific":0.42,"other":0.18}, 32),
+        ("Nature Climate Change", "paper",      {"economic":0.14,"security":0.08,"humanitarian":0.22,"legal":0.11,"political":0.10,"scientific":0.78,"other":0.04}, 58),
+        ("IMF Working Papers",    "paper",      {"economic":0.82,"security":0.10,"humanitarian":0.16,"legal":0.20,"political":0.28,"scientific":0.34,"other":0.03}, 24),
+        ("Energy Policy Podcast", "transcript", {"economic":0.44,"security":0.22,"humanitarian":0.18,"legal":0.24,"political":0.58,"scientific":0.28,"other":0.09}, 18),
+    ]
+
+    outlets = []
+    for src, stype, frames, dc in sources:
+        vec = np.array([frames.get(f, 0.0) for f in FRAME_LABELS], dtype=np.float32)
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec /= norm
+        outlets.append(OutletVector(source=src, source_type=stype, doc_count=dc, vector=vec))
+
+    matrix = np.stack([o.vector for o in outlets])
+    return run_clustering(outlets, matrix, k_min=2, k_max=5)
+
+
+def run_live():
+    import os, duckdb
+    from src.argument_mining.outlet_clustering import build_outlet_vectors, run_clustering  # type: ignore[import]
+
+    db = os.environ.get("NEURONEWS_DB_PATH", str(REPO / "data" / "local_warehouse.duckdb"))
+    conn = duckdb.connect(db, read_only=True)
+    outlets, matrix = build_outlet_vectors(conn, date_range="90d")
+    conn.close()
+    if len(outlets) < 2:
+        raise RuntimeError(f"only {len(outlets)} outlet(s) with frame data — run frame extraction first")
+    return run_clustering(outlets, matrix, k_min=2, k_max=8)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", action="store_true", help="Query real warehouse instead of synthetic data")
+    args = ap.parse_args()
+
+    print(LINE)
+    print("  Outlet Clustering — smoke-test")
+    print(LINE)
+
+    mode = "live warehouse" if args.live else "synthetic vectors"
+    print(f"  Mode: {mode}\n")
+
+    try:
+        result = run_live() if args.live else run_synthetic()
+    except Exception as e:
+        print(f"\n  FAIL: {e}")
+        sys.exit(1)
+
+    print(f"  k={result.k}  method={result.method}  silhouette={result.silhouette:.4f}"
+          f"  outlets={result.n_outlets}")
+    print()
+
+    by_cluster: dict = {}
+    for o in result.outlets:
+        by_cluster.setdefault(o.cluster_id, []).append(o)
+
+    for cid in sorted(by_cluster):
+        members = by_cluster[cid]
+        label = members[0].cluster_label
+        dominant = members[0].dominant_frame
+        print(f"  Cluster {cid} — {label}  (dominant: {dominant})")
+        for m in members:
+            print(f"    [{m.source_type:<12}] {m.source}  ({m.doc_count} docs)")
+        print()
+
+    # Validation checks
+    errors = []
+    if result.k < 2:
+        errors.append(f"k={result.k} < 2 (too few clusters)")
+    if result.silhouette < 0:
+        errors.append(f"silhouette={result.silhouette:.4f} < 0 (clusters worse than random)")
+    if result.n_outlets < 2:
+        errors.append(f"n_outlets={result.n_outlets} < 2 (need more data)")
+
+    # Each cluster should have at least one member
+    for cid in range(result.k):
+        if cid not in by_cluster:
+            errors.append(f"cluster {cid} is empty")
+
+    # PCA coords should not all be zero
+    all_zero = all(abs(o.pca_x) < 1e-6 and abs(o.pca_y) < 1e-6 for o in result.outlets)
+    if all_zero:
+        errors.append("all PCA coordinates are zero — PCA failed")
+
+    print(LINE)
+    if errors:
+        for e in errors:
+            print(f"  FAIL: {e}")
+        sys.exit(1)
+    else:
+        print("  RESULT: PASS — clustering produced valid k-cluster assignment with PCA coords")
+    print(LINE)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -23,6 +23,7 @@ import type {
   ControversyGraph,
   SourceStance,
   StanceDriftEvent,
+  OutletCluster,
 } from "../types";
 
 const NOW = Date.now();
@@ -465,3 +466,24 @@ export const mockFramesBySource: FrameSource[] = [
   { source: "IMF Working Papers",     source_type: "paper",      frames: { economic: 0.82, political: 0.28, security: 0.10, scientific: 0.34, humanitarian: 0.16, legal: 0.20, other: 0.03 }, doc_count: 24, dominant: "economic",     concentrated: true,  concentrated_frame: "economic"    },
   { source: "Energy Policy Podcast",  source_type: "transcript", frames: { economic: 0.44, political: 0.58, security: 0.22, scientific: 0.28, humanitarian: 0.18, legal: 0.24, other: 0.09 }, doc_count: 18, dominant: "political",    concentrated: false, concentrated_frame: null          },
 ];
+
+// Outlet editorial-framing clusters (#115) — 5 clusters, PCA 2D projection
+// Cluster labels derived from dominant frame centroid; pca_x/y are illustrative
+// but maintain realistic relative distances between editorial families.
+export const mockOutletClusters: OutletCluster[] = [
+  // Cluster 0 — economic-dominant (financial press)
+  { source: "Bloomberg",              source_type: "news",       cluster_id: 0, cluster_label: "economic-dominant",         pca_x: -1.42, pca_y:  0.28, dominant_frame: "economic",     doc_count: 69, computed_at: null },
+  { source: "Reuters",                source_type: "news",       cluster_id: 0, cluster_label: "economic-dominant",         pca_x: -1.28, pca_y:  0.11, dominant_frame: "economic",     doc_count: 64, computed_at: null },
+  { source: "Financial Times",        source_type: "news",       cluster_id: 0, cluster_label: "economic-dominant",         pca_x: -1.10, pca_y:  0.47, dominant_frame: "economic",     doc_count: 68, computed_at: null },
+  { source: "IMF Working Papers",     source_type: "paper",      cluster_id: 0, cluster_label: "economic-dominant",         pca_x: -1.55, pca_y: -0.18, dominant_frame: "economic",     doc_count: 24, computed_at: null },
+  // Cluster 1 — scientific-dominant (science & research)
+  { source: "Nature Climate Change",  source_type: "paper",      cluster_id: 1, cluster_label: "scientific-dominant",       pca_x:  1.60, pca_y:  0.95, dominant_frame: "scientific",   doc_count: 58, computed_at: null },
+  { source: "STAT News",              source_type: "news",       cluster_id: 1, cluster_label: "scientific-dominant",       pca_x:  1.22, pca_y:  0.82, dominant_frame: "scientific",   doc_count: 35, computed_at: null },
+  { source: "Wired",                  source_type: "news",       cluster_id: 1, cluster_label: "scientific-dominant",       pca_x:  1.38, pca_y:  0.60, dominant_frame: "scientific",   doc_count: 32, computed_at: null },
+  // Cluster 2 — balanced-political-economic (broad broadsheets)
+  { source: "The Guardian",           source_type: "news",       cluster_id: 2, cluster_label: "balanced-political-economic", pca_x: -0.22, pca_y:  1.18, dominant_frame: "political",   doc_count: 70, computed_at: null },
+  { source: "energy-transition.blog", source_type: "blog",       cluster_id: 2, cluster_label: "balanced-political-economic", pca_x:  0.18, pca_y:  1.32, dominant_frame: "political",   doc_count: 32, computed_at: null },
+  // Cluster 3 — political-focused (policy commentary)
+  { source: "Energy Policy Podcast",  source_type: "transcript", cluster_id: 3, cluster_label: "political-focused",         pca_x: -0.60, pca_y: -1.10, dominant_frame: "political",   doc_count: 18, computed_at: null },
+];
+

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -307,6 +307,18 @@ export interface RawActorSummary {
   avg_confidence: number;
 }
 
+export interface RawOutletCluster {
+  source: string;
+  source_type: string;
+  cluster_id: number;
+  cluster_label: string;
+  pca_x: number;
+  pca_y: number;
+  dominant_frame: string;
+  doc_count: number;
+  computed_at: string | null;
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -380,4 +392,7 @@ export const api = {
 
   argumentActorsSummary: (params?: { source_type?: string; role?: string; limit?: number }) =>
     request<{ actors: RawActorSummary[]; count: number }>("/api/v1/arguments/actors/summary", params),
+
+  argumentOutletClusters: (params?: { source_type?: string; cluster_id?: number; limit?: number }) =>
+    request<{ outlets: RawOutletCluster[]; count: number }>("/api/v1/arguments/outlets/clusters", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -33,7 +33,7 @@ import {
   mockDriftEvents,
   mockFramesBySource,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActor, RawActorSummary } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActor, RawActorSummary, RawOutletCluster } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -57,6 +57,7 @@ import type {
   StanceDriftEvent,
   DocumentActor,
   ActorSummary,
+  OutletCluster,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -438,6 +439,29 @@ export function useArgumentActors(params?: { document_id?: string; source_type?:
         role:         r.role,
         confidence:   r.confidence,
         extracted_at: r.extracted_at,
+      }));
+    },
+    [],
+  );
+}
+
+export function useOutletClusters(params?: { source_type?: string; cluster_id?: number }): Result<OutletCluster[]> {
+  const key = `outletClusters-${params?.source_type ?? "all"}-${params?.cluster_id ?? ""}`;
+  return useWithFallback(
+    key,
+    async (): Promise<OutletCluster[]> => {
+      const res = await api.argumentOutletClusters(params);
+      if (!res.outlets.length) throw new Error("empty");
+      return res.outlets.map((r: RawOutletCluster) => ({
+        source:        r.source,
+        source_type:   r.source_type as SourceType,
+        cluster_id:    r.cluster_id,
+        cluster_label: r.cluster_label,
+        pca_x:         r.pca_x,
+        pca_y:         r.pca_y,
+        dominant_frame: r.dominant_frame,
+        doc_count:     r.doc_count,
+        computed_at:   r.computed_at,
       }));
     },
     [],

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -314,6 +314,18 @@ export interface ActorSummary {
   avg_confidence: number;
 }
 
+export interface OutletCluster {
+  source: string;
+  source_type: SourceType;
+  cluster_id: number;
+  cluster_label: string;
+  pca_x: number;
+  pca_y: number;
+  dominant_frame: string;
+  doc_count: number;
+  computed_at: string | null;
+}
+
 export interface KnowledgeDocument {
   document_id: string;
   source_type: SourceType;

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
-import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources, useArgumentStanceDrift, useArgumentFramesBySource } from "../lib/queries";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources, useArgumentStanceDrift, useArgumentFramesBySource, useOutletClusters } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
-import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource, PositionUpdate, UpdateType } from "../types";
+import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource, PositionUpdate, UpdateType, OutletCluster } from "../types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -1276,6 +1276,166 @@ function DriftTimeline({ source, sourceType }: { source: string; sourceType: str
   );
 }
 
+// ─── Outlet cluster scatter plot (#115) ──────────────────────────────────────
+
+// 8 distinct colours for up to 8 clusters (Okabe–Ito palette, colourblind-safe)
+const CLUSTER_COLORS = [
+  "#0072B2", "#E69F00", "#009E73", "#CC79A7",
+  "#56B4E9", "#D55E00", "#F0E442", "#999999",
+];
+
+// (reuses FRAME_COLORS defined at module level)
+
+function OutletClusterScatter({ outlets }: { outlets: OutletCluster[] }) {
+  const [hovered, setHovered] = useState<OutletCluster | null>(null);
+  const W = 440, H = 260, PAD = 32;
+
+  if (outlets.length === 0) {
+    return (
+      <div style={{ padding: "18px 0", textAlign: "center", color: palette.dim, fontFamily: fonts.mono, fontSize: 11 }}>
+        No cluster data. Run <code style={{ color: ACCENT }}>POST /api/v1/arguments/outlets/cluster</code> to generate.
+      </div>
+    );
+  }
+
+  const xs = outlets.map((o) => o.pca_x);
+  const ys = outlets.map((o) => o.pca_y);
+  const xMin = Math.min(...xs), xMax = Math.max(...xs);
+  const yMin = Math.min(...ys), yMax = Math.max(...ys);
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+
+  function toSvg(o: OutletCluster) {
+    const px = PAD + ((o.pca_x - xMin) / xRange) * (W - 2 * PAD);
+    const py = PAD + (1 - (o.pca_y - yMin) / yRange) * (H - 2 * PAD);
+    return { px, py };
+  }
+
+  // Cluster label positions — centroid of member points
+  const clusterCentroids: Record<number, { px: number; py: number; label: string }> = {};
+  for (const o of outlets) {
+    const { px, py } = toSvg(o);
+    if (!clusterCentroids[o.cluster_id]) {
+      clusterCentroids[o.cluster_id] = { px: 0, py: 0, label: o.cluster_label };
+    }
+    clusterCentroids[o.cluster_id].px += px;
+    clusterCentroids[o.cluster_id].py += py;
+  }
+  const clusterSizes: Record<number, number> = {};
+  for (const o of outlets) clusterSizes[o.cluster_id] = (clusterSizes[o.cluster_id] ?? 0) + 1;
+  for (const [cid, c] of Object.entries(clusterCentroids)) {
+    const n = clusterSizes[Number(cid)] ?? 1;
+    c.px /= n; c.py /= n;
+  }
+
+  // Unique clusters for legend
+  const uniqueClusters = Array.from(
+    new Map(outlets.map((o) => [o.cluster_id, o])).entries()
+  ).sort(([a], [b]) => a - b);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>
+          Editorial Framing Clusters
+        </span>
+        <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>
+          PCA 2D · {outlets.length} outlets
+        </span>
+      </div>
+
+      <div style={{ position: "relative", borderRadius: 10, overflow: "hidden", border: `1px solid ${colors.border}`, background: colors.card }}>
+        <svg width={W} height={H} style={{ display: "block" }}>
+          {/* Faint grid */}
+          {[0.25, 0.5, 0.75].map((t) => (
+            <g key={t}>
+              <line x1={PAD + t * (W - 2 * PAD)} y1={PAD} x2={PAD + t * (W - 2 * PAD)} y2={H - PAD}
+                stroke={colors.border} strokeWidth={0.5} />
+              <line x1={PAD} y1={PAD + t * (H - 2 * PAD)} x2={W - PAD} y2={PAD + t * (H - 2 * PAD)}
+                stroke={colors.border} strokeWidth={0.5} />
+            </g>
+          ))}
+
+          {/* Cluster centroid labels */}
+          {Object.entries(clusterCentroids).map(([cid, c]) => (
+            <text key={cid}
+              x={c.px} y={c.py - 14}
+              textAnchor="middle"
+              style={{ fontFamily: fonts.mono, fontSize: 8, fill: CLUSTER_COLORS[Number(cid) % CLUSTER_COLORS.length], opacity: 0.75, pointerEvents: "none" }}
+            >
+              {c.label}
+            </text>
+          ))}
+
+          {/* Outlet circles */}
+          {outlets.map((o) => {
+            const { px, py } = toSvg(o);
+            const color = CLUSTER_COLORS[o.cluster_id % CLUSTER_COLORS.length];
+            const isHov = hovered?.source === o.source && hovered?.source_type === o.source_type;
+            const r = Math.max(5, Math.min(11, 4 + Math.sqrt(o.doc_count / 10)));
+            return (
+              <g key={`${o.source_type}::${o.source}`}
+                onMouseEnter={() => setHovered(o)}
+                onMouseLeave={() => setHovered(null)}
+                style={{ cursor: "pointer" }}
+              >
+                <circle cx={px} cy={py} r={r + (isHov ? 3 : 0)}
+                  fill={color} fillOpacity={isHov ? 0.95 : 0.65}
+                  stroke={color} strokeWidth={isHov ? 2 : 1}
+                />
+              </g>
+            );
+          })}
+        </svg>
+
+        {/* Tooltip */}
+        {hovered && (() => {
+          const { px, py } = toSvg(hovered);
+          const clr = CLUSTER_COLORS[hovered.cluster_id % CLUSTER_COLORS.length];
+          const frameClr = FRAME_COLORS[hovered.dominant_frame as keyof typeof FRAME_COLORS] ?? palette.dim;
+          const left = px < W / 2 ? px + 14 : undefined;
+          const right = px >= W / 2 ? W - px + 14 : undefined;
+          return (
+            <div style={{
+              position: "absolute",
+              top: py - 4,
+              left: left !== undefined ? left : undefined,
+              right: right !== undefined ? right : undefined,
+              pointerEvents: "none",
+              background: colors.cardInner, border: `1px solid ${clr}60`,
+              borderRadius: 7, padding: "6px 10px",
+              fontFamily: fonts.mono, fontSize: 10, color: colors.text,
+              whiteSpace: "nowrap", zIndex: 10, boxShadow: "0 2px 8px #0004",
+            }}>
+              <div style={{ fontWeight: 700, color: clr, marginBottom: 2 }}>{hovered.source}</div>
+              <div style={{ color: palette.dim }}>{hovered.cluster_label}</div>
+              <div style={{ marginTop: 3 }}>
+                <span style={{ color: frameClr }}>{hovered.dominant_frame}</span>
+                <span style={{ color: palette.dim }}> · {hovered.doc_count} docs</span>
+              </div>
+            </div>
+          );
+        })()}
+      </div>
+
+      {/* Cluster legend */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {uniqueClusters.map(([cid, o]) => {
+          const color = CLUSTER_COLORS[cid % CLUSTER_COLORS.length];
+          return (
+            <div key={cid} style={{ display: "flex", alignItems: "center", gap: 5 }}>
+              <div style={{ width: 8, height: 8, borderRadius: "50%", background: color }} />
+              <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>
+                {o.cluster_label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 // ─── Sources panel ────────────────────────────────────────────────────────────
 
 function SourcesPanel({ sourceType }: { sourceType: string }) {
@@ -1283,6 +1443,7 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
   const [expandedSource, setExpandedSource] = useState<string | null>(null);
   const params = sourceType !== "all" ? { source_type: sourceType } : undefined;
   const { data: stances, source, isLoading } = useArgumentStanceSources(params);
+  const { data: clusters } = useOutletClusters(params);
 
   const topics = Array.from(new Set(stances.map((s) => s.topic))).sort();
   const filtered = selectedTopic === "all" ? stances : stances.filter((s) => s.topic === selectedTopic);
@@ -1301,10 +1462,16 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-      {/* Header */}
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Stance by Source</span>
-        <SourceBadge source={source} isLoading={isLoading} />
+      {/* Editorial framing cluster scatter plot (#115) */}
+      <OutletClusterScatter outlets={clusters} />
+
+      {/* Separator */}
+      <div style={{ borderTop: `1px solid ${colors.border}`, paddingTop: 14 }}>
+        {/* Header */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>Stance by Source</span>
+          <SourceBadge source={source} isLoading={isLoading} />
+        </div>
       </div>
 
       {/* Topic filter pills */}

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -2024,3 +2024,95 @@ async def get_actors_summary(
         ],
         "count": len(rows),
     }
+
+
+# ---------------------------------------------------------------------------
+# Outlet editorial-framing cluster endpoints (#115)
+# ---------------------------------------------------------------------------
+
+@router.get("/outlets/clusters")
+async def get_outlet_clusters(
+    source_type: Optional[str] = Query(None, description="Filter by content type"),
+    cluster_id:  Optional[int] = Query(None, description="Filter by cluster ID"),
+    limit: int = Query(200, ge=1, le=1000),
+) -> Dict[str, Any]:
+    """
+    Return stored outlet cluster assignments with PCA 2D coordinates.
+
+    Each record includes source name, source_type, cluster_id, descriptive
+    cluster_label, pca_x/pca_y scatter coordinates, dominant_frame, and
+    doc_count.  Coordinates are in PCA space (arbitrary scale, centered near 0).
+
+    Run ``POST /outlets/cluster`` first if the table is empty.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions: list[str] = []
+    params: list[Any] = []
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if cluster_id is not None:
+        conditions.append("cluster_id = ?")
+        params.append(cluster_id)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT source, source_type, cluster_id, cluster_label,
+                   pca_x, pca_y, dominant_frame, doc_count, computed_at
+            FROM outlet_clusters
+            {where}
+            ORDER BY cluster_id, doc_count DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+
+    outlets = [
+        {
+            "source":        r[0],
+            "source_type":   r[1],
+            "cluster_id":    r[2],
+            "cluster_label": r[3],
+            "pca_x":         round(r[4], 4) if r[4] is not None else 0.0,
+            "pca_y":         round(r[5], 4) if r[5] is not None else 0.0,
+            "dominant_frame": r[6],
+            "doc_count":     r[7],
+            "computed_at":   r[8],
+        }
+        for r in rows
+    ]
+    return {"outlets": outlets, "count": len(outlets)}
+
+
+@router.post("/outlets/cluster")
+async def trigger_outlet_clustering(
+    date_range: str = Query("90d", description="Frame aggregation window: 7d|30d|90d|180d|365d"),
+    k_min: int = Query(2, ge=2, le=5,  description="Minimum number of clusters to try"),
+    k_max: int = Query(8, ge=2, le=12, description="Maximum number of clusters to try"),
+) -> Dict[str, Any]:
+    """
+    Embed outlets as frame vectors, run k-means + hierarchical clustering (k_min..k_max),
+    select best k via silhouette score, project to 2D via PCA, and persist results.
+
+    Safe to call repeatedly — each call overwrites the previous run.
+
+    Returns a summary: n_outlets, chosen k, method, silhouette score.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.outlet_clustering import run_cluster_pipeline
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+    return run_cluster_pipeline(conn, lock, date_range=date_range, k_min=k_min, k_max=k_max)

--- a/src/argument_mining/__init__.py
+++ b/src/argument_mining/__init__.py
@@ -10,4 +10,5 @@ Entry points:
     from src.argument_mining.conflict_graph import compute_claim_conflicts, build_conflict_graph, cosine_similarity
     from src.argument_mining.attribution import classify_attribution, run_attribution_batch
     from src.argument_mining.metadata import extract_actors, store_actors, run_actor_batch
+    from src.argument_mining.outlet_clustering import run_cluster_pipeline, build_outlet_vectors, run_clustering
 """

--- a/src/argument_mining/outlet_clustering.py
+++ b/src/argument_mining/outlet_clustering.py
@@ -1,0 +1,366 @@
+"""
+Outlet editorial-framing cluster analysis — issue #115.
+
+Embeds each news outlet as a 7-dimensional frame-score vector (from
+``document_frames`` aggregated over the last 90 days), runs k-means and
+hierarchical (Ward) clustering, picks the best k by silhouette score, and
+projects down to 2D via PCA for scatter-plot visualisation.
+
+Public API
+----------
+  build_outlet_vectors(conn, date_range="90d") -> (sources, matrix)
+  run_clustering(sources, matrix, k_min?, k_max?) -> ClusterResult
+  store_clusters(result, conn) -> None
+  run_cluster_pipeline(conn, lock, date_range?, k_min?, k_max?) -> dict
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Frame dimension order — matches FRAME_LABELS from dataset.py
+FRAME_LABELS = ["economic", "security", "humanitarian", "legal",
+                 "political", "scientific", "other"]
+
+_DOMINANT_THRESHOLD = 0.50   # single frame dominates
+_BALANCED_GAP = 0.12         # top-2 within this gap → balanced label
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OutletVector:
+    source: str
+    source_type: str
+    doc_count: int
+    vector: np.ndarray          # shape (7,), L2-normalised
+
+
+@dataclass
+class OutletCluster:
+    source: str
+    source_type: str
+    cluster_id: int
+    cluster_label: str
+    pca_x: float
+    pca_y: float
+    dominant_frame: str
+    doc_count: int
+    computed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass
+class ClusterResult:
+    outlets: List[OutletCluster]
+    k: int
+    method: str          # "kmeans" | "hierarchical"
+    silhouette: float
+    n_outlets: int
+    date_range: str
+    computed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data extraction
+# ---------------------------------------------------------------------------
+
+def _date_cutoff(date_range: str) -> Optional[str]:
+    from datetime import timedelta
+    mapping = {"7d": 7, "30d": 30, "90d": 90, "180d": 180, "365d": 365}
+    days = mapping.get(date_range, 90)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    return cutoff
+
+
+def build_outlet_vectors(conn, date_range: str = "90d") -> Tuple[List[OutletVector], np.ndarray]:
+    """
+    Aggregate per-outlet frame distributions from DuckDB and return
+    (outlet_list, matrix) where matrix is shape (n_outlets, 7).
+
+    Outlets with fewer than 3 documents are excluded to avoid noisy vectors.
+    """
+    cutoff = _date_cutoff(date_range)
+    cutoff_clause = f"AND n.publish_date >= '{cutoff}'" if cutoff else ""
+
+    # news branch — join to news_articles for outlet name
+    news_rows = conn.execute(f"""
+        SELECT n.source,
+               'news' AS source_type,
+               df.frame,
+               AVG(df.score)                  AS avg_score,
+               COUNT(DISTINCT df.document_id) AS doc_count
+        FROM document_frames df
+        JOIN news_articles n ON df.document_id = n.id
+        WHERE n.source IS NOT NULL
+          {cutoff_clause}
+        GROUP BY n.source, df.frame
+    """).fetchall()
+
+    # non-news branch — source_type as proxy for outlet name
+    other_rows = conn.execute(f"""
+        SELECT df.source_type AS source,
+               df.source_type,
+               df.frame,
+               AVG(df.score)                  AS avg_score,
+               COUNT(DISTINCT df.document_id) AS doc_count
+        FROM document_frames df
+        WHERE df.source_type != 'news'
+        GROUP BY df.source_type, df.frame
+    """).fetchall()
+
+    # Aggregate into per-outlet dicts
+    raw: Dict[str, Dict[str, object]] = {}
+    for src, src_type, frame, avg_score, doc_count in list(news_rows) + list(other_rows):
+        key = f"{src_type}::{src}"
+        if key not in raw:
+            raw[key] = {"source": src, "source_type": src_type,
+                        "frames": {}, "doc_count": 0}
+        raw[key]["frames"][frame] = float(avg_score)       # type: ignore[index]
+        raw[key]["doc_count"] = max(int(raw[key]["doc_count"]), int(doc_count))  # type: ignore[arg-type]
+
+    outlets: List[OutletVector] = []
+    for data in raw.values():
+        if data["doc_count"] < 3:  # type: ignore[operator]
+            continue
+        vec = np.array([
+            float(data["frames"].get(f, 0.0))  # type: ignore[union-attr]
+            for f in FRAME_LABELS
+        ], dtype=np.float32)
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec = vec / norm
+        outlets.append(OutletVector(
+            source=str(data["source"]),
+            source_type=str(data["source_type"]),
+            doc_count=int(data["doc_count"]),  # type: ignore[arg-type]
+            vector=vec,
+        ))
+
+    if not outlets:
+        return [], np.empty((0, len(FRAME_LABELS)), dtype=np.float32)
+
+    matrix = np.stack([o.vector for o in outlets])
+    return outlets, matrix
+
+
+# ---------------------------------------------------------------------------
+# Cluster labelling
+# ---------------------------------------------------------------------------
+
+def _label_cluster(centroid: np.ndarray) -> Tuple[str, str]:
+    """Return (cluster_label, dominant_frame) from a normalised centroid vector."""
+    scores = {f: float(centroid[i]) for i, f in enumerate(FRAME_LABELS)}
+    ranked = sorted(scores.items(), key=lambda x: -x[1])
+    top_frame, top_score = ranked[0]
+    second_frame, second_score = ranked[1]
+
+    dominant = top_frame
+    if top_score > _DOMINANT_THRESHOLD:
+        label = f"{top_frame}-dominant"
+    elif (top_score - second_score) < _BALANCED_GAP:
+        label = f"balanced-{top_frame}-{second_frame}"
+        dominant = top_frame
+    else:
+        label = f"{top_frame}-focused"
+
+    return label, dominant
+
+
+# ---------------------------------------------------------------------------
+# Clustering
+# ---------------------------------------------------------------------------
+
+def run_clustering(
+    outlets: List[OutletVector],
+    matrix: np.ndarray,
+    k_min: int = 2,
+    k_max: int = 8,
+) -> ClusterResult:
+    """
+    Run k-means (k_min..k_max) + Ward hierarchical clustering; choose the
+    best (method, k) pair by silhouette score.
+
+    Falls back to k=2 with a dummy label when the matrix is too small to score.
+    """
+    from sklearn.cluster import KMeans, AgglomerativeClustering
+    from sklearn.decomposition import PCA
+    from sklearn.metrics import silhouette_score
+
+    n = len(outlets)
+    date_range = "90d"  # communicated to caller via ClusterResult
+
+    # Need at least 2 samples and 2 clusters to compute silhouette
+    effective_kmax = min(k_max, n - 1)
+    effective_kmin = min(k_min, effective_kmax)
+
+    best_score = -1.0
+    best_labels: np.ndarray = np.zeros(n, dtype=int)
+    best_k = effective_kmin
+    best_method = "kmeans"
+
+    for k in range(effective_kmin, effective_kmax + 1):
+        # k-means
+        try:
+            km = KMeans(n_clusters=k, n_init="auto", random_state=42)
+            km_labels = km.fit_predict(matrix)
+            if len(set(km_labels)) > 1:
+                s = silhouette_score(matrix, km_labels)
+                if s > best_score:
+                    best_score = s
+                    best_labels = km_labels
+                    best_k = k
+                    best_method = "kmeans"
+        except Exception:
+            pass
+
+        # hierarchical (Ward)
+        try:
+            hc = AgglomerativeClustering(n_clusters=k, linkage="ward")
+            hc_labels = hc.fit_predict(matrix)
+            if len(set(hc_labels)) > 1:
+                s = silhouette_score(matrix, hc_labels)
+                if s > best_score:
+                    best_score = s
+                    best_labels = hc_labels
+                    best_k = k
+                    best_method = "hierarchical"
+        except Exception:
+            pass
+
+    # PCA 2D projection
+    try:
+        n_components = min(2, matrix.shape[1], n)
+        pca = PCA(n_components=n_components, random_state=42)
+        coords_2d = pca.fit_transform(matrix)
+        if coords_2d.shape[1] == 1:
+            coords_2d = np.hstack([coords_2d, np.zeros((n, 1))])
+    except Exception:
+        coords_2d = np.zeros((n, 2))
+
+    # Compute per-cluster centroids for labelling
+    cluster_centroids: Dict[int, np.ndarray] = {}
+    for i, label_id in enumerate(best_labels):
+        cid = int(label_id)
+        if cid not in cluster_centroids:
+            cluster_centroids[cid] = np.zeros(matrix.shape[1])
+        cluster_centroids[cid] += matrix[i]
+
+    cluster_counts: Dict[int, int] = {}
+    for label_id in best_labels:
+        cluster_counts[int(label_id)] = cluster_counts.get(int(label_id), 0) + 1
+
+    cluster_labels_map: Dict[int, str] = {}
+    cluster_dominant_map: Dict[int, str] = {}
+    for cid, centroid_sum in cluster_centroids.items():
+        centroid = centroid_sum / cluster_counts[cid]
+        label, dominant = _label_cluster(centroid)
+        cluster_labels_map[cid] = label
+        cluster_dominant_map[cid] = dominant
+
+    ts = datetime.now(timezone.utc).isoformat()
+    result_outlets: List[OutletCluster] = []
+    for i, ov in enumerate(outlets):
+        cid = int(best_labels[i])
+        result_outlets.append(OutletCluster(
+            source=ov.source,
+            source_type=ov.source_type,
+            cluster_id=cid,
+            cluster_label=cluster_labels_map.get(cid, f"cluster-{cid}"),
+            pca_x=float(coords_2d[i, 0]),
+            pca_y=float(coords_2d[i, 1]),
+            dominant_frame=cluster_dominant_map.get(cid, "other"),
+            doc_count=ov.doc_count,
+            computed_at=ts,
+        ))
+
+    return ClusterResult(
+        outlets=result_outlets,
+        k=best_k,
+        method=best_method,
+        silhouette=round(float(best_score), 4),
+        n_outlets=n,
+        date_range=date_range,
+        computed_at=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def store_clusters(result: ClusterResult, conn) -> None:
+    """Write cluster assignments to ``outlet_clusters`` (full replace)."""
+    conn.execute("DELETE FROM outlet_clusters")
+    for o in result.outlets:
+        conn.execute(
+            """
+            INSERT INTO outlet_clusters
+                (source, source_type, cluster_id, cluster_label,
+                 pca_x, pca_y, dominant_frame, doc_count, computed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [o.source, o.source_type, o.cluster_id, o.cluster_label,
+             o.pca_x, o.pca_y, o.dominant_frame, o.doc_count, o.computed_at],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline entry point
+# ---------------------------------------------------------------------------
+
+def run_cluster_pipeline(
+    conn, lock,
+    date_range: str = "90d",
+    k_min: int = 2,
+    k_max: int = 8,
+) -> dict:
+    """
+    Full pipeline: extract vectors → cluster → persist.
+
+    Returns a summary dict suitable for API/MCP responses.
+    """
+    try:
+        with lock:
+            outlets, matrix = build_outlet_vectors(conn, date_range=date_range)
+    except Exception as e:
+        return {"error": f"vector build failed: {e}"}
+
+    if len(outlets) < 2:
+        return {
+            "error": "not enough outlets with frame data",
+            "n_outlets": len(outlets),
+        }
+
+    try:
+        result = run_clustering(outlets, matrix, k_min=k_min, k_max=k_max)
+        result.date_range = date_range
+    except Exception as e:
+        return {"error": f"clustering failed: {e}"}
+
+    try:
+        with lock:
+            store_clusters(result, conn)
+    except Exception as e:
+        return {"error": f"store failed: {e}"}
+
+    return {
+        "n_outlets": result.n_outlets,
+        "k": result.k,
+        "method": result.method,
+        "silhouette": result.silhouette,
+        "date_range": date_range,
+        "computed_at": result.computed_at,
+    }

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -132,6 +132,19 @@ CREATE TABLE IF NOT EXISTS document_actors (
     extracted_at VARCHAR,
     PRIMARY KEY (document_id, actor_name, role)
 );
+
+CREATE TABLE IF NOT EXISTS outlet_clusters (
+    source         VARCHAR NOT NULL,
+    source_type    VARCHAR NOT NULL,
+    cluster_id     INTEGER NOT NULL,
+    cluster_label  VARCHAR NOT NULL,
+    pca_x          DOUBLE,
+    pca_y          DOUBLE,
+    dominant_frame VARCHAR,
+    doc_count      INTEGER,
+    computed_at    VARCHAR,
+    PRIMARY KEY (source, source_type)
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -22,6 +22,10 @@ Tools (non-overlapping with pipeline_mcp which owns positions/conflicts):
   actor_summary(source_type?, role?,      -> top actors by document frequency
                 limit?)
   trigger_actor_batch(limit?)             -> extract actors from news_articles (RW)
+  list_outlet_clusters(source_type?,      -> stored outlet cluster assignments
+                       cluster_id?)
+  trigger_outlet_clustering(date_range?,  -> embed+cluster outlets, persist (RW)
+                            k_min?, k_max?)
 
 Design constraints (same as pipeline_mcp):
   * Lazy imports inside each tool — top-level imports are stdlib + fastmcp only.
@@ -697,6 +701,119 @@ def trigger_actor_batch(limit: int = 200) -> dict:
         rw_conn = duckdb.connect(db_path, read_only=False)
         lock = threading.Lock()
         result = run_actor_batch(rw_conn, lock, limit=limit)
+        rw_conn.close()
+        return result
+    except Exception as e:
+        return {"error": f"write connection failed — warehouse may be locked: {e}"}
+
+
+@mcp.tool
+def list_outlet_clusters(
+    source_type: Optional[str] = None,
+    cluster_id: Optional[int] = None,
+    limit: int = MAX_LIST,
+) -> dict:
+    """
+    Return stored outlet cluster assignments with PCA 2D coordinates.
+
+    Each record includes source, cluster_id, descriptive cluster_label,
+    pca_x/pca_y scatter coordinates, dominant_frame, and doc_count.
+
+    Run ``trigger_outlet_clustering()`` first if the table is empty.
+
+    Args:
+        source_type: Filter by content type (news|blog|paper|transcript…).
+        cluster_id:  Filter to one cluster.
+        limit:       Max rows (default 50).
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+
+    conditions: list[str] = []
+    params: list = []
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+    if cluster_id is not None:
+        conditions.append("cluster_id = ?")
+        params.append(cluster_id)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT source, source_type, cluster_id, cluster_label,
+                   ROUND(pca_x, 3) AS pca_x, ROUND(pca_y, 3) AS pca_y,
+                   dominant_frame, doc_count, computed_at
+            FROM outlet_clusters
+            {where}
+            ORDER BY cluster_id, doc_count DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {
+        "count": len(rows),
+        "outlets": [
+            {
+                "source":         r[0],
+                "source_type":    r[1],
+                "cluster_id":     r[2],
+                "cluster_label":  r[3],
+                "pca_x":          r[4],
+                "pca_y":          r[5],
+                "dominant_frame": r[6],
+                "doc_count":      r[7],
+                "computed_at":    r[8],
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool
+def trigger_outlet_clustering(
+    date_range: str = "90d",
+    k_min: int = 2,
+    k_max: int = 8,
+) -> dict:
+    """
+    Embed news outlets as 7-dim frame vectors, run k-means + hierarchical
+    clustering (k_min..k_max), pick best k by silhouette score, project to
+    2D via PCA, and persist results to ``outlet_clusters``.
+
+    Safe to call repeatedly — each call overwrites the previous run.
+
+    Args:
+        date_range: Frame aggregation window: 7d|30d|90d|180d|365d (default "90d").
+        k_min:      Minimum k to try (default 2).
+        k_max:      Maximum k to try (default 8).
+
+    Returns {"n_outlets", "k", "method", "silhouette", "computed_at"}.
+    """
+    import os, threading, duckdb
+
+    try:
+        from src.argument_mining.outlet_clustering import run_cluster_pipeline  # type: ignore[import]
+    except ImportError as e:
+        return {"error": f"outlet_clustering module unavailable: {e}"}
+
+    db_path = os.environ.get(
+        "NEURONEWS_DB_PATH",
+        str(REPO_ROOT / "data" / "local_warehouse.duckdb"),
+    )
+    try:
+        rw_conn = duckdb.connect(db_path, read_only=False)
+        lock = threading.Lock()
+        result = run_cluster_pipeline(
+            rw_conn, lock, date_range=date_range, k_min=k_min, k_max=k_max
+        )
         rw_conn.close()
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary

- Embeds each news outlet as a 7-dim frame-score vector (aggregated over a configurable time window, default 90 days) from `document_frames`
- Runs k-means and Ward hierarchical clustering for k=2..8, selects best (method, k) pair by silhouette score; auto-labels clusters descriptively from the centroid (e.g. `economic-dominant`, `scientific-dominant`, `balanced-political-economic`)
- Projects to 2D via PCA for scatter-plot visualisation in the **Sources** tab
- Re-run monthly by calling `POST /api/v1/arguments/outlets/cluster` or the `trigger_outlet_clustering()` MCP tool

## Files changed

| Area | File | What |
|---|---|---|
| Backend | `src/argument_mining/outlet_clustering.py` | `build_outlet_vectors`, `run_clustering`, `store_clusters`, `run_cluster_pipeline` |
| DB | `src/database/local_warehouse_seed.py` | `outlet_clusters` table |
| API | `src/api/routes/argument_routes.py` | `GET /outlets/clusters`, `POST /outlets/cluster` |
| MCP | `tools/argument_mcp/server.py` | `list_outlet_clusters`, `trigger_outlet_clustering` |
| Frontend | `types.ts`, `api.ts`, `queries.ts` | `OutletCluster` type, `useOutletClusters` hook |
| UI | `apps/web/src/views/Arguments.tsx` | `OutletClusterScatter` SVG component at top of Sources tab |
| Mock | `apps/web/src/data/mock.ts` | 10 demo outlets across 4 clusters with realistic PCA coords |
| Skill | `.claude/skills/verify-outlet-clustering/` | Synthetic + live smoke-test |

## Test plan

- [x] `python3 .claude/skills/verify-outlet-clustering/verify.py` — PASS (k=2, silhouette=0.43)
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — no errors
- [x] Python syntax check on all changed files — clean
- [ ] Manual: navigate to Arguments → Sources tab — scatter plot renders with hover tooltips and cluster legend
- [ ] Manual: `POST /api/v1/arguments/outlets/cluster` when frame data is present → returns k, silhouette, n_outlets
- [ ] Manual: MCP `trigger_outlet_clustering()` → stores results, `list_outlet_clusters()` returns them

Closes #115