### PR TITLE
R2: Discovery-derived panel catalog - annotation ADR, annotated tools, merge with static fallback

### DIFF
--- a/docs/architecture/ADR-001-tool-panel-annotation.md
+++ b/docs/architecture/ADR-001-tool-panel-annotation.md
@@ -1,0 +1,103 @@
+# ADR-001: Tool-to-panel annotation format
+
+Status: accepted. Part of R2 (Discovery-derived catalog) in
+`MCP_REARCHITECTURE_PLAN.md`; resolves that plan's open question 1.
+
+## Context
+
+Stage 1 derives the generative-UI panel catalog from the MCP servers
+themselves: a tool that corresponds to a canvas panel announces that fact,
+and the backend catalog builder (`src/genui/discovery.py`) turns the
+annotation into a `PanelDef` at discovery time. Unannotated tools stay
+invisible to the catalog by design.
+
+Two candidate formats were considered:
+
+1. **FastMCP tags** (`@mcp.tool(tags={"panel:claims"})`). Rejected: tags
+   are a FastMCP-side filtering feature and their wire representation has
+   moved between FastMCP releases (serialized under a private `_fastmcp`
+   meta namespace when exposed at all). A catalog contract must not track
+   a framework's private serialization.
+2. **An explicit `panel` block in the tool's MCP `_meta` field**
+   (`@mcp.tool(meta={"panel": {...}})`). Accepted: `_meta` is part of the
+   MCP specification itself, round-trips through `tools/list` verbatim on
+   any compliant client, and the block is plain data the builder can
+   validate without knowing anything about the server framework.
+
+## Decision
+
+A panel-shaped tool declares:
+
+```python
+@mcp.tool(
+    output_schema={"type": "object", "properties": {...}},
+    meta={"panel": {
+        "type": "claims",                          # required: renderer key
+        "title": "Extracted claims",               # optional: panel heading
+        "description": "Claims mined from ...",    # optional: for planners
+        "endpoint": "/api/v1/arguments/claims",    # REST endpoint the panel fetches
+        "facets": ["claims", "conflict"],          # required: intents it serves
+        "tables": ["argument_claims"],             # availability hints
+        "ui_flag": None,                           # domain-pack gate, if any
+        "default_span": 6,                         # 12-column grid units
+        "topic_param": "topic",                    # params mapping: the query
+        "source_type_param": "source_type",        #   param names the endpoint
+        "days_param": None,                        #   accepts (None = not taken)
+        "max_days": None,                          # endpoint's days upper bound
+    }},
+)
+def list_claims(...) -> dict: ...
+```
+
+Field semantics are exactly `PanelDef` in `src/genui/catalog.py` (the
+static catalog remains the single source of truth for the *shape*; the
+codegen from R0 keeps the frontend and contract in sync with it).
+
+Rules enforced by the builder (`panel_def_from_annotation`):
+
+- `type` is required, `^[a-z][a-z0-9_]{1,63}$`.
+- `facets` is required and non-empty (list of non-empty strings).
+- `default_span` is an int in 3..12 (default 6); `max_days` a positive
+  int or absent; `tables` a list of strings.
+- **`outputSchema` is required.** An annotated tool without a declared
+  output schema is skipped with a warning: if a tool feeds a panel, its
+  output must be introspectable. FastMCP derives a schema from the
+  return annotation (`-> dict` and `-> list` both produce one), which
+  satisfies the rule; an explicit `output_schema=` documenting the
+  result fields is preferred. This is also the hook the Track DS
+  statistical-honesty convention (R5) extends later.
+- Anything malformed is skipped with a warning, never an error: a bad
+  annotation must not break the catalog or the API.
+
+Merge semantics (`merged_catalog`): the static catalog defines order and
+remains the fallback; a discovered annotation for an existing type
+overrides it in place; new types append after the static ones. With no
+host, no connected servers, or no annotated tools, the merged catalog is
+byte-identical to the static one (the R2 litmus). `GET /api/v1/ui/panels`
+serves the merged catalog; each entry carries a `source` field (server
+name or `"static"`) only when discovery contributed at least one def.
+
+One tool maps to at most one panel block, and the first server (sorted
+order) wins on duplicate types.
+
+## Exemptions
+
+Two catalog types are *composed* panels with no data tool behind them, by
+design:
+
+- `note` — the plan narrative, written by the planner itself.
+- `timeline` — the story timeline, composed client-side (no backend
+  endpoint exists).
+
+They remain static-catalog-only; every other panel type has at least one
+annotated tool counterpart (R2 exit criterion).
+
+## Consequences
+
+- Dropping in a new annotated server surfaces its panel type in
+  `/api/v1/ui/panels` with zero genui code changes.
+- The planner and `validate_spec` still read the static catalog; planning
+  from discovered defs (and tool-sourced availability) is R3.
+- Reference implementation: `list_claims` in
+  `tools/argument_mcp/server.py`, round-trip verified against a live
+  `tools/list` in the R2 verification run.

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -53,6 +53,19 @@ feature-flag pattern in `src/api/app.py`):
   status, MCP host health (per-server state / last-seen / tool counts)
 - `GET /api/v1/ui/panels` — the panel catalog
 
+### Discovery-derived catalog (`src/genui/discovery.py`, R2)
+
+Tools annotated with a `meta.panel` block (format:
+`docs/architecture/ADR-001-tool-panel-annotation.md`) become `PanelDef`s
+at discovery time and merge over the static catalog, which stays the
+fallback: `GET /api/v1/ui/panels` serves the merged catalog, and with no
+servers connected its payload is byte-identical to the static one.
+Annotated tools must declare an `outputSchema`; malformed annotations are
+skipped with a warning, never an error. Every data-backed panel type has
+an annotated counterpart across `tools/*_mcp` (`note` and `timeline` are
+composed panels, exempt by design); the planner still reads the static
+catalog until R3.
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/src/api/routes/genui_routes.py
+++ b/src/api/routes/genui_routes.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
 from src.genui.adaptivity import data_availability, merged_ui_flags
-from src.genui.catalog import panel_catalog_dict
+from src.genui.discovery import merged_catalog_dict
 from src.genui.llm import llm_config, plan_with_llm
 from src.genui.planner import plan
 from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, validate_spec
@@ -119,9 +119,15 @@ def ui_context() -> Dict[str, Any]:
 
 @router.get("/panels")
 async def ui_panels() -> Dict[str, Any]:
