### PR TITLE
R1: MCP host runtime - supervised session pool, TTL discovery cache, health in /ui/context

### DIFF
--- a/docs/genui.md
+++ b/docs/genui.md
@@ -49,8 +49,23 @@ Routes (`src/api/routes/genui_routes.py`, registered via the standard
 feature-flag pattern in `src/api/app.py`):
 
 - `POST /api/v1/ui/generate` — `{intent, source_type?, signals?}` → `{spec, meta}`
-- `GET /api/v1/ui/context` — merged ui_flags, availability map, LLM planner status
+- `GET /api/v1/ui/context` — merged ui_flags, availability map, LLM planner
+  status, MCP host health (per-server state / last-seen / tool counts)
 - `GET /api/v1/ui/panels` — the panel catalog
+
+### MCP host runtime (`src/mcp_host/`, R1)
+
+The API process supervises the repo's 12 `tools/*_mcp` stdio servers:
+pooled sessions with lazy connect and capped-backoff restart, a TTL
+discovery cache over `tools/list` (default 60s, `NOESIS_MCP_TTL`), and
+health states (connected / degraded / down) surfaced in the `mcp` block of
+`GET /api/v1/ui/context`. Status reads are lock-guarded snapshots — a hung
+server can never stall a request. Server list comes from `.mcp.json`
+(project python servers only). Kill switch: `NOESIS_MCP_HOST=off`;
+`TESTING=true` short-circuits entirely; without the `mcp` client SDK the
+host reports itself unavailable instead of failing. No planning behavior
+reads from it yet — that lands with R2/R3 (discovery-derived catalog,
+tool-sourced adaptivity).
 
 ### Frontend (`apps/web/src/genui/`)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,11 @@ umap-learn>=0.5.0
 # Local analytics warehouse (Snowflake alternative for local dev)
 duckdb>=1.0.0,<2.0.0
 
+# MCP host runtime (src/mcp_host): client SDK used to supervise the repo's
+# tools/*_mcp stdio servers from the API process. Optional at runtime: the
+# host reports itself unavailable when this is missing.
+mcp>=1.0.0
+
 # Media connector (#523) — all optional; connector degrades gracefully without them
 openai-whisper>=20231117   # local Whisper model inference (pip install openai-whisper)
 faster-whisper>=1.0.0      # faster CTranslate2-based Whisper (GPU/CPU)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -827,6 +827,20 @@ def initialize_app():
                 "Resource monitor could not be started", exc_info=True
             )
 
+    # Start the MCP host runtime (best-effort): supervised sessions for the
+    # repo's tools/*_mcp servers with health surfaced in /api/v1/ui/context.
+    # Connects are lazy and happen in a background thread, so API boot time
+    # is unaffected; TESTING and NOESIS_MCP_HOST=off short-circuit inside.
+    try:
+        from src.mcp_host import start_host, stop_host
+        if start_host() is not None:
+            app.add_event_handler("shutdown", stop_host)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "MCP host could not be started", exc_info=True
+        )
+
     return app
 
 

