### PR TITLE
R3: Adaptivity from tools - tool-sourced availability/flags, documents-corpus anchor, pack-supplied telemetry

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useTicker } from "./lib/queries";
+import { useUiTelemetry } from "./lib/queries";
 import { useCanvases } from "./genui/canvases";
 import Sidebar from "./components/Sidebar";
 import TopBar from "./components/TopBar";
@@ -10,7 +10,7 @@ import Canvas from "./genui/Canvas";
 // startup screen is intentionally empty except for the prompt.
 export default function App() {
   const manager = useCanvases();
-  const { data: ticker } = useTicker();
+  const { data: telemetry } = useUiTelemetry();
   const hasIntent = manager.active.intent.trim().length > 0;
 
   return (
@@ -25,7 +25,11 @@ export default function App() {
 
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar onIntent={manager.open} />
-        {hasIntent ? <BreakingTicker text={ticker} /> : null}
+        {/* Pack-provided signal strip (BREAKING for news, NEW IN LIBRARY
+            for the corpus fallback) — absent when no pack supplies one. */}
+        {hasIntent && telemetry.ticker ? (
+          <BreakingTicker label={telemetry.ticker.label} text={telemetry.ticker.text} />
+        ) : null}
         <main className="min-h-0 flex-1">
           <Canvas key={manager.active.id} canvas={manager.active} onIntent={manager.open} />
         </main>

--- a/apps/web/src/components/BreakingTicker.tsx
+++ b/apps/web/src/components/BreakingTicker.tsx
@@ -1,10 +1,13 @@
 import { palette, fonts } from "../theme";
 
+// The pack-provided signal strip: news supplies BREAKING, the library
+// fallback supplies NEW IN LIBRARY — the label comes from telemetry.
 interface Props {
   text: string;
+  label?: string;
 }
 
-export default function BreakingTicker({ text }: Props) {
+export default function BreakingTicker({ text, label = "BREAKING" }: Props) {
   return (
     <div
       style={{
@@ -33,7 +36,7 @@ export default function BreakingTicker({ text }: Props) {
           zIndex: 2,
         }}
       >
-        BREAKING
+        {label}
       </div>
       <div style={{ flex: 1, overflow: "hidden", whiteSpace: "nowrap" }}>
         <div

--- a/apps/web/src/genui/Canvas.tsx
+++ b/apps/web/src/genui/Canvas.tsx
@@ -6,7 +6,7 @@
 import { RotateCcw } from "lucide-react";
 import SpecRenderer from "./SpecRenderer";
 import EntityGraph from "../components/charts/EntityGraph";
-import { useArticles, useClusters, useEntityGraph, useTrending, usePackStatus } from "../lib/queries";
+import { useArticles, useClusters, useEntityGraph, useUiTelemetry } from "../lib/queries";
 import { useUiSpec } from "./useUiSpec";
 import { useAdaptiveSignals, hasSignals } from "./signals";
 import { PANEL_DEFS } from "./spec";
@@ -35,12 +35,21 @@ const PLANNER_BADGE: Record<string, { label: string; className: string; hint: st
 const QUIET_SUGGESTIONS = ["daily briefing", "fact-check claims about the economy", "library documents"];
 
 function EmptyState({ onIntent }: { onIntent: (intent: string) => void }) {
-  const { newsPack } = usePackStatus();
+  // The ambient signal is pack-supplied (R3): whichever packs the backend
+  // has enabled advertise movers/signals; the library fallback keeps a
+  // zero-news corpus alive. No news hook is hardcoded here anymore.
+  const { data: telemetry } = useUiTelemetry();
   const { data: graph } = useEntityGraph();
-  const { data: trending } = useTrending();
   const { data: articles } = useArticles();
   const { data: clusters } = useClusters();
-  const movers = trending.slice(0, 5);
+  const movers = telemetry.movers;
+  const signals = telemetry.signals.length
+    ? telemetry.signals
+    : [
+        { label: "DOCS", value: articles.length },
+        { label: "CLUSTERS", value: clusters.length },
+        { label: "TOPICS MOVING", value: movers.length },
+      ];
 
   return (
     <div className="relative flex-1 overflow-hidden">
@@ -65,36 +74,40 @@ function EmptyState({ onIntent }: { onIntent: (intent: string) => void }) {
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" style={{ animation: "blink 2s infinite" }} />
             LIVE SIGNAL
           </span>
-          <span>{articles.length} DOCS</span>
-          <span>{clusters.length} CLUSTERS</span>
-          <span>{trending.length} TOPICS MOVING</span>
+          {signals.map((s) => (
+            <span key={s.label}>
+              {s.value} {s.label}
+            </span>
+          ))}
         </div>
 
-        {newsPack && movers.length > 0 ? (
+        {movers.length > 0 ? (
           <div className="w-full max-w-lg">
             <div className="mb-2 text-center font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60">
-              MOVING NOW — GENERATE A COVERAGE VIEW
+              MOVING NOW — GENERATE A VIEW
             </div>
             <div className="flex flex-col gap-1">
               {movers.map((t, i) => (
                 <Button
-                  key={t.topic}
+                  key={t.label}
                   variant="ghost"
-                  onClick={() => onIntent(`coverage of ${t.topic.toLowerCase()}`)}
-                  title={`Generate: “coverage of ${t.topic.toLowerCase()}”`}
+                  onClick={() => onIntent(t.intent)}
+                  title={`Generate: “${t.intent}”`}
                   className="h-auto w-full justify-start gap-3 px-3 py-2 font-normal"
                 >
                   <span className="w-4 shrink-0 text-right font-mono text-[11px] text-muted-foreground/50">
                     {i + 1}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-left text-[13px]">{t.topic}</span>
-                  <span
-                    className={
-                      "font-mono text-[11px] " + (t.change >= 0 ? "text-emerald-400" : "text-red-400")
-                    }
-                  >
-                    {(t.change >= 0 ? "+" : "") + t.change}%
-                  </span>
+                  <span className="min-w-0 flex-1 truncate text-left text-[13px]">{t.label}</span>
+                  {typeof t.change === "number" ? (
+                    <span
+                      className={
+                        "font-mono text-[11px] " + (t.change >= 0 ? "text-emerald-400" : "text-red-400")
+                      }
+                    >
+                      {(t.change >= 0 ? "+" : "") + t.change}%
+                    </span>
+                  ) : null}
                   <span className="font-mono text-[10px] text-muted-foreground/40">▸ generate</span>
                 </Button>
               ))}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -372,6 +372,15 @@ export interface RawUiContext {
   llm: { enabled: boolean; provider: string | null };
 }
 
+// Pack-supplied empty-canvas telemetry (R3): whichever packs are enabled
+// advertise the ambient signal; "library" marks the engine fallback.
+export interface RawUiTelemetry {
+  signals: { label: string; value: number }[];
+  movers: { label: string; intent: string; change?: number }[];
+  ticker: { label: string; items: string[] } | null;
+  packs: string[];
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -384,6 +393,8 @@ export const api = {
   }) => requestPost<RawUiSpecResponse>("/api/v1/ui/generate", body),
 
   uiContext: () => request<RawUiContext>("/api/v1/ui/context"),
+
+  uiTelemetry: () => request<RawUiTelemetry>("/api/v1/ui/telemetry"),
 
   articles: (params?: { category?: string; source?: string }) =>
     request<RawArticle[]>("/api/v1/news/articles", params),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -220,21 +220,50 @@ export function usePackStatus(): { newsPack: boolean; isLoading: boolean } {
   return { newsPack: q.data?.newsPack ?? true, isLoading: q.isLoading };
 }
 
-export function useTicker(): Result<string> {
+// Pack-supplied empty-canvas telemetry (R3): the ambient signal comes from
+// whichever packs the backend has enabled (news movers and BREAKING ticker,
+// or the engine's library telemetry when news is off). The demo fallback
+// reproduces the news-flavored visuals so the UI is unchanged offline.
+export interface UiTelemetry {
+  signals: { label: string; value: number }[];
+  movers: { label: string; intent: string; change?: number }[];
+  ticker: { label: string; text: string } | null;
+  packs: string[];
+}
+
+const mockTelemetry: UiTelemetry = {
+  signals: [],
+  movers: mockTrending.slice(0, 5).map((t) => ({
+    label: t.topic,
+    intent: `coverage of ${t.topic.toLowerCase()}`,
+    change: t.change,
+  })),
+  ticker: { label: "BREAKING", text: mockTickerText },
+  packs: ["news"],
+};
+
+export function useUiTelemetry(): Result<UiTelemetry> {
   return useWithFallback(
-    "ticker",
+    "uiTelemetry",
     async () => {
-      const news = await api.breakingNews({ limit: 6 });
-      if (!news.length) throw new Error("empty");
-      const text =
-        "  " +
-        news
-          .map((n) => n.sample_headlines?.split("|")[0]?.trim() || n.cluster_name)
-          .filter(Boolean)
-          .join("  ●  ");
-      return `  ●${text}  `;
+      const raw = await api.uiTelemetry();
+      if (!raw.signals.length && !raw.movers.length && !raw.ticker) {
+        throw new Error("empty");
+      }
+      return {
+        signals: raw.signals,
+        movers: raw.movers.slice(0, 5),
+        ticker:
+          raw.ticker && raw.ticker.items.length
+            ? {
+                label: raw.ticker.label,
+                text: "  ●  " + raw.ticker.items.join("  ●  ") + "  ",
+              }
+            : null,
+        packs: raw.packs,
+      };
     },
-    mockTickerText,
+    mockTelemetry,
   );
 }
 

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -42,15 +42,20 @@ intent ──► POST /api/v1/ui/generate ──► ui-spec-v1 ──► SpecRen
 | `codegen.py` | Stage 0 codegen: renders `apps/web/src/genui/catalog.gen.ts` and the `ui-spec-v1` contract enums from `catalog.py`. Run `python scripts/genui/codegen.py` after editing the catalog; CI (and `tests/unit/genui/test_codegen.py`) fail while the generated files are stale. |
 | `spec.py` | `ui-spec-v1` dataclasses + pure-Python `validate_spec` (contract: `contracts/schemas/jsonschema/ui-spec-v1.json`). |
 | `planner.py` | Heuristic planner: facet scoring from keyword evidence, topic / source-type / time-window extraction, panel assembly. No model, no network. |
-| `adaptivity.py` | The adaptive inputs: DuckDB table probing (`data_availability`), merged domain-pack `ui_flags`, and usage-signal re-ranking (`apply_signals`). |
+| `adaptivity.py` | The adaptive inputs. Since R3 availability and `ui_flags` are tool-sourced (`resolve_availability` / `resolve_ui_flags` call the servers' stats tools through the MCP host, cached ~30s) with the DuckDB probe and pack registry as servers-down fallbacks; usage-signal re-ranking (`apply_signals`). Overview panels anchor on the `documents` corpus (union of `documents` and `news_articles`), so a zero-news corpus keeps a live overview. |
+| `telemetry.py` | Pack-supplied empty-canvas telemetry (R3): enabled packs advertise `signals`/`movers`/`ticker` via `DomainPack.telemetry`; the engine's library fallback (recently ingested documents) fills whatever no pack supplies. |
 | `llm.py` | Optional LLM planner (Anthropic or OpenAI). Any failure — no key, no SDK, bad JSON, invalid spec — falls back to the heuristic planner. |
 
 Routes (`src/api/routes/genui_routes.py`, registered via the standard
 feature-flag pattern in `src/api/app.py`):
 
 - `POST /api/v1/ui/generate` — `{intent, source_type?, signals?}` → `{spec, meta}`
-- `GET /api/v1/ui/context` — merged ui_flags, availability map, LLM planner
-  status, MCP host health (per-server state / last-seen / tool counts)
+- `GET /api/v1/ui/context` — merged ui_flags, availability map (each with a
+  `_source` field: `tools` when server-derived, `warehouse`/`packs` on
+  fallback), LLM planner status, MCP host health
+- `GET /api/v1/ui/telemetry` — pack-supplied ambient signal for the empty
+  canvas (KPI signals, movers, ticker); with the news pack off it carries
+  the library telemetry instead of an empty gap
 - `GET /api/v1/ui/panels` — the panel catalog
 
 ### Discovery-derived catalog (`src/genui/discovery.py`, R2)
@@ -104,8 +109,10 @@ The provenance strip above the canvas shows which planner ran:
 ## Adaptivity guarantees
 
 - **Data-aware**: panels whose warehouse tables are empty are dropped and
-  listed in the plan note ("Hidden for now…"). Unknown availability keeps
-  every panel (frontend demo fallback covers empty endpoints).
+  listed in the plan note ("Hidden for now…"). Availability is read from
+  the MCP servers' stats tools when the host is up, from the DuckDB probe
+  otherwise; unknown availability keeps every panel (frontend demo
+  fallback covers empty endpoints).
 - **Pack-aware**: panels gated by a domain-pack `ui_flag` disappear when
   the pack is disabled.
 - **Usage-aware**: pins always include and boost a panel type; mutes hide

--- a/src/api/routes/genui_routes.py
+++ b/src/api/routes/genui_routes.py
@@ -12,11 +12,12 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from src.genui.adaptivity import data_availability, merged_ui_flags
+from src.genui.adaptivity import resolve_availability, resolve_ui_flags
 from src.genui.discovery import merged_catalog_dict
 from src.genui.llm import llm_config, plan_with_llm
 from src.genui.planner import plan
 from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, validate_spec
+from src.genui.telemetry import pack_telemetry
 from src.mcp_host import host_status
 
 router = APIRouter(prefix="/api/v1/ui", tags=["generative_ui"])
@@ -54,8 +55,8 @@ def generate_ui(request: GenerateUiRequest) -> Dict[str, Any]:
     event loop.
     """
     try:
-        availability = data_availability()
-        ui_flags = merged_ui_flags()
+        availability, availability_source = resolve_availability()
+        ui_flags, _ = resolve_ui_flags()
         signals = request.signals.model_dump() if request.signals else None
 
         spec = plan_with_llm(
@@ -86,6 +87,7 @@ def generate_ui(request: GenerateUiRequest) -> Dict[str, Any]:
             "meta": {
                 "generated_by": spec.generated_by,
                 "availability_known": availability is not None,
+                "availability_source": availability_source,
                 "ui_flags": ui_flags,
             },
         }
@@ -97,13 +99,21 @@ def generate_ui(request: GenerateUiRequest) -> Dict[str, Any]:
 
 @router.get("/context")
 def ui_context() -> Dict[str, Any]:
-    """Expose the adaptive inputs the planner uses (sync: blocking probe)."""
+    """Expose the adaptive inputs the planner uses (sync: blocking probe).
+
+    R3: availability and ui_flags come from the servers' stats tools when
+    the host runtime is up (source ``tools``); the DuckDB probe / registry
+    fallbacks report ``warehouse`` / ``packs``.
+    """
     try:
-        availability = data_availability()
+        availability, availability_source = resolve_availability()
+        ui_flags, ui_flags_source = resolve_ui_flags()
         config = llm_config()
         return {
-            "ui_flags": merged_ui_flags(),
+            "ui_flags": ui_flags,
+            "ui_flags_source": ui_flags_source,
             "availability": availability,
+            "availability_source": availability_source,
             "availability_known": availability is not None,
             "llm": {
                 "enabled": config is not None,
@@ -115,6 +125,20 @@ def ui_context() -> Dict[str, Any]:
         }
     except Exception as err:
         raise HTTPException(status_code=500, detail=f"UI context failed: {err}")
+
+
+@router.get("/telemetry")
+def ui_telemetry() -> Dict[str, Any]:
+    """Ambient empty-canvas telemetry supplied by the enabled packs (R3).
+
+    Sync on purpose (warehouse reads run in the threadpool). With the news
+    pack disabled the payload still carries the engine's library telemetry
+    (recently ingested documents), never an empty gap.
+    """
+    try:
+        return pack_telemetry()
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"UI telemetry failed: {err}")
 
 
 @router.get("/panels")

--- a/src/domains/base.py
+++ b/src/domains/base.py
@@ -60,6 +60,12 @@ class DomainPack:
             e.g. ``["src.api.routes.news_routes"]``
         ui_flags: Feature flags forwarded to the frontend.
             e.g. ``{"timeline": True, "clusters": True}``
+        telemetry: Optional zero-arg callable advertising this pack's
+            ambient empty-canvas telemetry (R3 / Track N2). Returns a dict
+            with any of ``signals`` (KPI strip entries: {label, value}),
+            ``movers`` (suggestion rows: {label, intent, change?}) and
+            ``ticker`` ({label, items}). Exceptions are swallowed by the
+            collector — a pack's telemetry must never break the canvas.
     """
 
     name: str
@@ -68,3 +74,4 @@ class DomainPack:
     enrichers: List[Enricher] = field(default_factory=list)
     route_modules: List[str] = field(default_factory=list)
     ui_flags: Dict[str, bool] = field(default_factory=dict)
+    telemetry: Optional[Callable[[], Dict[str, Any]]] = None

--- a/src/domains/news/pack.py
+++ b/src/domains/news/pack.py
@@ -6,6 +6,7 @@ and tests can import the pack object directly without triggering registration.
 """
 
 from src.domains.base import DomainPack, Enricher
+from src.domains.news.telemetry import news_telemetry
 from src.domains.news.enrichers import (
     event_clusterer_enricher,
     fake_news_enricher,
@@ -73,4 +74,5 @@ NewsDomainPack = DomainPack(
     enrichers=_NEWS_ENRICHERS,
     route_modules=_NEWS_ROUTE_MODULES,
     ui_flags=_NEWS_UI_FLAGS,
+    telemetry=news_telemetry,
 )

--- a/src/domains/news/telemetry.py
+++ b/src/domains/news/telemetry.py
@@ -1,0 +1,68 @@
+"""
+News-pack ambient telemetry (R3 / Track N2).
+
+Advertises the empty canvas's news signal — moving topics, a BREAKING
+ticker, headline counts — from the warehouse. Registered on the pack via
+``DomainPack.telemetry`` so the canvas only shows news telemetry while
+the news pack is enabled; the genui collector swallows any failure here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+MAX_MOVERS = 5
+MAX_TICKER = 6
+
+
+def news_telemetry() -> Dict[str, Any]:
+    """Movers, ticker and KPI signals from the news_articles table."""
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    conn = get_shared_connection()
+    with _LOCK:
+        total = conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
+        sources = conn.execute(
+            "SELECT COUNT(DISTINCT source) FROM news_articles"
+        ).fetchone()[0]
+        movers_rows = conn.execute(
+            """
+            SELECT category, COUNT(*) AS n,
+                   COUNT(*) FILTER (
+                       WHERE publish_date >= CURRENT_TIMESTAMP - INTERVAL 7 DAY
+                   ) AS recent
+            FROM news_articles
+            GROUP BY category ORDER BY n DESC LIMIT ?
+            """,
+            [MAX_MOVERS],
+        ).fetchall()
+        ticker_rows = conn.execute(
+            "SELECT title FROM news_articles "
+            "ORDER BY publish_date DESC NULLS LAST LIMIT ?",
+            [MAX_TICKER],
+        ).fetchall()
+
+    movers = []
+    for category, count, recent in movers_rows:
+        if not category:
+            continue
+        share = round(100 * (recent or 0) / count) if count else 0
+        movers.append(
+            {
+                "label": str(category),
+                "intent": f"coverage of {str(category).lower()}",
+                "change": share,
+            }
+        )
+    return {
+        "signals": [
+            {"label": "ARTICLES", "value": int(total)},
+            {"label": "SOURCES", "value": int(sources)},
+            {"label": "TOPICS MOVING", "value": len(movers)},
+        ],
+        "movers": movers,
+        "ticker": {
+            "label": "BREAKING",
+            "items": [str(r[0]) for r in ticker_rows if r[0]],
+        },
+    }

--- a/src/genui/adaptivity.py
+++ b/src/genui/adaptivity.py
@@ -1,27 +1,41 @@
 """
 Adaptivity layer: the three inputs that reshape a generated layout.
 
-* :func:`data_availability` probes the DuckDB warehouse for which tables
-  actually hold rows, so the planner can hide panels that would render
-  empty. The probe degrades to ``None`` ("unknown") on any failure — a
-  missing warehouse must never break UI generation.
-* :func:`merged_ui_flags` merges the ``ui_flags`` of all enabled domain
-  packs (same merge the domain-packs MCP server exposes) so pack-gated
-  panels disappear when their pack is off.
+* :func:`resolve_availability` maps each catalog table to whether it holds
+  rows. Since R3 the primary source is the MCP servers' own stats tools
+  (``am_stats``, ``article_stats``, ``document_stats``, ...) through the
+  host runtime; the direct DuckDB probe (:func:`data_availability`) is the
+  fallback, so with servers down behavior is identical to before. Both
+  sources degrade to ``None`` ("unknown") rather than failing — a missing
+  warehouse must never break UI generation.
+* :func:`resolve_ui_flags` merges the ``ui_flags`` of all enabled domain
+  packs, preferring the domain-packs MCP server's ``get_ui_flags`` tool
+  and falling back to the in-process registry
+  (:func:`merged_ui_flags`).
 * :func:`apply_signals` folds client usage signals — pinned, dismissed and
   interaction weights persisted by the frontend — into panel priorities.
+
+Overview panels anchor on the virtual ``documents`` corpus (Track N2):
+its availability is the union of the ``documents`` table and
+``news_articles``, so a corpus with zero news still gets a live overview.
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from src.genui.catalog import PANEL_CATALOG, get_panel_def
 from src.genui.spec import PanelSpec
 
-# Tables the catalog references; probed in one round-trip.
+# The "documents" anchor is a corpus, not one table: available when either
+# the documents table or the legacy news_articles table has rows.
+DOCUMENT_CORPUS_TABLES: Tuple[str, ...] = ("documents", "news_articles")
+
+# Tables the catalog references; probed in one round-trip. The corpus
+# tables are always included so the union can be computed.
 _PROBE_TABLES: Tuple[str, ...] = tuple(
-    sorted({t for p in PANEL_CATALOG for t in p.tables})
+    sorted({t for p in PANEL_CATALOG for t in p.tables} | set(DOCUMENT_CORPUS_TABLES))
 )
 
 MAX_SIGNAL_WEIGHT = 20
@@ -164,17 +178,26 @@ def _default_probe() -> Dict[str, int]:
     return counts
 
 
+def _availability_from_counts(counts: Dict[str, int]) -> Dict[str, bool]:
+    """Counts -> availability map, with the documents-corpus union applied."""
+    availability = {table: counts.get(table, 0) > 0 for table in _PROBE_TABLES}
+    availability["documents"] = any(
+        availability.get(t, False) for t in DOCUMENT_CORPUS_TABLES
+    )
+    return availability
+
+
 def data_availability(
     probe: Optional[Callable[[], Dict[str, int]]] = None,
 ) -> Optional[Dict[str, bool]]:
-    """Map each catalog table to whether it currently holds rows.
+    """Map each catalog table to whether it currently holds rows, from the
+    direct DuckDB warehouse probe (the servers-down fallback path).
 
     Returns ``None`` when the warehouse cannot be reached — callers treat
     unknown availability as "keep every panel".
     """
     try:
-        counts = (probe or _default_probe)()
-        return {table: counts.get(table, 0) > 0 for table in _PROBE_TABLES}
+        return _availability_from_counts((probe or _default_probe)())
     except Exception:
         return None
 
@@ -190,3 +213,127 @@ def merged_ui_flags() -> Dict[str, bool]:
         return flags
     except Exception:
         return {}
+
+
+# --------------------------------------------------------------------------
+# R3: tool-sourced adaptivity. The MCP servers' stats tools are the primary
+# source for availability and ui_flags; everything above is the fallback.
+# Results are cached briefly so a burst of generates does not hammer the
+# servers (R4 generalizes this cache and shares it with the planning loop).
+# --------------------------------------------------------------------------
+
+TOOL_STATS_TTL = 30.0
+
+# Servers whose stats tools cover every catalog table.
+_STATS_SERVERS = ("neuronews-arguments", "neuronews-pipeline")
+_FLAGS_SERVER = "neuronews-domain-packs"
+
+# am_stats reports row counts for these catalog tables directly.
+_AM_STATS_TABLES = (
+    "argument_claims",
+    "claim_conflicts",
+    "source_stances",
+    "stance_drift_events",
+    "policy_positions",
+    "document_frames",
+)
+# Tables probed via a limit-1 list call ({"count": 0|1} tells presence).
+_LIMIT_PROBE_TOOLS = (
+    ("outlet_scores", "list_outlet_scores"),
+    ("outlet_clusters", "list_outlet_clusters"),
+    ("document_actors", "actor_summary"),
+)
+
+_cache: Dict[str, Any] = {"availability": None, "flags": None}
+
+
+def reset_tool_cache() -> None:
+    """Drop cached tool-sourced results (tests and pack toggles)."""
+    _cache["availability"] = None
+    _cache["flags"] = None
+
+
+def _get_host():
+    from src.mcp_host import get_host
+
+    return get_host()
+
+
+def _servers_connected(host, names) -> bool:
+    servers = host.status().get("servers", {})
+    return all(servers.get(n, {}).get("state") == "connected" for n in names)
+
+
+def _tool_counts(host) -> Dict[str, int]:
+    """Row counts for every catalog table via the servers' stats tools."""
+    counts: Dict[str, int] = {}
+
+    am = host.call_tool("neuronews-arguments", "am_stats")
+    if "error" in am:
+        raise RuntimeError(am["error"])
+    for table in _AM_STATS_TABLES:
+        value = am.get(table)
+        counts[table] = value if isinstance(value, int) else 0
+
+    articles = host.call_tool("neuronews-pipeline", "article_stats")
+    if "error" in articles:
+        raise RuntimeError(articles["error"])
+    counts["news_articles"] = int(articles.get("total_articles", 0))
+
+    documents = host.call_tool("neuronews-pipeline", "document_stats")
+    if "error" in documents:
+        raise RuntimeError(documents["error"])
+    counts["documents"] = int(documents.get("total_documents", 0))
+
+    for table, tool in _LIMIT_PROBE_TOOLS:
+        result = host.call_tool("neuronews-arguments", tool, {"limit": 1})
+        if "error" in result:
+            raise RuntimeError(result["error"])
+        counts[table] = int(result.get("count", 0))
+    return counts
+
+
+def resolve_availability() -> Tuple[Optional[Dict[str, bool]], str]:
+    """``(availability, source)`` with source one of ``tools`` /
+    ``warehouse`` / ``unknown``.
+
+    Tool-sourced when the host runtime is up and the stats servers are
+    connected; the DuckDB probe otherwise, keeping servers-down behavior
+    identical to pre-R3.
+    """
+    cached = _cache["availability"]
+    if cached is not None and time.time() < cached[1]:
+        return cached[0], "tools"
+    try:
+        host = _get_host()
+        if host is not None and _servers_connected(host, _STATS_SERVERS):
+            availability = _availability_from_counts(_tool_counts(host))
+            _cache["availability"] = (availability, time.time() + TOOL_STATS_TTL)
+            return availability, "tools"
+    except Exception:
+        pass
+    availability = data_availability()
+    return availability, ("warehouse" if availability is not None else "unknown")
+
+
+def resolve_ui_flags() -> Tuple[Dict[str, bool], str]:
+    """``(ui_flags, source)`` with source ``tools`` or ``packs``.
+
+    Prefers the domain-packs server's ``get_ui_flags`` tool (server
+    presence + tool result); falls back to the in-process registry merge.
+    """
+    cached = _cache["flags"]
+    if cached is not None and time.time() < cached[1]:
+        return cached[0], "tools"
+    try:
+        host = _get_host()
+        if host is not None and _servers_connected(host, (_FLAGS_SERVER,)):
+            result = host.call_tool(_FLAGS_SERVER, "get_ui_flags")
+            flags = result.get("flags")
+            if isinstance(flags, dict):
+                flags = {str(k): bool(v) for k, v in flags.items()}
+                _cache["flags"] = (flags, time.time() + TOOL_STATS_TTL)
+                return flags, "tools"
+    except Exception:
+        pass
+    return merged_ui_flags(), "packs"

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -64,13 +64,16 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         facets=FACETS,
         default_span=12,
     ),
+    # Overview panels anchor availability on the "documents" corpus (Track
+    # N2 / R3): adaptivity treats it as the union of the documents table and
+    # news_articles, so a zero-news corpus still gets a live overview.
     PanelDef(
         type="kpi_row",
         title="Signal summary",
         description="Headline counts across articles, clusters and topics.",
         endpoint="/api/v1/news/articles",
         facets=("overview",),
-        tables=("news_articles",),
+        tables=("documents",),
         default_span=12,
     ),
     PanelDef(
@@ -79,7 +82,7 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         description="Most recent matching articles and documents.",
         endpoint="/api/v1/news/articles",
         facets=("overview", "sentiment"),
-        tables=("news_articles",),
+        tables=("documents",),
         default_span=6,
     ),
     PanelDef(
@@ -162,7 +165,7 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         description="Co-mention network of entities in recent coverage.",
         endpoint="/api/v1/entity_graph",
         facets=("entities", "actors", "overview"),
-        tables=("news_articles",),
+        tables=("documents",),
         ui_flag="influence_graph",
         default_span=6,
         days_param="days",

--- a/src/genui/telemetry.py
+++ b/src/genui/telemetry.py
@@ -1,0 +1,175 @@
+"""
+Pack-supplied empty-canvas telemetry (R3 / Track N2).
+
+The empty canvas's ambient signal (KPI strip, movers list, ticker) is no
+longer hardcoded to news hooks: enabled domain packs advertise telemetry
+via ``DomainPack.telemetry`` and this module collects it. When no enabled
+pack contributes a slot, the engine-level **library** telemetry fills it
+from the document corpus (the documents table, falling back to
+news_articles — both are documents in the corpus sense), so a canvas with
+the news pack disabled still shows a live ambient signal: recently
+ingested documents instead of an empty gap.
+
+Every failure degrades to an empty slot; telemetry must never break the
+canvas or the API.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_MOVERS = 5
+MAX_TICKER = 6
+
+
+def _clean_signals(raw: Any) -> List[Dict[str, Any]]:
+    out = []
+    for item in raw if isinstance(raw, list) else []:
+        if isinstance(item, dict) and isinstance(item.get("label"), str):
+            out.append({"label": item["label"], "value": item.get("value", 0)})
+    return out
+
+
+def _clean_movers(raw: Any) -> List[Dict[str, Any]]:
+    out = []
+    for item in raw if isinstance(raw, list) else []:
+        if (
+            isinstance(item, dict)
+            and isinstance(item.get("label"), str)
+            and isinstance(item.get("intent"), str)
+        ):
+            mover = {"label": item["label"], "intent": item["intent"]}
+            if isinstance(item.get("change"), (int, float)):
+                mover["change"] = item["change"]
+            out.append(mover)
+    return out
+
+
+def _clean_ticker(raw: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict) or not isinstance(raw.get("label"), str):
+        return None
+    items = [i for i in raw.get("items") or [] if isinstance(i, str) and i.strip()]
+    return {"label": raw["label"], "items": items[:MAX_TICKER]} if items else None
+
+
+def _library_telemetry() -> Dict[str, Any]:
+    """Engine-level fallback: the document corpus itself is the signal."""
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    conn = get_shared_connection()
+    with _LOCK:
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+        if "documents" in tables:
+            total = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            rows = conn.execute(
+                "SELECT title, source_type FROM documents "
+                "ORDER BY created_at DESC NULLS LAST LIMIT ?",
+                [MAX_TICKER],
+            ).fetchall()
+            types = conn.execute(
+                "SELECT source_type, COUNT(*) FROM documents "
+                "GROUP BY source_type ORDER BY COUNT(*) DESC LIMIT ?",
+                [MAX_MOVERS],
+            ).fetchall()
+        elif "news_articles" in tables:
+            total = conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
+            rows = conn.execute(
+                "SELECT title, category FROM news_articles "
+                "ORDER BY publish_date DESC NULLS LAST LIMIT ?",
+                [MAX_TICKER],
+            ).fetchall()
+            types = conn.execute(
+                "SELECT category, COUNT(*) FROM news_articles "
+                "GROUP BY category ORDER BY COUNT(*) DESC LIMIT ?",
+                [MAX_MOVERS],
+            ).fetchall()
+        else:
+            return {}
+
+    movers = [
+        {
+            "label": str(kind),
+            "intent": f"library documents about {str(kind).lower()}",
+            "change": int(count),
+        }
+        for kind, count in types
+        if kind
+    ]
+    return {
+        "signals": [{"label": "DOCS", "value": int(total)}],
+        "movers": movers,
+        "ticker": {
+            "label": "NEW IN LIBRARY",
+            "items": [str(r[0]) for r in rows if r[0]],
+        },
+    }
+
+
+def pack_telemetry() -> Dict[str, Any]:
+    """Collect ambient telemetry from whichever packs are enabled.
+
+    Returns ``{signals, movers, ticker, packs}``. ``packs`` lists the
+    contributors; ``"library"`` marks the engine fallback.
+    """
+    signals: List[Dict[str, Any]] = []
+    movers: List[Dict[str, Any]] = []
+    ticker: Optional[Dict[str, Any]] = None
+    contributing: List[str] = []
+
+    try:
+        from src.domains.registry import get_enabled_packs
+
+        packs = get_enabled_packs()
+    except Exception:
+        packs = []
+
+    for pack in packs:
+        provider = getattr(pack, "telemetry", None)
+        if provider is None:
+            continue
+        try:
+            supplied = provider() or {}
+        except Exception:
+            logger.warning("telemetry provider of pack %r failed", pack.name, exc_info=True)
+            continue
+        pack_signals = _clean_signals(supplied.get("signals"))
+        pack_movers = _clean_movers(supplied.get("movers"))
+        pack_ticker = _clean_ticker(supplied.get("ticker"))
+        if not (pack_signals or pack_movers or pack_ticker):
+            continue
+        signals.extend(pack_signals)
+        movers.extend(pack_movers)
+        if ticker is None:
+            ticker = pack_ticker
+        contributing.append(pack.name)
+
+    # Engine fallback: fill whatever no pack supplied from the corpus.
+    if not (signals and movers and ticker):
+        try:
+            library = _library_telemetry()
+        except Exception:
+            library = {}
+        if library:
+            if not signals:
+                signals = _clean_signals(library.get("signals"))
+            if not movers:
+                movers = _clean_movers(library.get("movers"))
+            if ticker is None:
+                ticker = _clean_ticker(library.get("ticker"))
+            contributing.append("library")
+
+    return {
+        "signals": signals,
+        "movers": movers[:MAX_MOVERS],
+        "ticker": ticker,
+        "packs": contributing,
+    }

--- a/src/mcp_host/host.py
+++ b/src/mcp_host/host.py
@@ -169,6 +169,9 @@ class MCPHost:
         self._statuses: Dict[str, _ServerStatus] = {
             spec.name: _ServerStatus() for spec in self.specs
         }
+        # Live session objects for call_tool, keyed by server name; entries
+        # exist only while the supervise loop holds an open session.
+        self._sessions: Dict[str, Any] = {}
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         # Created loop-less here (safe since 3.10) so stop() always has an
@@ -242,6 +245,8 @@ class MCPHost:
                     # Reconnect invalidates the discovery cache: the fresh
                     # tools/list result replaces whatever was cached.
                     tools = await _list_tools(session)
+                    with self._lock:
+                        self._sessions[spec.name] = session
                     self._mark_connected(spec.name, tools, reconnected=not first_connect)
                     first_connect = False
                     while not self._stop_event.is_set():
@@ -255,6 +260,9 @@ class MCPHost:
             except Exception as err:
                 failures = self._mark_failed(spec.name, err)
                 await self._sleep_or_stop(backoff_delay(failures))
+            finally:
+                with self._lock:
+                    self._sessions.pop(spec.name, None)
         return None
 
     async def _sleep_or_stop(self, delay: float) -> None:
@@ -290,6 +298,43 @@ class MCPHost:
                 else STATE_DEGRADED
             )
             return status.consecutive_failures
+
+    # -- tool calls ----------------------------------------------------------
+
+    def call_tool(
+        self,
+        server: str,
+        tool: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        timeout: float = CALL_TIMEOUT,
+    ) -> Dict[str, Any]:
+        """Call a tool on a connected server's live session, from any thread.
+
+        Raises RuntimeError when the host loop or the server session is not
+        available, on tool errors, and on timeout. Callers (R3 adaptivity)
+        treat any exception as "fall back to the warehouse probe".
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            raise RuntimeError("MCP host loop is not running")
+        with self._lock:
+            session = self._sessions.get(server)
+        if session is None:
+            raise RuntimeError(f"server {server!r} has no live session")
+        future = asyncio.run_coroutine_threadsafe(
+            self._call_tool(session, tool, arguments or {}, timeout), loop
+        )
+        return future.result(timeout=timeout + 1.0)
+
+    @staticmethod
+    async def _call_tool(
+        session: Any, tool: str, arguments: Dict[str, Any], timeout: float
+    ) -> Dict[str, Any]:
+        result = await asyncio.wait_for(session.call_tool(tool, arguments), timeout)
+        if getattr(result, "isError", False):
+            raise RuntimeError(f"tool {tool!r} returned an error: {result.content}")
+        structured = getattr(result, "structuredContent", None)
+        return structured if isinstance(structured, dict) else {}
 
     # -- non-blocking readers ------------------------------------------------
 

--- a/tests/unit/api/routes/test_genui_routes_coverage.py
+++ b/tests/unit/api/routes/test_genui_routes_coverage.py
@@ -6,8 +6,8 @@ ui_flag gating, the LLM planner path (spec returned / None fallback),
 planner and validation failures (500), and the context/panels error paths.
 
 The route module is loaded BY PATH (never via ``src.api.routes``, whose
-__init__ eagerly imports heavy ML modules). ``data_availability``,
-``merged_ui_flags``, ``plan``, ``plan_with_llm``, ``llm_config``,
+__init__ eagerly imports heavy ML modules). ``resolve_availability``,
+``resolve_ui_flags``, ``plan``, ``plan_with_llm``, ``llm_config``,
 ``validate_spec`` and ``panel_catalog_dict`` are from-imported into the
 route module's namespace, so every patch targets the loaded module object
 (``mod``) via monkeypatch — state never leaks across tests or files.
@@ -49,8 +49,8 @@ def _hermetic(monkeypatch):
     """Deterministic defaults; individual tests override per branch."""
     monkeypatch.setenv("NOESIS_GENUI_LLM", "off")
     monkeypatch.setenv("NOESIS_MCP_HOST", "off")
-    monkeypatch.setattr(mod, "data_availability", lambda: None)
-    monkeypatch.setattr(mod, "merged_ui_flags", lambda: {})
+    monkeypatch.setattr(mod, "resolve_availability", lambda: (None, "unknown"))
+    monkeypatch.setattr(mod, "resolve_ui_flags", lambda: ({}, "packs"))
 
 
 @pytest.fixture
@@ -87,7 +87,9 @@ def test_generate_signals_dismissed_removed_pinned_added(client):
 # ---------------------------------------------------------------------------
 def test_generate_availability_all_false_keeps_only_tableless_panels(client, monkeypatch):
     monkeypatch.setattr(
-        mod, "data_availability", lambda: {t: False for t in ALL_TABLES}
+        mod,
+        "resolve_availability",
+        lambda: ({t: False for t in ALL_TABLES}, "warehouse"),
     )
     resp = client.post("/api/v1/ui/generate", json={"intent": "ai overview"})
     assert resp.status_code == 200
@@ -102,7 +104,9 @@ def test_generate_availability_all_false_keeps_only_tableless_panels(client, mon
 
 def test_generate_availability_all_false_falls_back_for_warehouse_only_facet(client, monkeypatch):
     monkeypatch.setattr(
-        mod, "data_availability", lambda: {t: False for t in ALL_TABLES}
+        mod,
+        "resolve_availability",
+        lambda: ({t: False for t in ALL_TABLES}, "warehouse"),
     )
     # A stance/conflict intent selects only warehouse-backed panels, so the
     # fallback-overview path fires when every table is empty.
@@ -116,7 +120,7 @@ def test_generate_availability_all_false_falls_back_for_warehouse_only_facet(cli
 
 
 def test_generate_availability_unknown(client, monkeypatch):
-    monkeypatch.setattr(mod, "data_availability", lambda: None)
+    monkeypatch.setattr(mod, "resolve_availability", lambda: (None, "unknown"))
     resp = client.post("/api/v1/ui/generate", json={"intent": "ai overview"})
     assert resp.status_code == 200
     body = resp.json()
@@ -128,7 +132,7 @@ def test_generate_availability_unknown(client, monkeypatch):
 # POST /generate — ui_flags gating
 # ---------------------------------------------------------------------------
 def test_generate_ui_flag_hides_trending_panel(client, monkeypatch):
-    monkeypatch.setattr(mod, "merged_ui_flags", lambda: {"trending": False})
+    monkeypatch.setattr(mod, "resolve_ui_flags", lambda: ({"trending": False}, "packs"))
     resp = client.post(
         "/api/v1/ui/generate", json={"intent": "trending topics this week"}
     )
@@ -203,7 +207,9 @@ def test_context_llm_enabled(client, monkeypatch):
         "llm_config",
         lambda: {"provider": "anthropic", "model": "m", "api_key": "k"},
     )
-    monkeypatch.setattr(mod, "data_availability", lambda: {"news_articles": True})
+    monkeypatch.setattr(
+        mod, "resolve_availability", lambda: ({"news_articles": True}, "warehouse")
+    )
     resp = client.get("/api/v1/ui/context")
     assert resp.status_code == 200
     body = resp.json()
@@ -218,7 +224,7 @@ def test_context_error_returns_500(client, monkeypatch):
     def boom():
         raise RuntimeError("warehouse down")
 
-    monkeypatch.setattr(mod, "data_availability", boom)
+    monkeypatch.setattr(mod, "resolve_availability", boom)
     resp = client.get("/api/v1/ui/context")
     assert resp.status_code == 500
     assert "UI context failed" in resp.json()["detail"]

--- a/tests/unit/api/routes/test_genui_routes_smoke.py
+++ b/tests/unit/api/routes/test_genui_routes_smoke.py
@@ -37,8 +37,8 @@ def client(monkeypatch):
     # mcp block deterministic regardless of the SDK being installed).
     monkeypatch.setenv("NOESIS_GENUI_LLM", "off")
     monkeypatch.setenv("NOESIS_MCP_HOST", "off")
-    monkeypatch.setattr(mod, "data_availability", lambda: None)
-    monkeypatch.setattr(mod, "merged_ui_flags", lambda: {})
+    monkeypatch.setattr(mod, "resolve_availability", lambda: (None, "unknown"))
+    monkeypatch.setattr(mod, "resolve_ui_flags", lambda: ({}, "packs"))
     app = FastAPI()
     app.include_router(mod.router)
     return TestClient(app, raise_server_exceptions=False)
@@ -100,9 +100,19 @@ def test_context_returns_adaptive_inputs(client):
     resp = client.get("/api/v1/ui/context")
     assert resp.status_code == 200
     body = resp.json()
-    assert set(body) == {"ui_flags", "availability", "availability_known", "llm", "mcp"}
+    assert set(body) == {
+        "ui_flags",
+        "ui_flags_source",
+        "availability",
+        "availability_source",
+        "availability_known",
+        "llm",
+        "mcp",
+    }
     assert body["ui_flags"] == {}
+    assert body["ui_flags_source"] == "packs"
     assert body["availability"] is None
+    assert body["availability_source"] == "unknown"
     assert body["availability_known"] is False
     assert set(body["llm"]) == {"enabled", "provider"}
     assert body["llm"]["enabled"] is False
@@ -165,6 +175,35 @@ def test_panels_exposes_catalog(client):
         assert "type" in panel
         assert "title" in panel
         assert "facets" in panel
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/ui/telemetry (R3: pack-supplied ambient signal)
+# ---------------------------------------------------------------------------
+def test_telemetry_returns_pack_supplied_signal(client, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "pack_telemetry",
+        lambda: {
+            "signals": [{"label": "DOCS", "value": 12}],
+            "movers": [{"label": "paper", "intent": "library documents about paper"}],
+            "ticker": {"label": "NEW IN LIBRARY", "items": ["Doc title"]},
+            "packs": ["library"],
+        },
+    )
+    body = client.get("/api/v1/ui/telemetry").json()
+    assert body["packs"] == ["library"]
+    assert body["ticker"]["label"] == "NEW IN LIBRARY"
+
+
+def test_telemetry_error_returns_500(client, monkeypatch):
+    def boom():
+        raise RuntimeError("telemetry broke")
+
+    monkeypatch.setattr(mod, "pack_telemetry", boom)
+    resp = client.get("/api/v1/ui/telemetry")
+    assert resp.status_code == 500
+    assert "UI telemetry failed" in resp.json()["detail"]
 
 
 # R2 litmus (a): a new annotated server surfaces its panel type through

--- a/tests/unit/genui/test_genui_adaptivity.py
+++ b/tests/unit/genui/test_genui_adaptivity.py
@@ -153,7 +153,7 @@ class TestAvailabilityAndFlags:
 
     def test_filter_panels_drops_by_availability(self):
         panels = [_panel("note"), _panel("claims"), _panel("articles")]
-        availability = {"argument_claims": False, "news_articles": True}
+        availability = {"argument_claims": False, "documents": True}
         kept, dropped = filter_panels(panels, availability, None)
         assert [p.type for p in kept] == ["note", "articles"]
         assert dropped == ["claims"]

--- a/tests/unit/genui/test_genui_telemetry.py
+++ b/tests/unit/genui/test_genui_telemetry.py
@@ -1,0 +1,239 @@
+"""Unit tests for pack-supplied empty-canvas telemetry (R3, #591).
+
+Covers the collector (src/genui/telemetry.py), the library fallback over
+an in-memory warehouse, and the news pack's provider. The exit-criterion
+test: with the news pack disabled the canvas telemetry still carries
+recently ingested documents, never an empty gap.
+"""
+
+from types import SimpleNamespace
+
+import duckdb
+import pytest
+
+import src.genui.telemetry as telemetry
+from src.genui.telemetry import (
+    _clean_movers,
+    _clean_signals,
+    _clean_ticker,
+    _library_telemetry,
+    pack_telemetry,
+)
+
+
+def make_pack(name, provider):
+    return SimpleNamespace(name=name, telemetry=provider)
+
+
+@pytest.fixture
+def packs(monkeypatch):
+    def _install(pack_list):
+        import src.domains.registry as registry
+
+        monkeypatch.setattr(registry, "get_enabled_packs", lambda: pack_list)
+
+    return _install
+
+
+@pytest.fixture
+def memory_warehouse(monkeypatch):
+    """In-memory DuckDB standing in for the shared analytics connection."""
+    import threading
+
+    import src.database.local_analytics_connector as connector
+
+    conn = duckdb.connect(":memory:")
+    monkeypatch.setattr(connector, "get_shared_connection", lambda: conn)
+    monkeypatch.setattr(connector, "_LOCK", threading.Lock())
+    return conn
+
+
+NEWS_SUPPLY = {
+    "signals": [{"label": "ARTICLES", "value": 64}],
+    "movers": [{"label": "Ai Policy", "intent": "coverage of ai policy", "change": 12}],
+    "ticker": {"label": "BREAKING", "items": ["Headline one", "Headline two"]},
+}
+
+
+# ---------------------------------------------------------------------------
+# Cleaning helpers
+# ---------------------------------------------------------------------------
+
+
+def test_clean_helpers_accept_valid_shapes():
+    assert _clean_signals(NEWS_SUPPLY["signals"]) == NEWS_SUPPLY["signals"]
+    assert _clean_movers(NEWS_SUPPLY["movers"]) == NEWS_SUPPLY["movers"]
+    ticker = _clean_ticker(NEWS_SUPPLY["ticker"])
+    assert ticker == {"label": "BREAKING", "items": ["Headline one", "Headline two"]}
+
+
+def test_clean_helpers_reject_junk():
+    assert _clean_signals("nope") == []
+    assert _clean_signals([{"value": 3}, 7]) == []
+    assert _clean_movers([{"label": "x"}, {"intent": "y"}, None]) == []
+    assert _clean_ticker(None) is None
+    assert _clean_ticker({"label": "X", "items": []}) is None
+    assert _clean_ticker({"items": ["a"]}) is None
+    # Non-string items are dropped; movers without numeric change lose it.
+    assert _clean_ticker({"label": "X", "items": ["a", 3, " "]}) == {
+        "label": "X",
+        "items": ["a"],
+    }
+    assert _clean_movers([{"label": "a", "intent": "b", "change": "hot"}]) == [
+        {"label": "a", "intent": "b"}
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_pack_supplies_telemetry(packs):
+    packs([make_pack("news", lambda: NEWS_SUPPLY)])
+    result = pack_telemetry()
+    assert result["packs"] == ["news"]
+    assert result["signals"] == NEWS_SUPPLY["signals"]
+    assert result["movers"] == NEWS_SUPPLY["movers"]
+    assert result["ticker"]["label"] == "BREAKING"
+
+
+def test_pack_without_provider_is_skipped(packs, monkeypatch):
+    monkeypatch.setattr(telemetry, "_library_telemetry", lambda: {})
+    packs([make_pack("quiet", None)])
+    result = pack_telemetry()
+    assert result == {"signals": [], "movers": [], "ticker": None, "packs": []}
+
+
+def test_failing_provider_never_breaks_the_canvas(packs, monkeypatch):
+    def boom():
+        raise RuntimeError("pack exploded")
+
+    monkeypatch.setattr(telemetry, "_library_telemetry", lambda: {})
+    packs([make_pack("news", boom)])
+    result = pack_telemetry()
+    assert result["packs"] == []
+    assert result["ticker"] is None
+
+
+def test_first_ticker_wins_and_movers_are_capped(packs, monkeypatch):
+    monkeypatch.setattr(telemetry, "_library_telemetry", lambda: {})
+    many_movers = [
+        {"label": f"m{i}", "intent": f"view {i}"} for i in range(10)
+    ]
+    packs(
+        [
+            make_pack("a", lambda: {"ticker": {"label": "FIRST", "items": ["x"]}, "movers": many_movers}),
+            make_pack("b", lambda: {"ticker": {"label": "SECOND", "items": ["y"]}}),
+        ]
+    )
+    result = pack_telemetry()
+    assert result["ticker"]["label"] == "FIRST"
+    assert len(result["movers"]) == telemetry.MAX_MOVERS
+    assert result["packs"] == ["a", "b"]
+
+
+def test_news_off_falls_back_to_library(packs, monkeypatch):
+    """The R3 exit criterion: news disabled, telemetry still live."""
+    packs([])  # no enabled packs advertise anything
+    monkeypatch.setattr(
+        telemetry,
+        "_library_telemetry",
+        lambda: {
+            "signals": [{"label": "DOCS", "value": 12}],
+            "movers": [{"label": "paper", "intent": "library documents about paper", "change": 7}],
+            "ticker": {"label": "NEW IN LIBRARY", "items": ["Attention is all you need"]},
+        },
+    )
+    result = pack_telemetry()
+    assert result["packs"] == ["library"]
+    assert result["ticker"]["label"] == "NEW IN LIBRARY"
+    assert result["movers"][0]["intent"].startswith("library documents")
+
+
+def test_library_failure_degrades_to_empty(packs, monkeypatch):
+    packs([])
+
+    def boom():
+        raise RuntimeError("no warehouse")
+
+    monkeypatch.setattr(telemetry, "_library_telemetry", boom)
+    result = pack_telemetry()
+    assert result == {"signals": [], "movers": [], "ticker": None, "packs": []}
+
+
+def test_registry_failure_degrades_to_library(monkeypatch):
+    import src.domains.registry as registry
+
+    def boom():
+        raise RuntimeError("registry broken")
+
+    monkeypatch.setattr(registry, "get_enabled_packs", boom)
+    monkeypatch.setattr(telemetry, "_library_telemetry", lambda: {})
+    assert pack_telemetry()["packs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Library fallback over a real (in-memory) warehouse
+# ---------------------------------------------------------------------------
+
+
+def test_library_telemetry_prefers_documents_table(memory_warehouse):
+    memory_warehouse.execute(
+        "CREATE TABLE documents (title VARCHAR, source_type VARCHAR, created_at TIMESTAMP)"
+    )
+    memory_warehouse.execute(
+        "INSERT INTO documents VALUES "
+        "('Paper A', 'paper', '2026-07-01'), ('Book B', 'book', '2026-07-02')"
+    )
+    result = _library_telemetry()
+    assert result["signals"] == [{"label": "DOCS", "value": 2}]
+    assert result["ticker"]["label"] == "NEW IN LIBRARY"
+    assert "Book B" in result["ticker"]["items"]
+    intents = {m["intent"] for m in result["movers"]}
+    assert "library documents about paper" in intents
+
+
+def test_library_telemetry_uses_news_articles_when_no_documents(memory_warehouse):
+    memory_warehouse.execute(
+        "CREATE TABLE news_articles (title VARCHAR, category VARCHAR, publish_date TIMESTAMP)"
+    )
+    memory_warehouse.execute(
+        "INSERT INTO news_articles VALUES ('Headline', 'Politics', '2026-07-01')"
+    )
+    result = _library_telemetry()
+    assert result["signals"] == [{"label": "DOCS", "value": 1}]
+    assert result["ticker"]["items"] == ["Headline"]
+
+
+def test_library_telemetry_empty_warehouse_returns_nothing(memory_warehouse):
+    assert _library_telemetry() == {}
+
+
+# ---------------------------------------------------------------------------
+# News pack provider over a real (in-memory) warehouse
+# ---------------------------------------------------------------------------
+
+
+def test_news_telemetry_provider(memory_warehouse):
+    from src.domains.news.telemetry import news_telemetry
+
+    memory_warehouse.execute(
+        "CREATE TABLE news_articles ("
+        "title VARCHAR, source VARCHAR, category VARCHAR, publish_date TIMESTAMP)"
+    )
+    memory_warehouse.execute(
+        "INSERT INTO news_articles VALUES "
+        "('H1', 'Reuters', 'Politics', CURRENT_TIMESTAMP), "
+        "('H2', 'AP', 'Politics', CURRENT_TIMESTAMP), "
+        "('H3', 'AP', 'Tech', TIMESTAMP '2020-01-01')"
+    )
+    result = news_telemetry()
+    labels = {s["label"]: s["value"] for s in result["signals"]}
+    assert labels["ARTICLES"] == 3
+    assert labels["SOURCES"] == 2
+    assert result["ticker"]["label"] == "BREAKING"
+    assert set(result["ticker"]["items"]) == {"H1", "H2", "H3"}
+    politics = next(m for m in result["movers"] if m["label"] == "Politics")
+    assert politics["intent"] == "coverage of politics"
+    assert politics["change"] == 100  # both articles in the last 7 days

--- a/tests/unit/genui/test_genui_tool_adaptivity.py
+++ b/tests/unit/genui/test_genui_tool_adaptivity.py
@@ -1,0 +1,228 @@
+"""Unit tests for R3 tool-sourced adaptivity (src/genui/adaptivity.py).
+
+resolve_availability / resolve_ui_flags prefer the MCP servers' stats
+tools and fall back to the DuckDB probe / pack registry. All host access
+goes through fakes; the fallback probe is stubbed so nothing touches a
+real warehouse.
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+import src.genui.adaptivity as adaptivity
+from src.genui.adaptivity import (
+    DOCUMENT_CORPUS_TABLES,
+    reset_tool_cache,
+    resolve_availability,
+    resolve_ui_flags,
+)
+
+
+class FakeHost:
+    """Scripted host: connected servers + canned call_tool results."""
+
+    def __init__(self, connected, results: Dict[str, Any]):
+        self.connected = set(connected)
+        self.results = results
+        self.calls = []
+
+    def status(self):
+        return {
+            "servers": {
+                name: {"state": "connected"} for name in self.connected
+            }
+        }
+
+    def call_tool(self, server, tool, arguments=None, timeout=10.0):
+        self.calls.append((server, tool))
+        result = self.results[tool]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+ALL_STATS_SERVERS = ("neuronews-arguments", "neuronews-pipeline", "neuronews-domain-packs")
+
+GOOD_RESULTS = {
+    "am_stats": {
+        "argument_claims": 5,
+        "claim_conflicts": 0,
+        "source_stances": 3,
+        "stance_drift_events": "table_missing",
+        "policy_positions": 1,
+        "document_frames": 0,
+        "total_claims": 5,
+    },
+    "article_stats": {"total_articles": 64, "sources": 9},
+    "document_stats": {"total_documents": 0, "by_source_type": []},
+    "list_outlet_scores": {"count": 1, "outlets": [{}]},
+    "list_outlet_clusters": {"count": 0, "outlets": []},
+    "actor_summary": {"count": 1, "actors": [{}]},
+    "get_ui_flags": {"flags": {"trending": True, "watchlists": False}, "contributing": ["news"]},
+}
+
+
+@pytest.fixture(autouse=True)
+def clean(monkeypatch):
+    reset_tool_cache()
+    # The fallback must never hit a real warehouse in these tests.
+    monkeypatch.setattr(adaptivity, "data_availability", lambda probe=None: None)
+    yield
+    reset_tool_cache()
+
+
+def install(monkeypatch, host):
+    monkeypatch.setattr(adaptivity, "_get_host", lambda: host)
+    return host
+
+
+# ---------------------------------------------------------------------------
+# resolve_availability
+# ---------------------------------------------------------------------------
+
+
+def test_tools_path_maps_counts_to_availability(monkeypatch):
+    host = install(monkeypatch, FakeHost(ALL_STATS_SERVERS, GOOD_RESULTS))
+    availability, source = resolve_availability()
+    assert source == "tools"
+    assert availability["argument_claims"] is True
+    assert availability["claim_conflicts"] is False
+    assert availability["source_stances"] is True
+    assert availability["stance_drift_events"] is False  # table_missing -> 0
+    assert availability["news_articles"] is True
+    assert availability["outlet_scores"] is True
+    assert availability["outlet_clusters"] is False
+    assert availability["document_actors"] is True
+    # Corpus union: zero documents rows, but news_articles has rows.
+    assert availability["documents"] is True
+
+
+def test_corpus_union_from_documents_only(monkeypatch):
+    results = dict(GOOD_RESULTS)
+    results["article_stats"] = {"total_articles": 0}
+    results["document_stats"] = {"total_documents": 12}
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, results))
+    availability, source = resolve_availability()
+    assert source == "tools"
+    assert availability["news_articles"] is False
+    assert availability["documents"] is True
+
+
+def test_results_are_cached_within_ttl(monkeypatch):
+    host = install(monkeypatch, FakeHost(ALL_STATS_SERVERS, GOOD_RESULTS))
+    resolve_availability()
+    first_calls = len(host.calls)
+    availability, source = resolve_availability()
+    assert source == "tools"
+    assert len(host.calls) == first_calls  # served from cache
+
+    reset_tool_cache()
+    resolve_availability()
+    assert len(host.calls) == 2 * first_calls
+
+
+def test_no_host_falls_back(monkeypatch):
+    install(monkeypatch, None)
+    monkeypatch.setattr(
+        adaptivity, "data_availability", lambda probe=None: {"news_articles": True}
+    )
+    availability, source = resolve_availability()
+    assert source == "warehouse"
+    assert availability == {"news_articles": True}
+
+
+def test_stats_server_down_falls_back(monkeypatch):
+    install(monkeypatch, FakeHost(("neuronews-arguments",), GOOD_RESULTS))
+    availability, source = resolve_availability()
+    assert source == "unknown"
+    assert availability is None
+
+
+def test_tool_error_falls_back(monkeypatch):
+    results = dict(GOOD_RESULTS)
+    results["am_stats"] = {"error": "warehouse locked"}
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, results))
+    availability, source = resolve_availability()
+    assert source == "unknown"
+    assert availability is None
+
+
+def test_tool_exception_falls_back(monkeypatch):
+    results = dict(GOOD_RESULTS)
+    results["article_stats"] = RuntimeError("session died")
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, results))
+    availability, source = resolve_availability()
+    assert source == "unknown"
+
+
+@pytest.mark.parametrize("tool", ["article_stats", "document_stats", "actor_summary"])
+def test_any_stats_tool_error_falls_back(monkeypatch, tool):
+    results = dict(GOOD_RESULTS)
+    results[tool] = {"error": "warehouse locked"}
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, results))
+    availability, source = resolve_availability()
+    assert source == "unknown"
+    assert availability is None
+
+
+def test_get_host_reads_the_singleton(monkeypatch):
+    """The real _get_host goes through src.mcp_host.get_host."""
+    host = FakeHost(ALL_STATS_SERVERS, GOOD_RESULTS)
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: host)
+    availability, source = resolve_availability()
+    assert source == "tools"
+    assert availability is not None
+
+
+# ---------------------------------------------------------------------------
+# resolve_ui_flags
+# ---------------------------------------------------------------------------
+
+
+def test_ui_flags_from_domain_packs_server(monkeypatch):
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, GOOD_RESULTS))
+    flags, source = resolve_ui_flags()
+    assert source == "tools"
+    assert flags == {"trending": True, "watchlists": False}
+
+
+def test_ui_flags_fall_back_to_registry(monkeypatch):
+    install(monkeypatch, None)
+    monkeypatch.setattr(adaptivity, "merged_ui_flags", lambda: {"clusters": True})
+    flags, source = resolve_ui_flags()
+    assert source == "packs"
+    assert flags == {"clusters": True}
+
+
+def test_ui_flags_bad_tool_payload_falls_back(monkeypatch):
+    results = dict(GOOD_RESULTS)
+    results["get_ui_flags"] = {"error": "no packs"}
+    install(monkeypatch, FakeHost(ALL_STATS_SERVERS, results))
+    monkeypatch.setattr(adaptivity, "merged_ui_flags", lambda: {})
+    flags, source = resolve_ui_flags()
+    assert source == "packs"
+    assert flags == {}
+
+
+def test_ui_flags_cached(monkeypatch):
+    host = install(monkeypatch, FakeHost(ALL_STATS_SERVERS, GOOD_RESULTS))
+    resolve_ui_flags()
+    n = len(host.calls)
+    resolve_ui_flags()
+    assert len(host.calls) == n
+
+
+# ---------------------------------------------------------------------------
+# Corpus union in the warehouse fallback path
+# ---------------------------------------------------------------------------
+
+
+def test_probe_availability_applies_corpus_union():
+    counts = {"news_articles": 4, "documents": 0, "argument_claims": 1}
+    availability = adaptivity._availability_from_counts(counts)
+    assert availability["documents"] is True
+    assert availability["news_articles"] is True
+
+    empty = adaptivity._availability_from_counts({t: 0 for t in DOCUMENT_CORPUS_TABLES})
+    assert empty["documents"] is False

--- a/tests/unit/mcp_host/test_mcp_host.py
+++ b/tests/unit/mcp_host/test_mcp_host.py
@@ -49,6 +49,9 @@ class ScriptedServer:
         self.fail_connects = 0
         self.alive = True
         self.connects = 0
+        self.call_result = SimpleNamespace(
+            isError=False, structuredContent={"ok": True}
+        )
 
     @contextlib.asynccontextmanager
     async def factory(self, spec):
@@ -64,6 +67,11 @@ class ScriptedServer:
         return SimpleNamespace(
             tools=[SimpleNamespace(name=n, description="d") for n in self.tools]
         )
+
+    async def call_tool(self, name, arguments):
+        if not self.alive:
+            raise ConnectionError("server killed")
+        return self.call_result
 
 
 @pytest.fixture
@@ -248,6 +256,55 @@ def test_ttl_env_override(monkeypatch):
     assert MCPHost(specs=[]).ttl_seconds == 7.0
     monkeypatch.setenv("NOESIS_MCP_TTL", "junk")
     assert MCPHost(specs=[]).ttl_seconds == host_mod.DEFAULT_TTL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# call_tool (R3: stats tools feed adaptivity)
+# ---------------------------------------------------------------------------
+
+
+def test_call_tool_returns_structured_content(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert h.call_tool("fake", "anything", {"x": 1}) == {"ok": True}
+
+
+def test_call_tool_requires_running_loop():
+    h = MCPHost(specs=[SPEC], session_factory=None, ttl_seconds=1)
+    with pytest.raises(RuntimeError, match="not running"):
+        h.call_tool("fake", "anything")
+
+
+def test_call_tool_requires_live_session(make_host):
+    server = ScriptedServer()
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    with pytest.raises(RuntimeError, match="no live session"):
+        h.call_tool("other-server", "anything")
+
+
+def test_call_tool_raises_on_tool_error(make_host):
+    server = ScriptedServer()
+    server.call_result = SimpleNamespace(
+        isError=True, structuredContent=None, content="boom"
+    )
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    with pytest.raises(RuntimeError, match="returned an error"):
+        h.call_tool("fake", "anything")
+
+
+def test_call_tool_non_dict_content_becomes_empty(make_host):
+    server = ScriptedServer()
+    server.call_result = SimpleNamespace(isError=False, structuredContent=[1, 2])
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert h.call_tool("fake", "anything") == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/kg_mcp/server.py
+++ b/tools/kg_mcp/server.py
@@ -106,7 +106,7 @@ def kg_ontology() -> dict:
         "description": "Co-mention network of entities in recent coverage.",
         "endpoint": "/api/v1/entity_graph",
         "facets": ["entities", "actors", "overview"],
-        "tables": ["news_articles"],
+        "tables": ["documents"],
         "ui_flag": "influence_graph",
         "default_span": 6,
         "days_param": "days",

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -992,7 +992,7 @@ def _cutoff(days: int):
         "description": "Headline counts across articles, clusters and topics.",
         "endpoint": "/api/v1/news/articles",
         "facets": ["overview"],
-        "tables": ["news_articles"],
+        "tables": ["documents"],
         "default_span": 12,
     }},
 )
@@ -1042,7 +1042,7 @@ def article_stats(days: int = 7) -> dict:
         "description": "Most recent matching articles and documents.",
         "endpoint": "/api/v1/news/articles",
         "facets": ["overview", "sentiment"],
-        "tables": ["news_articles"],
+        "tables": ["documents"],
         "default_span": 6,
     }},
 )


### PR DESCRIPTION
# Pull Request: Adaptivity from tools (milestone R3)

## Overview

Implements milestone **R3** of the MCP rearchitecture plan (Stage 1 + Track N2): the adaptive inputs that shape every generated layout now come from the MCP servers themselves, the overview canvas anchors on the document corpus instead of the news table, and the empty canvas's ambient signal is supplied by whichever domain packs are enabled. With the host down, every path falls back to the pre-R3 behavior (DuckDB probe, in-process pack registry, demo visuals).

Closes #589. Closes #590. Closes #591.

## Changes Summary

**Tool-sourced availability and ui_flags (#589)**

- `MCPHost.call_tool`: thread-safe tool invocation on the supervised live sessions (session registry per server, scheduled onto the host loop, structured content returned, errors raise so callers fall back).
- `resolve_availability`: row counts come from `am_stats`, `article_stats`, `document_stats` and limit-1 list probes across the arguments/pipeline servers; results cached ~30 s (R4 generalizes this cache). `resolve_ui_flags`: flags come from the domain-packs server's `get_ui_flags`. Any failure, missing server, or disabled host falls back to the DuckDB probe / registry merge.
- `GET /api/v1/ui/context` and the generate `meta` now report `availability_source` (`tools` / `warehouse` / `unknown`) and `ui_flags_source` (`tools` / `packs`).

**Documents-corpus anchor (#590)**

- `kpi_row`, `articles` and `entity_graph` anchor availability on a virtual `documents` corpus: available when either the `documents` table or `news_articles` has rows. Applied identically in the tool-sourced and probe paths; the catalog and the tool annotations changed in lockstep (the R2 parity suite enforces they can never drift).

**Pack-supplied telemetry (#591)**

- `DomainPack` grows an optional `telemetry` provider; the news pack advertises movers, the BREAKING ticker and headline counts from the warehouse.
- `src/genui/telemetry.py` collects from enabled packs (failures are swallowed per pack) and fills unsupplied slots with the engine's library telemetry: recently ingested documents, `NEW IN LIBRARY` ticker. Served by the new `GET /api/v1/ui/telemetry`.
- Frontend: the empty state's movers/KPI strip and the signal strip render whatever the packs advertise; the ticker label is telemetry-provided (`BREAKING` vs `NEW IN LIBRARY`) and the strip disappears when no pack supplies one. The demo fallback reproduces today's news-flavored visuals offline. No news hook remains hardcoded in the empty canvas.

## Testing Status

- [x] 302 tests pass (36 new: tool-sourced adaptivity with scripted hosts, call_tool paths, telemetry collector/cleaners, library fallback and the news provider over in-memory DuckDB, route tests for the telemetry endpoint and the new source fields)
- [x] Coverage: telemetry 99%, discovery 99%, adaptivity 91%, mcp_host 95%
- [x] `tsc --noEmit` and `vite build` clean; codegen staleness gate clean; `TESTING=true` app import unaffected
- [x] `tests/test_domain_packs.py` failures are identical on unmodified main (pre-existing, unrelated)

## Live verification (R3 exit criteria)

Against the real arguments/pipeline/domain-packs servers over stdio:

- `resolve_availability` and `resolve_ui_flags` reported source `tools` with servers up; stopping the host fell back to source `warehouse` with the same catalog tables resolved
- A zero-news corpus (documents only) planned a live overview canvas: `kpi_row`, `articles`, `documents`, `entity_graph`
- With the news pack enabled: `BREAKING` ticker and 5 news movers. With it disabled: `NEW IN LIBRARY` ticker and library movers ("library documents about economy", ...), never an empty gap