### PR TITLE
R4: Grounded LLM planning - bounded tool-use loop, shared stats cache, latency budget

### DIFF
--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -500,6 +500,21 @@ output still sanitized, validated, signal-enforced.
 panels; p95 generate latency with the loop stays within an agreed
 budget.
 
+*Delivered.* The loop lives in `src/genui/llm.py`: with the host up the
+LLM planner may call a curated read-only inspection allowlist
+(`am_stats`, `article_stats`, `document_stats`, the `list_*` / `*_stats`
+tools — never the RW `trigger_*`/`run_*`/`compute_*` tools) for up to
+`MAX_TOOL_ROUNDS` (3) rounds, then emits the spec. **Latency budget:**
+`NOESIS_GENUI_LOOP_BUDGET_MS` (default 9000 ms) bounds the whole loop's
+wall-clock; when the remaining budget drops below `MIN_LOOP_BUDGET_MS`
+(1500 ms) at the start, or the deadline is crossed mid-loop, the planner
+degrades to a single one-shot completion (the pre-R4 path) rather than
+issuing more turns. Tool results are served through the host's shared
+`call_tool_cached` (per `(server, tool, args)`, TTL
+`NOESIS_MCP_STATS_TTL`, default 60 s, invalidated on reconnect), which
+the adaptivity layer also reads — so two consecutive generates trigger at
+most one live round per stats tool. Kill switch: `NOESIS_GENUI_LOOP=off`.
+
 **R5 — Analytics foundation + first tools** *(Track DS Wave 1a)*
 The batch-fit pattern (trigger tools / scheduler → result tables →
 MLflow) plus `detect_anomalies` and `score_confidence` with

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -44,7 +44,7 @@ intent ──► POST /api/v1/ui/generate ──► ui-spec-v1 ──► SpecRen
 | `planner.py` | Heuristic planner: facet scoring from keyword evidence, topic / source-type / time-window extraction, panel assembly. No model, no network. |
 | `adaptivity.py` | The adaptive inputs. Since R3 availability and `ui_flags` are tool-sourced (`resolve_availability` / `resolve_ui_flags` call the servers' stats tools through the MCP host, cached ~30s) with the DuckDB probe and pack registry as servers-down fallbacks; usage-signal re-ranking (`apply_signals`). Overview panels anchor on the `documents` corpus (union of `documents` and `news_articles`), so a zero-news corpus keeps a live overview. |
 | `telemetry.py` | Pack-supplied empty-canvas telemetry (R3): enabled packs advertise `signals`/`movers`/`ticker` via `DomainPack.telemetry`; the engine's library fallback (recently ingested documents) fills whatever no pack supplies. |
-| `llm.py` | Optional LLM planner (Anthropic or OpenAI). Any failure — no key, no SDK, bad JSON, invalid spec — falls back to the heuristic planner. |
+| `llm.py` | Optional LLM planner (Anthropic or OpenAI). Since R4, with the MCP host up it runs as a bounded tool-use loop: the model may call a read-only inspection allowlist (stats/listing tools) to ground the layout in what data exists, then emits the spec. The loop is budgeted (`NOESIS_GENUI_LOOP_BUDGET_MS`, default 9000; `MAX_TOOL_ROUNDS` = 3) and degrades to one-shot planning when the budget would be blown. Any failure — no key, no SDK, bad JSON, invalid spec — falls back to the heuristic planner. |
 
 Routes (`src/api/routes/genui_routes.py`, registered via the standard
 feature-flag pattern in `src/api/app.py`):

--- a/src/genui/adaptivity.py
+++ b/src/genui/adaptivity.py
@@ -264,29 +264,39 @@ def _servers_connected(host, names) -> bool:
     return all(servers.get(n, {}).get("state") == "connected" for n in names)
 
 
+def _cached_call(host, server: str, tool: str, arguments=None) -> Dict[str, Any]:
+    """Read a stats tool through the host's shared cache (R4 #593) when
+    available, so the adaptivity layer and the LLM planning loop don't each
+    re-inspect. Falls back to a plain call on older hosts."""
+    cached = getattr(host, "call_tool_cached", None)
+    if callable(cached):
+        return cached(server, tool, arguments)
+    return host.call_tool(server, tool, arguments)
+
+
 def _tool_counts(host) -> Dict[str, int]:
     """Row counts for every catalog table via the servers' stats tools."""
     counts: Dict[str, int] = {}
 
-    am = host.call_tool("neuronews-arguments", "am_stats")
+    am = _cached_call(host, "neuronews-arguments", "am_stats")
     if "error" in am:
         raise RuntimeError(am["error"])
     for table in _AM_STATS_TABLES:
         value = am.get(table)
         counts[table] = value if isinstance(value, int) else 0
 
-    articles = host.call_tool("neuronews-pipeline", "article_stats")
+    articles = _cached_call(host, "neuronews-pipeline", "article_stats")
     if "error" in articles:
         raise RuntimeError(articles["error"])
     counts["news_articles"] = int(articles.get("total_articles", 0))
 
-    documents = host.call_tool("neuronews-pipeline", "document_stats")
+    documents = _cached_call(host, "neuronews-pipeline", "document_stats")
     if "error" in documents:
         raise RuntimeError(documents["error"])
     counts["documents"] = int(documents.get("total_documents", 0))
 
     for table, tool in _LIMIT_PROBE_TOOLS:
-        result = host.call_tool("neuronews-arguments", tool, {"limit": 1})
+        result = _cached_call(host, "neuronews-arguments", tool, {"limit": 1})
         if "error" in result:
             raise RuntimeError(result["error"])
         counts[table] = int(result.get("count", 0))
@@ -328,7 +338,7 @@ def resolve_ui_flags() -> Tuple[Dict[str, bool], str]:
     try:
         host = _get_host()
         if host is not None and _servers_connected(host, (_FLAGS_SERVER,)):
-            result = host.call_tool(_FLAGS_SERVER, "get_ui_flags")
+            result = _cached_call(host, _FLAGS_SERVER, "get_ui_flags")
             flags = result.get("flags")
             if isinstance(flags, dict):
                 flags = {str(k): bool(v) for k, v in flags.items()}

--- a/src/genui/llm.py
+++ b/src/genui/llm.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.genui.catalog import get_panel_def, panel_catalog_dict
 from src.genui.spec import (
@@ -42,6 +44,83 @@ _DEFAULT_MODELS = {
 }
 
 _MAX_OUTPUT_TOKENS = 2000
+
+# ---------------------------------------------------------------------------
+# Grounded planning loop config (R4 / Stage 2).
+#
+# When the MCP host is up the LLM planner runs as a bounded tool-use loop: it
+# may call a small allowlist of read-only inspection tools to learn what data
+# exists, then emits the final ui-spec-v1 JSON. The loop is budgeted (call
+# count + wall-clock) and degrades to one-shot planning when the budget would
+# be blown; every path funnels through the same sanitize/validate/signal
+# enforcement, so the output contract is identical to the one-shot planner.
+# ---------------------------------------------------------------------------
+
+# Max tool-use rounds before the model is forced to answer. Each round is one
+# LLM turn plus its tool executions.
+MAX_TOOL_ROUNDS = 3
+
+# Total wall-clock budget for the whole loop (env-overridable). p95 target for
+# the /generate endpoint with the loop enabled; blown budget => one-shot.
+DEFAULT_LOOP_BUDGET_MS = 9000
+# Per-LLM-turn timeout.
+LOOP_TURN_TIMEOUT = 6.0
+# Below this much remaining budget we don't start the loop at all.
+MIN_LOOP_BUDGET_MS = 1500
+
+# Read-only inspection tools the loop may call, per server. Deliberately a
+# curated allowlist (not "everything read-only"): grounding needs the stats
+# and listing tools, never the trigger_/run_/compute_/subscribe_ RW tools.
+INSPECTION_ALLOWLIST: Dict[str, frozenset] = {
+    "neuronews-arguments": frozenset(
+        {
+            "am_stats",
+            "list_claims",
+            "list_stances",
+            "list_frames",
+            "list_drift_events",
+            "list_outlet_scores",
+            "list_outlet_clusters",
+            "actor_summary",
+            "list_actors",
+            "list_unsourced_claims",
+        }
+    ),
+    "neuronews-pipeline": frozenset(
+        {
+            "article_stats",
+            "document_stats",
+            "latest_articles",
+            "sentiment_by_topic",
+            "sentiment_heatmap",
+            "coverage_clusters",
+            "query_positions",
+            "query_conflicts",
+        }
+    ),
+    "neuronews-kg": frozenset({"kg_stats", "list_entities", "evolving_topics"}),
+    "neuronews-domain-packs": frozenset({"get_ui_flags", "pack_status"}),
+    "neuronews-sources": frozenset(
+        {"compare_sources", "list_trustworthiness", "get_source_profile"}
+    ),
+}
+
+
+def loop_enabled() -> bool:
+    """Whether the grounded tool-use loop may run (env kill switch)."""
+    return os.getenv("NOESIS_GENUI_LOOP", "auto").strip().lower() not in (
+        "off",
+        "0",
+        "false",
+    )
+
+
+def _loop_budget_ms() -> int:
+    raw = os.getenv("NOESIS_GENUI_LOOP_BUDGET_MS", "").strip()
+    try:
+        return int(raw) if raw else DEFAULT_LOOP_BUDGET_MS
+    except ValueError:
+        return DEFAULT_LOOP_BUDGET_MS
 
 
 def llm_config() -> Optional[Dict[str, str]]:
@@ -209,28 +288,295 @@ def _apply_usage_signals(spec: UISpec, signals: Optional[Dict[str, Any]]) -> Non
         panel.id = f"p{i + 1}"
 
 
-def plan_with_llm(
-    intent: str,
-    source_type: Optional[str] = None,
-    availability: Optional[Dict[str, bool]] = None,
-    ui_flags: Optional[Dict[str, bool]] = None,
-    signals: Optional[Dict[str, Any]] = None,
-) -> Optional[UISpec]:
-    """Plan a layout with the configured LLM; None on any failure."""
-    config = llm_config()
-    if config is None:
-        return None
+# ---------------------------------------------------------------------------
+# Bounded tool-use loop (R4 #592).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolInvocation:
+    """One tool call the model asked for, resolved to a server+tool."""
+
+    call_id: str
+    advertised_name: str
+    arguments: Dict[str, Any]
+
+
+@dataclass
+class ToolResult:
+    """The outcome of a tool call, fed back to the model."""
+
+    call_id: str
+    advertised_name: str
+    content: Any
+    is_error: bool = False
+
+
+@dataclass
+class LLMTurn:
+    """One model response: either a final answer or a batch of tool calls."""
+
+    final_text: Optional[str] = None
+    tool_calls: List[ToolInvocation] = field(default_factory=list)
+
+
+def _advertise_tools(host) -> Tuple[List[Dict[str, Any]], Dict[str, Tuple[str, str]]]:
+    """Build the provider tool list from the host's cached discovery,
+    filtered to the read-only allowlist. Returns (tool specs, name map
+    advertised_name -> (server, tool)). Advertised names are ``server__tool``
+    (a valid provider tool name; hyphens and underscores are allowed)."""
+    specs: List[Dict[str, Any]] = []
+    name_map: Dict[str, Tuple[str, str]] = {}
     try:
-        text = _complete(config, _build_prompt(intent, source_type, availability, ui_flags))
+        by_server = host.tools()
     except Exception:
-        logger.warning("genui LLM completion failed; using heuristic planner", exc_info=True)
-        return None
-    if not text:
-        return None
-    parsed = _extract_json(text)
-    if parsed is None:
-        logger.warning("genui LLM returned unparseable output; using heuristic planner")
-        return None
+        return specs, name_map
+    for server, tools in sorted(by_server.items()):
+        allowed = INSPECTION_ALLOWLIST.get(server, frozenset())
+        for tool in tools:
+            name = tool.get("name")
+            if name not in allowed:
+                continue
+            advertised = f"{server}__{name}"
+            name_map[advertised] = (server, name)
+            specs.append(
+                {
+                    "name": advertised,
+                    "description": tool.get("description", "")[:400],
+                    "input_schema": tool.get("input_schema") or {"type": "object"},
+                }
+            )
+    return specs, name_map
+
+
+def _execute_tool_calls(
+    host, calls: List[ToolInvocation], name_map: Dict[str, Tuple[str, str]]
+) -> List[ToolResult]:
+    """Run each requested tool through the shared cache, enforcing the
+    allowlist. A rejected or failed call becomes an error result the model
+    can react to — it never aborts the loop."""
+    results: List[ToolResult] = []
+    for call in calls:
+        target = name_map.get(call.advertised_name)
+        if target is None:
+            results.append(
+                ToolResult(
+                    call.call_id,
+                    call.advertised_name,
+                    {"error": f"tool {call.advertised_name!r} is not permitted"},
+                    is_error=True,
+                )
+            )
+            continue
+        server, tool = target
+        try:
+            content = host.call_tool_cached(server, tool, call.arguments)
+            results.append(
+                ToolResult(
+                    call.call_id,
+                    call.advertised_name,
+                    content,
+                    is_error=isinstance(content, dict) and "error" in content,
+                )
+            )
+        except Exception as err:
+            results.append(
+                ToolResult(
+                    call.call_id,
+                    call.advertised_name,
+                    {"error": f"{type(err).__name__}: {err}"},
+                    is_error=True,
+                )
+            )
+    return results
+
+
+def _loop_system_prompt() -> str:
+    return (
+        "You are the layout planner for Noesis, a knowledge-intelligence "
+        "dashboard. You may call the provided read-only inspection tools to "
+        "check what data actually exists (row counts, available topics, "
+        "outlets) before composing the layout. Call tools only when it "
+        "changes the layout; a couple of calls is plenty. When you have "
+        "enough signal, STOP calling tools and reply with ONLY the final "
+        "JSON layout object (no prose, no code fences). Omit panels whose "
+        "underlying data is empty."
+    )
+
+
+class Conversation:
+    """Provider-neutral multi-turn tool-use conversation.
+
+    ``send(results, allow_tools)`` advances the exchange: it feeds back the
+    previous turn's tool results (None on the first call) and returns the
+    model's next :class:`LLMTurn`. When ``allow_tools`` is False the model is
+    offered no tools, forcing a final text answer (the budget-exhaustion
+    degrade path).
+    """
+
+    def send(
+        self, results: Optional[List[ToolResult]], allow_tools: bool
+    ) -> LLMTurn:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class _AnthropicConversation(Conversation):
+    def __init__(self, config, system, user_prompt, tools, timeout):
+        import anthropic  # lazy: optional dependency
+
+        self._client = anthropic.Anthropic(api_key=config["api_key"], timeout=timeout)
+        self._model = config["model"]
+        self._system = system
+        self._tools = tools
+        self._messages: List[Dict[str, Any]] = [
+            {"role": "user", "content": user_prompt}
+        ]
+
+    def send(self, results, allow_tools):
+        if results is not None:
+            self._messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": r.call_id,
+                            "content": json.dumps(r.content, default=str)[:4000],
+                            "is_error": r.is_error,
+                        }
+                        for r in results
+                    ],
+                }
+            )
+        kwargs: Dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": _MAX_OUTPUT_TOKENS,
+            "system": self._system,
+            "messages": self._messages,
+        }
+        if allow_tools and self._tools:
+            kwargs["tools"] = self._tools
+        response = self._client.messages.create(**kwargs)
+        self._messages.append({"role": "assistant", "content": response.content})
+        text_parts, calls = [], []
+        for block in response.content:
+            btype = getattr(block, "type", "")
+            if btype == "text":
+                text_parts.append(block.text)
+            elif btype == "tool_use":
+                calls.append(
+                    ToolInvocation(block.id, block.name, dict(block.input or {}))
+                )
+        if calls:
+            return LLMTurn(tool_calls=calls)
+        return LLMTurn(final_text="".join(text_parts) or None)
+
+
+class _OpenAIConversation(Conversation):
+    def __init__(self, config, system, user_prompt, tools, timeout):
+        import openai  # lazy: optional dependency
+
+        self._client = openai.OpenAI(api_key=config["api_key"], timeout=timeout)
+        self._model = config["model"]
+        self._tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t["description"],
+                    "parameters": t["input_schema"],
+                },
+            }
+            for t in tools
+        ]
+        self._messages: List[Dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_prompt},
+        ]
+
+    def send(self, results, allow_tools):
+        if results is not None:
+            for r in results:
+                self._messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": r.call_id,
+                        "content": json.dumps(r.content, default=str)[:4000],
+                    }
+                )
+        kwargs: Dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": _MAX_OUTPUT_TOKENS,
+            "messages": self._messages,
+        }
+        if allow_tools and self._tools:
+            kwargs["tools"] = self._tools
+        response = self._client.chat.completions.create(**kwargs)
+        message = response.choices[0].message
+        self._messages.append(message)
+        calls = []
+        for tc in getattr(message, "tool_calls", None) or []:
+            try:
+                args = json.loads(tc.function.arguments or "{}")
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            calls.append(ToolInvocation(tc.id, tc.function.name, args))
+        if calls:
+            return LLMTurn(tool_calls=calls)
+        return LLMTurn(final_text=message.content or None)
+
+
+def _make_conversation(config, system, user_prompt, tools, timeout) -> Conversation:
+    """Build the provider conversation. Monkeypatched in tests to inject a
+    scripted driver, so the loop logic is exercised without any SDK."""
+    if config["provider"] == "anthropic":
+        return _AnthropicConversation(config, system, user_prompt, tools, timeout)
+    return _OpenAIConversation(config, system, user_prompt, tools, timeout)
+
+
+def _run_grounded_loop(
+    config: Dict[str, str],
+    intent: str,
+    source_type: Optional[str],
+    availability: Optional[Dict[str, bool]],
+    ui_flags: Optional[Dict[str, bool]],
+    host,
+    budget_ms: int,
+) -> Optional[str]:
+    """Drive the bounded tool-use loop; return the final layout JSON text, or
+    None to signal the caller should fall back to the heuristic planner."""
+    tools, name_map = _advertise_tools(host)
+    user_prompt = _build_prompt(intent, source_type, availability, ui_flags)
+    convo = _make_conversation(
+        config, _loop_system_prompt(), user_prompt, tools, LOOP_TURN_TIMEOUT
+    )
+
+    deadline = time.monotonic() + budget_ms / 1000.0
+    results: Optional[List[ToolResult]] = None
+    for step in range(MAX_TOOL_ROUNDS + 1):
+        # Force a final answer when out of rounds or out of time.
+        force_final = step == MAX_TOOL_ROUNDS or time.monotonic() >= deadline
+        try:
+            turn = convo.send(results, allow_tools=not force_final)
+        except Exception:
+            logger.warning("genui planning loop turn failed", exc_info=True)
+            return None
+        if turn.final_text is not None:
+            return turn.final_text
+        if not turn.tool_calls or force_final:
+            # No usable answer within budget: degrade to the heuristic planner.
+            return None
+        results = _execute_tool_calls(host, turn.tool_calls, name_map)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point.
+# ---------------------------------------------------------------------------
+
+
+def _finalize(parsed: Dict[str, Any], intent: str, signals) -> Optional[UISpec]:
+    """Sanitize -> enforce usage signals -> validate. None on any failure."""
     try:
         spec = _sanitize(spec_from_dict(parsed), intent)
         _apply_usage_signals(spec, signals)