-    """Expose the panel catalog the frontend renderer mirrors."""
+    """Expose the panel catalog the frontend renderer mirrors.
+
+    R2: discovery-derived defs from annotated MCP tools merge over the
+    static catalog; with no servers connected the payload is byte-identical
+    to the static catalog. Reads the host's cache only, so this stays
+    non-blocking in the event loop.
+    """
     try:
-        panels = panel_catalog_dict()
+        panels = merged_catalog_dict()
         return {"panels": panels, "count": len(panels)}
     except Exception as err:
         raise HTTPException(status_code=500, detail=f"UI panel catalog failed: {err}")

--- a/src/genui/discovery.py
+++ b/src/genui/discovery.py
@@ -1,0 +1,201 @@
+"""
+Discovery-derived panel catalog (MCP rearchitecture plan, R2 / Stage 1).
+
+Maps annotated MCP tools into ``PanelDef``s and merges them over the
+static catalog. The annotation format is decided in
+``docs/architecture/ADR-001-tool-panel-annotation.md``: a tool declares a
+``panel`` block inside its MCP ``_meta`` and MUST declare an
+``outputSchema``; everything else in ``tools/list`` is invisible to the
+catalog by design.
+
+Merge semantics: the static catalog (``catalog.py``) remains the fallback
+and defines the order; a discovered annotation for an existing type
+overrides it in place, and new types append after it. With no host, no
+connected servers, or no annotated tools, the merged catalog is exactly
+the static one — byte-identical output, which is the R2 litmus.
+
+The planner and spec validation still read the static catalog: planning
+from discovered defs is R3 (adaptivity from tools). This module only
+feeds ``GET /api/v1/ui/panels`` and future consumers.
+
+Import-safe on purpose (stdlib + src.genui + src.mcp_host only).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.genui.catalog import PANEL_CATALOG, PanelDef, panel_catalog_dict
+
+logger = logging.getLogger(__name__)
+
+ANNOTATION_KEY = "panel"
+
+_TYPE_RE = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+_MIN_SPAN, _MAX_SPAN = 3, 12
+
+
+def _str_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def panel_def_from_annotation(
+    server: str, tool: Dict[str, Any]
+) -> Optional[PanelDef]:
+    """Validate one cached tool's ``meta.panel`` block into a PanelDef.
+
+    Returns None (with a warning) for anything malformed — a bad
+    annotation must never break the catalog, it just stays invisible.
+    Tools without an ``outputSchema`` are rejected: the ADR makes the
+    schema part of the annotation contract.
+    """
+    meta = tool.get("meta")
+    block = meta.get(ANNOTATION_KEY) if isinstance(meta, dict) else None
+    if block is None:
+        return None
+    name = f"{server}:{tool.get('name')}"
+    if not isinstance(block, dict):
+        logger.warning("genui discovery: %s has a non-dict panel block", name)
+        return None
+    if not tool.get("has_output_schema"):
+        logger.warning(
+            "genui discovery: %s annotated but declares no outputSchema; skipped",
+            name,
+        )
+        return None
+
+    panel_type = block.get("type")
+    if not isinstance(panel_type, str) or not _TYPE_RE.match(panel_type):
+        logger.warning("genui discovery: %s has invalid panel type %r", name, panel_type)
+        return None
+
+    facets = block.get("facets")
+    if (
+        not isinstance(facets, (list, tuple))
+        or not facets
+        or not all(isinstance(f, str) and f for f in facets)
+    ):
+        logger.warning("genui discovery: %s has invalid facets %r", name, facets)
+        return None
+
+    span = block.get("default_span", 6)
+    if not isinstance(span, int) or isinstance(span, bool) or not (
+        _MIN_SPAN <= span <= _MAX_SPAN
+    ):
+        logger.warning("genui discovery: %s has invalid default_span %r", name, span)
+        return None
+
+    tables = block.get("tables", [])
+    if not isinstance(tables, (list, tuple)) or not all(
+        isinstance(t, str) and t for t in tables
+    ):
+        logger.warning("genui discovery: %s has invalid tables %r", name, tables)
+        return None
+
+    max_days = block.get("max_days")
+    if max_days is not None and (
+        not isinstance(max_days, int) or isinstance(max_days, bool) or max_days < 1
+    ):
+        logger.warning("genui discovery: %s has invalid max_days %r", name, max_days)
+        return None
+
+    return PanelDef(
+        type=panel_type,
+        title=_str_or_none(block.get("title")) or panel_type.replace("_", " ").title(),
+        description=_str_or_none(block.get("description"))
+        or _str_or_none(tool.get("description"))
+        or "",
+        endpoint=_str_or_none(block.get("endpoint")),
+        facets=tuple(facets),
+        tables=tuple(tables),
+        ui_flag=_str_or_none(block.get("ui_flag")),
+        default_span=span,
+        topic_param=_str_or_none(block.get("topic_param")),
+        source_type_param=_str_or_none(block.get("source_type_param")),
+        days_param=_str_or_none(block.get("days_param")),
+        max_days=max_days,
+    )
+
+
+def discovered_panel_defs() -> Dict[str, Tuple[PanelDef, str]]:
+    """Panel type -> (PanelDef, source server) from the host's tool cache.
+
+    Reads the R1 discovery cache only (never a live round-trip). Empty when
+    the host is disabled, not started, or nothing is annotated. On duplicate
+    types the first annotation wins, scanning servers in sorted order.
+    """
+    try:
+        from src.mcp_host import get_host
+
+        host = get_host()
+    except Exception:  # pragma: no cover - defensive import guard
+        return {}
+    if host is None:
+        return {}
+
+    defs: Dict[str, Tuple[PanelDef, str]] = {}
+    for server in sorted(host.tools()):
+        for tool in host.tools(server).get(server, []):
+            panel_def = panel_def_from_annotation(server, tool)
+            if panel_def is None:
+                continue
+            if panel_def.type in defs:
+                logger.warning(
+                    "genui discovery: duplicate panel type %r from %s ignored "
+                    "(kept the one from %s)",
+                    panel_def.type,
+                    server,
+                    defs[panel_def.type][1],
+                )
+                continue
+            defs[panel_def.type] = (panel_def, server)
+    return defs
+
+
+def merged_catalog() -> List[Tuple[PanelDef, Optional[str]]]:
+    """Static catalog with discovered overrides in place and new types
+    appended; the second tuple item is the source server (None = static)."""
+    discovered = discovered_panel_defs()
+    merged: List[Tuple[PanelDef, Optional[str]]] = []
+    for panel in PANEL_CATALOG:
+        if panel.type in discovered:
+            override, server = discovered.pop(panel.type)
+            merged.append((override, server))
+        else:
+            merged.append((panel, None))
+    for panel_type in sorted(discovered):
+        merged.append(discovered[panel_type])
+    return merged
+
+
+def merged_catalog_dict() -> List[Dict[str, Any]]:
+    """JSON-ready merged catalog for ``GET /api/v1/ui/panels``.
+
+    With nothing discovered this returns ``panel_catalog_dict()`` verbatim
+    (the servers-down litmus: byte-identical to the static catalog). When
+    discovery contributes, every entry gains a ``source`` field: the server
+    name for discovered defs, ``"static"`` otherwise.
+    """
+    merged = merged_catalog()
+    if all(server is None for _, server in merged):
+        return panel_catalog_dict()
+    return [
+        {
+            "type": p.type,
+            "title": p.title,
+            "description": p.description,
+            "endpoint": p.endpoint,
+            "facets": list(p.facets),
+            "tables": list(p.tables),
+            "ui_flag": p.ui_flag,
+            "default_span": p.default_span,
+            "topic_param": p.topic_param,
+            "source_type_param": p.source_type_param,
+            "days_param": p.days_param,
+            "max_days": p.max_days,
+            "source": server or "static",
+        }
+        for p, server in merged
+    ]

--- a/src/mcp_host/host.py
+++ b/src/mcp_host/host.py
@@ -113,13 +113,26 @@ async def _default_session(spec: ServerSpec):
             yield session
 
 
-async def _list_tools(session: Any) -> List[Dict[str, str]]:
-    """One health-check round-trip; doubles as the discovery refresh."""
+async def _list_tools(session: Any) -> List[Dict[str, Any]]:
+    """One health-check round-trip; doubles as the discovery refresh.
+
+    Each cached tool carries its ``_meta`` block and whether it declares an
+    ``outputSchema`` — the two things the R2 discovery-derived catalog
+    (src/genui/discovery.py) needs to map annotated tools into PanelDefs.
+    """
     result = await asyncio.wait_for(session.list_tools(), CALL_TIMEOUT)
-    return [
-        {"name": tool.name, "description": (tool.description or "").strip()}
-        for tool in result.tools
-    ]
+    tools: List[Dict[str, Any]] = []
+    for tool in result.tools:
+        meta = getattr(tool, "meta", None)
+        tools.append(
+            {
+                "name": tool.name,
+                "description": (tool.description or "").strip(),
+                "meta": meta if isinstance(meta, dict) else {},
+                "has_output_schema": getattr(tool, "outputSchema", None) is not None,
+            }
+        )
+    return tools
 
 
 def sdk_available() -> bool:
@@ -308,8 +321,9 @@ class MCPHost:
             "servers": servers,
         }
 
-    def tools(self, server: Optional[str] = None) -> Dict[str, List[Dict[str, str]]]:
-        """Cached discovery results (name/description per tool), per server."""
+    def tools(self, server: Optional[str] = None) -> Dict[str, List[Dict[str, Any]]]:
+        """Cached discovery results per server (name, description, meta,
+        has_output_schema). Snapshot read; never triggers a round-trip."""
         with self._lock:
             if server is not None:
                 status = self._statuses.get(server)

--- a/tests/unit/api/routes/test_genui_routes_coverage.py
+++ b/tests/unit/api/routes/test_genui_routes_coverage.py
@@ -231,7 +231,7 @@ def test_panels_error_returns_500(client, monkeypatch):
     def boom():
         raise RuntimeError("catalog broke")
 
-    monkeypatch.setattr(mod, "panel_catalog_dict", boom)
+    monkeypatch.setattr(mod, "merged_catalog_dict", boom)
     resp = client.get("/api/v1/ui/panels")
     assert resp.status_code == 500
     assert "UI panel catalog failed" in resp.json()["detail"]

--- a/tests/unit/api/routes/test_genui_routes_smoke.py
+++ b/tests/unit/api/routes/test_genui_routes_smoke.py
@@ -165,3 +165,51 @@ def test_panels_exposes_catalog(client):
         assert "type" in panel
         assert "title" in panel
         assert "facets" in panel
+
+
+# R2 litmus (a): a new annotated server surfaces its panel type through
+# /api/v1/ui/panels with zero genui code changes — only the host cache
+# differs between this test and the static one below.
+def test_panels_surfaces_discovered_type(client, monkeypatch):
+    class FakeHost:
+        _data = {
+            "research-server": [
+                {
+                    "name": "citations",
+                    "description": "Citation network for papers.",
+                    "meta": {
+                        "panel": {
+                            "type": "citation_graph",
+                            "title": "Citation graph",
+                            "facets": ["entities", "library"],
+                            "default_span": 6,
+                        }
+                    },
+                    "has_output_schema": True,
+                }
+            ]
+        }
+
+        def tools(self, server=None):
+            if server is not None:
+                return {server: self._data.get(server, [])}
+            return dict(self._data)
+
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: FakeHost())
+    body = client.get("/api/v1/ui/panels").json()
+    by_type = {p["type"]: p for p in body["panels"]}
+    assert "citation_graph" in by_type
+    assert by_type["citation_graph"]["source"] == "research-server"
+    assert by_type["claims"]["source"] == "static"
+    assert body["count"] == len(body["panels"])
+
+
+# R2 litmus (b): with no discovery (host down/absent) the payload is
+# byte-identical to the static catalog.
+def test_panels_byte_identical_without_discovery(client, monkeypatch):
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: None)
+    from src.genui.catalog import panel_catalog_dict
+
+    body = client.get("/api/v1/ui/panels").json()
+    static = panel_catalog_dict()
+    assert body == {"panels": static, "count": len(static)}

--- a/tests/unit/genui/test_genui_annotations.py
+++ b/tests/unit/genui/test_genui_annotations.py
@@ -1,0 +1,117 @@
+"""Annotation-parity litmus for the R2 tool annotations (ADR-001).
+
+Loads the annotated MCP servers, lists their tools over an in-memory
+FastMCP client (the true wire form, i.e. a real ``tools/list`` round
+trip), and checks that:
+
+* every static catalog panel type except the composed panels (note,
+  timeline) has exactly one annotated tool counterpart, and
+* every annotation that mirrors a static panel type matches the static
+  ``PanelDef`` field for field, so discovery overrides can never silently
+  change what a panel means.
+
+Requires fastmcp (a server-side dev dependency, not in requirements.txt),
+so the whole module skips where it is not installed.
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from src.genui.catalog import PANEL_TYPES, get_panel_def
+from src.genui.discovery import panel_def_from_annotation
+
+REPO = Path(__file__).resolve().parents[3]
+
+ANNOTATED_SERVERS = {
+    "neuronews-arguments": REPO / "tools/argument_mcp/server.py",
+    "neuronews-kg": REPO / "tools/kg_mcp/server.py",
+    "neuronews-blog-feeds": REPO / "tools/blog_mcp/server.py",
+    "neuronews-pipeline": REPO / "tools/pipeline_mcp/server.py",
+}
+
+COMPOSED_PANELS = {"note", "timeline"}  # ADR-001 exemptions
+
+
+def _load_server(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(f"annotation_test_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.mcp
+
+
+async def _wire_tools(mcp) -> list:
+    from fastmcp.client import Client
+
+    async with Client(mcp) as client:
+        return await client.list_tools()
+
+
+def discover_all():
+    """server name -> list of cache-shaped tool dicts, via real tools/list."""
+    out = {}
+    for name, path in ANNOTATED_SERVERS.items():
+        tools = asyncio.run(_wire_tools(_load_server(name, path)))
+        out[name] = [
+            {
+                "name": t.name,
+                "description": (t.description or "").strip(),
+                "meta": t.meta if isinstance(t.meta, dict) else {},
+                "has_output_schema": t.outputSchema is not None,
+            }
+            for t in tools
+        ]
+    return out
+
+
+@pytest.fixture(scope="module")
+def wire():
+    return discover_all()
+
+
+def test_every_data_panel_type_has_an_annotated_counterpart(wire):
+    discovered = {}
+    for server, tools in wire.items():
+        for tool in tools:
+            panel = panel_def_from_annotation(server, tool)
+            if panel is not None:
+                assert panel.type not in discovered, (
+                    f"duplicate annotation for {panel.type} "
+                    f"({discovered[panel.type]} and {server}:{tool['name']})"
+                )
+                discovered[panel.type] = f"{server}:{tool['name']}"
+
+    expected = set(PANEL_TYPES) - COMPOSED_PANELS
+    missing = expected - set(discovered)
+    extra = set(discovered) - expected
+    assert not missing, f"panel types without an annotated tool: {sorted(missing)}"
+    assert not extra, f"annotated types not in the static catalog: {sorted(extra)}"
+
+
+def test_annotations_mirror_the_static_catalog(wire):
+    for server, tools in wire.items():
+        for tool in tools:
+            panel = panel_def_from_annotation(server, tool)
+            if panel is None:
+                continue
+            static = get_panel_def(panel.type)
+            assert static is not None
+            assert panel == static, (
+                f"{server}:{tool['name']} annotation drifted from the static "
+                f"catalog for {panel.type}:\n  annotated: {panel}\n  static:    {static}"
+            )
+
+
+def test_annotated_tools_all_declare_output_schemas(wire):
+    for server, tools in wire.items():
+        for tool in tools:
+            if "panel" in tool["meta"]:
+                assert tool["has_output_schema"], (
+                    f"{server}:{tool['name']} is annotated but has no outputSchema"
+                )

--- a/tests/unit/genui/test_genui_discovery.py
+++ b/tests/unit/genui/test_genui_discovery.py
@@ -1,0 +1,206 @@
+"""Unit tests for the discovery-derived panel catalog (src/genui/discovery.py).
+
+Covers the ADR-001 annotation validator, the merge-over-static semantics,
+and the two R2 litmus properties: a new annotated server surfaces a new
+panel type, and with nothing discovered the output is byte-identical to
+the static catalog. All host access goes through fakes.
+"""
+
+from typing import Dict, List
+
+import pytest
+
+from src.genui.catalog import PANEL_CATALOG, panel_catalog_dict
+from src.genui.discovery import (
+    discovered_panel_defs,
+    merged_catalog,
+    merged_catalog_dict,
+    panel_def_from_annotation,
+)
+
+
+def make_tool(panel=None, name="some_tool", has_output_schema=True, meta=None):
+    tool = {
+        "name": name,
+        "description": "a tool description",
+        "meta": meta if meta is not None else ({"panel": panel} if panel is not None else {}),
+        "has_output_schema": has_output_schema,
+    }
+    return tool
+
+
+GOOD = {
+    "type": "citation_graph",
+    "title": "Citation graph",
+    "description": "Paper citation network.",
+    "endpoint": "/api/v1/research/citations",
+    "facets": ["entities", "library"],
+    "tables": ["documents"],
+    "ui_flag": "research",
+    "default_span": 6,
+    "topic_param": "topic",
+    "days_param": "days",
+    "max_days": 90,
+}
+
+
+class FakeHost:
+    def __init__(self, tools_by_server: Dict[str, List[dict]]):
+        self._tools = tools_by_server
+
+    def tools(self, server=None):
+        if server is not None:
+            return {server: self._tools.get(server, [])}
+        return dict(self._tools)
+
+
+@pytest.fixture
+def fake_host(monkeypatch):
+    def _install(tools_by_server):
+        host = FakeHost(tools_by_server)
+        monkeypatch.setattr("src.mcp_host.get_host", lambda: host)
+        return host
+
+    return _install
+
+
+@pytest.fixture
+def no_host(monkeypatch):
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# Annotation validation (ADR-001 rules)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_annotation_builds_panel_def():
+    panel = panel_def_from_annotation("research", make_tool(GOOD))
+    assert panel is not None
+    assert panel.type == "citation_graph"
+    assert panel.title == "Citation graph"
+    assert panel.endpoint == "/api/v1/research/citations"
+    assert panel.facets == ("entities", "library")
+    assert panel.tables == ("documents",)
+    assert panel.ui_flag == "research"
+    assert panel.default_span == 6
+    assert panel.topic_param == "topic"
+    assert panel.source_type_param is None
+    assert panel.days_param == "days"
+    assert panel.max_days == 90
+
+
+def test_title_and_description_default():
+    panel = panel_def_from_annotation(
+        "s", make_tool({"type": "my_new_panel", "facets": ["overview"]})
+    )
+    assert panel.title == "My New Panel"
+    assert panel.description == "a tool description"
+    assert panel.default_span == 6
+
+
+def test_unannotated_tool_is_invisible():
+    assert panel_def_from_annotation("s", make_tool(meta={})) is None
+    assert panel_def_from_annotation("s", make_tool(meta={"other": 1})) is None
+
+
+def test_output_schema_is_required():
+    assert (
+        panel_def_from_annotation("s", make_tool(GOOD, has_output_schema=False)) is None
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"type": None},
+        {"type": ""},
+        {"type": "Bad-Type"},
+        {"type": "x" * 80},
+        {"facets": []},
+        {"facets": "overview"},
+        {"facets": [1]},
+        {"default_span": 2},
+        {"default_span": 13},
+        {"default_span": "6"},
+        {"default_span": True},
+        {"tables": "documents"},
+        {"tables": [1]},
+        {"max_days": 0},
+        {"max_days": "30"},
+        {"max_days": True},
+    ],
+)
+def test_malformed_blocks_are_skipped(mutation):
+    block = {**GOOD, **mutation}
+    assert panel_def_from_annotation("s", make_tool(block)) is None
+
+
+def test_non_dict_block_is_skipped():
+    assert panel_def_from_annotation("s", make_tool(meta={"panel": "claims"})) is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery + merge semantics
+# ---------------------------------------------------------------------------
+
+
+def test_no_host_yields_no_discovery(no_host):
+    assert discovered_panel_defs() == {}
+    assert merged_catalog_dict() == panel_catalog_dict()
+
+
+def test_duplicate_type_first_server_wins(fake_host):
+    fake_host(
+        {
+            "b-server": [make_tool({**GOOD, "title": "From B"})],
+            "a-server": [make_tool({**GOOD, "title": "From A"})],
+        }
+    )
+    defs = discovered_panel_defs()
+    assert defs["citation_graph"][0].title == "From A"
+    assert defs["citation_graph"][1] == "a-server"
+
+
+def test_merge_overrides_in_place_and_appends_new(fake_host):
+    override = {
+        "type": "claims",
+        "title": "Discovered claims",
+        "facets": ["claims"],
+        "default_span": 6,
+    }
+    fake_host({"srv": [make_tool(override), make_tool(GOOD, name="t2")]})
+
+    merged = merged_catalog()
+    types = [p.type for p, _ in merged]
+    static_types = [p.type for p in PANEL_CATALOG]
+    # Same order as static, with the new type appended at the end.
+    assert types == static_types + ["citation_graph"]
+
+    by_type = {p.type: (p, src) for p, src in merged}
+    assert by_type["claims"][0].title == "Discovered claims"
+    assert by_type["claims"][1] == "srv"
+    assert by_type["citation_graph"][1] == "srv"
+    # Untouched static entries carry no source server.
+    assert by_type["kpi_row"][1] is None
+
+
+def test_merged_dict_carries_source_only_when_discovery_contributes(fake_host):
+    fake_host({"srv": [make_tool(GOOD)]})
+    panels = merged_catalog_dict()
+    by_type = {p["type"]: p for p in panels}
+    assert by_type["citation_graph"]["source"] == "srv"
+    assert by_type["claims"]["source"] == "static"
+    # Every static field is still present alongside source.
+    assert set(panel_catalog_dict()[0]) | {"source"} == set(by_type["claims"])
+
+
+def test_servers_down_is_byte_identical(fake_host):
+    # Host present but its caches are empty (all servers down / unannotated).
+    fake_host({"srv": []})
+    import json
+
+    assert json.dumps(merged_catalog_dict(), sort_keys=True) == json.dumps(
+        panel_catalog_dict(), sort_keys=True
+    )
+    assert merged_catalog_dict() == panel_catalog_dict()

