### PR TITLE
feat(knowledge-graph): live KG updates and emerging-connections tracking (#42)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -23,6 +23,7 @@ DOCUMENT_ROUTES_AVAILABLE = False
 REPORT_ROUTES_AVAILABLE = False
 ALERT_ROUTES_AVAILABLE = False
 ARGUMENT_ROUTES_AVAILABLE = False
+KG_STREAM_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -280,6 +281,19 @@ def try_import_argument_routes():
         return False
 
 
+def try_import_kg_stream_routes():
+    """Try to import knowledge-graph streaming-update routes (issue #42)."""
+    global KG_STREAM_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import kg_stream_routes
+        _imported_modules['kg_stream_routes'] = kg_stream_routes
+        KG_STREAM_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        KG_STREAM_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -330,6 +344,7 @@ def check_all_imports():
     try_import_report_routes()
     try_import_alert_routes()
     try_import_argument_routes()
+    try_import_kg_stream_routes()
     _load_domain_packs()
 
 
@@ -609,6 +624,13 @@ def include_optional_routers(app):
             app.include_router(argument_routes.router)
             routers_included += 1
 
+    # Include KG streaming-update routes (issue #42)
+    if KG_STREAM_ROUTES_AVAILABLE:
+        kg_stream_routes = _imported_modules.get('kg_stream_routes')
+        if kg_stream_routes:
+            app.include_router(kg_stream_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -695,6 +717,7 @@ async def root():
             "graph_search": GRAPH_SEARCH_AVAILABLE,
             "influence_analysis": INFLUENCE_ANALYSIS_AVAILABLE,
             "document_routes": DOCUMENT_ROUTES_AVAILABLE,
+            "kg_stream": KG_STREAM_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/document_routes.py
+++ b/src/api/routes/document_routes.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from services.ingest.common.document_model import SOURCE_TYPES
@@ -58,12 +58,19 @@ _store: Dict[str, Dict[str, Any]] = {}
 # --------------------------------------------------------------------------- #
 
 @router.post("/ingest", response_model=DocumentOut, status_code=201)
-async def ingest_document(doc: DocumentIn) -> Dict[str, Any]:
+async def ingest_document(
+    doc: DocumentIn,
+    background_tasks: BackgroundTasks,
+) -> Dict[str, Any]:
     """Ingest a document into the knowledge engine.
 
     This endpoint is source-type-agnostic — it accepts any ``source_type``
     from the document-ingest-v1 contract. News-specific enrichment is applied
     downstream by the news domain pack when enabled.
+
+    A background task updates the live knowledge graph after the response is
+    sent, extracting entity mentions and recording new connections so they
+    are visible via GET /kg/connections/emerging and GET /kg/topics/evolving.
     """
     if doc.source_type not in SOURCE_TYPES:
         raise HTTPException(
@@ -73,6 +80,13 @@ async def ingest_document(doc: DocumentIn) -> Dict[str, Any]:
     record = doc.model_dump()
     record["ingested_at"] = int(time.time() * 1000)
     _store[doc.document_id] = record
+
+    try:
+        from src.knowledge_graph.kg_updater import update_from_document
+        background_tasks.add_task(update_from_document, record)
+    except Exception:
+        pass  # KG update is best-effort; never block the ingestion response
+
     return record
 
 

--- a/src/api/routes/kg_stream_routes.py
+++ b/src/api/routes/kg_stream_routes.py
@@ -1,0 +1,100 @@
+"""
+Knowledge Graph streaming-update routes — Issue #42.
+
+Exposes the live state of the in-process knowledge graph that is updated
+by background tasks every time a document is ingested:
+
+  GET /kg/connections/emerging   — new edges added since a given timestamp
+  GET /kg/topics/evolving        — entities with a recent burst of new edges
+  GET /kg/stats                  — current node/triple counts
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException, Query
+
+router = APIRouter(prefix="/kg", tags=["knowledge-graph-stream"])
+
+
+def _load_updater():
+    from src.knowledge_graph.kg_updater import (
+        get_emerging_connections,
+        get_evolving_topics,
+        get_store_stats,
+    )
+    return get_emerging_connections, get_evolving_topics, get_store_stats
+
+
+@router.get("/connections/emerging", response_model=List[Dict[str, Any]])
+async def emerging_connections(
+    since: str = Query(
+        None,
+        description=(
+            "ISO-8601 UTC timestamp. Returns connections added after this point. "
+            "Defaults to 1 hour ago."
+        ),
+        example="2025-01-01T00:00:00Z",
+    ),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of connections to return"),
+):
+    """
+    Return knowledge-graph edges (triples) that were added since *since*.
+
+    Each item describes one new connection: the two entities it links, the
+    relation type, which document triggered it, and the exact timestamp it
+    was recorded.
+
+    Use this endpoint to watch for newly discovered relationships as documents
+    are ingested in real time.
+    """
+    get_emerging_connections, _, _ = _load_updater()
+
+    if since is None:
+        since_dt = datetime.now(timezone.utc) - timedelta(hours=1)
+    else:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid ISO-8601 timestamp: {since!r}. "
+                       "Expected format: 2025-01-01T00:00:00Z",
+            )
+
+    return get_emerging_connections(since=since_dt, limit=limit)
+
+
+@router.get("/topics/evolving", response_model=List[Dict[str, Any]])
+async def evolving_topics(
+    window_minutes: int = Query(
+        60,
+        ge=1,
+        le=1440,
+        description="Look-back window in minutes (default: 60, max: 1440 = 24 h)",
+    ),
+    top_n: int = Query(20, ge=1, le=100, description="Maximum number of topics to return"),
+):
+    """
+    Return entities ranked by how many new connections they accumulated in the
+    last *window_minutes* minutes.
+
+    A high ``new_connections`` count means many recently ingested documents
+    mention this entity — it is an actively evolving topic right now.  The
+    ``source_docs`` list shows which documents drove the activity.
+    """
+    _, get_evolving_topics, _ = _load_updater()
+    return get_evolving_topics(window_seconds=window_minutes * 60, top_n=top_n)
+
+
+@router.get("/stats", response_model=Dict[str, Any])
+async def kg_stats():
+    """
+    Return current knowledge-graph statistics: total node and triple counts,
+    number of background-update events recorded since startup, and live status.
+    """
+    _, _, get_store_stats = _load_updater()
+    return get_store_stats()

--- a/src/knowledge_graph/kg_updater.py
+++ b/src/knowledge_graph/kg_updater.py
@@ -1,0 +1,334 @@
+"""
+Knowledge graph live-update service — Issue #42.
+
+When a document is ingested (POST /documents/ingest) this service runs as a
+FastAPI background task and:
+
+1. Extracts entity mentions from the document text via lightweight heuristic
+   NER (no external deps required; always available).
+2. Upserts canonical nodes and DOCUMENT→entity MENTIONS triples into a
+   process-level KnowledgeGraphStore shared across all background tasks.
+3. Records wall-clock timestamps on every mutation so callers can query
+   "what connections emerged in the last N minutes?" and "which topics are
+   accumulating connections right now?".
+"""
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from src.knowledge_graph.foundation import (
+    EntityResolver,
+    EntityType,
+    KnowledgeGraphStore,
+    Node,
+    Provenance,
+    RelationType,
+    Triple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Process-level singleton (shared KG store + resolver)
+# ---------------------------------------------------------------------------
+
+_store_lock = threading.Lock()
+_store: Optional[KnowledgeGraphStore] = None
+_resolver: Optional[EntityResolver] = None
+
+
+def _shared_store() -> KnowledgeGraphStore:
+    global _store, _resolver
+    with _store_lock:
+        if _store is None:
+            _store = KnowledgeGraphStore()
+            _resolver = EntityResolver()
+    return _store
+
+
+def _shared_resolver() -> EntityResolver:
+    _shared_store()  # ensures both are initialised
+    assert _resolver is not None
+    return _resolver
+
+
+# ---------------------------------------------------------------------------
+# Mutation event log (provides the time dimension for "emerging" queries)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _MutationEvent:
+    kind: str        # "node" | "triple"
+    entity_id: str   # node_id  –or–  "subject_id:predicate:object_id"
+    label: str       # human-readable description
+    doc_id: str
+    ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+_events: List[_MutationEvent] = []
+_events_lock = threading.Lock()
+
+
+def _record(kind: str, entity_id: str, label: str, doc_id: str) -> None:
+    with _events_lock:
+        _events.append(_MutationEvent(kind, entity_id, label, doc_id))
+
+
+# ---------------------------------------------------------------------------
+# Lightweight heuristic NER (no spaCy / transformers required)
+# ---------------------------------------------------------------------------
+
+# Capitalised-word sequences of 1–4 tokens as candidate named entities.
+_CAP_SEQ = re.compile(r"\b([A-Z][a-z]{1,}(?:\s+[A-Z][a-z]{1,}){0,3})\b")
+
+_ORG_SUFFIXES = frozenset([
+    "Inc", "Corp", "Ltd", "LLC", "Company", "Group", "Institute",
+    "Association", "Foundation", "Ministry", "Department", "University",
+    "College", "Bank", "Fund", "Agency", "Bureau", "Committee", "Organisation",
+    "Organization",
+])
+
+_PERSON_TITLES = frozenset([
+    "Mr", "Ms", "Mrs", "Dr", "Prof", "President", "CEO", "CTO", "CFO",
+    "Senator", "Representative", "Minister", "Director", "Secretary", "General",
+])
+
+# Stop-words that match the capitalised pattern but are not entities.
+_STOP = frozenset([
+    "The", "A", "An", "In", "On", "At", "By", "For", "With", "From",
+    "And", "Or", "But", "To", "Of", "As", "Is", "Are", "Was", "Were",
+    "This", "That", "These", "Those", "It", "He", "She", "We", "They",
+    "His", "Her", "Their", "Its", "Our", "Your", "My",
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+])
+
+
+def _infer_type(tokens: List[str], preceding_word: str) -> EntityType:
+    last = tokens[-1] if tokens else ""
+    first = tokens[0] if tokens else ""
+    if first in _PERSON_TITLES or preceding_word.rstrip(".") in _PERSON_TITLES:
+        return EntityType.PERSON
+    if last in _ORG_SUFFIXES or any(t in _ORG_SUFFIXES for t in tokens):
+        return EntityType.ORGANIZATION
+    if len(tokens) == 2:
+        # "Firstname Lastname" shape → person
+        return EntityType.PERSON
+    return EntityType.CONCEPT
+
+
+def _extract_mentions(text: str) -> List[tuple]:
+    """Return ``(surface_form, EntityType)`` pairs from plain text."""
+    text = text or ""
+    words = text.split()
+
+    # Build preceding-word index for type inference
+    preceding: Dict[str, str] = {}
+    for i in range(1, len(words)):
+        surface = words[i].rstrip(".,;:\"'")
+        preceding.setdefault(surface, words[i - 1].rstrip(".,;:\"'"))
+
+    seen: set = set()
+    results = []
+    for m in _CAP_SEQ.finditer(text):
+        name = m.group(1).strip()
+        tokens = name.split()
+        if len(name) < 3:
+            continue
+        if tokens[0] in _STOP or name in _STOP:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        etype = _infer_type(tokens, preceding.get(tokens[0], ""))
+        results.append((name, etype))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Core update logic
+# ---------------------------------------------------------------------------
+
+def update_from_document(doc: Dict[str, Any]) -> None:
+    """
+    Extract entities from *doc* and update the shared KnowledgeGraphStore.
+
+    Called as a FastAPI ``BackgroundTasks`` callback after the HTTP response
+    for ``POST /documents/ingest`` has already been sent.
+
+    *doc* must contain ``document_id`` and at least one of ``title`` / ``content``.
+    """
+    doc_id = doc.get("document_id", "unknown")
+    text = " ".join(filter(None, [doc.get("title", ""), doc.get("content", "")]))
+
+    if not text.strip():
+        logger.debug("KG updater: no text content for doc=%r, skipping", doc_id)
+        return
+
+    store = _shared_store()
+    resolver = _shared_resolver()
+
+    # 1. Anchor document node
+    doc_node = Node(type=EntityType.DOCUMENT, name=doc_id)
+    try:
+        store.add_node(doc_node)
+        _record("node", doc_node.node_id, doc_node.name, doc_id)
+    except Exception:
+        # Node already exists — fine, we still want to add new entity triples
+        pass
+
+    # 2. Extract entities and upsert into the store
+    entity_node_ids: List[str] = []
+    for name, etype in _extract_mentions(text):
+        try:
+            # EntityResolver handles deduplication; returns the canonical Node
+            canonical = resolver.resolve(etype, name)
+            # Add to store (add_node merges if it already exists)
+            stored = store.add_node(canonical)
+            entity_node_ids.append(stored.node_id)
+            _record("node", stored.node_id, stored.name, doc_id)
+        except Exception as exc:
+            logger.debug("KG node upsert skipped for %r: %s", name, exc)
+
+    # 3. Link document → each entity with MENTIONS triples
+    new_triples = 0
+    for eid in entity_node_ids:
+        try:
+            triple = Triple(
+                subject=doc_node.node_id,
+                predicate=RelationType.MENTIONS,
+                object=eid,
+                provenance=Provenance(
+                    source_doc=doc_id,
+                    confidence=0.8,
+                    extractor="heuristic-ner",
+                ),
+            )
+            store.add_triple(triple)
+            # Use "|" as separator; node_ids contain ":" so we can't use that.
+            key_str = "|".join([triple.subject, triple.predicate.value, triple.object])
+            _record("triple", key_str, f"MENTIONS:{eid}", doc_id)
+            new_triples += 1
+        except Exception as exc:
+            logger.debug("KG triple skipped: %s", exc)
+
+    logger.info(
+        "KG background update complete: doc=%r entities=%d triples=%d",
+        doc_id, len(entity_node_ids), new_triples,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query helpers consumed by kg_stream_routes
+# ---------------------------------------------------------------------------
+
+def get_emerging_connections(since: datetime, limit: int = 50) -> List[Dict[str, Any]]:
+    """
+    Return triples added to the KG after *since*.
+
+    Each result describes one new edge: subject entity, predicate, object
+    entity, which source document triggered it, and when it was added.
+    """
+    with _events_lock:
+        recent = [
+            e for e in _events
+            if e.kind == "triple" and e.ts >= since
+        ][-limit:]
+
+    store = _shared_store()
+    results = []
+    for ev in recent:
+        parts = ev.entity_id.split("|", 2)
+        subj_id = parts[0] if len(parts) > 0 else ""
+        pred = parts[1] if len(parts) > 1 else "MENTIONS"
+        obj_id = parts[2] if len(parts) > 2 else ""
+
+        entry: Dict[str, Any] = {
+            "subject_id": subj_id,
+            "predicate": pred,
+            "object_id": obj_id,
+            "source_doc": ev.doc_id,
+            "added_at": ev.ts.isoformat(),
+        }
+
+        subj_node = store.get_node(subj_id)
+        obj_node = store.get_node(obj_id)
+        if subj_node:
+            entry["subject_name"] = subj_node.name
+            entry["subject_type"] = subj_node.type.value
+        if obj_node:
+            entry["object_name"] = obj_node.name
+            entry["object_type"] = obj_node.type.value
+
+        results.append(entry)
+    return results
+
+
+def get_evolving_topics(window_seconds: int = 3600, top_n: int = 20) -> List[Dict[str, Any]]:
+    """
+    Return entities ranked by how many new MENTIONS triples they received in
+    the last *window_seconds* seconds.
+
+    High counts signal a topic that is rapidly accumulating new documents —
+    i.e. an evolving/emerging topic.
+    """
+    now = datetime.now(timezone.utc).timestamp()
+    cutoff = now - window_seconds
+
+    with _events_lock:
+        recent = [e for e in _events if e.ts.timestamp() >= cutoff]
+
+    counts: Dict[str, int] = defaultdict(int)
+    docs_per_entity: Dict[str, set] = defaultdict(set)
+
+    for ev in recent:
+        if ev.kind != "triple":
+            continue
+        parts = ev.entity_id.split("|", 2)
+        # The object of a MENTIONS triple is the entity being mentioned
+        obj_id = parts[2] if len(parts) > 2 else ""
+        if obj_id:
+            counts[obj_id] += 1
+            docs_per_entity[obj_id].add(ev.doc_id)
+
+    store = _shared_store()
+    results = []
+    for node_id, count in sorted(counts.items(), key=lambda x: -x[1])[:top_n]:
+        node = store.get_node(node_id)
+        if node is None:
+            continue
+        results.append({
+            "entity_id": node_id,
+            "name": node.name,
+            "type": node.type.value,
+            "new_connections": count,
+            "source_docs": sorted(docs_per_entity[node_id]),
+            "window_seconds": window_seconds,
+        })
+    return results
+
+
+def get_store_stats() -> Dict[str, Any]:
+    """Return current statistics for the shared KnowledgeGraphStore."""
+    store = _shared_store()
+    with _events_lock:
+        total_events = len(_events)
+        triple_events = sum(1 for e in _events if e.kind == "triple")
+        node_events = sum(1 for e in _events if e.kind == "node")
+
+    return {
+        "node_count": store.node_count,
+        "triple_count": store.triple_count,
+        "total_update_events": total_events,
+        "triple_events": triple_events,
+        "node_events": node_events,
+        "status": "live",
+    }

--- a/tests/knowledge_graph/test_kg_updater.py
+++ b/tests/knowledge_graph/test_kg_updater.py
@@ -1,0 +1,250 @@
+"""
+Tests for the knowledge-graph live-update service (Issue #42).
+
+Covers:
+- Heuristic NER entity extraction
+- KG store population from document dicts
+- Emerging-connections query
+- Evolving-topics query
+- Stats endpoint
+- Thread-safety: multiple concurrent background-task calls
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _doc(
+    document_id: str = "doc-1",
+    title: str = "",
+    content: str = "",
+) -> Dict[str, Any]:
+    return {"document_id": document_id, "title": title, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# Isolate each test from shared singleton state
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_kg_state():
+    """Reset the process-level KG store and event log before every test."""
+    import src.knowledge_graph.kg_updater as mod
+    mod._store = None
+    mod._resolver = None
+    mod._events.clear()
+    yield
+    mod._store = None
+    mod._resolver = None
+    mod._events.clear()
+
+
+# ---------------------------------------------------------------------------
+# Heuristic NER
+# ---------------------------------------------------------------------------
+
+class TestExtractMentions:
+    def _extract(self, text: str):
+        from src.knowledge_graph.kg_updater import _extract_mentions
+        return _extract_mentions(text)
+
+    def test_person_two_tokens(self):
+        results = self._extract("Angela Merkel spoke at the summit.")
+        names = [name for name, _ in results]
+        assert "Angela Merkel" in names
+
+    def test_organisation_suffix(self):
+        results = self._extract("Microsoft Corp released a new model.")
+        names = [name for name, _ in results]
+        assert any("Microsoft" in n for n in names)
+
+    def test_stop_word_filtered(self):
+        results = self._extract("The President signed the bill.")
+        names = [name for name, _ in results]
+        assert "The" not in names
+
+    def test_empty_text(self):
+        assert self._extract("") == []
+
+    def test_deduplication(self):
+        results = self._extract("Elon Musk said Elon Musk again.")
+        names = [name for name, _ in results]
+        assert names.count("Elon Musk") == 1
+
+
+# ---------------------------------------------------------------------------
+# update_from_document
+# ---------------------------------------------------------------------------
+
+class TestUpdateFromDocument:
+    def test_nodes_added_to_store(self):
+        from src.knowledge_graph.kg_updater import update_from_document, _shared_store
+        update_from_document(_doc(title="Tim Cook unveiled Apple Inc products."))
+        store = _shared_store()
+        assert store.node_count >= 1  # at least the document anchor
+
+    def test_triple_count_grows(self):
+        from src.knowledge_graph.kg_updater import update_from_document, _shared_store
+        update_from_document(_doc(title="Angela Merkel met Emmanuel Macron in Paris."))
+        store = _shared_store()
+        assert store.triple_count >= 1
+
+    def test_events_recorded(self):
+        import src.knowledge_graph.kg_updater as mod
+        mod.update_from_document(_doc(title="Satya Nadella runs Microsoft Corp."))
+        assert len(mod._events) > 0
+        kinds = {e.kind for e in mod._events}
+        assert "node" in kinds
+        assert "triple" in kinds
+
+    def test_empty_document_is_no_op(self):
+        import src.knowledge_graph.kg_updater as mod
+        mod.update_from_document(_doc())
+        assert len(mod._events) == 0
+
+    def test_duplicate_ingest_does_not_error(self):
+        from src.knowledge_graph.kg_updater import update_from_document
+        doc = _doc(title="Jeff Bezos founded Amazon Inc.")
+        update_from_document(doc)
+        update_from_document(doc)  # should not raise
+
+    def test_multiple_documents_accumulate(self):
+        from src.knowledge_graph.kg_updater import update_from_document, _shared_store
+        update_from_document(_doc("d1", title="Apple Inc announced iPhone."))
+        update_from_document(_doc("d2", title="Tim Cook presented at Apple Inc event."))
+        store = _shared_store()
+        assert store.triple_count >= 2
+
+    def test_concurrent_updates_safe(self):
+        from src.knowledge_graph.kg_updater import update_from_document, _shared_store
+        errors = []
+
+        def _run(i):
+            try:
+                update_from_document(_doc(f"doc-{i}", title=f"Entity{i} Inc released report{i}."))
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_run, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent updates raised: {errors}"
+        store = _shared_store()
+        assert store.node_count >= 10
+
+
+# ---------------------------------------------------------------------------
+# get_emerging_connections
+# ---------------------------------------------------------------------------
+
+class TestGetEmergingConnections:
+    def test_returns_connections_after_since(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_emerging_connections
+        before = datetime.now(timezone.utc) - timedelta(seconds=1)
+        update_from_document(_doc(title="Elon Musk leads Tesla Inc."))
+        results = get_emerging_connections(since=before)
+        assert len(results) > 0
+
+    def test_returns_empty_when_since_is_future(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_emerging_connections
+        update_from_document(_doc(title="Elon Musk leads Tesla Inc."))
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        assert get_emerging_connections(since=future) == []
+
+    def test_result_structure(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_emerging_connections
+        before = datetime.now(timezone.utc) - timedelta(seconds=1)
+        update_from_document(_doc("d1", title="Angela Merkel led Germany."))
+        results = get_emerging_connections(since=before)
+        assert len(results) > 0
+        r = results[0]
+        assert "subject_id" in r
+        assert "predicate" in r
+        assert "object_id" in r
+        assert "source_doc" in r
+        assert "added_at" in r
+
+    def test_limit_respected(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_emerging_connections
+        before = datetime.now(timezone.utc) - timedelta(seconds=1)
+        for i in range(5):
+            update_from_document(_doc(f"d{i}", title=f"Entity{i} Corp signed deal{i}."))
+        results = get_emerging_connections(since=before, limit=3)
+        assert len(results) <= 3
+
+
+# ---------------------------------------------------------------------------
+# get_evolving_topics
+# ---------------------------------------------------------------------------
+
+class TestGetEvolvingTopics:
+    def test_returns_entities_in_window(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_evolving_topics
+        update_from_document(_doc("d1", title="Microsoft Corp released Windows."))
+        update_from_document(_doc("d2", title="Microsoft Corp keynote event."))
+        results = get_evolving_topics(window_seconds=60)
+        names = [r["name"] for r in results]
+        assert any("Microsoft" in n for n in names)
+
+    def test_result_structure(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_evolving_topics
+        update_from_document(_doc(title="Google Inc announced Gemini."))
+        results = get_evolving_topics(window_seconds=60)
+        if results:
+            r = results[0]
+            assert "entity_id" in r
+            assert "name" in r
+            assert "type" in r
+            assert "new_connections" in r
+            assert "source_docs" in r
+
+    def test_top_n_respected(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_evolving_topics
+        for i in range(10):
+            update_from_document(_doc(f"d{i}", title=f"Company{i} Corp deal{i}."))
+        results = get_evolving_topics(window_seconds=60, top_n=3)
+        assert len(results) <= 3
+
+    def test_empty_when_window_excludes_all(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_evolving_topics
+        import src.knowledge_graph.kg_updater as mod
+        update_from_document(_doc(title="Apple Inc released iPhone."))
+        # Backdate all events so they fall outside the 1-second window
+        old_ts = datetime.now(timezone.utc) - timedelta(seconds=120)
+        for e in mod._events:
+            e.ts = old_ts
+        results = get_evolving_topics(window_seconds=1)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_store_stats
+# ---------------------------------------------------------------------------
+
+class TestGetStoreStats:
+    def test_initial_stats(self):
+        from src.knowledge_graph.kg_updater import get_store_stats
+        stats = get_store_stats()
+        assert stats["node_count"] == 0
+        assert stats["triple_count"] == 0
+        assert stats["status"] == "live"
+
+    def test_stats_after_update(self):
+        from src.knowledge_graph.kg_updater import update_from_document, get_store_stats
+        update_from_document(_doc(title="Tim Cook runs Apple Inc globally."))
+        stats = get_store_stats()
+        assert stats["node_count"] >= 1
+        assert stats["triple_count"] >= 1
+        assert stats["total_update_events"] > 0


### PR DESCRIPTION
## Summary

- Adds `src/knowledge_graph/kg_updater.py`: a thread-safe singleton service that runs as a FastAPI `BackgroundTasks` callback on every `POST /documents/ingest`, extracts entity mentions via heuristic NER, and upserts nodes + `MENTIONS` triples into a shared `KnowledgeGraphStore` (with `EntityResolver` deduplication). A timestamped mutation event log powers the time-windowed query helpers.
- Adds `src/api/routes/kg_stream_routes.py` with three new endpoints:
  - `GET /kg/connections/emerging?since=<iso>` — edges added after a given timestamp
  - `GET /kg/topics/evolving?window_minutes=<int>` — entities ranked by recent mention burst
  - `GET /kg/stats` — live node/triple counts
- Wires `POST /documents/ingest` (`document_routes.py`) to schedule the background KG update after the HTTP response is sent (never blocks ingestion).
- Registers the new router in `app.py` via the existing feature-flag pattern.
- Adds `tests/knowledge_graph/test_kg_updater.py`: 22 tests covering NER, store population, concurrent updates, emerging-connections queries, evolving-topics queries, and stats — all passing.

Closes #42.

## Test plan

- [ ] `python -m pytest tests/knowledge_graph/test_kg_updater.py -v` — 22/22 pass
- [ ] `POST /documents/ingest` with a title-bearing document, then `GET /kg/connections/emerging` returns the new edges and `GET /kg/topics/evolving` ranks the mentioned entities