@@ -242,3 +588,65 @@ def plan_with_llm(
         logger.warning("genui LLM spec failed validation: %s", "; ".join(errors[:5]))
         return None
     return spec
+
+
+def _one_shot(config, intent, source_type, availability, ui_flags) -> Optional[str]:
+    """Single completion, no tools — the pre-R4 path and the degrade target."""
+    try:
+        return _complete(config, _build_prompt(intent, source_type, availability, ui_flags))
+    except Exception:
+        logger.warning("genui LLM completion failed; using heuristic planner", exc_info=True)
+        return None
+
+
+def plan_with_llm(
+    intent: str,
+    source_type: Optional[str] = None,
+    availability: Optional[Dict[str, bool]] = None,
+    ui_flags: Optional[Dict[str, bool]] = None,
+    signals: Optional[Dict[str, Any]] = None,
+) -> Optional[UISpec]:
+    """Plan a layout with the configured LLM; None on any failure.
+
+    With the MCP host up and the loop enabled, runs the bounded grounded
+    tool-use loop (R4); otherwise, or when the latency budget is too small,
+    falls back to a single one-shot completion (the pre-R4 behavior). Both
+    paths funnel through the same sanitize/validate/signal enforcement.
+    """
+    config = llm_config()
+    if config is None:
+        return None
+
+    text: Optional[str] = None
+    host = _planning_host()
+    budget_ms = _loop_budget_ms()
+    if (
+        loop_enabled()
+        and host is not None
+        and budget_ms >= MIN_LOOP_BUDGET_MS
+        and _advertise_tools(host)[0]
+    ):
+        text = _run_grounded_loop(
+            config, intent, source_type, availability, ui_flags, host, budget_ms
+        )
+    if text is None:
+        text = _one_shot(config, intent, source_type, availability, ui_flags)
+    if not text:
+        return None
+
+    parsed = _extract_json(text)
+    if parsed is None:
+        logger.warning("genui LLM returned unparseable output; using heuristic planner")
+        return None
+    return _finalize(parsed, intent, signals)
+
+
+def _planning_host():
+    """The MCP host to ground planning against, or None. Isolated so tests
+    can stub it without touching the singleton."""
+    try:
+        from src.mcp_host import get_host
+
+        return get_host()
+    except Exception:
+        return None

--- a/src/mcp_host/host.py
+++ b/src/mcp_host/host.py
@@ -55,6 +55,10 @@ STATE_DEGRADED = "degraded"
 STATE_DOWN = "down"
 
 DEFAULT_TTL_SECONDS = 60.0
+# Shared stats cache (R4): tool-call results cached per (server, tool, args)
+# and reused by the adaptivity layer and the LLM planning loop, so repeated
+# generates do not re-inspect. Invalidated per server on reconnect.
+STATS_CACHE_TTL = 60.0
 CONNECT_TIMEOUT = 15.0
 CALL_TIMEOUT = 10.0
 BACKOFF_BASE = 1.0
@@ -124,12 +128,16 @@ async def _list_tools(session: Any) -> List[Dict[str, Any]]:
     tools: List[Dict[str, Any]] = []
     for tool in result.tools:
         meta = getattr(tool, "meta", None)
+        input_schema = getattr(tool, "inputSchema", None)
         tools.append(
             {
                 "name": tool.name,
                 "description": (tool.description or "").strip(),
                 "meta": meta if isinstance(meta, dict) else {},
                 "has_output_schema": getattr(tool, "outputSchema", None) is not None,
+                # The R4 planning loop advertises tools to the LLM provider,
+                # which needs each tool's argument schema.
+                "input_schema": input_schema if isinstance(input_schema, dict) else {"type": "object"},
             }
         )
     return tools
@@ -172,6 +180,13 @@ class MCPHost:
         # Live session objects for call_tool, keyed by server name; entries
         # exist only while the supervise loop holds an open session.
         self._sessions: Dict[str, Any] = {}
+        # (server, tool, canonical-args) -> (result, expires_at).
+        self._call_cache: Dict[Any, Any] = {}
+        env_stats_ttl = os.getenv("NOESIS_MCP_STATS_TTL", "").strip()
+        try:
+            self.stats_ttl = float(env_stats_ttl) if env_stats_ttl else STATS_CACHE_TTL
+        except ValueError:
+            self.stats_ttl = STATS_CACHE_TTL
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         # Created loop-less here (safe since 3.10) so stop() always has an
@@ -275,6 +290,10 @@ class MCPHost:
         self, name: str, tools: List[Dict[str, str]], reconnected: bool = False
     ) -> None:
         now = time.time()