--- a/tests/unit/mcp_host/test_mcp_host.py
+++ b/tests/unit/mcp_host/test_mcp_host.py
@@ -111,8 +111,8 @@ def test_connects_and_reports_connected(make_host):
     assert status["restarts"] == 0
     assert h.tools("fake") == {
         "fake": [
-            {"name": "alpha", "description": "d"},
-            {"name": "beta", "description": "d"},
+            {"name": "alpha", "description": "d", "meta": {}, "has_output_schema": False},
+            {"name": "beta", "description": "d", "meta": {}, "has_output_schema": False},
         ]
     }
 
@@ -205,7 +205,7 @@ def test_kill_restart_cycle_reconnects_and_counts_restart(make_host):
     server.alive = True
     assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
     assert wait_until(
-        lambda: h.tools("fake") == {"fake": [{"name": "gamma", "description": "d"}]}
+        lambda: [t["name"] for t in h.tools("fake")["fake"]] == ["gamma"]
     )
     assert h.status()["servers"]["fake"]["restarts"] >= 1
 

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -12,6 +12,8 @@ Tools (non-overlapping with pipeline_mcp which owns positions/conflicts):
                stance?, limit?)
   list_drift_events(source?, topic?,      -> stance-drift timeline entries
                     limit?)
+  list_frames(source_type?, frame?,       -> frame distribution rows from
+              limit?)                        document_frames
   claim_evidence_pairs(claim_id?,         -> claim-to-claim evidence pairs
                        relation?, limit?)
   list_unsourced_claims(source_type?,     -> unattributed claim records
@@ -134,7 +136,27 @@ def am_stats() -> dict:
     return counts
 
 
-@mcp.tool
+# ADR-001 reference implementation: the meta.panel block marks this tool as
+# the discovery counterpart of a canvas panel type; the block's fields mirror
+# the PanelDef in src/genui/catalog.py. See docs/architecture/ADR-001.
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "claims": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "claims",
+        "title": "Extracted claims",
+        "description": "Claims mined from documents with fact-check verdicts.",
+        "endpoint": "/api/v1/arguments/claims",
+        "facets": ["claims", "conflict"],
+        "tables": ["argument_claims"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
 def list_claims(
     source_type: Optional[str] = None,
     topic: Optional[str] = None,
@@ -210,7 +232,24 @@ def list_claims(
     }
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "stances": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "stance",
+        "title": "Stance breakdown",
+        "description": "Supportive / critical / neutral stance mix per topic.",
+        "endpoint": "/api/v1/arguments/stance",
+        "facets": ["stance", "conflict", "sentiment"],
+        "tables": ["source_stances"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
 def list_stances(
     source: Optional[str] = None,
     topic: Optional[str] = None,
@@ -283,7 +322,24 @@ def list_stances(
     }
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "events": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "drift",
+        "title": "Stance drift",
+        "description": "Detected stance reversals and shifts per source.",
+        "endpoint": "/api/v1/arguments/stance/drift",
+        "facets": ["trend", "stance"],
+        "tables": ["stance_drift_events"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
 def list_drift_events(
     source: Optional[str] = None,
     topic: Optional[str] = None,
@@ -348,6 +404,88 @@ def list_drift_events(
                 "confidence_delta": round(r[5], 3) if r[5] is not None else None,
                 "window_pair":      r[6],
                 "detected_at":      r[7],
+            }
+            for r in rows
+        ],
+    }
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "frames": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "frames",
+        "title": "Framing by source",
+        "description": "How each outlet frames the story (economic, legal, …).",
+        "endpoint": "/api/v1/arguments/frames/source",
+        "facets": ["sources", "claims"],
+        "tables": ["document_frames"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
+def list_frames(
+    source_type: Optional[str] = None,
+    frame: Optional[str] = None,
+    limit: int = MAX_LIST,
+) -> dict:
+    """
+    Frame distribution rows from ``document_frames``, aggregated per
+    (frame, source_type): how often each framing appears and how confidently.
+
+    Args:
+        source_type: Filter by source type (news/blog/paper/...).
+        frame:       Exact or partial frame label match (ILIKE).
+        limit:       Max rows (default 30, max 100).
+
+    Returns {"count": int, "frames": [{frame, source_type, doc_count,
+    avg_score}, ...]}.
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+
+    limit = min(limit, 100)
+    where: list[str] = []
+    params: list = []
+
+    if source_type:
+        where.append("source_type = ?")
+        params.append(source_type)
+    if frame:
+        where.append("frame ILIKE ?")
+        params.append(f"%{frame}%")
+
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params.append(limit)
+
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT frame, source_type, COUNT(*) AS doc_count, AVG(score) AS avg_score
+            FROM document_frames
+            {clause}
+            GROUP BY frame, source_type
+            ORDER BY doc_count DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {
+        "count": len(rows),
+        "frames": [
+            {
+                "frame":       r[0],
+                "source_type": r[1],
+                "doc_count":   r[2],
+                "avg_score":   float(r[3]) if r[3] is not None else 0.0,
             }
             for r in rows
         ],
@@ -611,7 +749,23 @@ def list_actors(
     }
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "actors": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "actors",
+        "title": "Key actors",
+        "description": "Most-mentioned speakers, subjects and authors.",
+        "endpoint": "/api/v1/arguments/actors/summary",
+        "facets": ["actors", "entities"],
+        "tables": ["document_actors"],
+        "default_span": 6,
+        "source_type_param": "source_type",
+    }},
+)
 def actor_summary(
     source_type: Optional[str] = None,
     role: Optional[str] = None,
@@ -711,7 +865,23 @@ def trigger_actor_batch(limit: int = 200) -> dict:
         return {"error": f"write connection failed — warehouse may be locked: {e}"}
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "outlets": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "outlet_clusters",
+        "title": "Outlet clusters",
+        "description": "Outlets grouped by editorial framing (PCA scatter).",
+        "endpoint": "/api/v1/arguments/outlets/clusters",
+        "facets": ["sources", "entities"],
+        "tables": ["outlet_clusters"],
+        "default_span": 6,
+        "source_type_param": "source_type",
+    }},
+)
 def list_outlet_clusters(
     source_type: Optional[str] = None,
     cluster_id: Optional[int] = None,
@@ -824,7 +994,23 @@ def trigger_outlet_clustering(
         return {"error": f"write connection failed — warehouse may be locked: {e}"}
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "outlets": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "outlet_ranking",
+        "title": "Outlet transparency ranking",
+        "description": "Outlets scored by framing diversity, attribution, neutrality.",
+        "endpoint": "/api/v1/arguments/outlets/ranking",
+        "facets": ["sources"],
+        "tables": ["outlet_scores"],
+        "default_span": 6,
+        "source_type_param": "source_type",
+    }},
+)
 def list_outlet_scores(
     source_type: Optional[str] = None,
     sort_by: str = "composite_score",

--- a/tools/blog_mcp/server.py
+++ b/tools/blog_mcp/server.py
@@ -262,7 +262,22 @@ def ingest_feeds(
     }
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"matches": {"type": "array"}, "feeds_checked": {"type": "integer"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "watchlists",
+        "title": "Watchlist",
+        "description": "Tracked entities and topics with mention velocity and alerts.",
+        "endpoint": None,
+        "facets": ["events", "trend"],
+        "ui_flag": "watchlists",
+        "default_span": 6,
+    }},
+)
 def run_watchlist(
     keywords: str,
     tag_filter: str = "",

--- a/tools/kg_mcp/server.py
+++ b/tools/kg_mcp/server.py
@@ -99,7 +99,20 @@ def kg_ontology() -> dict:
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    meta={"panel": {
+        "type": "entity_graph",
+        "title": "Entity graph",
+        "description": "Co-mention network of entities in recent coverage.",
+        "endpoint": "/api/v1/entity_graph",
+        "facets": ["entities", "actors", "overview"],
+        "tables": ["news_articles"],
+        "ui_flag": "influence_graph",
+        "default_span": 6,
+        "days_param": "days",
+        "max_days": 30,
+    }},
+)
 def list_entities(
     entity_type: Optional[str] = None,
     name_filter: Optional[str] = None,
@@ -254,7 +267,20 @@ def emerging_connections(
     return get_emerging_connections(since=since, limit=limit)
 
 
-@mcp.tool()
+@mcp.tool(
+    meta={"panel": {
+        "type": "trending",
+        "title": "Trending topics",
+        "description": "Topics ranked by mention velocity.",
+        "endpoint": "/topics/trending",
+        "facets": ["overview", "trend", "events"],
+        "tables": ["news_articles"],
+        "ui_flag": "trending",
+        "default_span": 6,
+        "days_param": "days",
+        "max_days": 30,
+    }},
+)
 def evolving_topics(
     window_minutes: int = 60,
     top_n: int = 15,

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -21,6 +21,12 @@ Tools:
   trigger_followthrough_check(limit?)       -> run nightly follow-through batch on-demand (#111)
   query_conflicts(topic?, source_type?, ...) -> query claim_conflicts table for conflict pairs (#112)
   compute_conflicts(limit?, date_range?)    -> run semantic-similarity conflict detection batch (#112)
+  article_stats(days?)                      -> headline warehouse counts (signal-summary panel)
+  latest_articles(topic?, limit?)           -> newest matching article summaries
+  document_stats(source_type?)              -> ingested-document counts by source type
+  sentiment_by_topic(days?)                 -> average sentiment per topic
+  sentiment_heatmap(days?)                  -> topic-by-day sentiment grid
+  coverage_clusters(days?)                  -> grouped coverage summary (clusters panel)
 
 Design constraints (learned the hard way in this repo):
   * Lazy imports inside tools. The top of this module imports only stdlib +
@@ -619,7 +625,24 @@ def trace_article(id: str) -> dict:
     return trace
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "positions": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "positions",
+        "title": "Actor positions",
+        "description": "Policy positions held by actors, with updates over time.",
+        "endpoint": "/api/v1/arguments/positions",
+        "facets": ["actors", "stance"],
+        "tables": ["policy_positions"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
 def query_positions(
     actor: Optional[str] = None,
     topic: Optional[str] = None,
@@ -808,7 +831,24 @@ def trigger_followthrough_check(limit: int = 50) -> dict:
         return {"error": str(exc)}
 
 
-@mcp.tool
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "conflicts": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "controversy",
+        "title": "Conflicts",
+        "description": "Actor pairs with contradicting claims, by intensity.",
+        "endpoint": "/api/v1/arguments/controversy",
+        "facets": ["conflict", "claims"],
+        "tables": ["claim_conflicts"],
+        "default_span": 6,
+        "topic_param": "topic",
+        "source_type_param": "source_type",
+    }},
+)
 def query_conflicts(
     topic: Optional[str] = None,
     source_type: Optional[str] = None,
@@ -921,6 +961,361 @@ def compute_conflicts(limit: int = 300, date_range: Optional[str] = None) -> dic
         return {"status": "ok", **counts}
     except Exception as exc:
         return {"error": str(exc)}
+
+
+# --------------------------------------------------------------------------- #
+# Panel-shaped warehouse summaries (R2 discovery counterparts; see            #
+# docs/architecture/ADR-001-tool-panel-annotation.md). Read-only, capped,     #
+# and never full payloads — same house rules as the tools above.             #
+# --------------------------------------------------------------------------- #
+
+def _cutoff(days: int):
+    from datetime import datetime, timedelta, timezone
+
+    return datetime.now(timezone.utc) - timedelta(days=max(1, days))
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "total_articles": {"type": "integer"},
+            "window_articles": {"type": "integer"},
+            "sources": {"type": "integer"},
+            "categories": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "kpi_row",
+        "title": "Signal summary",
+        "description": "Headline counts across articles, clusters and topics.",
+        "endpoint": "/api/v1/news/articles",
+        "facets": ["overview"],
+        "tables": ["news_articles"],
+        "default_span": 12,
+    }},
+)
+def article_stats(days: int = 7) -> dict:
+    """Headline warehouse counts: total articles, articles in the window,
+    distinct sources, and per-category counts.
+
+    Args:
+        days: Look-back window in days (default 7).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        total = con.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
+        window = con.execute(
+            "SELECT COUNT(*) FROM news_articles WHERE publish_date >= ?", [_cutoff(days)]
+        ).fetchone()[0]
+        sources = con.execute("SELECT COUNT(DISTINCT source) FROM news_articles").fetchone()[0]
+        cats = con.execute(
+            "SELECT category, COUNT(*) FROM news_articles GROUP BY category "
+            "ORDER BY COUNT(*) DESC LIMIT 12"
+        ).fetchall()
+        return {
+            "total_articles": total,
+            "window_articles": window,
+            "window_days": max(1, days),
+            "sources": sources,
+            "categories": [{"category": c, "articles": n} for c, n in cats],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "articles": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "articles",
+        "title": "Latest documents",
+        "description": "Most recent matching articles and documents.",
+        "endpoint": "/api/v1/news/articles",
+        "facets": ["overview", "sentiment"],
+        "tables": ["news_articles"],
+        "default_span": 6,
+    }},
+)
+def latest_articles(topic: Optional[str] = None, limit: int = 10) -> dict:
+    """Newest articles as compact summaries (title, source, date, sentiment
+    label) — never full content.
+
+    Args:
+        topic: Substring match against the title (ILIKE).
+        limit: Max rows (default 10, max 20).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    limit = min(max(1, limit), 20)
+    where, params = "", []
+    if topic:
+        where = "WHERE title ILIKE ?"
+        params.append(f"%{topic}%")
+    params.append(limit)
+    try:
+        rows = con.execute(
+            f"""
+            SELECT id, title, source, category, publish_date, sentiment_label
+            FROM news_articles {where}
+            ORDER BY publish_date DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "articles": [
+                {
+                    "id": r[0],
+                    "title": r[1],
+                    "source": r[2],
+                    "category": r[3],
+                    "publish_date": r[4].isoformat() if r[4] else None,
+                    "sentiment_label": r[5],
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"total_documents": {"type": "integer"}, "by_source_type": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "documents",
+        "title": "Library",
+        "description": "Ingested documents across all source types (books, papers, transcripts, …).",
+        "endpoint": "/api/v1/documents",
+        "facets": ["library", "overview"],
+        "default_span": 6,
+        "source_type_param": "source_type",
+    }},
+)
+def document_stats(source_type: Optional[str] = None) -> dict:
+    """Ingested-document counts by source type from the ``documents`` corpus
+    table; reports ``table_missing`` when the corpus has not been created yet.
+
+    Args:
+        source_type: Restrict counts to one source type.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        where, params = "", []
+        if source_type:
+            where = "WHERE source_type = ?"
+            params.append(source_type)
+        rows = con.execute(
+            f"SELECT source_type, COUNT(*) FROM documents {where} "
+            "GROUP BY source_type ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall()
+        return {
+            "total_documents": sum(r[1] for r in rows),
+            "by_source_type": [{"source_type": r[0], "documents": r[1]} for r in rows],
+        }
+    except Exception as exc:
+        msg = str(exc)
+        if "does not exist" in msg or "not found" in msg.lower():
+            return {"total_documents": 0, "by_source_type": [], "status": "table_missing: documents"}
+        return {"error": msg}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "topics": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "topic_sentiment",
+        "title": "Sentiment by topic",
+        "description": "Average sentiment score per topic.",
+        "endpoint": "/news_sentiment/topics",
+        "facets": ["sentiment"],
+        "tables": ["news_articles"],
+        "ui_flag": "sentiment_dashboard",
+        "default_span": 6,
+        "days_param": "days",
+        "max_days": 90,
+    }},
+)
+def sentiment_by_topic(days: int = 30) -> dict:
+    """Average sentiment score and article count per topic (category) in the
+    window.
+
+    Args:
+        days: Look-back window in days (default 30, max 90).
+    """
+    days = min(max(1, days), 90)
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        rows = con.execute(
+            """
+            SELECT category, AVG(sentiment_score), COUNT(*)
+            FROM news_articles WHERE publish_date >= ?
+            GROUP BY category ORDER BY COUNT(*) DESC LIMIT 20
+            """,
+            [_cutoff(days)],
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "window_days": days,
+            "topics": [
+                {
+                    "topic": r[0],
+                    "avg_sentiment": float(r[1]) if r[1] is not None else 0.0,
+                    "articles": r[2],
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "cells": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "sentiment_heatmap",
+        "title": "Sentiment heatmap",
+        "description": "Topic × time sentiment intensity grid.",
+        "endpoint": "/news_sentiment/heatmap",
+        "facets": ["sentiment", "trend"],
+        "tables": ["news_articles"],
+        "ui_flag": "sentiment_dashboard",
+        "default_span": 6,
+        "days_param": "days",
+        "max_days": 60,
+    }},
+)
+def sentiment_heatmap(days: int = 14) -> dict:
+    """Topic-by-day average sentiment cells for the heatmap panel.
+
+    Args:
+        days: Look-back window in days (default 14, max 60).
+    """
+    days = min(max(1, days), 60)
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        rows = con.execute(
+            """
+            SELECT category, CAST(publish_date AS DATE), AVG(sentiment_score), COUNT(*)
+            FROM news_articles WHERE publish_date >= ?
+            GROUP BY 1, 2 ORDER BY 2 DESC, 4 DESC LIMIT 200
+            """,
+            [_cutoff(days)],
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "window_days": days,
+            "cells": [
+                {
+                    "topic": r[0],
+                    "date": r[1].isoformat() if r[1] else None,
+                    "avg_sentiment": float(r[2]) if r[2] is not None else 0.0,
+                    "articles": r[3],
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"count": {"type": "integer"}, "clusters": {"type": "array"}},
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "clusters",
+        "title": "Event clusters",
+        "description": "Grouped event coverage with velocity and impact.",
+        "endpoint": "/api/v1/events/clusters",
+        "facets": ["overview", "events"],
+        "tables": ["news_articles"],
+        "ui_flag": "clusters",
+        "default_span": 6,
+    }},
+)
+def coverage_clusters(days: int = 7) -> dict:
+    """Cluster-shaped coverage summary: articles grouped by category with
+    volume, distinct-source count and latest publish time. This is a plain
+    warehouse aggregation, not the API's event-clustering pipeline — it
+    answers "where is coverage concentrated" for planners and inspection.
+
+    Args:
+        days: Look-back window in days (default 7).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        rows = con.execute(
+            """
+            SELECT category, COUNT(*), COUNT(DISTINCT source), MAX(publish_date)
+            FROM news_articles WHERE publish_date >= ?
+            GROUP BY category ORDER BY COUNT(*) DESC LIMIT 15
+            """,
+            [_cutoff(days)],
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "window_days": max(1, days),
+            "clusters": [
+                {
+                    "label": r[0],
+                    "articles": r[1],
+                    "sources": r[2],
+                    "latest": r[3].isoformat() if r[3] else None,
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request: Discovery-derived panel catalog (milestone R2)

## Overview

Implements milestone **R2** of the MCP rearchitecture plan (Stage 1): the generative-UI panel catalog can now be derived from the MCP servers themselves. A tool that corresponds to a canvas panel announces that with a `meta.panel` annotation; the backend builder validates the annotation into a `PanelDef` and merges it over the static catalog, which remains the fallback. Dropping in a new annotated server surfaces its panel type in `GET /api/v1/ui/panels` with zero genui code changes; with every server down the payload is byte-identical to today. The planner still reads the static catalog until R3.

Closes #586. Closes #587. Closes #588.

## Changes Summary

**ADR (#586)**

- `docs/architecture/ADR-001-tool-panel-annotation.md`: an explicit `panel` block in the tool's MCP `_meta` field, chosen over FastMCP tags because `_meta` is MCP-spec-stable while tag serialization is framework-private (verified empirically: FastMCP serializes its own tags under a separate `fastmcp` meta namespace). Fields mirror `PanelDef`; `outputSchema` is required on annotated tools (FastMCP's derived schema satisfies the rule, explicit schemas preferred); `note` and `timeline` are documented as composed panels with no tool counterpart by design.

**Annotations (#587)**

- 18 tools annotated across four servers, mirroring the static catalog field for field: claims, stance, drift, outlet_ranking, outlet_clusters, actors, frames (arguments); entity_graph, trending (kg); watchlists (blog-feeds); positions, controversy, kpi_row, articles, documents, topic_sentiment, sentiment_heatmap, clusters (pipeline).
- New read-only warehouse summary tools where no counterpart existed, in each server's house style (capped summaries, graceful degradation): `list_frames` (arguments) and `article_stats`, `latest_articles`, `document_stats`, `sentiment_by_topic`, `sentiment_heatmap`, `coverage_clusters` (pipeline). `coverage_clusters` is honestly documented as a coverage aggregation, not the API's event-clustering pipeline.
- Every data-backed panel type in the static catalog now has exactly one annotated counterpart discoverable via `tools/list`.

**Catalog builder (#588)**

- `src/mcp_host` tool cache now carries each tool's `_meta` block and `outputSchema` presence (still a non-blocking snapshot).
- `src/genui/discovery.py`: validates annotations (malformed blocks are skipped with a warning, never an error; missing outputSchema rejects), merges discovered defs over the static catalog (override in place, new types appended, first server wins on duplicates), and serves the result through `GET /api/v1/ui/panels`. Entries carry a `source` field only when discovery contributed, so the no-discovery payload stays byte-identical.

## Testing Status

- [x] 266 tests pass; `src/genui/discovery.py` at 99% coverage
- [x] Litmus (a) in CI: a fake annotated server surfaces `citation_graph` through the route with zero genui changes
- [x] Litmus (b) in CI: with no discovery the `/ui/panels` payload equals the static catalog exactly
- [x] Annotation-parity suite (runs where fastmcp is installed): lists the real servers in-memory and asserts every annotation matches the static catalog field for field, every annotated tool has an outputSchema, and coverage equals all types minus the two composed panels
- [x] Codegen staleness gate clean; `TESTING=true` app import unaffected

## Live verification (R2 exit criterion)

- All 7 new tools ran against the real warehouse through a FastMCP client with valid, schema-conforming output
- 4 annotated servers plus a brand-new temporary `research-lit` server (written to a temp file, one annotated tool) connected over real stdio; `list_claims`'s `meta.panel` round-tripped through a real `tools/list` (the ADR reference implementation)
- The merged catalog served 21 panels: 20 static plus the new server's `citation_graph`, sourced from `research-lit`, with zero genui changes