### PR TITLE
feat(knowledge-graph): user-driven entity corrections (#44)

### DIFF
--- a/.claude/skills/verify-entity-corrections/SKILL.md
+++ b/.claude/skills/verify-entity-corrections/SKILL.md
@@ -1,0 +1,40 @@
+# verify-entity-corrections
+
+Smoke-test the user-driven entity corrections pipeline end-to-end.
+
+**Use when:** you've changed `src/knowledge_graph/entity_corrections.py`,
+`src/api/routes/entity_correction_routes.py`, or the `kg_updater.py` store,
+and want to confirm the full lifecycle works before opening a PR.
+
+## What it tests
+
+1. Seeds a KG entity directly in the shared store.
+2. Submits each correction type (rename, add_alias, remove_alias,
+   add_property, remove_property, merge) as a trusted user.
+3. Verifies each correction is stored as `pending`.
+4. Approves all pending corrections as an admin.
+5. Verifies each approved change is visible in the live KG store.
+6. Rejects one additional correction and confirms it is rejected.
+7. Prints a pass/fail summary table.
+
+No API server, no auth tokens, no DB: imports the Python layer directly.
+
+## Steps
+
+Run the smoke-test script:
+
+```bash
+PYTHONPATH=/home/Ikey/NeuroNews python3 .claude/skills/verify-entity-corrections/smoke.py
+```
+
+All lines must print `PASS`. If any print `FAIL`, investigate
+`src/knowledge_graph/entity_corrections.py` and re-run.
+
+## Interpreting failures
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `KeyError: entity not found` on approve | `_shared_store()` was reset between submit and approve — check singleton wiring |
+| Correction applied but node unchanged | `_apply_correction` mutates the wrong object — check `store.get_node()` returns a mutable reference |
+| Version sequence wrong | `_entity_version` counter not thread-safe — check lock scope |
+| Merge source not removed | `store._nodes.pop()` path not reached — check `_apply_merge` logic |

--- a/.claude/skills/verify-entity-corrections/smoke.py
+++ b/.claude/skills/verify-entity-corrections/smoke.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Smoke-test for the entity corrections pipeline (Issue #44).
+Run from repo root: PYTHONPATH=. python3 .claude/skills/verify-entity-corrections/smoke.py
+"""
+from __future__ import annotations
+
+import sys
+import traceback
+
+# Reset singletons so this script is re-runnable in the same process
+import src.knowledge_graph.entity_corrections as _ec_mod
+import src.knowledge_graph.kg_updater as _ku_mod
+_ec_mod._correction_store = None
+_ku_mod._store = None
+_ku_mod._resolver = None
+_ku_mod._events.clear()
+
+from src.knowledge_graph.foundation import Node, EntityType
+from src.knowledge_graph.kg_updater import _shared_store
+from src.knowledge_graph.entity_corrections import (
+    CorrectionType, CorrectionStatus, get_correction_store,
+)
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+results: list[tuple[str, bool, str]] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    results.append((label, condition, detail))
+    status = PASS if condition else FAIL
+    suffix = f"  — {detail}" if detail else ""
+    print(f"  {status}  {label}{suffix}")
+
+
+def run() -> None:
+    store = _shared_store()
+    cs = get_correction_store()
+
+    # ---- seed entities ---------------------------------------------------- #
+    target = Node(type=EntityType.PERSON, name="Tim Cook")
+    source = Node(type=EntityType.PERSON, name="Timothy Cook")
+    org    = Node(type=EntityType.ORGANIZATION, name="Apple")
+    for n in [target, source, org]:
+        store.add_node(n)
+
+    print("\n── Submission ──────────────────────────────────────────────────")
+
+    c_rename = cs.submit(target.node_id, CorrectionType.RENAME,
+                         {"new_name": "Tim D. Cook"}, "full middle name", "user-1")
+    check("rename submitted as pending", c_rename.status == CorrectionStatus.PENDING)
+
+    c_alias = cs.submit(target.node_id, CorrectionType.ADD_ALIAS,
+                        {"alias": "Timothy Donald Cook"}, "formal name", "user-1")
+    check("add_alias submitted as pending", c_alias.status == CorrectionStatus.PENDING)
+
+    c_rem_alias = cs.submit(target.node_id, CorrectionType.REMOVE_ALIAS,
+                            {"alias": "Timothy Donald Cook"}, "undo alias", "user-1")
+    check("remove_alias submitted as pending", c_rem_alias.status == CorrectionStatus.PENDING)
+
+    c_add_prop = cs.submit(target.node_id, CorrectionType.ADD_PROPERTY,
+                           {"key": "title", "value": "CEO"}, "add title", "user-1")
+    check("add_property submitted as pending", c_add_prop.status == CorrectionStatus.PENDING)
+
+    c_rem_prop = cs.submit(target.node_id, CorrectionType.REMOVE_PROPERTY,
+                           {"key": "title"}, "remove title", "user-1")
+    check("remove_property submitted as pending", c_rem_prop.status == CorrectionStatus.PENDING)
+
+    c_merge = cs.submit(target.node_id, CorrectionType.MERGE,
+                        {"merge_from": source.node_id}, "deduplicate", "user-1")
+    check("merge submitted as pending", c_merge.status == CorrectionStatus.PENDING)
+
+    c_reject = cs.submit(org.node_id, CorrectionType.RENAME,
+                         {"new_name": "Wrong Name"}, "bad correction", "user-99")
+    check("reject-candidate submitted", c_reject.status == CorrectionStatus.PENDING)
+
+    check("versions are monotonic per entity",
+          [c.version for c in [c_rename, c_alias, c_rem_alias, c_add_prop, c_rem_prop, c_merge]]
+          == list(range(1, 7)))
+
+    print("\n── Approval (checked immediately after each) ───────────────────")
+
+    cs.approve(c_rename.correction_id, reviewed_by="admin-1", review_note="ok")
+    check("rename applied",
+          store.get_node(target.node_id).name == "Tim D. Cook",
+          store.get_node(target.node_id).name)
+
+    cs.approve(c_alias.correction_id, reviewed_by="admin-1")
+    node = store.get_node(target.node_id)
+    check("add_alias applied",
+          "Timothy Donald Cook" in node.aliases,
+          str(node.aliases))
+
+    cs.approve(c_rem_alias.correction_id, reviewed_by="admin-1")
+    node = store.get_node(target.node_id)
+    check("remove_alias applied",
+          "Timothy Donald Cook" not in node.aliases,
+          str(node.aliases))
+
+    cs.approve(c_add_prop.correction_id, reviewed_by="admin-1")
+    node = store.get_node(target.node_id)
+    check("add_property applied",
+          node.properties.get("title") == "CEO",
+          str(node.properties))
+
+    cs.approve(c_rem_prop.correction_id, reviewed_by="admin-1")
+    node = store.get_node(target.node_id)
+    check("remove_property applied",
+          "title" not in node.properties,
+          str(node.properties))
+
+    cs.approve(c_merge.correction_id, reviewed_by="admin-1")
+    check("merge: source node removed",
+          store.get_node(source.node_id) is None)
+
+    check("merge: source name in target aliases",
+          "Timothy Cook" in store.get_node(target.node_id).aliases,
+          str(store.get_node(target.node_id).aliases))
+
+    print("\n── Rejection ───────────────────────────────────────────────────")
+
+    cs.reject(c_reject.correction_id, reviewed_by="admin-1", review_note="incorrect data")
+    check("rejection recorded",
+          c_reject.status == CorrectionStatus.REJECTED)
+    check("rejected correction note preserved",
+          c_reject.review_note == "incorrect data")
+    check("org name unchanged after rejection",
+          store.get_node(org.node_id).name == "Apple")
+
+    print("\n── Double-review guard ─────────────────────────────────────────")
+
+    try:
+        cs.approve(c_rename.correction_id, reviewed_by="admin-2")
+        check("double-approve prevented", False, "no exception raised")
+    except ValueError:
+        check("double-approve prevented", True)
+
+    try:
+        cs.reject(c_reject.correction_id, reviewed_by="admin-2")
+        check("double-reject prevented", False, "no exception raised")
+    except ValueError:
+        check("double-reject prevented", True)
+
+    print("\n── Query helpers ───────────────────────────────────────────────")
+
+    pending = cs.list_corrections(status=CorrectionStatus.PENDING)
+    check("no pending corrections remain", len(pending) == 0, f"found {len(pending)}")
+
+    approved_list = cs.list_corrections(status=CorrectionStatus.APPROVED)
+    check("6 approved corrections", len(approved_list) == 6, f"found {len(approved_list)}")
+
+    by_entity = cs.list_corrections(entity_id=target.node_id)
+    check("list_corrections filters by entity", all(c.entity_id == target.node_id for c in by_entity))
+
+    fetched = cs.get(c_rename.correction_id)
+    check("get() returns correct correction", fetched is not None and fetched.correction_id == c_rename.correction_id)
+
+
+def main() -> None:
+    print("verify-entity-corrections smoke test")
+    print("=" * 50)
+    try:
+        run()
+    except Exception:
+        traceback.print_exc()
+        print(f"\n{FAIL}  Unhandled exception — see traceback above")
+        sys.exit(1)
+
+    passed = sum(1 for _, ok, _ in results if ok)
+    failed = sum(1 for _, ok, _ in results if not ok)
+    print(f"\n{'=' * 50}")
+    print(f"Results: {passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)
+    print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.mcp.json
+++ b/.mcp.json
@@ -100,6 +100,14 @@
         "tools/argument_mcp/server.py"
       ],
       "env": {}
+    },
+    "neuronews-kg": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/kg_mcp/server.py"
+      ],
+      "env": {}
     }
   }
 }

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -24,6 +24,7 @@ REPORT_ROUTES_AVAILABLE = False
 ALERT_ROUTES_AVAILABLE = False
 ARGUMENT_ROUTES_AVAILABLE = False
 KG_STREAM_ROUTES_AVAILABLE = False
+ENTITY_CORRECTION_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -294,6 +295,19 @@ def try_import_kg_stream_routes():
         return False
 
 
+def try_import_entity_correction_routes():
+    """Try to import user-driven entity correction routes (issue #44)."""
+    global ENTITY_CORRECTION_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import entity_correction_routes
+        _imported_modules['entity_correction_routes'] = entity_correction_routes
+        ENTITY_CORRECTION_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        ENTITY_CORRECTION_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -345,6 +359,7 @@ def check_all_imports():
     try_import_alert_routes()
     try_import_argument_routes()
     try_import_kg_stream_routes()
+    try_import_entity_correction_routes()
     _load_domain_packs()
 
 
@@ -631,6 +646,13 @@ def include_optional_routers(app):
             app.include_router(kg_stream_routes.router)
             routers_included += 1
 
+    # Include entity correction routes (issue #44)
+    if ENTITY_CORRECTION_ROUTES_AVAILABLE:
+        entity_correction_routes = _imported_modules.get('entity_correction_routes')
+        if entity_correction_routes:
+            app.include_router(entity_correction_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -718,6 +740,7 @@ async def root():
             "influence_analysis": INFLUENCE_ANALYSIS_AVAILABLE,
             "document_routes": DOCUMENT_ROUTES_AVAILABLE,
             "kg_stream": KG_STREAM_ROUTES_AVAILABLE,
+            "entity_corrections": ENTITY_CORRECTION_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/entity_correction_routes.py
+++ b/src/api/routes/entity_correction_routes.py
@@ -1,0 +1,301 @@
+"""
+Entity correction routes — Issue #44.
+
+Trusted users (PREMIUM+) submit corrections; admins approve or reject them.
+
+User endpoints  (require READ_KNOWLEDGE_GRAPH permission):
+  GET  /entities/{entity_id}                          entity details from live KG
+  POST /entities/{entity_id}/corrections              submit a correction
+  GET  /entities/{entity_id}/corrections              correction history for entity
+
+Admin endpoints  (require UPDATE_KNOWLEDGE_GRAPH permission):
+  GET  /admin/entity-corrections                      all pending corrections
+  GET  /admin/entity-corrections/{correction_id}      single correction detail
+  POST /admin/entity-corrections/{correction_id}/approve   approve + apply
+  POST /admin/entity-corrections/{correction_id}/reject    reject
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from src.api.auth.jwt_auth import require_auth
+
+router = APIRouter(tags=["entity-corrections"])
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+def _require_trusted(user: dict = Depends(require_auth)) -> dict:
+    """PREMIUM or ADMIN users may submit corrections."""
+    role = user.get("role", "").lower()
+    if role not in ("premium", "admin", "administrator"):
+        raise HTTPException(
+            status_code=403,
+            detail="A Premium or Admin account is required to submit entity corrections",
+        )
+    return user
+
+
+def _require_admin(user: dict = Depends(require_auth)) -> dict:
+    """Only ADMINs may approve or reject corrections."""
+    role = user.get("role", "").lower()
+    if role not in ("admin", "administrator"):
+        raise HTTPException(
+            status_code=403,
+            detail="Admin privileges required to review entity corrections",
+        )
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Lazy loaders (keep heavy imports out of module scope)
+# ---------------------------------------------------------------------------
+
+def _store():
+    from src.knowledge_graph.entity_corrections import get_correction_store
+    return get_correction_store()
+
+
+def _kg_store():
+    from src.knowledge_graph.kg_updater import _shared_store
+    return _shared_store()
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+class CorrectionSubmitRequest(BaseModel):
+    correction_type: str = Field(
+        ...,
+        description=(
+            "One of: rename | add_alias | remove_alias | "
+            "add_property | remove_property | merge"
+        ),
+    )
+    payload: Dict[str, Any] = Field(
+        ...,
+        description=(
+            "Type-specific data. "
+            "rename → {new_name}; "
+            "add_alias / remove_alias → {alias}; "
+            "add_property → {key, value}; "
+            "remove_property → {key}; "
+            "merge → {merge_from: entity_id}"
+        ),
+    )
+    reason: str = Field(..., min_length=5, description="Why this correction is needed")
+
+
+# ---------------------------------------------------------------------------
+# User endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/entities/{entity_id}", response_model=Dict[str, Any])
+async def get_entity(
+    entity_id: str,
+    user: dict = Depends(require_auth),
+):
+    """
+    Return the current state of a knowledge-graph entity by its node id.
+
+    The node id has the form ``{type_lower}:{12-char-hex}`` — e.g.
+    ``person:4a7f2c9d1b3e``.  Use ``GET /kg/stats`` to see total counts or
+    ``GET /kg/topics/evolving`` to find active entity names.
+    """
+    node = _kg_store().get_node(entity_id)
+    if node is None:
+        raise HTTPException(
+            status_code=404, detail=f"Entity {entity_id!r} not found in the knowledge graph"
+        )
+    return node.to_dict()
+
+
+@router.post("/entities/{entity_id}/corrections", response_model=Dict[str, Any], status_code=201)
+async def submit_correction(
+    entity_id: str,
+    body: CorrectionSubmitRequest,
+    user: dict = Depends(_require_trusted),
+):
+    """
+    Submit a correction request for an entity.
+
+    The correction is stored as **pending** and visible to admins in the review
+    queue.  It is NOT applied to the live knowledge graph until an admin
+    approves it via ``POST /admin/entity-corrections/{id}/approve``.
+
+    **Correction types and required payload fields**
+
+    | type            | required payload keys         |
+    |-----------------|-------------------------------|
+    | rename          | new_name                      |
+    | add_alias       | alias                         |
+    | remove_alias    | alias                         |
+    | add_property    | key, value                    |
+    | remove_property | key                           |
+    | merge           | merge_from (source entity id) |
+    """
+    from src.knowledge_graph.entity_corrections import CorrectionType
+
+    # Validate correction_type enum
+    try:
+        ct = CorrectionType(body.correction_type)
+    except ValueError:
+        valid = [t.value for t in CorrectionType]
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown correction_type {body.correction_type!r}. Valid: {valid}",
+        )
+
+    # Ensure target entity exists in the KG (except for merge where source is checked at apply)
+    if ct != CorrectionType.MERGE:
+        if _kg_store().get_node(entity_id) is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Entity {entity_id!r} not found in the knowledge graph",
+            )
+
+    try:
+        correction = _store().submit(
+            entity_id=entity_id,
+            correction_type=ct,
+            payload=body.payload,
+            reason=body.reason,
+            submitted_by=user.get("sub", user.get("user_id", "unknown")),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return correction.to_dict()
+
+
+@router.get("/entities/{entity_id}/corrections", response_model=List[Dict[str, Any]])
+async def list_entity_corrections(
+    entity_id: str,
+    status: Optional[str] = Query(None, description="Filter: pending | approved | rejected"),
+    limit: int = Query(50, ge=1, le=200),
+    user: dict = Depends(require_auth),
+):
+    """
+    List the full correction history for a specific entity, newest first.
+    """
+    from src.knowledge_graph.entity_corrections import CorrectionStatus
+
+    status_filter = None
+    if status is not None:
+        try:
+            status_filter = CorrectionStatus(status)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown status {status!r}. Valid: pending, approved, rejected",
+            )
+
+    corrections = _store().list_corrections(
+        entity_id=entity_id, status=status_filter, limit=limit
+    )
+    return [c.to_dict() for c in corrections]
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/admin/entity-corrections", response_model=List[Dict[str, Any]])
+async def list_all_corrections(
+    status: Optional[str] = Query("pending", description="Filter: pending | approved | rejected | all"),
+    entity_id: Optional[str] = Query(None, description="Filter by entity id"),
+    limit: int = Query(50, ge=1, le=200),
+    admin: dict = Depends(_require_admin),
+):
+    """
+    Admin view of all entity correction requests.
+
+    Defaults to showing only **pending** corrections (the review queue).
+    Pass ``status=all`` to see the full history.
+    """
+    from src.knowledge_graph.entity_corrections import CorrectionStatus
+
+    status_filter: Optional[CorrectionStatus] = None
+    if status and status != "all":
+        try:
+            status_filter = CorrectionStatus(status)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown status {status!r}. Valid: pending, approved, rejected, all",
+            )
+
+    corrections = _store().list_corrections(
+        entity_id=entity_id, status=status_filter, limit=limit
+    )
+    return [c.to_dict() for c in corrections]
+
+
+@router.get("/admin/entity-corrections/{correction_id}", response_model=Dict[str, Any])
+async def get_correction(
+    correction_id: str,
+    admin: dict = Depends(_require_admin),
+):
+    """Return full details of a single correction request."""
+    correction = _store().get(correction_id)
+    if correction is None:
+        raise HTTPException(status_code=404, detail=f"Correction {correction_id!r} not found")
+    return correction.to_dict()
+
+
+@router.post("/admin/entity-corrections/{correction_id}/approve", response_model=Dict[str, Any])
+async def approve_correction(
+    correction_id: str,
+    note: Optional[str] = Body(default=None, description="Optional reviewer note"),
+    admin: dict = Depends(_require_admin),
+):
+    """
+    Approve a pending correction and immediately apply it to the live
+    knowledge graph.
+
+    The admin's user id and the current timestamp are recorded on the
+    correction for traceability.
+    """
+    try:
+        correction = _store().approve(
+            correction_id=correction_id,
+            reviewed_by=admin.get("sub", admin.get("user_id", "unknown")),
+            review_note=note,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    return correction.to_dict()
+
+
+@router.post("/admin/entity-corrections/{correction_id}/reject", response_model=Dict[str, Any])
+async def reject_correction(
+    correction_id: str,
+    note: Optional[str] = Body(default=None, description="Optional reviewer note"),
+    admin: dict = Depends(_require_admin),
+):
+    """
+    Reject a pending correction.  No knowledge-graph change is made.
+
+    The rejection reason (``note``) is recorded for the submitter to see.
+    """
+    try:
+        correction = _store().reject(
+            correction_id=correction_id,
+            reviewed_by=admin.get("sub", admin.get("user_id", "unknown")),
+            review_note=note,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    return correction.to_dict()

--- a/src/knowledge_graph/entity_corrections.py
+++ b/src/knowledge_graph/entity_corrections.py
@@ -1,0 +1,353 @@
+"""
+User-driven entity corrections — Issue #44.
+
+Trusted users (PREMIUM+) can submit corrections to knowledge-graph entities.
+Admins review, approve (applying the change to the live store), or reject.
+
+Every action is version-stamped per entity so the full history is auditable.
+
+Correction types:
+  rename           change the entity's canonical display name
+  add_alias        add a surface-form alias
+  remove_alias     remove a surface-form alias
+  add_property     set/update an arbitrary property key
+  remove_property  delete a property key
+  merge            absorb another entity's triples into this one
+
+The store is an in-memory singleton (thread-safe).  Applied corrections mutate
+the live KnowledgeGraphStore from kg_updater.py.
+"""
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+class CorrectionType(str, Enum):
+    RENAME = "rename"
+    ADD_ALIAS = "add_alias"
+    REMOVE_ALIAS = "remove_alias"
+    ADD_PROPERTY = "add_property"
+    REMOVE_PROPERTY = "remove_property"
+    MERGE = "merge"
+
+
+class CorrectionStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+# Payload shapes per correction type:
+#   rename:           {"new_name": str}
+#   add_alias:        {"alias": str}
+#   remove_alias:     {"alias": str}
+#   add_property:     {"key": str, "value": Any}
+#   remove_property:  {"key": str}
+#   merge:            {"merge_from": str}   # entity_id to absorb
+
+
+@dataclass
+class EntityCorrection:
+    """One proposed change to a KG entity."""
+
+    correction_id: str
+    entity_id: str
+    correction_type: CorrectionType
+    payload: Dict[str, Any]
+    reason: str
+    submitted_by: str
+    submitted_at: datetime
+    version: int                         # monotonic per entity
+    status: CorrectionStatus = CorrectionStatus.PENDING
+    reviewed_by: Optional[str] = None
+    reviewed_at: Optional[datetime] = None
+    review_note: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "correction_id": self.correction_id,
+            "entity_id": self.entity_id,
+            "correction_type": self.correction_type.value,
+            "payload": self.payload,
+            "reason": self.reason,
+            "submitted_by": self.submitted_by,
+            "submitted_at": self.submitted_at.isoformat(),
+            "version": self.version,
+            "status": self.status.value,
+            "reviewed_by": self.reviewed_by,
+            "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "review_note": self.review_note,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Singleton correction store
+# ---------------------------------------------------------------------------
+
+class EntityCorrectionStore:
+    """Thread-safe in-memory store for entity correction requests."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # correction_id -> EntityCorrection
+        self._corrections: Dict[str, EntityCorrection] = {}
+        # entity_id -> monotonic version counter
+        self._entity_version: Dict[str, int] = defaultdict(int)
+
+    # ---- submission --------------------------------------------------------
+
+    def submit(
+        self,
+        entity_id: str,
+        correction_type: CorrectionType,
+        payload: Dict[str, Any],
+        reason: str,
+        submitted_by: str,
+    ) -> EntityCorrection:
+        """Create a new pending correction and return it."""
+        _validate_payload(correction_type, payload)
+
+        with self._lock:
+            self._entity_version[entity_id] += 1
+            version = self._entity_version[entity_id]
+            correction = EntityCorrection(
+                correction_id=str(uuid.uuid4()),
+                entity_id=entity_id,
+                correction_type=correction_type,
+                payload=dict(payload),
+                reason=reason,
+                submitted_by=submitted_by,
+                submitted_at=datetime.now(timezone.utc),
+                version=version,
+            )
+            self._corrections[correction.correction_id] = correction
+        return correction
+
+    # ---- review ------------------------------------------------------------
+
+    def approve(
+        self,
+        correction_id: str,
+        reviewed_by: str,
+        review_note: Optional[str] = None,
+    ) -> EntityCorrection:
+        """Mark a correction approved and apply it to the live KG store."""
+        with self._lock:
+            c = self._get_or_raise(correction_id)
+            if c.status != CorrectionStatus.PENDING:
+                raise ValueError(
+                    f"Correction {correction_id!r} is already {c.status.value}"
+                )
+            _apply_correction(c)
+            c.status = CorrectionStatus.APPROVED
+            c.reviewed_by = reviewed_by
+            c.reviewed_at = datetime.now(timezone.utc)
+            c.review_note = review_note
+        return c
+
+    def reject(
+        self,
+        correction_id: str,
+        reviewed_by: str,
+        review_note: Optional[str] = None,
+    ) -> EntityCorrection:
+        """Mark a correction rejected (no KG change)."""
+        with self._lock:
+            c = self._get_or_raise(correction_id)
+            if c.status != CorrectionStatus.PENDING:
+                raise ValueError(
+                    f"Correction {correction_id!r} is already {c.status.value}"
+                )
+            c.status = CorrectionStatus.REJECTED
+            c.reviewed_by = reviewed_by
+            c.reviewed_at = datetime.now(timezone.utc)
+            c.review_note = review_note
+        return c
+
+    # ---- queries -----------------------------------------------------------
+
+    def list_corrections(
+        self,
+        entity_id: Optional[str] = None,
+        status: Optional[CorrectionStatus] = None,
+        limit: int = 50,
+    ) -> List[EntityCorrection]:
+        with self._lock:
+            results = list(self._corrections.values())
+        if entity_id is not None:
+            results = [c for c in results if c.entity_id == entity_id]
+        if status is not None:
+            results = [c for c in results if c.status == status]
+        results.sort(key=lambda c: c.submitted_at, reverse=True)
+        return results[:limit]
+
+    def get(self, correction_id: str) -> Optional[EntityCorrection]:
+        with self._lock:
+            return self._corrections.get(correction_id)
+
+    # ---- internal ----------------------------------------------------------
+
+    def _get_or_raise(self, correction_id: str) -> EntityCorrection:
+        c = self._corrections.get(correction_id)
+        if c is None:
+            raise KeyError(f"Correction {correction_id!r} not found")
+        return c
+
+
+# ---------------------------------------------------------------------------
+# Process-level singleton
+# ---------------------------------------------------------------------------
+
+_store_lock = threading.Lock()
+_correction_store: Optional[EntityCorrectionStore] = None
+
+
+def get_correction_store() -> EntityCorrectionStore:
+    global _correction_store
+    with _store_lock:
+        if _correction_store is None:
+            _correction_store = EntityCorrectionStore()
+    return _correction_store
+
+
+# ---------------------------------------------------------------------------
+# Payload validation
+# ---------------------------------------------------------------------------
+
+def _validate_payload(correction_type: CorrectionType, payload: Dict[str, Any]) -> None:
+    required: Dict[CorrectionType, List[str]] = {
+        CorrectionType.RENAME: ["new_name"],
+        CorrectionType.ADD_ALIAS: ["alias"],
+        CorrectionType.REMOVE_ALIAS: ["alias"],
+        CorrectionType.ADD_PROPERTY: ["key", "value"],
+        CorrectionType.REMOVE_PROPERTY: ["key"],
+        CorrectionType.MERGE: ["merge_from"],
+    }
+    missing = [k for k in required[correction_type] if k not in payload]
+    if missing:
+        raise ValueError(
+            f"Correction type {correction_type.value!r} requires payload keys: "
+            f"{required[correction_type]}; missing: {missing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Apply an approved correction to the live KG store
+# ---------------------------------------------------------------------------
+
+def _apply_correction(correction: EntityCorrection) -> None:
+    """
+    Mutate the live KnowledgeGraphStore to reflect an approved correction.
+
+    Raises ``KeyError`` if the target entity doesn't exist in the store.
+    This is intentional: approving a correction for a non-existent entity is a
+    data error that the admin should see rather than silently ignore.
+    """
+    from src.knowledge_graph.kg_updater import _shared_store
+
+    store = _shared_store()
+    entity_id = correction.entity_id
+    ct = correction.correction_type
+    payload = correction.payload
+
+    # All types except MERGE need the target node to exist
+    if ct != CorrectionType.MERGE:
+        node = store.get_node(entity_id)
+        if node is None:
+            raise KeyError(f"Entity {entity_id!r} not found in the knowledge graph")
+
+    if ct == CorrectionType.RENAME:
+        node = store.get_node(entity_id)
+        node.name = payload["new_name"]
+
+    elif ct == CorrectionType.ADD_ALIAS:
+        node = store.get_node(entity_id)
+        alias = payload["alias"]
+        if alias not in node.aliases:
+            node.aliases.append(alias)
+
+    elif ct == CorrectionType.REMOVE_ALIAS:
+        node = store.get_node(entity_id)
+        alias = payload["alias"]
+        if alias in node.aliases:
+            node.aliases.remove(alias)
+
+    elif ct == CorrectionType.ADD_PROPERTY:
+        node = store.get_node(entity_id)
+        node.properties[payload["key"]] = payload["value"]
+
+    elif ct == CorrectionType.REMOVE_PROPERTY:
+        node = store.get_node(entity_id)
+        node.properties.pop(payload["key"], None)
+
+    elif ct == CorrectionType.MERGE:
+        merge_from_id = payload["merge_from"]
+        _apply_merge(store, target_id=entity_id, source_id=merge_from_id)
+
+
+def _apply_merge(store: Any, target_id: str, source_id: str) -> None:
+    """
+    Absorb ``source_id`` into ``target_id``:
+      1. Copy source's aliases and properties onto the target.
+      2. Rewrite every triple that references source_id to target_id.
+      3. Remove the source node and its triples from the store.
+    """
+    target = store.get_node(target_id)
+    source = store.get_node(source_id)
+    if target is None:
+        raise KeyError(f"Merge target {target_id!r} not found")
+    if source is None:
+        raise KeyError(f"Merge source {source_id!r} not found")
+
+    # Merge aliases (dedup)
+    for alias in source.aliases + [source.name]:
+        if alias not in target.aliases and alias != target.name:
+            target.aliases.append(alias)
+
+    # Merge properties (target wins on conflict)
+    for k, v in source.properties.items():
+        target.properties.setdefault(k, v)
+
+    # Rewrite triples; collect keys to delete
+    to_delete = []
+    to_add = []
+    for key, triple in list(store._triples.items()):
+        if triple.subject == source_id or triple.object == source_id:
+            to_delete.append(key)
+            from src.knowledge_graph.foundation.model import Triple
+            new_subj = target_id if triple.subject == source_id else triple.subject
+            new_obj = target_id if triple.object == source_id else triple.object
+            # Skip self-loops that the merge would create
+            if new_subj == new_obj:
+                continue
+            new_triple = Triple(
+                subject=new_subj,
+                predicate=triple.predicate,
+                object=new_obj,
+                provenance=triple.provenance,
+                properties=dict(triple.properties),
+            )
+            to_add.append(new_triple)
+
+    for key in to_delete:
+        store._triples.pop(key, None)
+        store._provenance.pop(key, None)
+
+    for triple in to_add:
+        try:
+            store.add_triple(triple)
+        except Exception:
+            pass  # ontology violation after rewrite — skip
+
+    # Remove source node
+    store._nodes.pop(source_id, None)

--- a/tests/knowledge_graph/test_entity_corrections.py
+++ b/tests/knowledge_graph/test_entity_corrections.py
@@ -1,0 +1,357 @@
+"""
+Tests for the user-driven entity corrections system — Issue #44.
+
+Covers:
+- Submission (payload validation, version tracking)
+- Admin approval (applies change to the live KG store)
+- Admin rejection (no KG change)
+- All correction types: rename, add_alias, remove_alias, add_property,
+  remove_property, merge
+- Concurrent submissions are safe
+- Double-approve / double-reject raise ValueError
+"""
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset correction store and KG store before each test."""
+    import src.knowledge_graph.entity_corrections as ec
+    import src.knowledge_graph.kg_updater as ku
+
+    ec._correction_store = None
+    ku._store = None
+    ku._resolver = None
+    ku._events.clear()
+    yield
+    ec._correction_store = None
+    ku._store = None
+    ku._resolver = None
+    ku._events.clear()
+
+
+def _seed_entity(name: str = "Tim Cook", entity_type: str = "Person") -> str:
+    """Add an entity to the live KG store and return its node_id."""
+    from src.knowledge_graph.kg_updater import _shared_store
+    from src.knowledge_graph.foundation import Node, EntityType
+    store = _shared_store()
+    node = Node(type=EntityType(entity_type), name=name)
+    store.add_node(node)
+    return node.node_id
+
+
+def _submit(entity_id: str, correction_type: str, payload: Dict[str, Any], reason: str = "fix") -> Any:
+    from src.knowledge_graph.entity_corrections import (
+        CorrectionType, get_correction_store,
+    )
+    return get_correction_store().submit(
+        entity_id=entity_id,
+        correction_type=CorrectionType(correction_type),
+        payload=payload,
+        reason=reason,
+        submitted_by="user-42",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submission
+# ---------------------------------------------------------------------------
+
+class TestSubmit:
+    def test_returns_correction_with_pending_status(self):
+        from src.knowledge_graph.entity_corrections import CorrectionStatus
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "Timothy Cook"})
+        assert c.status == CorrectionStatus.PENDING
+        assert c.entity_id == entity_id
+        assert c.correction_type.value == "rename"
+
+    def test_versions_are_monotonic_per_entity(self):
+        entity_id = _seed_entity()
+        c1 = _submit(entity_id, "rename", {"new_name": "Name One"})
+        c2 = _submit(entity_id, "rename", {"new_name": "Name Two"})
+        assert c2.version == c1.version + 1
+
+    def test_versions_are_independent_per_entity(self):
+        e1 = _seed_entity("Alice", "Person")
+        e2 = _seed_entity("Google", "Organization")
+        c1 = _submit(e1, "rename", {"new_name": "Alice Smith"})
+        c2 = _submit(e2, "rename", {"new_name": "Alphabet Inc"})
+        assert c1.version == 1
+        assert c2.version == 1
+
+    def test_missing_payload_raises(self):
+        entity_id = _seed_entity()
+        with pytest.raises(ValueError, match="requires payload keys"):
+            _submit(entity_id, "rename", {})
+
+    def test_correction_id_is_unique(self):
+        entity_id = _seed_entity()
+        ids = {_submit(entity_id, "rename", {"new_name": f"Name{i}"}).correction_id for i in range(5)}
+        assert len(ids) == 5
+
+    def test_to_dict_is_serialisable(self):
+        import json
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "X"})
+        serialised = c.to_dict()
+        json.dumps(serialised)  # must not raise
+        assert serialised["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Approval
+# ---------------------------------------------------------------------------
+
+class TestApprove:
+    def test_status_changes_to_approved(self):
+        from src.knowledge_graph.entity_corrections import CorrectionStatus, get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "Tim Cook Jr"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin-1")
+        assert c.status == CorrectionStatus.APPROVED
+
+    def test_reviewer_and_timestamp_recorded(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "Tim Cook Jr"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin-1", review_note="confirmed")
+        assert c.reviewed_by == "admin-1"
+        assert c.review_note == "confirmed"
+        assert c.reviewed_at is not None
+
+    def test_double_approve_raises(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "X"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin-1")
+        with pytest.raises(ValueError, match="already approved"):
+            get_correction_store().approve(c.correction_id, reviewed_by="admin-2")
+
+    def test_approve_unknown_correction_raises(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        with pytest.raises(KeyError):
+            get_correction_store().approve("no-such-id", reviewed_by="admin")
+
+
+# ---------------------------------------------------------------------------
+# Rejection
+# ---------------------------------------------------------------------------
+
+class TestReject:
+    def test_status_changes_to_rejected(self):
+        from src.knowledge_graph.entity_corrections import CorrectionStatus, get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "Wrong Name"})
+        get_correction_store().reject(c.correction_id, reviewed_by="admin-1", review_note="not correct")
+        assert c.status == CorrectionStatus.REJECTED
+        assert c.review_note == "not correct"
+
+    def test_double_reject_raises(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "X"})
+        get_correction_store().reject(c.correction_id, reviewed_by="admin-1")
+        with pytest.raises(ValueError, match="already rejected"):
+            get_correction_store().reject(c.correction_id, reviewed_by="admin-2")
+
+
+# ---------------------------------------------------------------------------
+# Correction type: rename
+# ---------------------------------------------------------------------------
+
+class TestRename:
+    def test_renames_entity_in_kg(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        entity_id = _seed_entity("Jeff Bezos")
+        _submit(entity_id, "rename", {"new_name": "Jeffrey Preston Bezos"})
+        c = get_correction_store().list_corrections(entity_id=entity_id)[0]
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        node = _shared_store().get_node(entity_id)
+        assert node.name == "Jeffrey Preston Bezos"
+
+
+# ---------------------------------------------------------------------------
+# Correction type: add_alias / remove_alias
+# ---------------------------------------------------------------------------
+
+class TestAliases:
+    def test_add_alias(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        entity_id = _seed_entity("Apple")
+        c = _submit(entity_id, "add_alias", {"alias": "Apple Inc"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        node = _shared_store().get_node(entity_id)
+        assert "Apple Inc" in node.aliases
+
+    def test_remove_alias(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        from src.knowledge_graph.foundation import Node, EntityType
+        # Seed node with an alias
+        store = _shared_store()
+        node = Node(type=EntityType.ORGANIZATION, name="Apple", aliases=["Apple Inc"])
+        store.add_node(node)
+        entity_id = node.node_id
+        c = _submit(entity_id, "remove_alias", {"alias": "Apple Inc"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        assert "Apple Inc" not in store.get_node(entity_id).aliases
+
+    def test_add_duplicate_alias_is_idempotent(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        entity_id = _seed_entity("Tesla")
+        c1 = _submit(entity_id, "add_alias", {"alias": "Tesla Inc"})
+        c2 = _submit(entity_id, "add_alias", {"alias": "Tesla Inc"})
+        get_correction_store().approve(c1.correction_id, reviewed_by="admin")
+        get_correction_store().approve(c2.correction_id, reviewed_by="admin")
+        node = _shared_store().get_node(entity_id)
+        assert node.aliases.count("Tesla Inc") == 1
+
+
+# ---------------------------------------------------------------------------
+# Correction type: add_property / remove_property
+# ---------------------------------------------------------------------------
+
+class TestProperties:
+    def test_add_property(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        entity_id = _seed_entity("Elon Musk")
+        c = _submit(entity_id, "add_property", {"key": "role", "value": "CEO"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        node = _shared_store().get_node(entity_id)
+        assert node.properties.get("role") == "CEO"
+
+    def test_remove_property(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        from src.knowledge_graph.foundation import Node, EntityType
+        store = _shared_store()
+        node = Node(type=EntityType.PERSON, name="Elon Musk", properties={"role": "CEO"})
+        store.add_node(node)
+        entity_id = node.node_id
+        c = _submit(entity_id, "remove_property", {"key": "role"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        assert "role" not in store.get_node(entity_id).properties
+
+    def test_remove_nonexistent_property_is_safe(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "remove_property", {"key": "does_not_exist"})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+
+
+# ---------------------------------------------------------------------------
+# Correction type: merge
+# ---------------------------------------------------------------------------
+
+class TestMerge:
+    def test_merge_copies_aliases_to_target(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        from src.knowledge_graph.foundation import Node, EntityType
+        store = _shared_store()
+        target = Node(type=EntityType.ORGANIZATION, name="Google")
+        source = Node(type=EntityType.ORGANIZATION, name="Alphabet", aliases=["Alphabet Inc"])
+        store.add_node(target)
+        store.add_node(source)
+        c = _submit(target.node_id, "merge", {"merge_from": source.node_id})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        t = store.get_node(target.node_id)
+        assert "Alphabet" in t.aliases or "Alphabet Inc" in t.aliases
+
+    def test_merge_removes_source_node(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        from src.knowledge_graph.kg_updater import _shared_store
+        from src.knowledge_graph.foundation import Node, EntityType
+        store = _shared_store()
+        target = Node(type=EntityType.ORGANIZATION, name="Google")
+        source = Node(type=EntityType.ORGANIZATION, name="Alphabet")
+        store.add_node(target)
+        store.add_node(source)
+        source_id = source.node_id
+        c = _submit(target.node_id, "merge", {"merge_from": source_id})
+        get_correction_store().approve(c.correction_id, reviewed_by="admin")
+        assert store.get_node(source_id) is None
+
+
+# ---------------------------------------------------------------------------
+# List / query
+# ---------------------------------------------------------------------------
+
+class TestList:
+    def test_list_by_status(self):
+        from src.knowledge_graph.entity_corrections import CorrectionStatus, get_correction_store
+        e1 = _seed_entity("Alice", "Person")
+        e2 = _seed_entity("Bob", "Person")
+        c1 = _submit(e1, "rename", {"new_name": "Alice Smith"})
+        _submit(e2, "rename", {"new_name": "Robert"})
+        get_correction_store().approve(c1.correction_id, reviewed_by="admin")
+        pending = get_correction_store().list_corrections(status=CorrectionStatus.PENDING)
+        approved = get_correction_store().list_corrections(status=CorrectionStatus.APPROVED)
+        assert len(pending) == 1
+        assert len(approved) == 1
+
+    def test_list_by_entity(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        e1 = _seed_entity("Alice", "Person")
+        e2 = _seed_entity("Bob", "Person")
+        _submit(e1, "rename", {"new_name": "Alice Smith"})
+        _submit(e2, "rename", {"new_name": "Robert"})
+        results = get_correction_store().list_corrections(entity_id=e1)
+        assert all(c.entity_id == e1 for c in results)
+        assert len(results) == 1
+
+    def test_get_by_id(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        c = _submit(entity_id, "rename", {"new_name": "X"})
+        found = get_correction_store().get(c.correction_id)
+        assert found is not None
+        assert found.correction_id == c.correction_id
+
+    def test_get_unknown_returns_none(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        assert get_correction_store().get("no-such-id") is None
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestConcurrency:
+    def test_concurrent_submissions_are_safe(self):
+        from src.knowledge_graph.entity_corrections import get_correction_store
+        entity_id = _seed_entity()
+        errors = []
+
+        def _run(i):
+            try:
+                _submit(entity_id, "rename", {"new_name": f"Name {i}"})
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=_run, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        store = get_correction_store()
+        corrections = store.list_corrections(entity_id=entity_id, limit=100)
+        assert len(corrections) == 20
+        versions = sorted(c.version for c in corrections)
+        assert versions == list(range(1, 21))

--- a/tools/kg_mcp/server.py
+++ b/tools/kg_mcp/server.py
@@ -1,0 +1,282 @@
+"""
+NeuroNews Knowledge-Graph inspector — MCP server.
+
+Token-efficient read-only access to:
+  • The live in-process KnowledgeGraphStore (nodes + triples)
+  • The entity-correction queue (pending / approved / rejected)
+  • The KG ontology (entity types, relation types, allowed pairs)
+  • Emerging-connections and evolving-topics summaries
+
+Tools:
+
+  kg_stats()                             -> node/triple counts + status
+  kg_ontology()                          -> entity types, relation types, constraints
+  list_entities(type?, name_filter?,     -> compact node list
+                limit?)
+  get_entity(entity_id)                  -> full node details + neighbour count
+  list_corrections(status?,              -> correction queue / history
+                   entity_id?, limit?)
+  get_correction(correction_id)          -> single correction detail
+  emerging_connections(since_minutes?,   -> new KG edges in the time window
+                       limit?)
+  evolving_topics(window_minutes?,       -> entities with recent edge bursts
+                  top_n?)
+
+Design constraints (same as other NeuroNews MCP servers):
+  * Lazy imports inside each tool — top-level imports are stdlib + fastmcp only.
+  * All results are capped summaries, never full payloads.
+  * Read-only: no tool mutates the KG store or the correction store.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+mcp = FastMCP("neuronews-kg")
+
+MAX_LIST = 50
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_kg_store():
+    from src.knowledge_graph.kg_updater import _shared_store
+    return _shared_store()
+
+
+def _get_correction_store():
+    from src.knowledge_graph.entity_corrections import get_correction_store
+    return get_correction_store()
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def kg_stats() -> dict:
+    """
+    Return current KnowledgeGraphStore statistics.
+
+    Fields: node_count, triple_count, total_update_events, triple_events,
+    node_events, status.
+    """
+    from src.knowledge_graph.kg_updater import get_store_stats
+    return get_store_stats()
+
+
+@mcp.tool()
+def kg_ontology() -> dict:
+    """
+    Return the KG ontology: entity types, relation types, and which
+    (subject_type, object_type) pairs each relation allows.
+
+    Use this instead of reading src/knowledge_graph/foundation/ontology.py.
+    """
+    from src.knowledge_graph.foundation.ontology import (
+        EntityType, RelationType, allowed_pairs,
+    )
+    return {
+        "entity_types": [e.value for e in EntityType],
+        "relation_types": [r.value for r in RelationType],
+        "constraints": {
+            rel.value: [
+                {"subject": s.value, "object": o.value}
+                for s, o in sorted(allowed_pairs(rel))
+            ]
+            for rel in RelationType
+        },
+    }
+
+
+@mcp.tool()
+def list_entities(
+    entity_type: Optional[str] = None,
+    name_filter: Optional[str] = None,
+    limit: int = MAX_LIST,
+) -> list:
+    """
+    List nodes in the live KG store.
+
+    Args:
+        entity_type:  Filter by type (Person, Organization, Concept, …).
+                      Omit to list all types.
+        name_filter:  Case-insensitive substring filter on node name.
+        limit:        Max results (default 50).
+
+    Returns a list of {node_id, type, name, alias_count, property_count}.
+    Use get_entity(node_id) for full details.
+    """
+    from src.knowledge_graph.foundation.ontology import EntityType
+
+    store = _get_kg_store()
+
+    if entity_type is not None:
+        try:
+            etype = EntityType(entity_type)
+        except ValueError:
+            valid = [e.value for e in EntityType]
+            return [{"error": f"Unknown entity_type {entity_type!r}. Valid: {valid}"}]
+        nodes = store.nodes_by_type(etype)
+    else:
+        nodes = list(store._nodes.values())
+
+    if name_filter:
+        nf = name_filter.lower()
+        nodes = [n for n in nodes if nf in n.name.lower()]
+
+    nodes = nodes[:limit]
+    return [
+        {
+            "node_id": n.node_id,
+            "type": n.type.value,
+            "name": n.name,
+            "alias_count": len(n.aliases),
+            "property_count": len(n.properties),
+        }
+        for n in nodes
+    ]
+
+
+@mcp.tool()
+def get_entity(entity_id: str) -> dict:
+    """
+    Return full details of a KG node plus its neighbour count.
+
+    Args:
+        entity_id:  The node id (e.g. ``person:4a7f2c9d1b3e``).
+    """
+    store = _get_kg_store()
+    node = store.get_node(entity_id)
+    if node is None:
+        return {"error": f"Entity {entity_id!r} not found"}
+
+    neighbours = store.neighbors(entity_id)
+    return {
+        **node.to_dict(),
+        "neighbour_count": len(neighbours),
+        "neighbours_sample": [
+            {
+                "predicate": t.predicate.value,
+                "other_id": t.object if t.subject == entity_id else t.subject,
+            }
+            for t in neighbours[:5]
+        ],
+    }
+
+
+@mcp.tool()
+def list_corrections(
+    status: Optional[str] = "pending",
+    entity_id: Optional[str] = None,
+    limit: int = MAX_LIST,
+) -> list:
+    """
+    List entity correction requests.
+
+    Args:
+        status:     pending | approved | rejected | all  (default: pending)
+        entity_id:  Filter to one entity's corrections.
+        limit:      Max results (default 50).
+
+    Returns compact correction summaries. Use get_correction(id) for details.
+    """
+    from src.knowledge_graph.entity_corrections import CorrectionStatus
+
+    cs = _get_correction_store()
+    status_filter = None
+    if status and status != "all":
+        try:
+            status_filter = CorrectionStatus(status)
+        except ValueError:
+            return [{"error": f"Unknown status {status!r}. Valid: pending, approved, rejected, all"}]
+
+    corrections = cs.list_corrections(entity_id=entity_id, status=status_filter, limit=limit)
+    return [
+        {
+            "correction_id": c.correction_id,
+            "entity_id": c.entity_id,
+            "correction_type": c.correction_type.value,
+            "status": c.status.value,
+            "submitted_by": c.submitted_by,
+            "submitted_at": c.submitted_at.isoformat(),
+            "version": c.version,
+            "reason": c.reason[:80],
+        }
+        for c in corrections
+    ]
+
+
+@mcp.tool()
+def get_correction(correction_id: str) -> dict:
+    """
+    Return full details of a single entity correction request.
+
+    Args:
+        correction_id:  UUID of the correction.
+    """
+    cs = _get_correction_store()
+    c = cs.get(correction_id)
+    if c is None:
+        return {"error": f"Correction {correction_id!r} not found"}
+    return c.to_dict()
+
+
+@mcp.tool()
+def emerging_connections(
+    since_minutes: int = 60,
+    limit: int = 20,
+) -> list:
+    """
+    Return KG edges that were added in the last ``since_minutes`` minutes.
+
+    Each item shows subject entity, predicate, object entity, source document,
+    and timestamp. Use to monitor newly discovered relationships.
+
+    Args:
+        since_minutes:  Look-back window in minutes (default 60).
+        limit:          Max results (default 20).
+    """
+    from datetime import datetime, timezone, timedelta
+    from src.knowledge_graph.kg_updater import get_emerging_connections
+
+    since = datetime.now(timezone.utc) - timedelta(minutes=since_minutes)
+    return get_emerging_connections(since=since, limit=limit)
+
+
+@mcp.tool()
+def evolving_topics(
+    window_minutes: int = 60,
+    top_n: int = 15,
+) -> list:
+    """
+    Return entities ranked by how many new MENTIONS triples they received in
+    the last ``window_minutes`` minutes.
+
+    A high ``new_connections`` count signals a topic that many recently
+    ingested documents reference — i.e. an actively evolving topic.
+
+    Args:
+        window_minutes:  Look-back window in minutes (default 60).
+        top_n:           Maximum number of results (default 15).
+    """
+    from src.knowledge_graph.kg_updater import get_evolving_topics
+    return get_evolving_topics(window_seconds=window_minutes * 60, top_n=top_n)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

- Adds `src/knowledge_graph/entity_corrections.py`: thread-safe `EntityCorrectionStore` with full lifecycle (submit → pending → approved/rejected). Approved corrections are applied atomically to the live `KnowledgeGraphStore`. Six correction types: `rename`, `add_alias`, `remove_alias`, `add_property`, `remove_property`, `merge`. Every correction carries a per-entity monotonic version for traceability.
- Adds `src/api/routes/entity_correction_routes.py` with seven endpoints:
  - `GET /entities/{id}` — entity details from live KG
  - `POST /entities/{id}/corrections` — submit correction (PREMIUM+ role)
  - `GET /entities/{id}/corrections` — correction history
  - `GET /admin/entity-corrections` — admin review queue (defaults to pending)
  - `GET /admin/entity-corrections/{id}` — single correction detail
  - `POST /admin/entity-corrections/{id}/approve` — approve + apply to KG
  - `POST /admin/entity-corrections/{id}/reject` — reject with note
- Adds `tests/knowledge_graph/test_entity_corrections.py`: 26 tests covering all correction types, concurrency, double-review guards, and query helpers — all passing.
- Adds `tools/kg_mcp/server.py` (`neuronews-kg` MCP): 7 read-only tools for token-efficient KG inspection during development — `kg_stats`, `kg_ontology`, `list_entities`, `get_entity`, `list_corrections`, `get_correction`, `emerging_connections`, `evolving_topics`. Registered in `.mcp.json`.
- Adds `.claude/skills/verify-entity-corrections/` skill: smoke-tests the full correction lifecycle in 24 checks without needing an API server. Run via `PYTHONPATH=. python3 .claude/skills/verify-entity-corrections/smoke.py`.

Closes #44.

## Test plan

- [ ] `python -m pytest tests/knowledge_graph/test_entity_corrections.py -v` — 26/26 pass
- [ ] `PYTHONPATH=. python3 .claude/skills/verify-entity-corrections/smoke.py` — 24/24 pass
- [ ] `POST /entities/{id}/corrections` with a non-admin JWT → 201
- [ ] `POST /admin/entity-corrections/{id}/approve` as admin → 200, KG node mutated