+        if reconnected:
+            # A restarted server may hold different data: cached call
+            # results for it are stale by definition.
+            self.invalidate_cached_calls(name)
         with self._lock:
             status = self._statuses[name]
             status.state = STATE_CONNECTED
@@ -335,6 +354,41 @@ class MCPHost:
             raise RuntimeError(f"tool {tool!r} returned an error: {result.content}")
         structured = getattr(result, "structuredContent", None)
         return structured if isinstance(structured, dict) else {}
+
+    def call_tool_cached(
+        self,
+        server: str,
+        tool: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        timeout: float = CALL_TIMEOUT,
+        ttl: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """``call_tool`` with a TTL result cache keyed per (server, tool,
+        args) — the shared stats cache (R4, #593). The adaptivity layer and
+        the LLM planning loop both read through this, so two consecutive
+        generates trigger at most one live round per tool within the TTL.
+        Errors are never cached."""
+        import json as _json
+
+        key = (server, tool, _json.dumps(arguments or {}, sort_keys=True, default=str))
+        now = time.time()
+        with self._lock:
+            hit = self._call_cache.get(key)
+            if hit is not None and now < hit[1]:
+                return hit[0]
+        result = self.call_tool(server, tool, arguments, timeout=timeout)
+        with self._lock:
+            self._call_cache[key] = (result, now + (ttl if ttl is not None else self.stats_ttl))
+        return result
+
+    def invalidate_cached_calls(self, server: Optional[str] = None) -> None:
+        """Drop cached tool results, for one server or all of them."""
+        with self._lock:
+            if server is None:
+                self._call_cache.clear()
+            else:
+                for key in [k for k in self._call_cache if k[0] == server]:
+                    del self._call_cache[key]
 
     # -- non-blocking readers ------------------------------------------------
 

--- a/tests/unit/genui/test_genui_planning_loop.py
+++ b/tests/unit/genui/test_genui_planning_loop.py
@@ -1,0 +1,496 @@
+"""Mock-MCP tests for the R4 grounded planning loop (src/genui/llm.py).
+
+The loop is exercised entirely against a fake host and a scripted
+conversation injected through ``_make_conversation`` — no provider SDK, no
+network, no subprocess. Covers the exit criterion (plans reflect inspected
+data), budget exhaustion, tool errors, allowlist rejection and the
+malformed-JSON fallback.
+"""
+
+import json
+
+import pytest
+
+import src.genui.llm as llm
+from src.genui.llm import (
+    INSPECTION_ALLOWLIST,
+    LLMTurn,
+    ToolInvocation,
+    ToolResult,
+    _advertise_tools,
+    _execute_tool_calls,
+    plan_with_llm,
+)
+
+CONFIG = {"provider": "anthropic", "model": "m", "api_key": "k"}
+
+
+class FakeHost:
+    """Cached tool host: canned results, records executed calls."""
+
+    def __init__(self, tools_by_server, results):
+        self._tools = tools_by_server
+        self._results = results
+        self.calls = []
+
+    def tools(self, server=None):
+        if server is not None:
+            return {server: self._tools.get(server, [])}
+        return dict(self._tools)
+
+    def call_tool_cached(self, server, tool, arguments=None, timeout=10.0, ttl=None):
+        self.calls.append((server, tool, arguments))
+        result = self._results[(server, tool)]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def tool_entry(name, schema=None):
+    return {
+        "name": name,
+        "description": f"{name} description",
+        "meta": {},
+        "has_output_schema": True,
+        "input_schema": schema or {"type": "object"},
+    }
+
+
+ARG_TOOLS = [
+    tool_entry("am_stats"),
+    tool_entry("list_stances"),
+    tool_entry("trigger_actor_batch"),  # RW: must never be advertised
+]
+
+
+class ScriptedConversation(llm.Conversation):
+    """Returns a fixed list of turns; records how it was driven."""
+
+    def __init__(self, turns):
+        self._turns = list(turns)
+        self.sends = []
+
+    def send(self, results, allow_tools):
+        self.sends.append((results, allow_tools))
+        return self._turns.pop(0)
+
+
+class GroundedModel(llm.Conversation):
+    """A fake model that actually reacts to am_stats: it asks for the stats,
+    then includes a stance panel only if source_stances has rows."""
+
+    def send(self, results, allow_tools):
+        if results is None:
+            return LLMTurn(
+                tool_calls=[ToolInvocation("c1", "neuronews-arguments__am_stats", {})]
+            )
+        am = results[0].content
+        panels = [
+            {"id": "p1", "type": "note", "title": "Plan", "span": 12, "priority": 1.0, "body": "x"}
+        ]
+        if am.get("source_stances", 0) > 0:
+            panels.append(
+                {"id": "p2", "type": "stance", "title": "Stance", "span": 6, "priority": 0.8}
+            )
+        else:
+            panels.append(
+                {"id": "p2", "type": "kpi_row", "title": "Summary", "span": 12, "priority": 0.8}
+            )
+        return LLMTurn(final_text=json.dumps({"title": "T", "panels": panels}))
+
+
+@pytest.fixture
+def loop_env(monkeypatch):
+    """Force the LLM path on and route the host/config through fakes."""
+    monkeypatch.setattr(llm, "llm_config", lambda: CONFIG)
+    monkeypatch.delenv("NOESIS_GENUI_LOOP", raising=False)
+    monkeypatch.delenv("NOESIS_GENUI_LOOP_BUDGET_MS", raising=False)
+
+    def _install(host, conversation):
+        monkeypatch.setattr(llm, "_planning_host", lambda: host)
+        monkeypatch.setattr(
+            llm, "_make_conversation", lambda *a, **k: conversation
+        )
+        return host, conversation
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Tool advertising + allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_advertise_only_allowlisted_tools():
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    specs, name_map = _advertise_tools(host)
+    names = {s["name"] for s in specs}
+    assert names == {
+        "neuronews-arguments__am_stats",
+        "neuronews-arguments__list_stances",
+    }
+    assert "neuronews-arguments__trigger_actor_batch" not in names
+    assert name_map["neuronews-arguments__am_stats"] == ("neuronews-arguments", "am_stats")
+
+
+def test_execute_rejects_non_allowlisted_call():
+    host = FakeHost({}, {})
+    _, name_map = _advertise_tools(FakeHost({"neuronews-arguments": ARG_TOOLS}, {}))
+    calls = [ToolInvocation("c1", "neuronews-arguments__trigger_actor_batch", {})]
+    results = _execute_tool_calls(host, calls, name_map)
+    assert results[0].is_error
+    assert "not permitted" in results[0].content["error"]
+    assert host.calls == []  # never reached the host
+
+
+def test_execute_wraps_tool_exceptions():
+    host = FakeHost(
+        {"neuronews-arguments": ARG_TOOLS},
+        {("neuronews-arguments", "am_stats"): RuntimeError("boom")},
+    )
+    _, name_map = _advertise_tools(host)
+    calls = [ToolInvocation("c1", "neuronews-arguments__am_stats", {})]
+    results = _execute_tool_calls(host, calls, name_map)
+    assert results[0].is_error
+    assert "RuntimeError" in results[0].content["error"]
+
+
+def test_execute_flags_error_payloads():
+    host = FakeHost(
+        {"neuronews-arguments": ARG_TOOLS},
+        {("neuronews-arguments", "am_stats"): {"error": "warehouse locked"}},
+    )
+    _, name_map = _advertise_tools(host)
+    calls = [ToolInvocation("c1", "neuronews-arguments__am_stats", {})]
+    results = _execute_tool_calls(host, calls, name_map)
+    assert results[0].is_error is True
+
+
+# ---------------------------------------------------------------------------
+# Exit criterion: plans reflect inspected data
+# ---------------------------------------------------------------------------
+
+
+def test_plan_includes_stance_when_data_present(loop_env):
+    host = FakeHost(
+        {"neuronews-arguments": ARG_TOOLS},
+        {("neuronews-arguments", "am_stats"): {"source_stances": 5}},
+    )
+    loop_env(host, GroundedModel())
+    spec = plan_with_llm("what is the stance on ai")
+    types = {p.type for p in spec.panels}
+    assert "stance" in types
+    assert host.calls == [("neuronews-arguments", "am_stats", {})]
+
+
+def test_plan_skips_stance_when_no_data(loop_env):
+    host = FakeHost(
+        {"neuronews-arguments": ARG_TOOLS},
+        {("neuronews-arguments", "am_stats"): {"source_stances": 0}},
+    )
+    loop_env(host, GroundedModel())
+    spec = plan_with_llm("what is the stance on ai")
+    types = {p.type for p in spec.panels}
+    assert "stance" not in types  # the loop grounded the plan in empty data
+    assert spec.generated_by == "llm"
+
+
+# ---------------------------------------------------------------------------
+# Budget + degradation
+# ---------------------------------------------------------------------------
+
+
+def test_final_without_tools_returns_spec(loop_env):
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    convo = ScriptedConversation(
+        [
+            LLMTurn(
+                final_text=json.dumps(
+                    {
+                        "title": "T",
+                        "panels": [
+                            {"id": "p1", "type": "note", "title": "Plan", "span": 12, "priority": 1.0, "body": "x"}
+                        ],
+                    }
+                )
+            )
+        ]
+    )
+    loop_env(host, convo)
+    spec = plan_with_llm("overview")
+    assert spec is not None and spec.generated_by == "llm"
+    # First send offers tools (allow_tools True) but the model answered directly.
+    assert convo.sends[0][1] is True
+
+
+def test_small_budget_skips_loop_and_uses_one_shot(loop_env, monkeypatch):
+    monkeypatch.setenv("NOESIS_GENUI_LOOP_BUDGET_MS", "100")  # < MIN_LOOP_BUDGET_MS
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    # The loop must not run; a scripted conversation that would explode if used.
+    exploding = ScriptedConversation([])
+    loop_env(host, exploding)
+    one_shot = json.dumps(
+        {"title": "T", "panels": [{"id": "p1", "type": "note", "title": "P", "span": 12, "priority": 1.0, "body": "x"}]}
+    )
+    monkeypatch.setattr(llm, "_complete", lambda config, prompt: one_shot)
+    spec = plan_with_llm("overview")
+    assert spec is not None
+    assert exploding.sends == []  # loop never entered
+    assert host.calls == []
+
+
+def test_loop_disabled_uses_one_shot(loop_env, monkeypatch):
+    monkeypatch.setenv("NOESIS_GENUI_LOOP", "off")
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    loop_env(host, ScriptedConversation([]))
+    monkeypatch.setattr(
+        llm,
+        "_complete",
+        lambda config, prompt: json.dumps(
+            {"title": "T", "panels": [{"id": "p1", "type": "note", "title": "P", "span": 12, "priority": 1.0, "body": "x"}]}
+        ),
+    )
+    assert plan_with_llm("overview") is not None
+
+
+def test_no_host_uses_one_shot(loop_env, monkeypatch):
+    loop_env(None, ScriptedConversation([]))
+    called = {}
+    one_shot = json.dumps(
+        {"title": "T", "panels": [{"id": "p1", "type": "note", "title": "P", "span": 12, "priority": 1.0, "body": "x"}]}
+    )
+
+    def fake_complete(config, prompt):
+        called["hit"] = True
+        return one_shot
+
+    monkeypatch.setattr(llm, "_complete", fake_complete)
+    assert plan_with_llm("overview") is not None
+    assert called.get("hit")
+
+
+def test_model_ignores_force_final_falls_back(loop_env, monkeypatch):
+    # A misbehaving model that always demands tools; when the loop forces a
+    # final answer it still asks for a tool, so the loop gives up and the
+    # one-shot path takes over.
+    host = FakeHost(
+        {"neuronews-arguments": ARG_TOOLS},
+        {("neuronews-arguments", "am_stats"): {"source_stances": 1}},
+    )
+
+    class AlwaysTools(llm.Conversation):
+        def send(self, results, allow_tools):
+            return LLMTurn(
+                tool_calls=[ToolInvocation("c1", "neuronews-arguments__am_stats", {})]
+            )
+
+    loop_env(host, AlwaysTools())
+    one_shot = json.dumps(
+        {"title": "T", "panels": [{"id": "p1", "type": "note", "title": "P", "span": 12, "priority": 1.0, "body": "x"}]}
+    )
+    monkeypatch.setattr(llm, "_complete", lambda config, prompt: one_shot)
+    spec = plan_with_llm("overview")
+    assert spec is not None  # degraded to one-shot after exhausting rounds
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_final_json_falls_back_to_heuristic(loop_env, monkeypatch):
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    loop_env(host, ScriptedConversation([LLMTurn(final_text="not json at all")]))
+    # One-shot also returns junk, so the whole LLM path yields None and the
+    # caller falls back to the heuristic planner.
+    monkeypatch.setattr(llm, "_complete", lambda config, prompt: "still not json")
+    assert plan_with_llm("overview") is None
+
+
+def test_conversation_exception_falls_back(loop_env, monkeypatch):
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+
+    class Boom(llm.Conversation):
+        def send(self, results, allow_tools):
+            raise RuntimeError("provider down")
+
+    loop_env(host, Boom())
+    monkeypatch.setattr(llm, "_complete", lambda config, prompt: None)
+    assert plan_with_llm("overview") is None
+
+
+def test_no_config_returns_none(monkeypatch):
+    monkeypatch.setattr(llm, "llm_config", lambda: None)
+    assert plan_with_llm("overview") is None
+
+
+def test_loop_enforces_usage_signals(loop_env):
+    """Pins/mutes are applied to the loop's output like the heuristic path."""
+    host = FakeHost({"neuronews-arguments": ARG_TOOLS}, {})
+    spec_json = json.dumps(
+        {
+            "title": "T",
+            "panels": [
+                {"id": "p1", "type": "note", "title": "Plan", "span": 12, "priority": 1.0, "body": "x"},
+                {"id": "p2", "type": "trending", "title": "Trending", "span": 6, "priority": 0.8},
+            ],
+        }
+    )
+    loop_env(host, ScriptedConversation([LLMTurn(final_text=spec_json)]))
+    spec = plan_with_llm(
+        "overview",
+        signals={"pinned": ["claims"], "dismissed": ["trending"], "weights": {}},
+    )
+    types = {p.type for p in spec.panels}
+    assert "trending" not in types  # muted
+    assert "claims" in types  # pinned
+
+
+# ---------------------------------------------------------------------------
+# Provider adapters (fake SDK modules; no network)
+# ---------------------------------------------------------------------------
+
+import sys  # noqa: E402
+import types as _types  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+ADVERTISED_TOOLS = [
+    {"name": "neuronews-arguments__am_stats", "description": "d", "input_schema": {"type": "object"}},
+]
+
+
+def _install_fake_module(monkeypatch, name, client_cls):
+    mod = _types.ModuleType(name)
+    mod.instances = []
+    monkeypatch.setitem(sys.modules, name, mod)
+    return mod
+
+
+def test_anthropic_conversation_normalizes_tool_then_final(monkeypatch):
+    mod = _install_fake_module(monkeypatch, "anthropic", None)
+    responses = [
+        SimpleNamespace(
+            content=[SimpleNamespace(type="tool_use", id="tu1", name="neuronews-arguments__am_stats", input={"limit": 1})]
+        ),
+        SimpleNamespace(content=[SimpleNamespace(type="text", text='{"title":"T","panels":[]}')]),
+    ]
+
+    class Client:
+        def __init__(self, api_key, timeout=None):
+            mod.instances.append(self)
+            self.messages = self
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return responses.pop(0)
+
+    mod.Anthropic = Client
+
+    convo = llm._AnthropicConversation(CONFIG, "sys", "user prompt", ADVERTISED_TOOLS, 5.0)
+    turn = convo.send(None, allow_tools=True)
+    assert turn.final_text is None
+    assert turn.tool_calls[0].advertised_name == "neuronews-arguments__am_stats"
+    assert turn.tool_calls[0].arguments == {"limit": 1}
+    # First request carried tools; system prompt passed through.
+    first = mod.instances[0].calls[0]
+    assert first["tools"] == ADVERTISED_TOOLS
+    assert first["system"] == "sys"
+
+    results = [ToolResult("tu1", "neuronews-arguments__am_stats", {"n": 3}, is_error=False)]
+    turn2 = convo.send(results, allow_tools=False)
+    assert turn2.final_text == '{"title":"T","panels":[]}'
+    # Force-final turn omits tools; a tool_result user message was fed back.
+    second = mod.instances[0].calls[1]
+    assert "tools" not in second
+    tool_results = [
+        b
+        for m in second["messages"]
+        if isinstance(m.get("content"), list)
+        for b in m["content"]
+        if isinstance(b, dict) and b.get("type") == "tool_result"
+    ]
+    assert tool_results and tool_results[0]["tool_use_id"] == "tu1"
+
+
+def test_openai_conversation_normalizes_tool_then_final(monkeypatch):
+    mod = _install_fake_module(monkeypatch, "openai", None)
+    tool_call = SimpleNamespace(
+        id="tc1",
+        function=SimpleNamespace(name="neuronews-arguments__am_stats", arguments='{"limit": 1}'),
+    )
+    responses = [
+        SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tool_call]))]),
+        SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='{"title":"T","panels":[]}', tool_calls=None))]
+        ),
+    ]
+
+    class Client:
+        def __init__(self, api_key, timeout=None):
+            mod.instances.append(self)
+            self.chat = SimpleNamespace(completions=self)
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return responses.pop(0)
+
+    mod.OpenAI = Client
+    config = {"provider": "openai", "model": "gpt", "api_key": "k"}
+
+    convo = llm._OpenAIConversation(config, "sys", "user prompt", ADVERTISED_TOOLS, 5.0)
+    turn = convo.send(None, allow_tools=True)
+    assert turn.final_text is None
+    assert turn.tool_calls[0].arguments == {"limit": 1}
+    first = mod.instances[0].calls[0]
+    assert first["tools"][0]["function"]["name"] == "neuronews-arguments__am_stats"
+
+    results = [ToolResult("tc1", "neuronews-arguments__am_stats", {"n": 3})]
+    turn2 = convo.send(results, allow_tools=False)
+    assert turn2.final_text == '{"title":"T","panels":[]}'
+    tool_msgs = [
+        m
+        for m in mod.instances[0].calls[1]["messages"]
+        if isinstance(m, dict) and m.get("role") == "tool"
+    ]
+    assert tool_msgs and tool_msgs[0]["tool_call_id"] == "tc1"
+
+
+def test_openai_bad_tool_arguments_default_to_empty(monkeypatch):
+    mod = _install_fake_module(monkeypatch, "openai", None)
+    tool_call = SimpleNamespace(
+        id="tc1", function=SimpleNamespace(name="neuronews-arguments__am_stats", arguments="{not json")
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tool_call]))]
+    )
+
+    class Client:
+        def __init__(self, api_key, timeout=None):
+            mod.instances.append(self)
+            self.chat = SimpleNamespace(completions=self)
+
+        def create(self, **kwargs):
+            return response
+
+    mod.OpenAI = Client
+    convo = llm._OpenAIConversation(
+        {"provider": "openai", "model": "g", "api_key": "k"}, "s", "u", ADVERTISED_TOOLS, 5.0
+    )
+    turn = convo.send(None, allow_tools=True)
+    assert turn.tool_calls[0].arguments == {}
+
+
+def test_make_conversation_dispatches_by_provider(monkeypatch):
+    mod_a = _install_fake_module(monkeypatch, "anthropic", None)
+    mod_a.Anthropic = lambda api_key, timeout=None: SimpleNamespace(messages=None)
+    conv = llm._make_conversation(CONFIG, "s", "u", [], 5.0)
+    assert isinstance(conv, llm._AnthropicConversation)
+
+    mod_o = _install_fake_module(monkeypatch, "openai", None)
+    mod_o.OpenAI = lambda api_key, timeout=None: SimpleNamespace(chat=SimpleNamespace(completions=None))
+    conv2 = llm._make_conversation(
+        {"provider": "openai", "model": "g", "api_key": "k"}, "s", "u", [], 5.0
+    )
+    assert isinstance(conv2, llm._OpenAIConversation)

