### PR TITLE
feat(argument-mining): outlet transparency ranking via 3-dim scoring (#116)

### DIFF
--- a/.claude/skills/verify-outlet-scoring/SKILL.md
+++ b/.claude/skills/verify-outlet-scoring/SKILL.md
@@ -1,0 +1,37 @@
+# verify-outlet-scoring skill
+
+Smoke-tests the outlet transparency scoring pipeline (#116).
+
+**All paths relative to repo root** (`/home/Ikey/NeuroNews`).
+
+## Usage
+
+```bash
+# Unit tests only (no warehouse required)
+python3 .claude/skills/verify-outlet-scoring/verify.py
+
+# Include live warehouse scoring
+python3 .claude/skills/verify-outlet-scoring/verify.py --live
+```
+
+## What it tests
+
+- `_shannon_entropy()` edge cases: balanced → 1.0, concentrated → 0.0, empty → 0.0
+- Partial distribution stays in (0, 1)
+- Equal 4-stance neutrality → 1.0
+- Live: `compute_outlet_scores()` against real `document_frames` + `argument_claims` + `source_stances`
+
+## Three score dimensions
+
+| Dimension | Formula | Range |
+|---|---|---|
+| `frame_diversity` | Shannon entropy of 7-frame dist / log(7) | 0–1, higher = more balanced |
+| `attribution_rate` | attributed_claims / total_claims | 0–1, higher = more attributed |
+| `stance_neutrality` | entropy of [sup,crit,neu,amb] dist / log(4) | 0–1, higher = more balanced |
+| `composite_score` | mean of the three | 0–1 |
+
+## When to use
+
+- After editing `outlet_scorer.py`
+- When verifying weekly scores after a new data ingestion run
+- When debugging unexpected score values for a specific outlet

--- a/.claude/skills/verify-outlet-scoring/verify.py
+++ b/.claude/skills/verify-outlet-scoring/verify.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Smoke-test for the outlet transparency scoring pipeline (#116).
+
+Validates scoring formulas and (optionally) runs against the live warehouse.
+
+Exit 0 = PASS, 1 = FAIL.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+LINE = "─" * 72
+
+
+def run_unit_tests():
+    from src.argument_mining.outlet_scorer import _shannon_entropy, FRAME_LABELS  # type: ignore[import]
+
+    results = []
+
+    # 1. Balanced 7-frame distribution => diversity = 1.0
+    balanced = {f: 1.0 for f in FRAME_LABELS}
+    d = _shannon_entropy(balanced, 7)
+    ok = abs(d - 1.0) < 1e-5
+    results.append(("balanced 7-frame entropy = 1.0", ok, f"{d:.4f}"))
+
+    # 2. Fully concentrated => entropy = 0.0
+    conc = {f: (1.0 if f == "economic" else 0.0) for f in FRAME_LABELS}
+    d2 = _shannon_entropy(conc, 7)
+    ok2 = abs(d2 - 0.0) < 1e-5
+    results.append(("concentrated entropy = 0.0", ok2, f"{d2:.4f}"))
+
+    # 3. Equal 4-stance distribution => neutrality = 1.0
+    equal_s = {"supportive": 1.0, "critical": 1.0, "neutral": 1.0, "ambiguous": 1.0}
+    s = _shannon_entropy(equal_s, 4)
+    ok3 = abs(s - 1.0) < 1e-5
+    results.append(("equal stance entropy = 1.0", ok3, f"{s:.4f}"))
+
+    # 4. Partial distribution stays in (0, 1)
+    partial = {"economic": 0.7, "political": 0.4, "security": 0.3, "humanitarian": 0.1,
+               "legal": 0.0, "scientific": 0.0, "other": 0.0}
+    p = _shannon_entropy(partial, 7)
+    ok4 = 0 < p < 1
+    results.append((f"partial 4-frame entropy ∈ (0,1) = {p:.4f}", ok4, ""))
+
+    # 5. Empty dict => 0.0
+    e = _shannon_entropy({}, 7)
+    ok5 = abs(e - 0.0) < 1e-5
+    results.append(("empty dict entropy = 0.0", ok5, f"{e:.4f}"))
+
+    return results
+
+
+def run_live():
+    import os, duckdb
+    from src.argument_mining.outlet_scorer import compute_outlet_scores  # type: ignore[import]
+
+    db = os.environ.get("NEURONEWS_DB_PATH", str(REPO / "data" / "local_warehouse.duckdb"))
+    conn = duckdb.connect(db, read_only=True)
+    rows = compute_outlet_scores(conn, date_range="90d")
+    conn.close()
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", action="store_true", help="Also run against live warehouse")
+    args = ap.parse_args()
+
+    print(LINE)
+    print("  Outlet Transparency Scoring — smoke-test")
+    print(LINE)
+
+    # Unit tests
+    print("\n  Unit tests:")
+    unit = run_unit_tests()
+    all_ok = True
+    for desc, ok, val in unit:
+        status = "PASS" if ok else "FAIL"
+        suffix = f"  ({val})" if val else ""
+        print(f"    [{status}] {desc}{suffix}")
+        if not ok:
+            all_ok = False
+
+    if args.live:
+        print("\n  Live warehouse scores:")
+        try:
+            rows = run_live()
+        except Exception as e:
+            print(f"    [FAIL] {e}")
+            all_ok = False
+            rows = []
+
+        if rows:
+            header = f"  {'Rank':>4}  {'Source':<30} {'Score':>6}  {'Div':>5}  {'Attr':>5}  {'Neut':>5}"
+            print(f"\n{header}")
+            print("  " + "─" * (len(header) - 2))
+            for i, r in enumerate(rows[:15], 1):
+                print(
+                    f"  {i:>4}  {r.source:<30} "
+                    f"{r.composite_score:>6.3f}  "
+                    f"{r.frame_diversity:>5.3f}  "
+                    f"{r.attribution_rate:>5.3f}  "
+                    f"{r.stance_neutrality:>5.3f}"
+                )
+        else:
+            print("    (no outlets with sufficient data — run frame extraction first)")
+
+    print()
+    print(LINE)
+    if all_ok:
+        print("  RESULT: PASS")
+    else:
+        print("  RESULT: FAIL")
+    print(LINE)
+
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -24,6 +24,7 @@ import type {
   SourceStance,
   StanceDriftEvent,
   OutletCluster,
+  OutletScore,
 } from "../types";
 
 const NOW = Date.now();
@@ -485,5 +486,20 @@ export const mockOutletClusters: OutletCluster[] = [
   { source: "energy-transition.blog", source_type: "blog",       cluster_id: 2, cluster_label: "balanced-political-economic", pca_x:  0.18, pca_y:  1.32, dominant_frame: "political",   doc_count: 32, computed_at: null },
   // Cluster 3 — political-focused (policy commentary)
   { source: "Energy Policy Podcast",  source_type: "transcript", cluster_id: 3, cluster_label: "political-focused",         pca_x: -0.60, pca_y: -1.10, dominant_frame: "political",   doc_count: 18, computed_at: null },
+];
+
+// Outlet transparency rankings (#116) — three-dimension scores + sparkline trends
+// trend arrays simulate 6 weekly snapshots, oldest → newest
+export const mockOutletRanking: OutletScore[] = [
+  { rank: 1, source: "Nature Climate Change",  source_type: "paper",      score_date: "2025-06-23", frame_diversity: 0.74, attribution_rate: 0.88, stance_neutrality: 0.81, composite_score: 0.81, doc_count: 58, claim_count: 42, trend: [0.67, 0.70, 0.72, 0.75, 0.79, 0.81] },
+  { rank: 2, source: "Reuters",                source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.71, attribution_rate: 0.82, stance_neutrality: 0.78, composite_score: 0.77, doc_count: 64, claim_count: 78, trend: [0.60, 0.65, 0.70, 0.73, 0.75, 0.77] },
+  { rank: 3, source: "Financial Times",        source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.68, attribution_rate: 0.79, stance_neutrality: 0.72, composite_score: 0.73, doc_count: 68, claim_count: 83, trend: [0.55, 0.60, 0.65, 0.68, 0.70, 0.73] },
+  { rank: 4, source: "Bloomberg",              source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.55, attribution_rate: 0.84, stance_neutrality: 0.74, composite_score: 0.71, doc_count: 69, claim_count: 91, trend: [0.58, 0.61, 0.64, 0.67, 0.69, 0.71] },
+  { rank: 5, source: "STAT News",              source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.62, attribution_rate: 0.75, stance_neutrality: 0.66, composite_score: 0.68, doc_count: 35, claim_count: 31, trend: [0.56, 0.58, 0.60, 0.63, 0.66, 0.68] },
+  { rank: 6, source: "The Guardian",           source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.70, attribution_rate: 0.58, stance_neutrality: 0.64, composite_score: 0.64, doc_count: 70, claim_count: 55, trend: [0.62, 0.63, 0.63, 0.64, 0.64, 0.64] },
+  { rank: 7, source: "Wired",                  source_type: "news",       score_date: "2025-06-23", frame_diversity: 0.58, attribution_rate: 0.61, stance_neutrality: 0.68, composite_score: 0.62, doc_count: 32, claim_count: 24, trend: [0.50, 0.53, 0.56, 0.58, 0.60, 0.62] },
+  { rank: 8, source: "energy-transition.blog", source_type: "blog",       score_date: "2025-06-23", frame_diversity: 0.64, attribution_rate: 0.42, stance_neutrality: 0.55, composite_score: 0.54, doc_count: 32, claim_count: 18, trend: [0.48, 0.49, 0.51, 0.52, 0.53, 0.54] },
+  { rank: 9, source: "IMF Working Papers",     source_type: "paper",      score_date: "2025-06-23", frame_diversity: 0.38, attribution_rate: 0.91, stance_neutrality: 0.60, composite_score: 0.63, doc_count: 24, claim_count: 44, trend: [0.55, 0.57, 0.59, 0.61, 0.62, 0.63] },
+  { rank:10, source: "Energy Policy Podcast",  source_type: "transcript", score_date: "2025-06-23", frame_diversity: 0.61, attribution_rate: 0.34, stance_neutrality: 0.52, composite_score: 0.49, doc_count: 18, claim_count: 12, trend: [0.44, 0.45, 0.46, 0.47, 0.48, 0.49] },
 ];
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -307,6 +307,20 @@ export interface RawActorSummary {
   avg_confidence: number;
 }
 
+export interface RawOutletScore {
+  rank: number;
+  source: string;
+  source_type: string;
+  score_date: string;
+  frame_diversity: number | null;
+  attribution_rate: number | null;
+  stance_neutrality: number | null;
+  composite_score: number | null;
+  doc_count: number;
+  claim_count: number;
+  trend: number[];
+}
+
 export interface RawOutletCluster {
   source: string;
   source_type: string;
@@ -395,4 +409,7 @@ export const api = {
 
   argumentOutletClusters: (params?: { source_type?: string; cluster_id?: number; limit?: number }) =>
     request<{ outlets: RawOutletCluster[]; count: number }>("/api/v1/arguments/outlets/clusters", params),
+
+  argumentOutletRanking: (params?: { source_type?: string; sort_by?: string; limit?: number }) =>
+    request<{ outlets: RawOutletScore[]; count: number }>("/api/v1/arguments/outlets/ranking", params),
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -32,8 +32,10 @@ import {
   mockSourceStances,
   mockDriftEvents,
   mockFramesBySource,
+  mockOutletRanking,
+  mockOutletClusters,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActor, RawActorSummary, RawOutletCluster } from "./api";
+import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActor, RawActorSummary, RawOutletCluster, RawOutletScore } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -58,6 +60,7 @@ import type {
   DocumentActor,
   ActorSummary,
   OutletCluster,
+  OutletScore,
 } from "../types";
 
 export type Source = "live" | "demo";
@@ -445,8 +448,39 @@ export function useArgumentActors(params?: { document_id?: string; source_type?:
   );
 }
 
+export function useOutletRanking(params?: { source_type?: string; sort_by?: string }): Result<OutletScore[]> {
+  const key = `outletRanking-${params?.source_type ?? "all"}-${params?.sort_by ?? "composite_score"}`;
+  const fallback = params?.source_type && params.source_type !== "all"
+    ? mockOutletRanking.filter((o) => o.source_type === params.source_type)
+    : mockOutletRanking;
+  return useWithFallback(
+    key,
+    async (): Promise<OutletScore[]> => {
+      const res = await api.argumentOutletRanking(params);
+      if (!res.outlets.length) throw new Error("empty");
+      return res.outlets.map((r: RawOutletScore) => ({
+        rank:             r.rank,
+        source:           r.source,
+        source_type:      r.source_type as SourceType,
+        score_date:       r.score_date,
+        frame_diversity:  r.frame_diversity,
+        attribution_rate: r.attribution_rate,
+        stance_neutrality: r.stance_neutrality,
+        composite_score:  r.composite_score,
+        doc_count:        r.doc_count,
+        claim_count:      r.claim_count,
+        trend:            r.trend ?? [],
+      }));
+    },
+    fallback,
+  );
+}
+
 export function useOutletClusters(params?: { source_type?: string; cluster_id?: number }): Result<OutletCluster[]> {
   const key = `outletClusters-${params?.source_type ?? "all"}-${params?.cluster_id ?? ""}`;
+  const fallback = params?.source_type && params.source_type !== "all"
+    ? mockOutletClusters.filter((o) => o.source_type === params.source_type)
+    : mockOutletClusters;
   return useWithFallback(
     key,
     async (): Promise<OutletCluster[]> => {
@@ -464,7 +498,7 @@ export function useOutletClusters(params?: { source_type?: string; cluster_id?: 
         computed_at:   r.computed_at,
       }));
     },
-    [],
+    fallback,
   );
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -314,6 +314,20 @@ export interface ActorSummary {
   avg_confidence: number;
 }
 
+export interface OutletScore {
+  rank: number;
+  source: string;
+  source_type: SourceType;
+  score_date: string;
+  frame_diversity: number | null;
+  attribution_rate: number | null;
+  stance_neutrality: number | null;
+  composite_score: number | null;
+  doc_count: number;
+  claim_count: number;
+  trend: number[];
+}
+
 export interface OutletCluster {
   source: string;
   source_type: SourceType;

--- a/apps/web/src/views/Arguments.tsx
+++ b/apps/web/src/views/Arguments.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { fonts, palette, colors, ACCENT, accentSoft, accentBorder } from "../theme";
-import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources, useArgumentStanceDrift, useArgumentFramesBySource, useOutletClusters } from "../lib/queries";
+import { useArgumentClaims, useArgumentStance, useArgumentFrames, useArgumentPositions, useArgumentControversy, useArgumentControversyGraph, useArgumentStanceSources, useArgumentStanceDrift, useArgumentFramesBySource, useOutletClusters, useOutletRanking } from "../lib/queries";
 import PageHeader from "../components/PageHeader";
 import SourceBadge from "../components/SourceBadge";
 import Sparkline from "../components/charts/Sparkline";
-import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource, PositionUpdate, UpdateType, OutletCluster } from "../types";
+import type { ArgumentTab, SourceType, StanceSummary, ControversyNode, ControversyEdge, SourceStance, StanceDriftEvent, FrameSource, PositionUpdate, UpdateType, OutletCluster, OutletScore } from "../types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -1436,6 +1436,151 @@ function OutletClusterScatter({ outlets }: { outlets: OutletCluster[] }) {
   );
 }
 
+// ─── Outlet ranking table (#116) ─────────────────────────────────────────────
+
+type SortKey = "composite_score" | "frame_diversity" | "attribution_rate" | "stance_neutrality";
+
+function ScoreBar({ value, color }: { value: number | null; color: string }) {
+  const v = value ?? 0;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+      <div style={{ flex: 1, height: 5, borderRadius: 3, background: colors.border, overflow: "hidden" }}>
+        <div style={{ width: `${Math.round(v * 100)}%`, height: "100%", background: color, borderRadius: 3 }} />
+      </div>
+      <span style={{ fontFamily: fonts.mono, fontSize: 10, color, minWidth: 28, textAlign: "right" }}>
+        {value !== null ? `${Math.round(v * 100)}` : "—"}
+      </span>
+    </div>
+  );
+}
+
+function OutletRankingTable({ sourceType }: { sourceType: string }) {
+  const [sortBy, setSortBy] = useState<SortKey>("composite_score");
+  const params = { ...(sourceType !== "all" ? { source_type: sourceType } : {}), sort_by: sortBy };
+  const { data: outlets, source: dataSource, isLoading } = useOutletRanking(params);
+
+  const sorted = [...outlets].sort((a, b) => (b[sortBy] ?? 0) - (a[sortBy] ?? 0));
+
+  const SORT_COLS: Array<{ key: SortKey; label: string; color: string }> = [
+    { key: "composite_score",   label: "Score",       color: ACCENT },
+    { key: "frame_diversity",   label: "Diversity",   color: palette.teal },
+    { key: "attribution_rate",  label: "Attribution", color: palette.blue },
+    { key: "stance_neutrality", label: "Neutrality",  color: palette.violet },
+  ];
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span style={{ fontFamily: fonts.grotesk, fontWeight: 600, fontSize: 14 }}>
+          Outlet Transparency Ranking
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <SourceBadge source={dataSource} isLoading={isLoading} />
+        </div>
+      </div>
+
+      {/* Sort controls */}
+      <div style={{ display: "flex", gap: 5 }}>
+        {SORT_COLS.map(({ key, label, color }) => {
+          const active = sortBy === key;
+          return (
+            <button key={key} onClick={() => setSortBy(key)} style={{
+              fontFamily: fonts.mono, fontSize: 10, padding: "3px 9px", borderRadius: 5,
+              border: active ? `1px solid ${color}80` : `1px solid ${colors.border2}`,
+              background: active ? `${color}18` : "transparent",
+              color: active ? color : palette.dim, cursor: "pointer", letterSpacing: "0.05em",
+            }}>
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {sorted.length === 0 ? (
+        <div style={{ padding: "18px 0", textAlign: "center", color: palette.dim, fontFamily: fonts.mono, fontSize: 11 }}>
+          No ranking data. Run <code style={{ color: ACCENT }}>POST /api/v1/arguments/outlets/score</code> to compute.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {sorted.map((o: OutletScore, i) => {
+            const stColor = ST_COLORS_SHARED[o.source_type] ?? palette.dim;
+            const score = o.composite_score;
+            const scoreColor = score === null ? palette.dim
+              : score >= 0.7 ? palette.pos
+              : score >= 0.5 ? palette.amber
+              : palette.neg;
+            return (
+              <div key={`${o.source_type}::${o.source}`} style={{
+                ...card, padding: "10px 14px",
+                display: "grid",
+                gridTemplateColumns: "28px 1fr 140px 96px",
+                alignItems: "center", gap: 10,
+              }}>
+                {/* Rank */}
+                <span style={{ fontFamily: fonts.mono, fontSize: 11, color: palette.dim, textAlign: "center" }}>
+                  #{i + 1}
+                </span>
+
+                {/* Name + badges + score bars */}
+                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                    <div style={{ width: 6, height: 6, borderRadius: "50%", background: stColor, flexShrink: 0 }} />
+                    <span style={{ fontFamily: fonts.mono, fontSize: 12, color: colors.text }}>{o.source}</span>
+                    <span style={{
+                      fontFamily: fonts.mono, fontSize: 9, letterSpacing: "0.08em",
+                      color: stColor, background: `${stColor}18`, border: `1px solid ${stColor}40`,
+                      borderRadius: 4, padding: "1px 5px", textTransform: "uppercase",
+                    }}>{o.source_type}</span>
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                    <ScoreBar value={o.frame_diversity}   color={palette.teal} />
+                    <ScoreBar value={o.attribution_rate}  color={palette.blue} />
+                    <ScoreBar value={o.stance_neutrality} color={palette.violet} />
+                  </div>
+                </div>
+
+                {/* Trend sparkline */}
+                <div>
+                  {o.trend.length > 1
+                    ? <Sparkline values={o.trend} color={scoreColor} />
+                    : <div style={{ height: 30 }} />}
+                  <div style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.dim, textAlign: "center", marginTop: 2 }}>
+                    {o.doc_count} docs · {o.claim_count} claims
+                  </div>
+                </div>
+
+                {/* Composite score */}
+                <div style={{ textAlign: "center" }}>
+                  <div style={{
+                    fontFamily: fonts.mono, fontSize: 20, fontWeight: 700, color: scoreColor, lineHeight: 1,
+                  }}>
+                    {score !== null ? Math.round(score * 100) : "—"}
+                  </div>
+                  <div style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.dim, marginTop: 2 }}>/ 100</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Dimension legend */}
+      <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+        {[
+          { label: "Frame diversity",  color: palette.teal   },
+          { label: "Attribution rate", color: palette.blue   },
+          { label: "Stance neutrality",color: palette.violet },
+        ].map(({ label, color }) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 5 }}>
+            <div style={{ width: 8, height: 3, borderRadius: 2, background: color }} />
+            <span style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.dim }}>{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ─── Sources panel ────────────────────────────────────────────────────────────
 
 function SourcesPanel({ sourceType }: { sourceType: string }) {
@@ -1462,8 +1607,13 @@ function SourcesPanel({ sourceType }: { sourceType: string }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {/* Outlet transparency ranking (#116) */}
+      <OutletRankingTable sourceType={sourceType} />
+
       {/* Editorial framing cluster scatter plot (#115) */}
-      <OutletClusterScatter outlets={clusters} />
+      <div style={{ borderTop: `1px solid ${colors.border}`, paddingTop: 14 }}>
+        <OutletClusterScatter outlets={clusters} />
+      </div>
 
       {/* Separator */}
       <div style={{ borderTop: `1px solid ${colors.border}`, paddingTop: 14 }}>

--- a/src/api/routes/argument_routes.py
+++ b/src/api/routes/argument_routes.py
@@ -2116,3 +2116,124 @@ async def trigger_outlet_clustering(
     conn = get_shared_connection()
     lock = getattr(conn, "_lock", None) or threading.Lock()
     return run_cluster_pipeline(conn, lock, date_range=date_range, k_min=k_min, k_max=k_max)
+
+
+# ---------------------------------------------------------------------------
+# Outlet transparency scoring endpoints (#116)
+# ---------------------------------------------------------------------------
+
+@router.get("/outlets/ranking")
+async def get_outlets_ranking(
+    source_type: Optional[str] = Query(None, description="Filter by content type"),
+    sort_by: str = Query("composite_score",
+                         description="Sort key: composite_score|frame_diversity|attribution_rate|stance_neutrality"),
+    limit: int = Query(50, ge=1, le=200),
+) -> Dict[str, Any]:
+    """
+    Return outlets ranked by transparency score with weekly sparkline history.
+
+    Each record includes the latest scores for all three dimensions plus a
+    ``trend`` array (up to 8 weekly composite_score snapshots, oldest first)
+    suitable for rendering as a sparkline.
+
+    Run ``POST /outlets/score`` first to populate ``outlet_scores``.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    _SORT_COLS = {"composite_score", "frame_diversity", "attribution_rate", "stance_neutrality"}
+    sort_col = sort_by if sort_by in _SORT_COLS else "composite_score"
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+
+    conditions: list[str] = []
+    params: list[Any] = []
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+
+    where = f"AND {' AND '.join(conditions)}" if conditions else ""
+
+    # Latest snapshot per outlet
+    params.append(limit)
+    with lock:
+        latest = conn.execute(f"""
+            SELECT source, source_type, score_date,
+                   frame_diversity, attribution_rate, stance_neutrality,
+                   composite_score, doc_count, claim_count, computed_at
+            FROM outlet_scores os
+            WHERE (source, source_type, score_date) IN (
+                SELECT source, source_type, MAX(score_date)
+                FROM outlet_scores
+                WHERE 1=1 {where}
+                GROUP BY source, source_type
+            )
+            ORDER BY {sort_col} DESC NULLS LAST
+            LIMIT ?
+        """, params).fetchall()
+
+    if not latest:
+        return {"outlets": [], "count": 0}
+
+    # Fetch trend history for all returned outlets
+    outlet_keys = [(r[0], r[1]) for r in latest]
+    # Build a single query for all history rows
+    placeholders = ", ".join(["(?, ?)"] * len(outlet_keys))
+    flat_keys = [v for pair in outlet_keys for v in pair]
+    with lock:
+        history_rows = conn.execute(f"""
+            SELECT source, source_type, score_date, composite_score
+            FROM outlet_scores
+            WHERE (source, source_type) IN ({placeholders})
+            ORDER BY source, source_type, score_date
+        """, flat_keys).fetchall()
+
+    # Group history by (source, source_type)
+    trends: Dict[tuple, list] = {}
+    for r in history_rows:
+        key = (r[0], r[1])
+        trends.setdefault(key, []).append(float(r[3]) if r[3] is not None else 0.0)
+
+    outlets = []
+    for rank, r in enumerate(latest, start=1):
+        key = (r[0], r[1])
+        trend = trends.get(key, [float(r[6]) if r[6] is not None else 0.0])
+        outlets.append({
+            "rank":             rank,
+            "source":           r[0],
+            "source_type":      r[1],
+            "score_date":       r[2],
+            "frame_diversity":  round(r[3], 4) if r[3] is not None else None,
+            "attribution_rate": round(r[4], 4) if r[4] is not None else None,
+            "stance_neutrality": round(r[5], 4) if r[5] is not None else None,
+            "composite_score":  round(r[6], 4) if r[6] is not None else None,
+            "doc_count":        r[7],
+            "claim_count":      r[8],
+            "trend":            trend,
+        })
+
+    return {"outlets": outlets, "count": len(outlets)}
+
+
+@router.post("/outlets/score")
+async def trigger_outlet_scoring(
+    date_range: str = Query("90d",
+                            description="Data window for computing scores: 7d|30d|90d|180d|365d"),
+) -> Dict[str, Any]:
+    """
+    Compute weekly transparency scores for all outlets and persist to ``outlet_scores``.
+
+    Idempotent — re-running in the same ISO week overwrites that week's row.
+
+    Returns: outlets_scored, score_date, top_outlet, top_composite.
+    """
+    import threading
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.argument_mining.outlet_scorer import run_scorer_batch
+
+    conn = get_shared_connection()
+    lock = getattr(conn, "_lock", None) or threading.Lock()
+    return run_scorer_batch(conn, lock, date_range=date_range)

--- a/src/argument_mining/__init__.py
+++ b/src/argument_mining/__init__.py
@@ -11,4 +11,5 @@ Entry points:
     from src.argument_mining.attribution import classify_attribution, run_attribution_batch
     from src.argument_mining.metadata import extract_actors, store_actors, run_actor_batch
     from src.argument_mining.outlet_clustering import run_cluster_pipeline, build_outlet_vectors, run_clustering
+    from src.argument_mining.outlet_scorer import compute_outlet_scores, run_scorer_batch
 """

--- a/src/argument_mining/outlet_scorer.py
+++ b/src/argument_mining/outlet_scorer.py
@@ -1,0 +1,288 @@
+"""
+Outlet transparency scoring — issue #116.
+
+Scores each outlet across three dimensions:
+
+  1. frame_diversity   — Shannon entropy over the outlet's 7-frame distribution
+                         (0 = all one frame, 1 = perfectly balanced coverage)
+  2. attribution_rate  — fraction of detected claims that have an attributed source
+                         (0 = nothing attributed, 1 = all claims attributed)
+  3. stance_neutrality — entropy of the outlet's aggregate stance distribution
+                         across contested topics (0 = all one stance, 1 = perfectly
+                         balanced supportive/critical/neutral/ambiguous)
+
+  composite_score = mean(frame_diversity, attribution_rate, stance_neutrality)
+
+Scores are computed per outlet and stored as weekly snapshots in
+``outlet_scores`` so sparklines can be drawn from the history.
+
+Public API
+----------
+  compute_outlet_scores(conn, date_range="90d") -> List[OutletScoreRow]
+  store_scores(rows, conn) -> None
+  run_scorer_batch(conn, lock, date_range?, date_override?) -> dict
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+FRAME_LABELS = ["economic", "security", "humanitarian", "legal",
+                 "political", "scientific", "other"]
+
+_EPS = 1e-9  # avoid log(0)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OutletScoreRow:
+    source: str
+    source_type: str
+    score_date: str                   # ISO-8601 Monday of the current week
+    frame_diversity: float            # 0–1
+    attribution_rate: float           # 0–1
+    stance_neutrality: float          # 0–1
+    composite_score: float            # mean of the three
+    doc_count: int
+    claim_count: int
+    computed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _week_date(override: Optional[str] = None) -> str:
+    if override:
+        return override
+    today = datetime.now(timezone.utc).date()
+    monday = today - timedelta(days=today.weekday())
+    return monday.isoformat()
+
+
+def _date_cutoff(date_range: str) -> str:
+    mapping = {"7d": 7, "14d": 14, "30d": 30, "90d": 90, "180d": 180, "365d": 365}
+    days = mapping.get(date_range, 90)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    return cutoff
+
+
+def _shannon_entropy(counts: Dict[str, float], n_bins: int) -> float:
+    """Normalised Shannon entropy ∈ [0, 1] for a dict of scores/counts."""
+    total = sum(counts.values())
+    if total < _EPS:
+        return 0.0
+    entropy = 0.0
+    for v in counts.values():
+        p = v / total
+        if p > _EPS:
+            entropy -= p * math.log(p)
+    return entropy / math.log(n_bins)
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension extractors
+# ---------------------------------------------------------------------------
+
+def _frame_diversity(conn, source: str, source_type: str, cutoff: str) -> tuple[float, int]:
+    """Return (diversity_score 0-1, doc_count)."""
+    if source_type == "news":
+        rows = conn.execute("""
+            SELECT df.frame, AVG(df.score) AS avg_score,
+                   COUNT(DISTINCT df.document_id) AS doc_count
+            FROM document_frames df
+            JOIN news_articles n ON df.document_id = n.id
+            WHERE n.source = ? AND n.publish_date >= ?
+            GROUP BY df.frame
+        """, [source, cutoff]).fetchall()
+    else:
+        rows = conn.execute("""
+            SELECT frame, AVG(score) AS avg_score,
+                   COUNT(DISTINCT document_id) AS doc_count
+            FROM document_frames
+            WHERE source_type = ? AND classified_at >= ?
+            GROUP BY frame
+        """, [source_type, cutoff]).fetchall()
+
+    if not rows:
+        return 0.0, 0
+
+    frame_scores = {r[0]: float(r[1]) for r in rows}
+    doc_count = max(int(r[2]) for r in rows)
+    diversity = _shannon_entropy(frame_scores, n_bins=len(FRAME_LABELS))
+    return round(diversity, 4), doc_count
+
+
+def _attribution_rate(conn, source: str, source_type: str, cutoff: str) -> tuple[float, int]:
+    """Return (attribution_rate 0-1, total_claim_count)."""
+    if source_type == "news":
+        row = conn.execute("""
+            SELECT
+                COUNT(*)                                       AS total,
+                COUNT(*) FILTER (WHERE c.attributed = true)   AS attributed
+            FROM argument_claims c
+            JOIN news_articles n ON c.document_id = n.id
+            WHERE n.source = ? AND c.extracted_at >= ?
+        """, [source, cutoff]).fetchone()
+    else:
+        row = conn.execute("""
+            SELECT
+                COUNT(*)                                     AS total,
+                COUNT(*) FILTER (WHERE attributed = true)   AS attributed
+            FROM argument_claims
+            WHERE source_type = ? AND extracted_at >= ?
+        """, [source_type, cutoff]).fetchone()
+
+    total = int(row[0]) if row and row[0] else 0
+    attributed = int(row[1]) if row and row[1] else 0
+    rate = round(attributed / total, 4) if total > 0 else 0.0
+    return rate, total
+
+
+def _stance_neutrality(conn, source: str, source_type: str) -> float:
+    """Return neutrality_score 0-1 from stance distribution in source_stances."""
+    rows = conn.execute("""
+        SELECT stance, SUM(document_count) AS n
+        FROM source_stances
+        WHERE source = ? AND source_type = ?
+        GROUP BY stance
+    """, [source, source_type]).fetchall()
+
+    if not rows:
+        # No stance data — return midpoint rather than penalising the outlet
+        return 0.5
+
+    stance_counts = {r[0]: float(r[1]) for r in rows}
+    # Ensure all four labels are present (with 0 if absent)
+    for lbl in ("supportive", "critical", "neutral", "ambiguous"):
+        stance_counts.setdefault(lbl, 0.0)
+
+    return round(_shannon_entropy(stance_counts, n_bins=4), 4)
+
+
+# ---------------------------------------------------------------------------
+# Main scorer
+# ---------------------------------------------------------------------------
+
+def compute_outlet_scores(
+    conn,
+    date_range: str = "90d",
+    score_date: Optional[str] = None,
+) -> List[OutletScoreRow]:
+    """
+    Compute transparency scores for every outlet that has frame data.
+
+    Returns one OutletScoreRow per (source, source_type) pair.
+    Outlets with fewer than 3 documents are excluded.
+    """
+    cutoff = _date_cutoff(date_range)
+    week = _week_date(score_date)
+    ts = datetime.now(timezone.utc).isoformat()
+
+    # Enumerate outlets from document_frames (same approach as outlet_clustering)
+    news_outlets = conn.execute("""
+        SELECT DISTINCT n.source AS source, 'news' AS source_type
+        FROM document_frames df
+        JOIN news_articles n ON df.document_id = n.id
+        WHERE n.source IS NOT NULL AND n.publish_date >= ?
+    """, [cutoff]).fetchall()
+
+    other_outlets = conn.execute("""
+        SELECT DISTINCT source_type AS source, source_type
+        FROM document_frames
+        WHERE source_type != 'news' AND classified_at >= ?
+    """, [cutoff]).fetchall()
+
+    results: List[OutletScoreRow] = []
+    for src, src_type in list(news_outlets) + list(other_outlets):
+        try:
+            diversity, doc_count = _frame_diversity(conn, src, src_type, cutoff)
+            if doc_count < 3:
+                continue
+            attr_rate, claim_count = _attribution_rate(conn, src, src_type, cutoff)
+            neutrality = _stance_neutrality(conn, src, src_type)
+            composite = round((diversity + attr_rate + neutrality) / 3.0, 4)
+
+            results.append(OutletScoreRow(
+                source=src,
+                source_type=src_type,
+                score_date=week,
+                frame_diversity=diversity,
+                attribution_rate=attr_rate,
+                stance_neutrality=neutrality,
+                composite_score=composite,
+                doc_count=doc_count,
+                claim_count=claim_count,
+                computed_at=ts,
+            ))
+        except Exception as e:
+            logger.debug("scorer: skipping %s/%s: %s", src, src_type, e)
+
+    results.sort(key=lambda r: -r.composite_score)
+    return results
+
+
+def store_scores(rows: List[OutletScoreRow], conn) -> None:
+    """Upsert scores into ``outlet_scores`` (INSERT OR REPLACE keyed by source+type+date)."""
+    for r in rows:
+        conn.execute("""
+            INSERT OR REPLACE INTO outlet_scores
+                (source, source_type, score_date,
+                 frame_diversity, attribution_rate, stance_neutrality,
+                 composite_score, doc_count, claim_count, computed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, [r.source, r.source_type, r.score_date,
+              r.frame_diversity, r.attribution_rate, r.stance_neutrality,
+              r.composite_score, r.doc_count, r.claim_count, r.computed_at])
+
+
+# ---------------------------------------------------------------------------
+# Pipeline entry point
+# ---------------------------------------------------------------------------
+
+def run_scorer_batch(
+    conn, lock,
+    date_range: str = "90d",
+    date_override: Optional[str] = None,
+) -> dict:
+    """
+    Compute + persist weekly transparency scores for all outlets.
+
+    Idempotent — re-running in the same week overwrites that week's row.
+
+    Returns a summary dict for API/MCP responses.
+    """
+    try:
+        with lock:
+            rows = compute_outlet_scores(conn, date_range=date_range,
+                                         score_date=date_override)
+    except Exception as e:
+        return {"error": f"score computation failed: {e}"}
+
+    if not rows:
+        return {"outlets_scored": 0, "score_date": _week_date(date_override),
+                "message": "no outlets with sufficient frame data"}
+
+    try:
+        with lock:
+            store_scores(rows, conn)
+    except Exception as e:
+        return {"error": f"store failed: {e}"}
+
+    return {
+        "outlets_scored": len(rows),
+        "score_date":     _week_date(date_override),
+        "top_outlet":     rows[0].source if rows else None,
+        "top_composite":  rows[0].composite_score if rows else None,
+    }

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -145,6 +145,20 @@ CREATE TABLE IF NOT EXISTS outlet_clusters (
     computed_at    VARCHAR,
     PRIMARY KEY (source, source_type)
 );
+
+CREATE TABLE IF NOT EXISTS outlet_scores (
+    source            VARCHAR NOT NULL,
+    source_type       VARCHAR NOT NULL,
+    score_date        VARCHAR NOT NULL,
+    frame_diversity   DOUBLE,
+    attribution_rate  DOUBLE,
+    stance_neutrality DOUBLE,
+    composite_score   DOUBLE,
+    doc_count         INTEGER,
+    claim_count       INTEGER,
+    computed_at       VARCHAR,
+    PRIMARY KEY (source, source_type, score_date)
+);
 """
 
 # Each topic seeds a cluster of articles sharing a leading title word (the

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -26,6 +26,9 @@ Tools (non-overlapping with pipeline_mcp which owns positions/conflicts):
                        cluster_id?)
   trigger_outlet_clustering(date_range?,  -> embed+cluster outlets, persist (RW)
                             k_min?, k_max?)
+  list_outlet_scores(source_type?,       -> latest transparency scores per outlet
+                     sort_by?, limit?)
+  trigger_outlet_scoring(date_range?)    -> compute+store weekly scores (RW)
 
 Design constraints (same as pipeline_mcp):
   * Lazy imports inside each tool — top-level imports are stdlib + fastmcp only.
@@ -814,6 +817,119 @@ def trigger_outlet_clustering(
         result = run_cluster_pipeline(
             rw_conn, lock, date_range=date_range, k_min=k_min, k_max=k_max
         )
+        rw_conn.close()
+        return result
+    except Exception as e:
+        return {"error": f"write connection failed — warehouse may be locked: {e}"}
+
+
+@mcp.tool
+def list_outlet_scores(
+    source_type: Optional[str] = None,
+    sort_by: str = "composite_score",
+    limit: int = 30,
+) -> dict:
+    """
+    Return latest weekly transparency scores for all outlets.
+
+    Each record includes frame_diversity, attribution_rate, stance_neutrality,
+    composite_score, doc_count, claim_count, and score_date.
+
+    Args:
+        source_type: Filter by content type (news|blog|paper|transcript…).
+        sort_by:     composite_score|frame_diversity|attribution_rate|stance_neutrality.
+        limit:       Max rows (default 30).
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+
+    _SORT_COLS = {"composite_score", "frame_diversity", "attribution_rate", "stance_neutrality"}
+    sort_col = sort_by if sort_by in _SORT_COLS else "composite_score"
+
+    conditions: list[str] = []
+    params: list = []
+    if source_type:
+        conditions.append("source_type = ?")
+        params.append(source_type)
+
+    where_extra = f"AND {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT source, source_type, score_date,
+                   frame_diversity, attribution_rate, stance_neutrality,
+                   composite_score, doc_count, claim_count, computed_at
+            FROM outlet_scores os
+            WHERE (source, source_type, score_date) IN (
+                SELECT source, source_type, MAX(score_date)
+                FROM outlet_scores
+                WHERE 1=1 {where_extra}
+                GROUP BY source, source_type
+            )
+            ORDER BY {sort_col} DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {
+        "count": len(rows),
+        "outlets": [
+            {
+                "source":            r[0],
+                "source_type":       r[1],
+                "score_date":        r[2],
+                "frame_diversity":   round(r[3], 4) if r[3] is not None else None,
+                "attribution_rate":  round(r[4], 4) if r[4] is not None else None,
+                "stance_neutrality": round(r[5], 4) if r[5] is not None else None,
+                "composite_score":   round(r[6], 4) if r[6] is not None else None,
+                "doc_count":         r[7],
+                "claim_count":       r[8],
+                "computed_at":       r[9],
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool
+def trigger_outlet_scoring(date_range: str = "90d") -> dict:
+    """
+    Compute weekly transparency scores for all outlets and persist to ``outlet_scores``.
+
+    Idempotent — re-running in the same ISO week overwrites that week's row.
+
+    Scores three dimensions per outlet:
+      - frame_diversity:   Shannon entropy of 7-frame distribution / log(7)
+      - attribution_rate:  % claims with attributed=True
+      - stance_neutrality: entropy of stance distribution / log(4)
+      - composite_score:   mean of the three
+
+    Args:
+        date_range: Data window: 7d|14d|30d|90d|180d|365d (default "90d").
+
+    Returns {"outlets_scored", "score_date", "top_outlet", "top_composite"}.
+    """
+    import os, threading, duckdb
+
+    try:
+        from src.argument_mining.outlet_scorer import run_scorer_batch  # type: ignore[import]
+    except ImportError as e:
+        return {"error": f"outlet_scorer module unavailable: {e}"}
+
+    db_path = os.environ.get(
+        "NEURONEWS_DB_PATH",
+        str(REPO_ROOT / "data" / "local_warehouse.duckdb"),
+    )
+    try:
+        rw_conn = duckdb.connect(db_path, read_only=False)
+        lock = threading.Lock()
+        result = run_scorer_batch(rw_conn, lock, date_range=date_range)
         rw_conn.close()
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary

- Computes weekly transparency scores per outlet across three independent dimensions: **frame diversity** (Shannon entropy of 7-frame distribution, normalised 0-1), **claim attribution rate** (% of detected claims with an attributed source), and **stance neutrality** (entropy of supportive/critical/neutral/ambiguous distribution, normalised 0-1)
- Stores weekly snapshots in `outlet_scores` so sparkline trends can be drawn (composite score history, oldest→newest)
- New sortable ranked table in the Sources tab with per-dimension progress bars, sparkline, and a colour-coded composite score (green ≥70, amber ≥50, red <50)

## Files changed

| Area | File | What |
|---|---|---|
| Scorer | `src/argument_mining/outlet_scorer.py` | `_shannon_entropy`, `compute_outlet_scores`, `run_scorer_batch` |
| DB | `src/database/local_warehouse_seed.py` | `outlet_scores` table |
| API | `src/api/routes/argument_routes.py` | `GET /outlets/ranking` (sort_by, trend array), `POST /outlets/score` |
| MCP | `tools/argument_mcp/server.py` | `list_outlet_scores`, `trigger_outlet_scoring` |
| Frontend | `types.ts`, `api.ts`, `queries.ts` | `OutletScore` type, `useOutletRanking` hook + mock fallback |
| UI | `apps/web/src/views/Arguments.tsx` | `OutletRankingTable` in Sources tab |
| Skill | `.claude/skills/verify-outlet-scoring/` | Unit tests + `--live` mode |

## Test plan

- [x] `python3 .claude/skills/verify-outlet-scoring/verify.py` — **PASS** (5/5 unit tests)
- [x] `npx tsc --noEmit` — no errors
- [x] Python syntax check — clean
- [ ] Manual: Arguments → Sources tab shows ranking table with mock data (demo mode)
- [ ] Manual: `POST /outlets/score` after frame extraction populates live scores
- [ ] Manual: sort buttons switch between Diversity / Attribution / Neutrality / Score columns
- [ ] Manual: MCP `trigger_outlet_scoring()` → `list_outlet_scores()` returns stored weekly row

Closes #116