--- a/src/api/routes/genui_routes.py
+++ b/src/api/routes/genui_routes.py
@@ -3,8 +3,8 @@
 POST /api/v1/ui/generate turns a natural-language intent into a validated
 ``ui-spec-v1`` layout; GET /api/v1/ui/context exposes the adaptive inputs
 (merged domain-pack ui_flags, warehouse data availability, LLM planner
-status); GET /api/v1/ui/panels exposes the panel catalog the frontend
-renderer mirrors.
+status, MCP host health); GET /api/v1/ui/panels exposes the panel catalog
+the frontend renderer mirrors.
 """
 
 from typing import Any, Dict, List, Optional
@@ -17,6 +17,7 @@ from src.genui.catalog import panel_catalog_dict
 from src.genui.llm import llm_config, plan_with_llm
 from src.genui.planner import plan
 from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, validate_spec
+from src.mcp_host import host_status
 
 router = APIRouter(prefix="/api/v1/ui", tags=["generative_ui"])
 
@@ -108,6 +109,9 @@ def ui_context() -> Dict[str, Any]:
                 "enabled": config is not None,
                 "provider": config["provider"] if config else None,
             },
+            # R1: per-server MCP host health. A pure snapshot read - a hung
+            # or dead server can never stall this endpoint.
+            "mcp": host_status(),
         }
     except Exception as err:
         raise HTTPException(status_code=500, detail=f"UI context failed: {err}")

--- a/src/mcp_host/__init__.py
+++ b/src/mcp_host/__init__.py
@@ -1,0 +1,27 @@
+"""
+MCP host runtime for the API process (MCP rearchitecture plan, R1).
+
+Supervises the repo's ``tools/*_mcp`` stdio servers from inside the
+FastAPI process: pooled sessions with lazy connect and backoff restart, a
+TTL discovery cache over ``tools/list``, and a non-blocking health
+snapshot surfaced through ``GET /api/v1/ui/context``.
+"""
+
+from src.mcp_host.config import ServerSpec, load_server_specs
+from src.mcp_host.host import (
+    MCPHost,
+    get_host,
+    host_status,
+    start_host,
+    stop_host,
+)
+
+__all__ = [
+    "ServerSpec",
+    "load_server_specs",
+    "MCPHost",
+    "get_host",
+    "host_status",
+    "start_host",
+    "stop_host",
+]

--- a/src/mcp_host/config.py
+++ b/src/mcp_host/config.py
@@ -1,0 +1,78 @@
+"""
+MCP host configuration: which servers the API process supervises.
+
+The single source of truth is the repo's ``.mcp.json`` (the same file
+developer MCP hosts read), filtered down to the project's own stdio
+servers — the ``tools/*_mcp`` Python processes. Third-party servers in
+that file (npx-launched memory/playwright/postgres helpers) are for
+interactive tooling and are never supervised by the API.
+
+Stdlib-only on purpose: importing this module must never fail, otherwise
+the feature-flag route registration in src/api/app.py silently disables
+the endpoints that report host health.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MCP_JSON = REPO_ROOT / ".mcp.json"
+
+_PYTHON_COMMANDS = ("python", "python3")
+
+
+@dataclass(frozen=True)
+class ServerSpec:
+    """One supervised stdio MCP server."""
+
+    name: str
+    command: str
+    args: Tuple[str, ...]
+    env: Dict[str, str] = field(default_factory=dict)
+    cwd: str = str(REPO_ROOT)
+
+
+def _is_project_server(entry: dict) -> bool:
+    """Keep only the repo's own python stdio servers (tools/*_mcp)."""
+    if entry.get("type", "stdio") != "stdio":
+        return False
+    if entry.get("command") not in _PYTHON_COMMANDS:
+        return False
+    args = entry.get("args") or []
+    return bool(args) and isinstance(args[0], str) and args[0].startswith("tools/")
+
+
+def load_server_specs(path: Optional[Path] = None) -> List[ServerSpec]:
+    """Parse .mcp.json into the list of servers the host supervises.
+
+    Never raises: a missing or malformed file yields an empty list (the
+    host then reports zero servers rather than breaking API startup).
+    """
+    mcp_json = Path(path) if path is not None else DEFAULT_MCP_JSON
+    try:
+        raw = json.loads(mcp_json.read_text(encoding="utf-8"))
+        servers = raw.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            return []
+    except (OSError, ValueError):
+        return []
+
+    specs: List[ServerSpec] = []
+    for name, entry in servers.items():
+        if not isinstance(entry, dict) or not _is_project_server(entry):
+            continue
+        env = entry.get("env") or {}
+        specs.append(
+            ServerSpec(
+                name=str(name),
+                command=str(entry["command"]),
+                args=tuple(str(a) for a in entry.get("args", [])),
+                env={str(k): str(v) for k, v in env.items()},
+                cwd=str(mcp_json.parent),
+            )
+        )
+    return specs

--- a/src/mcp_host/host.py
+++ b/src/mcp_host/host.py
@@ -1,0 +1,374 @@
+"""
+The MCP host runtime (MCP rearchitecture plan, R1).
+
+Pooled, supervised FastMCP stdio sessions inside the API process:
+
+* **Lazy connect** — ``MCPHost.start()`` only spawns a daemon thread with a
+  private asyncio loop; the actual connects happen in background tasks, so
+  API boot time is unaffected.
+* **Supervision** — one task per server keeps a session alive, reconnecting
+  with capped exponential backoff. State transitions: connecting, then
+  connected, degraded on the first failure, down after
+  ``DOWN_AFTER_FAILURES`` consecutive failures.
+* **Discovery cache** — ``tools/list`` results are cached per server and
+  refreshed on a TTL; the cache is replaced (invalidated) on every
+  reconnect. Readers never trigger a live round-trip.
+* **Non-blocking status** — ``status()`` and ``tools()`` read a snapshot
+  guarded by a plain lock; they never await anything, so a hung server can
+  never stall a request (``GET /api/v1/ui/context`` reads this).
+
+No planning-behavior changes live here: this is the risky infrastructure,
+isolated, per the plan.
+
+The default session factory uses the ``mcp`` client SDK, imported lazily;
+when the SDK is missing the host reports itself unavailable instead of
+breaking imports. Unit tests inject fake session factories and never spawn
+processes.
+
+Environment:
+
+* ``NOESIS_MCP_HOST``  — ``auto`` (default) or ``off``/``0``/``false``.
+* ``NOESIS_MCP_TTL``   — discovery-cache TTL seconds (default 60).
+* ``TESTING``          — truthy short-circuits ``start_host()`` entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from src.mcp_host.config import ServerSpec, load_server_specs
+
+logger = logging.getLogger(__name__)
+
+# States a supervised server moves through.
+STATE_CONNECTING = "connecting"
+STATE_CONNECTED = "connected"
+STATE_DEGRADED = "degraded"
+STATE_DOWN = "down"
+
+DEFAULT_TTL_SECONDS = 60.0
+CONNECT_TIMEOUT = 15.0
+CALL_TIMEOUT = 10.0
+BACKOFF_BASE = 1.0
+BACKOFF_CAP = 60.0
+DOWN_AFTER_FAILURES = 3
+# Stagger initial connects so 12 subprocesses don't spawn in one burst.
+CONNECT_STAGGER = 0.1
+
+
+def backoff_delay(consecutive_failures: int) -> float:
+    """Capped exponential backoff for reconnect attempts."""
+    if consecutive_failures <= 0:
+        return 0.0
+    return min(BACKOFF_CAP, BACKOFF_BASE * (2 ** (consecutive_failures - 1)))
+
+
+def _utc_iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(timespec="seconds")
+
+
+@dataclass
+class _ServerStatus:
+    """Mutable per-server snapshot (guarded by MCPHost._lock)."""
+
+    state: str = STATE_CONNECTING
+    last_seen: Optional[float] = None
+    last_error: Optional[str] = None
+    consecutive_failures: int = 0
+    restarts: int = 0
+    tool_count: int = 0
+    tools: List[Dict[str, str]] = field(default_factory=list)
+    tools_refreshed: Optional[float] = None
+
+
+@contextlib.asynccontextmanager
+async def _default_session(spec: ServerSpec):
+    """Connect a real stdio session via the ``mcp`` client SDK.
+
+    Imported lazily so the host degrades gracefully (instead of breaking
+    API imports) when the SDK is not installed.
+    """
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=spec.command,
+        args=list(spec.args),
+        env={**os.environ, **spec.env},
+        cwd=spec.cwd,
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await asyncio.wait_for(session.initialize(), CONNECT_TIMEOUT)
+            yield session
+
+
+async def _list_tools(session: Any) -> List[Dict[str, str]]:
+    """One health-check round-trip; doubles as the discovery refresh."""
+    result = await asyncio.wait_for(session.list_tools(), CALL_TIMEOUT)
+    return [
+        {"name": tool.name, "description": (tool.description or "").strip()}
+        for tool in result.tools
+    ]
+
+
+def sdk_available() -> bool:
+    """True when the ``mcp`` client SDK is importable."""
+    try:
+        import mcp  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+class MCPHost:
+    """Supervises the project's MCP servers from a background thread."""
+
+    def __init__(
+        self,
+        specs: Optional[List[ServerSpec]] = None,
+        session_factory: Optional[Callable[[ServerSpec], Any]] = None,
+        ttl_seconds: Optional[float] = None,
+    ):
+        self.specs = list(specs) if specs is not None else load_server_specs()
+        self._session_factory = session_factory or _default_session
+        env_ttl = os.getenv("NOESIS_MCP_TTL", "").strip()
+        if ttl_seconds is not None:
+            self.ttl_seconds = float(ttl_seconds)
+        else:
+            try:
+                self.ttl_seconds = float(env_ttl) if env_ttl else DEFAULT_TTL_SECONDS
+            except ValueError:
+                self.ttl_seconds = DEFAULT_TTL_SECONDS
+
+        self._lock = threading.Lock()
+        self._statuses: Dict[str, _ServerStatus] = {
+            spec.name: _ServerStatus() for spec in self.specs
+        }
+        self._thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        # Created loop-less here (safe since 3.10) so stop() always has an
+        # object to signal, even mid-startup.
+        self._stop_event = asyncio.Event()
+        self._started = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn the supervisor thread; returns immediately (lazy connect)."""
+        if self._started or not self.specs:
+            self._started = True
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._run_loop, name="mcp-host", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal the supervisor loop to exit and join the thread.
+
+        Tolerates being called while the loop thread is still starting up:
+        it polls until the loop is running before signalling.
+        """
+        deadline = time.monotonic() + timeout
+        while self._thread is not None and self._thread.is_alive():
+            loop = self._loop
+            if loop is not None and loop.is_running():
+                loop.call_soon_threadsafe(self._stop_event.set)
+                break
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+        self._started = False
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        try:
+            loop.run_until_complete(self._supervise_all())
+        except Exception:  # pragma: no cover - defensive; must never kill the API
+            logger.exception("MCP host supervisor crashed")
+        finally:
+            with contextlib.suppress(Exception):
+                loop.close()
+
+    async def _supervise_all(self) -> None:
+        tasks = [
+            asyncio.create_task(self._supervise(spec, index))
+            for index, spec in enumerate(self.specs)
+        ]
+        await self._stop_event.wait()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    # -- per-server supervision --------------------------------------------
+
+    async def _supervise(self, spec: ServerSpec, index: int) -> None:
+        """Keep one server connected; reconnect with capped backoff."""
+        await asyncio.sleep(index * CONNECT_STAGGER)
+        first_connect = True
+        while not self._stop_event.is_set():
+            try:
+                async with self._session_factory(spec) as session:
+                    # Reconnect invalidates the discovery cache: the fresh
+                    # tools/list result replaces whatever was cached.
+                    tools = await _list_tools(session)
+                    self._mark_connected(spec.name, tools, reconnected=not first_connect)
+                    first_connect = False
+                    while not self._stop_event.is_set():
+                        await self._sleep_or_stop(self.ttl_seconds)
+                        if self._stop_event.is_set():
+                            break
+                        tools = await _list_tools(session)
+                        self._mark_connected(spec.name, tools)
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                failures = self._mark_failed(spec.name, err)
+                await self._sleep_or_stop(backoff_delay(failures))
+        return None
+
+    async def _sleep_or_stop(self, delay: float) -> None:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._stop_event.wait(), timeout=max(delay, 0.001))
+
+    # -- status bookkeeping --------------------------------------------------
+
+    def _mark_connected(
+        self, name: str, tools: List[Dict[str, str]], reconnected: bool = False
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            status = self._statuses[name]
+            status.state = STATE_CONNECTED
+            status.last_seen = now
+            status.last_error = None
+            status.consecutive_failures = 0
+            status.tools = tools
+            status.tool_count = len(tools)
+            status.tools_refreshed = now
+            if reconnected:
+                status.restarts += 1
+
+    def _mark_failed(self, name: str, err: Exception) -> int:
+        with self._lock:
+            status = self._statuses[name]
+            status.consecutive_failures += 1
+            status.last_error = f"{type(err).__name__}: {err}"[:300]
+            status.state = (
+                STATE_DOWN
+                if status.consecutive_failures >= DOWN_AFTER_FAILURES
+                else STATE_DEGRADED
+            )
+            return status.consecutive_failures
+
+    # -- non-blocking readers ------------------------------------------------
+
+    def status(self) -> Dict[str, Any]:
+        """Snapshot for /api/v1/ui/context; never awaits or blocks on IO."""
+        now = time.time()
+        with self._lock:
+            servers = {
+                name: {
+                    "state": s.state,
+                    "tool_count": s.tool_count,
+                    "last_seen": _utc_iso(s.last_seen),
+                    "last_error": s.last_error,
+                    "restarts": s.restarts,
+                    "cache_age_seconds": (
+                        round(now - s.tools_refreshed, 1)
+                        if s.tools_refreshed is not None
+                        else None
+                    ),
+                }
+                for name, s in self._statuses.items()
+            }
+        connected = sum(1 for s in servers.values() if s["state"] == STATE_CONNECTED)
+        return {
+            "enabled": True,
+            "ttl_seconds": self.ttl_seconds,
+            "total": len(servers),
+            "connected": connected,
+            "servers": servers,
+        }
+
+    def tools(self, server: Optional[str] = None) -> Dict[str, List[Dict[str, str]]]:
+        """Cached discovery results (name/description per tool), per server."""
+        with self._lock:
+            if server is not None:
+                status = self._statuses.get(server)
+                return {server: list(status.tools)} if status else {}
+            return {name: list(s.tools) for name, s in self._statuses.items()}
+
+
+# -- module-level singleton ---------------------------------------------------
+
+_host: Optional[MCPHost] = None
+_host_lock = threading.Lock()
+
+
+def _disabled_status(reason: str) -> Dict[str, Any]:
+    return {"enabled": False, "reason": reason, "servers": {}, "total": 0, "connected": 0}
+
+
+def host_enabled() -> Optional[str]:
+    """None when the host may run; otherwise the reason it must not."""
+    if os.environ.get("TESTING", "").strip().lower() in ("1", "true", "yes"):
+        return "testing"
+    if os.getenv("NOESIS_MCP_HOST", "auto").strip().lower() in ("off", "0", "false"):
+        return "disabled by NOESIS_MCP_HOST"
+    if not sdk_available():
+        return "mcp client SDK not installed"
+    return None
+
+
+def start_host() -> Optional[MCPHost]:
+    """Create and start the singleton host (no-op under TESTING / kill switch)."""
+    global _host
+    if host_enabled() is not None:
+        return None
+    with _host_lock:
+        if _host is None:
+            _host = MCPHost()
+            _host.start()
+        return _host
+
+
+def stop_host() -> None:
+    """Stop and drop the singleton host (used by app shutdown and tests)."""
+    global _host
+    with _host_lock:
+        host, _host = _host, None
+    if host is not None:
+        host.stop()
+
+
+def get_host() -> Optional[MCPHost]:
+    return _host
+
+
+def host_status() -> Dict[str, Any]:
+    """The ``mcp`` block for /api/v1/ui/context; always safe to call."""
+    reason = host_enabled()
+    if reason is not None:
+        return _disabled_status(reason)
+    host = _host
+    if host is None:
+        return _disabled_status("not started")
+    return host.status()

--- a/tests/unit/api/routes/test_genui_routes_coverage.py
+++ b/tests/unit/api/routes/test_genui_routes_coverage.py
@@ -48,6 +48,7 @@ def _panel_types(body):
 def _hermetic(monkeypatch):
     """Deterministic defaults; individual tests override per branch."""
     monkeypatch.setenv("NOESIS_GENUI_LLM", "off")
+    monkeypatch.setenv("NOESIS_MCP_HOST", "off")
     monkeypatch.setattr(mod, "data_availability", lambda: None)
     monkeypatch.setattr(mod, "merged_ui_flags", lambda: {})
 

--- a/tests/unit/api/routes/test_genui_routes_smoke.py
+++ b/tests/unit/api/routes/test_genui_routes_smoke.py
@@ -33,8 +33,10 @@ _spec.loader.exec_module(mod)
 @pytest.fixture
 def client(monkeypatch):
     # Hermetic adaptivity inputs: no DuckDB warehouse probe, no pack
-    # registry, no live LLM planner.
+    # registry, no live LLM planner, no MCP host (kill switch keeps the
+    # mcp block deterministic regardless of the SDK being installed).
     monkeypatch.setenv("NOESIS_GENUI_LLM", "off")
+    monkeypatch.setenv("NOESIS_MCP_HOST", "off")
     monkeypatch.setattr(mod, "data_availability", lambda: None)
     monkeypatch.setattr(mod, "merged_ui_flags", lambda: {})
     app = FastAPI()
@@ -98,13 +100,56 @@ def test_context_returns_adaptive_inputs(client):
     resp = client.get("/api/v1/ui/context")
     assert resp.status_code == 200
     body = resp.json()
-    assert set(body) == {"ui_flags", "availability", "availability_known", "llm"}
+    assert set(body) == {"ui_flags", "availability", "availability_known", "llm", "mcp"}
     assert body["ui_flags"] == {}
     assert body["availability"] is None
     assert body["availability_known"] is False
     assert set(body["llm"]) == {"enabled", "provider"}
     assert body["llm"]["enabled"] is False
     assert body["llm"]["provider"] is None
+    # R1: MCP host health block. Disabled here either by the repo-wide
+    # TESTING short-circuit or by the fixture's kill switch.
+    assert body["mcp"]["enabled"] is False
+    assert body["mcp"]["reason"] in ("testing", "disabled by NOESIS_MCP_HOST")
+    assert body["mcp"]["servers"] == {}
+
+
+def test_context_reports_mcp_host_health(client, monkeypatch):
+    """With a live host, the mcp block carries per-server status."""
+    monkeypatch.setattr(
+        mod,
+        "host_status",
+        lambda: {
+            "enabled": True,
+            "ttl_seconds": 60.0,
+            "total": 2,
+            "connected": 1,
+            "servers": {
+                "neuronews-kg": {
+                    "state": "connected",
+                    "tool_count": 9,
+                    "last_seen": "2026-07-02T00:00:00+00:00",
+                    "last_error": None,
+                    "restarts": 0,
+                    "cache_age_seconds": 1.2,
+                },
+                "neuronews-pipeline": {
+                    "state": "down",
+                    "tool_count": 0,
+                    "last_seen": None,
+                    "last_error": "ConnectionError: boom",
+                    "restarts": 3,
+                    "cache_age_seconds": None,
+                },
+            },
+        },
+    )
+    body = client.get("/api/v1/ui/context").json()
+    mcp = body["mcp"]
+    assert mcp["enabled"] is True
+    assert mcp["connected"] == 1 and mcp["total"] == 2
+    assert mcp["servers"]["neuronews-kg"]["state"] == "connected"
+    assert mcp["servers"]["neuronews-pipeline"]["state"] == "down"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp_host/test_mcp_host.py
+++ b/tests/unit/mcp_host/test_mcp_host.py
@@ -1,0 +1,319 @@
+"""Unit tests for src/mcp_host/host.py.
+
+Everything runs against scripted fake sessions: no MCP SDK usage, no
+subprocesses. Timing-sensitive assertions poll with generous deadlines so
+the suite stays stable under parallel CI load.
+"""
+
+import asyncio
+import contextlib
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import src.mcp_host.host as host_mod
+from src.mcp_host.config import ServerSpec
+from src.mcp_host.host import (
+    DOWN_AFTER_FAILURES,
+    MCPHost,
+    STATE_CONNECTED,
+    STATE_CONNECTING,
+    STATE_DEGRADED,
+    STATE_DOWN,
+    backoff_delay,
+    host_enabled,
+    host_status,
+    sdk_available,
+    start_host,
+    stop_host,
+)
+
+SPEC = ServerSpec(name="fake", command="python3", args=("tools/fake/server.py",))
+
+
+def wait_until(predicate, timeout=5.0, interval=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+class ScriptedServer:
+    """A controllable fake server: connect failures, kills, tool changes."""
+
+    def __init__(self, tools=("alpha", "beta")):
+        self.tools = list(tools)
+        self.fail_connects = 0
+        self.alive = True
+        self.connects = 0
+
+    @contextlib.asynccontextmanager
+    async def factory(self, spec):
+        self.connects += 1
+        if self.fail_connects > 0:
+            self.fail_connects -= 1
+            raise ConnectionError("connect refused")
+        yield self
+
+    async def list_tools(self):
+        if not self.alive:
+            raise ConnectionError("server killed")
+        return SimpleNamespace(
+            tools=[SimpleNamespace(name=n, description="d") for n in self.tools]
+        )
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch):
+    monkeypatch.setattr(host_mod, "BACKOFF_BASE", 0.02)
+    monkeypatch.setattr(host_mod, "BACKOFF_CAP", 0.05)
+
+
+@pytest.fixture
+def make_host(fast_backoff):
+    hosts = []
+
+    def _make(server, ttl=0.05, specs=None):
+        h = MCPHost(
+            specs=specs if specs is not None else [SPEC],
+            session_factory=server.factory,
+            ttl_seconds=ttl,
+        )
+        hosts.append(h)
+        return h
+
+    yield _make
+    for h in hosts:
+        h.stop(timeout=3.0)
+
+
+def state_of(h, name="fake"):
+    return h.status()["servers"][name]["state"]
+
+
+# ---------------------------------------------------------------------------
+# #583: pool lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_connects_and_reports_connected(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    status = h.status()["servers"]["fake"]
+    assert status["tool_count"] == 2
+    assert status["last_seen"] is not None
+    assert status["last_error"] is None
+    assert status["restarts"] == 0
+    assert h.tools("fake") == {
+        "fake": [
+            {"name": "alpha", "description": "d"},
+            {"name": "beta", "description": "d"},
+        ]
+    }
+
+
+def test_start_returns_immediately_even_when_connect_hangs(fast_backoff):
+    @contextlib.asynccontextmanager
+    async def hanging_factory(spec):
+        await asyncio.Event().wait()
+        yield None  # pragma: no cover - never reached
+
+    h = MCPHost(specs=[SPEC], session_factory=hanging_factory, ttl_seconds=0.05)
+    began = time.monotonic()
+    h.start()
+    assert time.monotonic() - began < 1.0
+    # Status is a snapshot read: instant even while the connect hangs.
+    began = time.monotonic()
+    status = h.status()
+    assert time.monotonic() - began < 0.5
+    assert status["servers"]["fake"]["state"] == STATE_CONNECTING
+    h.stop(timeout=3.0)
+    assert not h._thread.is_alive()
+
+
+def test_stop_joins_thread_cleanly(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    h.stop(timeout=3.0)
+    assert not h._thread.is_alive()
+
+
+def test_no_specs_never_spawns_a_thread():
+    h = MCPHost(specs=[], session_factory=None, ttl_seconds=1)
+    h.start()
+    assert h._thread is None
+    status = h.status()
+    assert status["total"] == 0 and status["connected"] == 0
+    h.stop()
+
+
+def test_start_is_idempotent(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    thread = h._thread
+    h.start()
+    assert h._thread is thread
+
+
+def test_backoff_delay_is_capped_exponential():
+    assert backoff_delay(0) == 0.0
+    assert backoff_delay(1) == 1.0
+    assert backoff_delay(2) == 2.0
+    assert backoff_delay(3) == 4.0
+    assert backoff_delay(50) == 60.0
+
+
+# ---------------------------------------------------------------------------
+# #584: health transitions + discovery cache
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_then_down_on_consecutive_failures(make_host):
+    server = ScriptedServer()
+    server.fail_connects = 10_000
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_DEGRADED, timeout=3.0)
+    assert wait_until(lambda: state_of(h) == STATE_DOWN)
+    status = h.status()["servers"]["fake"]
+    assert "ConnectionError" in status["last_error"]
+    assert h.status()["connected"] == 0
+    assert server.connects >= DOWN_AFTER_FAILURES
+
+
+def test_kill_restart_cycle_reconnects_and_counts_restart(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+
+    # Kill: the next health tick fails and the server leaves connected.
+    server.alive = False
+    assert wait_until(lambda: state_of(h) in (STATE_DEGRADED, STATE_DOWN))
+
+    # While the server is down its tool set changes; the reconnect must
+    # replace (invalidate) the cache, not serve the stale list.
+    server.tools = ["gamma"]
+    server.alive = True
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert wait_until(
+        lambda: h.tools("fake") == {"fake": [{"name": "gamma", "description": "d"}]}
+    )
+    assert h.status()["servers"]["fake"]["restarts"] >= 1
+
+
+def test_ttl_refresh_updates_cache_within_one_ttl(make_host):
+    server = ScriptedServer(tools=("one",))
+    h = make_host(server, ttl=0.05)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    server.tools = ["one", "two"]
+    assert wait_until(lambda: h.status()["servers"]["fake"]["tool_count"] == 2)
+    age = h.status()["servers"]["fake"]["cache_age_seconds"]
+    assert age is not None and age < 5
+
+
+def test_kill_reflected_within_one_ttl(make_host):
+    ttl = 0.05
+    server = ScriptedServer()
+    h = make_host(server, ttl=ttl)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    server.alive = False
+    began = time.monotonic()
+    assert wait_until(lambda: state_of(h) != STATE_CONNECTED, timeout=3.0)
+    # Detection happens on the next TTL tick (generous bound for CI load).
+    assert time.monotonic() - began < 2.0
+
+
+def test_tools_accessor_shapes(make_host):
+    server = ScriptedServer(tools=("a",))
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert set(h.tools()) == {"fake"}
+    assert h.tools("missing") == {}
+
+
+def test_ttl_env_override(monkeypatch):
+    monkeypatch.setenv("NOESIS_MCP_TTL", "7")
+    assert MCPHost(specs=[]).ttl_seconds == 7.0
+    monkeypatch.setenv("NOESIS_MCP_TTL", "junk")
+    assert MCPHost(specs=[]).ttl_seconds == host_mod.DEFAULT_TTL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + short circuits
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("NOESIS_MCP_HOST", raising=False)
+    yield monkeypatch
+    stop_host()
+
+
+def test_testing_env_short_circuits(clean_env):
+    clean_env.setenv("TESTING", "true")
+    assert host_enabled() == "testing"
+    assert start_host() is None
+    status = host_status()
+    assert status["enabled"] is False and status["reason"] == "testing"
+    assert status["servers"] == {}
+
+
+def test_kill_switch_short_circuits(clean_env):
+    clean_env.setenv("NOESIS_MCP_HOST", "off")
+    assert host_enabled() == "disabled by NOESIS_MCP_HOST"
+    assert start_host() is None
+    assert host_status()["enabled"] is False
+
+
+def test_missing_sdk_short_circuits(clean_env):
+    clean_env.setattr(host_mod, "sdk_available", lambda: False)
+    assert host_enabled() == "mcp client SDK not installed"
+    assert host_status()["reason"] == "mcp client SDK not installed"
+
+
+def test_singleton_start_status_stop(clean_env):
+    class StubHost:
+        started = 0
+        stopped = 0
+
+        def start(self):
+            StubHost.started += 1
+
+        def stop(self, timeout=5.0):
+            StubHost.stopped += 1
+
+        def status(self):
+            return {"enabled": True, "servers": {}, "total": 0, "connected": 0}
+
+    clean_env.setattr(host_mod, "sdk_available", lambda: True)
+    clean_env.setattr(host_mod, "MCPHost", StubHost)
+    assert host_status()["reason"] == "not started"
+
+    first = start_host()
+    second = start_host()
+    assert first is second and StubHost.started == 1
+    assert host_status()["enabled"] is True
+
+    stop_host()
+    assert StubHost.stopped == 1
+    assert host_status()["reason"] == "not started"
+    stop_host()  # idempotent
+    assert StubHost.stopped == 1
+
+
+def test_sdk_available_returns_bool():
+    assert isinstance(sdk_available(), bool)

--- a/tests/unit/mcp_host/test_mcp_host_config.py
+++ b/tests/unit/mcp_host/test_mcp_host_config.py
@@ -1,0 +1,84 @@
+"""Unit tests for src/mcp_host/config.py (server spec loading)."""
+
+import json
+from pathlib import Path
+
+from src.mcp_host.config import DEFAULT_MCP_JSON, ServerSpec, load_server_specs
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_real_mcp_json_yields_only_project_servers():
+    specs = load_server_specs()
+    assert DEFAULT_MCP_JSON.exists()
+    names = {s.name for s in specs}
+    # All 12 tools/*_mcp servers, and nothing npx-launched.
+    assert len(specs) == 12
+    assert "neuronews-kg" in names
+    assert "neuronews-pipeline" in names
+    assert "memory" not in names
+    assert "playwright" not in names
+    assert "postgres" not in names
+    for spec in specs:
+        assert spec.command in ("python", "python3")
+        assert spec.args[0].startswith("tools/")
+        assert spec.args[0].endswith("server.py")
+        assert Path(spec.cwd) == REPO_ROOT
+        # The server entry point actually exists.
+        assert (REPO_ROOT / spec.args[0]).exists()
+
+
+def _write(tmp_path, payload) -> Path:
+    path = tmp_path / ".mcp.json"
+    path.write_text(json.dumps(payload) if not isinstance(payload, str) else payload)
+    return path
+
+
+def test_filters_non_project_entries(tmp_path):
+    path = _write(
+        tmp_path,
+        {
+            "mcpServers": {
+                "npx-thing": {"type": "stdio", "command": "npx", "args": ["-y", "x"]},
+                "http-thing": {"type": "http", "command": "python3", "args": ["tools/x.py"]},
+                "no-args": {"type": "stdio", "command": "python3"},
+                "elsewhere": {"type": "stdio", "command": "python3", "args": ["scripts/x.py"]},
+                "good": {
+                    "type": "stdio",
+                    "command": "python3",
+                    "args": ["tools/kg_mcp/server.py"],
+                    "env": {"FOO": "bar"},
+                },
+                "not-a-dict": "nope",
+            }
+        },
+    )
+    specs = load_server_specs(path)
+    assert [s.name for s in specs] == ["good"]
+    assert specs[0] == ServerSpec(
+        name="good",
+        command="python3",
+        args=("tools/kg_mcp/server.py",),
+        env={"FOO": "bar"},
+        cwd=str(tmp_path),
+    )
+
+
+def test_type_defaults_to_stdio(tmp_path):
+    path = _write(
+        tmp_path,
+        {"mcpServers": {"g": {"command": "python3", "args": ["tools/a/server.py"]}}},
+    )
+    assert len(load_server_specs(path)) == 1
+
+
+def test_missing_file_yields_empty_list(tmp_path):
+    assert load_server_specs(tmp_path / "nope.json") == []
+
+
+def test_malformed_json_yields_empty_list(tmp_path):
+    assert load_server_specs(_write(tmp_path, "{not json")) == []
+
+
+def test_non_dict_servers_yields_empty_list(tmp_path):
+    assert load_server_specs(_write(tmp_path, {"mcpServers": ["x"]})) == []


### PR DESCRIPTION
# Pull Request: MCP host runtime (milestone R1)

## Overview

Implements milestone **R1** of the MCP rearchitecture plan (`docs/architecture/MCP_REARCHITECTURE_PLAN.md`): pooled, supervised MCP sessions inside the API process, with a TTL discovery cache and per-server health surfaced over HTTP. This is deliberately the risky infrastructure in isolation: no planning behavior changes; the catalog, planners and adaptivity are untouched until R2/R3 consume the host.

Closes #583. Closes #584. Closes #585.

## Changes Summary

**Session pool (#583)**

- `src/mcp_host/config.py`: parses `.mcp.json` into the 12 supervised `tools/*_mcp` stdio server specs. Third-party npx servers (memory, playwright, postgres) are excluded; missing or malformed config yields zero servers instead of an exception.
- `src/mcp_host/host.py`: one supervision task per server on a private event loop in a daemon thread. Lazy connect (`start()` returns in under 1 ms), staggered initial connects, capped exponential backoff on reconnect, clean shutdown that tolerates stop-during-startup. No per-request process spawning.

**Discovery cache and health (#584)**

- `tools/list` results are cached per server and refreshed on a TTL (default 60 s, `NOESIS_MCP_TTL`); the refresh doubles as the health check. The cache is replaced on every reconnect.
- State transitions: connecting, connected, degraded on first failure, down after 3 consecutive failures.
- `status()` and `tools()` read lock-guarded snapshots and never await: a hung or dead server cannot stall a request.

**Health over HTTP (#585)**

- `GET /api/v1/ui/context` grows an `mcp` block: enabled flag, TTL, connected/total, and per-server state, last-seen, tool count, restarts, last error, cache age.

**Wiring and safety**

- Startup follows the existing best-effort background-collector pattern in `initialize_app`; shutdown handler registered only when the host actually started.
- `TESTING=true` and `NOESIS_MCP_HOST=off` short-circuit; a missing `mcp` client SDK makes the host report itself unavailable instead of breaking imports. `mcp>=1.0.0` added to `requirements.txt`.
- `docs/genui.md` documents the runtime and its environment variables.

## Testing Status

- [x] 25 new unit tests (scripted fake sessions, no subprocesses): connect, TTL refresh, kill/restart cycle with cache invalidation, degraded-to-down transitions, hung-connect non-blocking status, idempotent start, clean stop, env short-circuits, singleton lifecycle
- [x] `src/mcp_host` at 95% coverage (config 100%); 235 tests green across mcp_host, genui and the genui routes
- [x] Route tests assert the new `mcp` block in both disabled and live-host shapes
- [x] `TESTING=true` app import unaffected

## Live verification (R1 exit criterion)

Against the real 12 servers with a 5 s TTL:

- All 12 connected within 6 s; 69 tools cached across servers
- `start()` returned in 0.0005 s, so API boot time is unaffected (well within the 10% budget)
- SIGKILL of `neuronews-kg` was reflected as degraded after 4.0 s (within one TTL) and the server reconnected 6.5 s after the kill with `restarts=1` and a refreshed tool cache