--- a/tests/unit/genui/test_genui_tool_adaptivity.py
+++ b/tests/unit/genui/test_genui_tool_adaptivity.py
@@ -175,6 +175,29 @@ def test_get_host_reads_the_singleton(monkeypatch):
     assert availability is not None
 
 
+def test_availability_reads_through_shared_cache(monkeypatch):
+    """R4 #593: when the host exposes call_tool_cached, adaptivity uses it
+    (the shared stats cache) rather than call_tool, so results are shared
+    with the planning loop."""
+
+    class CachingHost(FakeHost):
+        def __init__(self):
+            super().__init__(ALL_STATS_SERVERS, GOOD_RESULTS)
+            self.cached_calls = []
+
+        def call_tool_cached(self, server, tool, arguments=None, timeout=10.0, ttl=None):
+            self.cached_calls.append((server, tool))
+            return self.call_tool(server, tool, arguments)
+
+    host = CachingHost()
+    install(monkeypatch, host)
+    availability, source = resolve_availability()
+    assert source == "tools"
+    # Every stats read went through the shared cache, not the raw path.
+    assert host.cached_calls
+    assert len(host.cached_calls) == len(host.calls)
+
+
 # ---------------------------------------------------------------------------
 # resolve_ui_flags
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp_host/test_mcp_host.py
+++ b/tests/unit/mcp_host/test_mcp_host.py
@@ -49,6 +49,7 @@ class ScriptedServer:
         self.fail_connects = 0
         self.alive = True
         self.connects = 0
+        self.tool_calls = 0
         self.call_result = SimpleNamespace(
             isError=False, structuredContent={"ok": True}
         )
@@ -71,6 +72,7 @@ class ScriptedServer:
     async def call_tool(self, name, arguments):
         if not self.alive:
             raise ConnectionError("server killed")
+        self.tool_calls += 1
         return self.call_result
 
 
@@ -119,8 +121,20 @@ def test_connects_and_reports_connected(make_host):
     assert status["restarts"] == 0
     assert h.tools("fake") == {
         "fake": [
-            {"name": "alpha", "description": "d", "meta": {}, "has_output_schema": False},
-            {"name": "beta", "description": "d", "meta": {}, "has_output_schema": False},
+            {
+                "name": "alpha",
+                "description": "d",
+                "meta": {},
+                "has_output_schema": False,
+                "input_schema": {"type": "object"},
+            },
+            {
+                "name": "beta",
+                "description": "d",
+                "meta": {},
+                "has_output_schema": False,
+                "input_schema": {"type": "object"},
+            },
         ]
     }
 
@@ -305,6 +319,64 @@ def test_call_tool_non_dict_content_becomes_empty(make_host):
     h.start()
     assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
     assert h.call_tool("fake", "anything") == {}
+
+
+# ---------------------------------------------------------------------------
+# call_tool_cached (R4 #593: shared stats cache)
+# ---------------------------------------------------------------------------
+
+
+def test_call_tool_cached_caches_within_ttl(make_host):
+    server = ScriptedServer()
+    server.call_result = SimpleNamespace(isError=False, structuredContent={"v": 1})
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+
+    assert h.call_tool_cached("fake", "t", {"a": 1}) == {"v": 1}
+    n = server.tool_calls
+    # Same (server, tool, args): served from cache, no new round-trip.
+    assert h.call_tool_cached("fake", "t", {"a": 1}) == {"v": 1}
+    assert server.tool_calls == n
+    # Different args are a different cache key.
+    h.call_tool_cached("fake", "t", {"a": 2})
+    assert server.tool_calls == n + 1
+
+
+def test_invalidate_cached_calls(make_host):
+    server = ScriptedServer()
+    server.call_result = SimpleNamespace(isError=False, structuredContent={"v": 1})
+    h = make_host(server)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    h.call_tool_cached("fake", "t")
+    n = server.tool_calls
+    h.invalidate_cached_calls("fake")
+    h.call_tool_cached("fake", "t")
+    assert server.tool_calls == n + 1
+    # Invalidate-all also clears.
+    h.invalidate_cached_calls()
+    h.call_tool_cached("fake", "t")
+    assert server.tool_calls == n + 2
+
+
+def test_reconnect_invalidates_call_cache(make_host):
+    server = ScriptedServer()
+    server.call_result = SimpleNamespace(isError=False, structuredContent={"v": 1})
+    h = make_host(server, ttl=0.05)
+    h.start()
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert h.call_tool_cached("fake", "t") == {"v": 1}
+
+    # Kill; on reconnect the server reports a new value, and the stale cache
+    # entry must be dropped so the fresh value is served.
+    server.alive = False
+    assert wait_until(lambda: state_of(h) != STATE_CONNECTED)
+    server.call_result = SimpleNamespace(isError=False, structuredContent={"v": 2})
+    server.alive = True
+    assert wait_until(lambda: h.status()["servers"]["fake"]["restarts"] >= 1)
+    assert wait_until(lambda: state_of(h) == STATE_CONNECTED)
+    assert h.call_tool_cached("fake", "t") == {"v": 2}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request: Grounded LLM planning (milestone R4)

## Overview

Implements milestone **R4** of the MCP rearchitecture plan (Stage 2): the optional LLM planner becomes a bounded, data-grounded tool-use loop. With the MCP host up, the model may call a curated read-only inspection allowlist to learn what data actually exists before composing the layout, so plans demonstrably skip empty-data panels. The loop is budgeted in both call count and wall-clock and degrades to one-shot planning when the budget would be blown. The heuristic planner remains the no-key default, untouched, and every LLM path still funnels through the same sanitize / validate / usage-signal enforcement.

Closes #592. Closes #593. Closes #594.

## Changes Summary

**Bounded tool-use loop (#592)**

- `plan_with_llm` advertises a curated read-only inspection allowlist (`am_stats`, `article_stats`, `document_stats`, the `list_*` / `*_stats` tools across arguments/pipeline/kg/domain-packs/sources), never the RW `trigger_*` / `run_*` / `compute_*` tools, and lets the model call them for up to `MAX_TOOL_ROUNDS` (3) rounds before emitting the spec.
- Provider-neutral `Conversation` abstraction with `anthropic` and `openai` adapters, so the loop logic is fully testable without any SDK. A rejected or failed tool call becomes an error result the model can react to; it never aborts the loop.

**Shared stats cache (#593)**

- `MCPHost.call_tool_cached` caches results per `(server, tool, args)` with a TTL (`NOESIS_MCP_STATS_TTL`, default 60 s), invalidated per server on reconnect. The R3 adaptivity layer and the planning loop both read through it, so two consecutive generates trigger at most one live round per stats tool.
- The host tool cache now also carries each tool's `input_schema` (for advertising to the provider).

**Latency budget (#594)**

- `NOESIS_GENUI_LOOP_BUDGET_MS` (default 9000 ms) bounds the whole loop's wall-clock. When the remaining budget is below `MIN_LOOP_BUDGET_MS` (1500 ms) at the start, or the deadline is crossed mid-loop, the planner degrades to a single one-shot completion (the pre-R4 path) instead of issuing more turns. Kill switch: `NOESIS_GENUI_LOOP=off`. Documented in `MCP_REARCHITECTURE_PLAN.md` and `docs/genui.md`.

## Testing Status

- [x] 325 tests pass; coverage: llm 93%, host 95%, genui overall 96%
- [x] Mock-MCP suite (no SDK, no network): grounding exit criterion (stance panel present iff `am_stats` reports rows), budget-too-small / loop-off / no-host one-shot degrade, model-ignores-force-final fallback, tool exceptions and error payloads, allowlist rejection (never reaches the host), malformed-final-JSON heuristic fallback, usage-signal enforcement on loop output
- [x] Both provider adapters covered via injected fake SDK modules (message serialization, tool-call normalization, force-final omitting tools)
- [x] Host-level cache tests: within-TTL hit, per-args keys, explicit invalidation, reconnect invalidation
- [x] Codegen staleness gate clean; `TESTING=true` app import unaffected

## Live verification (R4 exit criterion)

No provider key is available in the environment, so the LLM turn was a scripted model; every other moving part ran against the real MCP servers:

- 26 inspection tools advertised from real discovery, allowlist enforced (no RW tool leaked), each with a real `input_schema`
- The scripted model called `am_stats` on the real warehouse (which reports `source_stances=0`) and the final plan correctly omitted the stance panel, the grounding exit criterion demonstrated against live data
- A second generate within the TTL reused the cached `am_stats` result (one round per stats tool)

---

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY