### PR TITLE
R7: Research pack, the second first-class domain (venues, citation graph, literature claims)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -85,6 +85,14 @@
       ],
       "env": {}
     },
+    "neuronews-research": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/research_mcp/server.py"
+      ],
+      "env": {}
+    },
     "neuronews-dataset": {
       "type": "stdio",
       "command": "python3",

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -30,7 +30,10 @@ export type PanelType =
   | "lead_lag"
   | "narrative_thread"
   | "drift_trajectory"
-  | "forecast";
+  | "forecast"
+  | "venues"
+  | "citation_graph"
+  | "literature_claims";
 
 export type Facet =
   | "overview"
@@ -86,6 +89,9 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "narrative_thread", title: "Narrative threads", facets: ["events", "overview"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "drift_trajectory", title: "Meaning drift", facets: ["trend"], defaultSpan: 6, topicParam: true },
   { type: "forecast", title: "Coverage forecast", facets: ["trend"], defaultSpan: 6, topicParam: true },
+  { type: "venues", title: "Venue credibility", facets: ["sources", "library"], defaultSpan: 6 },
+  { type: "citation_graph", title: "Citation graph", facets: ["entities", "library"], defaultSpan: 6, topicParam: true },
+  { type: "literature_claims", title: "Literature claims", facets: ["claims", "library"], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/planner.ts
+++ b/apps/web/src/genui/planner.ts
@@ -19,7 +19,7 @@ const FACET_KEYWORDS: Record<Facet, string[]> = {
   sources: ["outlet", "outlets", "source", "sources", "bias", "biased", "framing", "frame", "frames", "coverage", "compare", "comparison", "transparency", "media", "publisher", "publishers", "leads", "lead", "leader", "leaders", "follows", "follow", "followers", "agenda", "first", "earliest", "sets"],
   entities: ["entity", "entities", "network", "graph", "connection", "connections", "related", "relationship", "relationships", "influence"],
   events: ["event", "events", "cluster", "clusters", "story", "stories", "breaking", "timeline", "happening", "developments", "watchlist", "watchlists", "alert", "alerts"],
-  library: ["library", "document", "documents", "docs", "archive", "reading", "publications", "ingested", "corpus"],
+  library: ["library", "document", "documents", "docs", "archive", "reading", "publications", "ingested", "corpus", "paper", "papers", "research", "scholarly", "academic", "literature", "citation", "citations", "cite", "cited", "venue", "venues", "journal", "journals", "peer-reviewed", "preprint", "study", "studies"],
 };
 
 const SOURCE_TYPE_WORDS: Record<string, string> = {

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -891,6 +891,82 @@ function ActorsPanel(props: PanelProps) {
   );
 }
 
+// R7 research-pack renderers. Data path lands with the MCP data proxy (R12);
+// until then each shows a representative fixture.
+const DEMO_VENUES = [
+  { venue: "Nature Climate Change", papers: 58, credibility: { value: 0.82, lo: 0.79, hi: 0.85 } },
+  { venue: "PNAS", papers: 41, credibility: { value: 0.76, lo: 0.72, hi: 0.8 } },
+  { venue: "arXiv preprint", papers: 120, credibility: { value: 0.58, lo: 0.55, hi: 0.61 } },
+  { venue: "Energy Policy", papers: 33, credibility: { value: 0.71, lo: 0.66, hi: 0.76 } },
+];
+
+function VenuesPanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {DEMO_VENUES.map((v, i) => (
+          <div key={v.venue} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{ ...mono, width: 18 }}>#{i + 1}</span>
+            <div style={{ flex: 1, minWidth: 0, fontSize: 12.5, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{v.venue}</div>
+            <span style={{ ...mono, width: 52, textAlign: "right" }}>{v.papers} papers</span>
+            <ScoreBar value={v.credibility.value} ci={{ lo: v.credibility.lo, hi: v.credibility.hi, level: 0.95, n: v.papers }} />
+            <span style={{ fontFamily: fonts.mono, fontSize: 11.5, color: palette.teal, width: 34, textAlign: "right" }}>{v.credibility.value.toFixed(2)}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>credibility generalizes the outlet transparency score to venues (95% CI)</div>
+    </GenPanel>
+  );
+}
+
+const DEMO_CITATIONS = {
+  nodes: [
+    { id: "p1", count: 120, color: ACCENT }, { id: "p2", count: 58, color: ACCENT },
+    { id: "p3", count: 41, color: palette.teal }, { id: "p4", count: 33, color: palette.teal },
+    { id: "p5", count: 22, color: palette.amber }, { id: "p6", count: 14, color: palette.amber },
+  ],
+  edges: [
+    { source: "p2", target: "p1" }, { source: "p3", target: "p1" },
+    { source: "p4", target: "p2" }, { source: "p5", target: "p3" }, { source: "p6", target: "p2" },
+  ],
+};
+
+function CitationGraphPanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <EntityGraph data={DEMO_CITATIONS as unknown as import("../types").LiveGraph} />
+      <div style={{ ...mono, marginTop: 4 }}>papers linked by citation, sized by citation count</div>
+    </GenPanel>
+  );
+}
+
+const DEMO_LIT_CLAIMS = [
+  { text: "Carbon capture at current cost is not scalable to 2030 targets.", verdict: "disputed", attributed: true },
+  { text: "Solar LCOE fell below coal in most markets by 2024.", verdict: "supported", attributed: true },
+  { text: "Grid storage duration is the binding constraint on renewables.", verdict: "unverified", attributed: false },
+];
+
+const VERDICT_COLOR: Record<string, string> = { supported: palette.pos, disputed: palette.neg, unverified: palette.dim };
+
+function LiteratureClaimsPanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {DEMO_LIT_CLAIMS.map((c, i) => (
+          <div key={i} style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+            <span style={{ ...chip(VERDICT_COLOR[c.verdict] ?? palette.dim), marginTop: 2 }}>{c.verdict}</span>
+            <div style={{ flex: 1, minWidth: 0, fontSize: 12.5, lineHeight: 1.35 }}>
+              {c.text}
+              {!c.attributed ? <span style={{ ...mono, color: palette.amber, marginLeft: 6 }}>uncited</span> : null}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>claims scoped to papers, from the shared claim layer</div>
+    </GenPanel>
+  );
+}
+
 function UnknownPanel(props: PanelProps) {
   return (
     <GenPanel {...props}>
@@ -925,6 +1001,9 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   narrative_thread: NarrativeThreadPanel,
   drift_trajectory: DriftTrajectoryPanel,
   forecast: ForecastPanel,
+  venues: VenuesPanel,
+  citation_graph: CitationGraphPanel,
+  literature_claims: LiteratureClaimsPanel,
 };
 
 export function panelComponent(type: string): ComponentType<PanelProps> {

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -571,6 +571,22 @@ research-flavored telemetry.
 on research panels; venue credibility renders via the generalized
 transparency machinery.
 
+*Delivered.* `src/domains/research/` is the second first-class pack,
+built the same way as news: paper-metadata enrichers (venue, citations,
+concept), `ui_flags` gating the research panel family, and
+`research_telemetry` (recent papers, emerging concepts) surfaced when the
+pack dominates. `tools/research_mcp/` exposes `venues`
+(credibility as a composite of concept diversity, attribution and
+citation impact, generalizing outlet transparency scoring, honesty-
+wrapped), `citation_graph` (paper citation network) and
+`literature_claims` (claims scoped to papers), annotated for the three
+new panels and surfaced through R2 discovery. The pack is registered in
+`.mcp.json` and at API/domain-pack startup; enable it with
+`NEURONEWS_ENABLED_PACKS=research`. Verified end-to-end with research on
+and news off: the three panels discover and plan, venue credibility
+carries a CI, telemetry becomes NEW PAPERS, and a generic briefing still
+gets a live overview.
+
 **R8 — Provisioning plane** *(Track P)*
 `kg_deploy` / `kg_attach_sources` / `kg_ingest` / `kg_status` /
 `kg_teardown` with table-prefix namespacing, lineage registration,

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -92,6 +92,18 @@ tool servers stay import-safe. The panels render the uncertainty fields
 today from demo data; live panel data arrives with the MCP data proxy
 (R12).
 
+### Research pack (`src/domains/research/`, R7)
+
+The second first-class domain, proving pack-plurality. Paper-metadata
+enrichers (venue, citations, concept) plus `ui_flags` gating a research
+panel family: `venues` (credibility generalizing the outlet transparency
+score to publication venues), `citation_graph` (paper citation network),
+`literature_claims` (claims scoped to papers). Served by
+`tools/research_mcp/` and surfaced through R2 discovery; research-flavored
+telemetry (recent papers, emerging concepts) takes over the empty canvas
+when the pack dominates. Enable with `NEURONEWS_ENABLED_PACKS=research`;
+with news off the canvas is fully functional on research panels.
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -403,6 +403,7 @@ def _load_domain_packs():
     try:
         from src.domains.registry import load_config
         import src.domains.news  # noqa: F401 — triggers register_pack(NewsDomainPack)
+        import src.domains.research  # noqa: F401 — triggers register_pack(ResearchDomainPack)
         load_config()
     except Exception:
         import logging

--- a/src/domains/research/__init__.py
+++ b/src/domains/research/__init__.py
@@ -1,0 +1,17 @@
+"""
+Research domain pack (R7 / Track N1).
+
+Bundles the paper-metadata enrichers, research panel ``ui_flags`` and
+research-flavored telemetry. Importing this module registers
+``ResearchDomainPack`` in the domain registry; the pack is *enabled* only
+when ``"research"`` appears in ``config/domain_packs.json`` (or the
+``NEURONEWS_ENABLED_PACKS`` env var). It is registered regardless so the
+registry always knows the pack exists.
+"""
+
+from src.domains.research.pack import ResearchDomainPack
+from src.domains.registry import register_pack
+
+register_pack(ResearchDomainPack)
+
+__all__ = ["ResearchDomainPack"]

--- a/src/domains/research/analytics.py
+++ b/src/domains/research/analytics.py
@@ -1,0 +1,201 @@
+"""
+Research-domain analytics (MCP rearchitecture plan, R7 / Track N1).
+
+Panel-facing reads over the ingested paper corpus:
+
+* :func:`venue_credibility` generalizes the outlet transparency scoring to
+  publication venues: a composite of concept diversity (Shannon entropy of a
+  venue's topic mix, mirroring outlet frame diversity), claim-attribution
+  rate, and normalized citation impact. Honesty-wrapped, so the venues panel
+  shows a defensible score, not a bare number.
+* :func:`citation_graph` builds the paper -> paper / paper -> venue citation
+  network from document metadata.
+* :func:`literature_claims` surfaces SUPPORTS / CONTRADICTS claims scoped to
+  papers from the shared claim layer.
+
+Reads a ``documents``-style corpus (``source_type = 'paper'``) and the shared
+``argument_claims`` table; both are queried defensively so a corpus without
+papers degrades to an empty (still valid) payload rather than an error.
+
+Stdlib-only maths (reuses :mod:`src.analytics`).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional
+
+from src.analytics.honesty import analytic_envelope, interval
+
+VENUE_METHOD = "composite transparency score generalized to venues"
+VENUE_ASSUMPTIONS = [
+    "credibility blends concept diversity, attribution rate and citation impact",
+    "concept diversity is Shannon entropy of the venue's topic mix (like outlet frame diversity)",
+    "needs several papers per venue; sparse venues carry wide intervals",
+]
+
+_EPS = 1e-9
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def _entropy(counts: List[int]) -> float:
+    total = sum(counts)
+    if total <= 0:
+        return 0.0
+    ent = -sum((c / total) * math.log(c / total + _EPS) for c in counts if c > 0)
+    # Normalize to 0..1 by the max entropy for this many categories.
+    max_ent = math.log(len([c for c in counts if c > 0]) + _EPS) if len(counts) > 1 else 1.0
+    return ent / max_ent if max_ent > _EPS else 0.0
+
+
+def venue_credibility(conn) -> Dict[str, Any]:
+    """Per-venue credibility over the paper corpus (generalized transparency)."""
+    if not _table_exists(conn, "documents"):
+        return analytic_envelope(
+            n=0, method=VENUE_METHOD, assumptions=VENUE_ASSUMPTIONS,
+            venues=[], note="no document corpus ingested",
+        )
+    rows = conn.execute(
+        """
+        SELECT venue,
+               COUNT(*) AS papers,
+               AVG(COALESCE(citations, 0)) AS avg_citations,
+               MAX(COALESCE(citations, 0)) AS max_citations
+        FROM documents
+        WHERE source_type = 'paper' AND venue IS NOT NULL
+        GROUP BY venue
+        ORDER BY papers DESC
+        """
+    ).fetchall()
+    corpus_max = max((r[3] for r in rows), default=0) or 1
+
+    # Attribution rate per venue from the shared claim layer, when present.
+    attribution: Dict[str, float] = {}
+    if _table_exists(conn, "argument_claims"):
+        try:
+            arows = conn.execute(
+                """
+                SELECT d.venue,
+                       AVG(CASE WHEN c.attributed THEN 1.0 ELSE 0.0 END)
+                FROM argument_claims c
+                JOIN documents d ON c.document_id = d.id
+                WHERE d.source_type = 'paper' AND d.venue IS NOT NULL
+                GROUP BY d.venue
+                """
+            ).fetchall()
+            attribution = {r[0]: float(r[1] or 0.0) for r in arows}
+        except Exception:
+            attribution = {}
+
+    # Concept-diversity input: paper counts per (venue) topic bucket.
+    concept_counts: Dict[str, List[int]] = {}
+    try:
+        crows = conn.execute(
+            "SELECT venue, COALESCE(concept, 'other'), COUNT(*) FROM documents "
+            "WHERE source_type = 'paper' AND venue IS NOT NULL GROUP BY 1, 2"
+        ).fetchall()
+        for venue, _concept, count in crows:
+            concept_counts.setdefault(venue, []).append(int(count))
+    except Exception:
+        concept_counts = {}
+
+    venues = []
+    for venue, papers, avg_cit, _max_cit in rows:
+        diversity = _entropy(concept_counts.get(venue, [papers]))
+        attr = attribution.get(venue, 0.0)
+        impact = min(1.0, (avg_cit or 0.0) / (corpus_max or 1))
+        composite = (diversity + attr + impact) / 3.0
+        # Interval width shrinks with the venue's paper count (more evidence).
+        half = 0.25 / math.sqrt(max(1, papers))
+        venues.append(
+            {
+                "venue": venue,
+                "papers": int(papers),
+                "credibility": interval(
+                    composite, max(0.0, composite - half), min(1.0, composite + half)
+                ),
+                "components": {
+                    "concept_diversity": round(diversity, 3),
+                    "attribution_rate": round(attr, 3),
+                    "citation_impact": round(impact, 3),
+                },
+            }
+        )
+    venues.sort(key=lambda v: -v["credibility"]["value"])
+    return analytic_envelope(
+        n=sum(r[1] for r in rows),
+        method=VENUE_METHOD,
+        assumptions=VENUE_ASSUMPTIONS,
+        venue_count=len(venues),
+        venues=venues,
+    )
+
+
+def citation_graph(conn, topic: Optional[str] = None, limit: int = 40) -> Dict[str, Any]:
+    """Paper citation network (nodes = papers, edges = citations) from the
+    ``documents`` corpus. Papers cite others via metadata ``references``,
+    persisted as a ``references`` column (comma-separated ids)."""
+    if not _table_exists(conn, "documents"):
+        return {"nodes": [], "edges": [], "note": "no document corpus ingested"}
+    where = ["source_type = 'paper'"]
+    params: List[Any] = []
+    if topic:
+        where.append("(concept = ? OR title ILIKE ?)")
+        params.extend([topic, f"%{topic}%"])
+    params.append(limit)
+    rows = conn.execute(
+        f"SELECT id, title, venue, COALESCE(citations, 0), COALESCE(refs, '') "
+        f"FROM documents WHERE {' AND '.join(where)} "
+        f"ORDER BY COALESCE(citations, 0) DESC LIMIT ?",
+        params,
+    ).fetchall()
+    ids = {r[0] for r in rows}
+    nodes = [
+        {"id": r[0], "title": r[1], "venue": r[2], "citations": int(r[3])}
+        for r in rows
+    ]
+    edges = []
+    for r in rows:
+        for ref in (r[4] or "").split(","):
+            ref = ref.strip()
+            if ref and ref in ids:
+                edges.append({"from": r[0], "to": ref})
+    return {"nodes": nodes, "edges": edges, "node_count": len(nodes), "edge_count": len(edges)}
+
+
+def literature_claims(conn, topic: Optional[str] = None, limit: int = 30) -> Dict[str, Any]:
+    """SUPPORTS / CONTRADICTS claims scoped to papers, from the claim layer."""
+    if not _table_exists(conn, "argument_claims"):
+        return {"claims": [], "note": "no claim layer available"}
+    where = ["source_type = 'paper'"]
+    params: List[Any] = []
+    if topic:
+        where.append("claim_text ILIKE ?")
+        params.append(f"%{topic}%")
+    params.append(limit)
+    rows = conn.execute(
+        f"SELECT claim_id, claim_text, COALESCE(factcheck_verdict, 'unverified'), "
+        f"COALESCE(attributed, FALSE) FROM argument_claims "
+        f"WHERE {' AND '.join(where)} ORDER BY confidence DESC NULLS LAST LIMIT ?",
+        params,
+    ).fetchall()
+    claims = [
+        {
+            "claim_id": r[0],
+            "text": (r[1] or "")[:180],
+            "verdict": r[2],
+            "attributed": bool(r[3]),
+        }
+        for r in rows
+    ]
+    return {"claims": claims, "count": len(claims), "topic": topic}

--- a/src/domains/research/enrichers.py
+++ b/src/domains/research/enrichers.py
@@ -1,0 +1,81 @@
+"""
+Research-domain enrichers (R7 / Track N1).
+
+Lightweight, dependency-free enrichers over paper metadata: normalize the
+publication venue, count citations/references, and tag key concepts from the
+title and abstract. They run only for ``source_type = 'paper'`` documents and
+follow the generic :class:`~src.domains.base.Enricher` interface (return a
+dict of results, or ``None`` to skip).
+
+Stdlib-only, so importing the pack never pulls a heavy dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _field(document: Any, key: str, default=None):
+    """Read a field from a Document dataclass or a plain dict."""
+    if isinstance(document, dict):
+        return document.get(key, default)
+    return getattr(document, key, default)
+
+
+def _metadata(document: Any) -> Dict[str, Any]:
+    meta = _field(document, "metadata", {})
+    return meta if isinstance(meta, dict) else {}
+
+
+def venue_enricher(document: Any) -> Optional[Dict[str, Any]]:
+    """Normalize the publication venue from metadata (venue / journal /
+    booktitle), title-casing and trimming."""
+    meta = _metadata(document)
+    raw = meta.get("venue") or meta.get("journal") or meta.get("booktitle")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return {"venue": raw.strip(), "enricher": "venue"}
+
+
+def citation_enricher(document: Any) -> Optional[Dict[str, Any]]:
+    """Count a paper's references and its incoming citation count from
+    metadata, tolerating either a list or an integer."""
+    meta = _metadata(document)
+    refs = meta.get("references")
+    ref_ids: List[str] = []
+    if isinstance(refs, list):
+        ref_ids = [str(r) for r in refs if r]
+    citations = meta.get("citations") or meta.get("cited_by")
+    if not isinstance(citations, int):
+        citations = len(ref_ids) if ref_ids else 0
+    if not ref_ids and not citations:
+        return None
+    return {
+        "citations": int(citations),
+        "refs": ",".join(ref_ids),
+        "reference_count": len(ref_ids),
+        "enricher": "citation",
+    }
+
+
+_CONCEPT_STOP = frozenset(
+    "study analysis approach method methods results paper using based novel "
+    "towards toward new model models framework via case learning".split()
+)
+
+
+def concept_enricher(document: Any) -> Optional[Dict[str, Any]]:
+    """Tag the paper's dominant concept from its title/abstract (the most
+    frequent salient noun-ish token), used to bucket a venue's topic mix."""
+    from src.analytics.text import tokenize
+
+    title = _field(document, "title", "") or ""
+    abstract = _metadata(document).get("abstract", "") or ""
+    tokens = [t for t in tokenize(f"{title} {title} {abstract}") if t not in _CONCEPT_STOP]
+    if not tokens:
+        return None
+    counts: Dict[str, int] = {}
+    for t in tokens:
+        counts[t] = counts.get(t, 0) + 1
+    concept = max(counts, key=lambda k: (counts[k], k))
+    return {"concept": concept, "enricher": "concept"}

--- a/src/domains/research/pack.py
+++ b/src/domains/research/pack.py
@@ -1,0 +1,60 @@
+"""
+Builds the research :class:`~src.domains.base.DomainPack` instance.
+
+The research pack is the second first-class domain (R7 / Track N1), proving
+pack-plurality: papers ingest with metadata enrichment (venue, citations,
+concepts), and the canvas grows research panels (`citation_graph`, `venues`,
+`literature_claims`) gated by the pack's ``ui_flags``. Its telemetry shifts
+the empty canvas to research signal when the pack dominates.
+"""
+
+from src.domains.base import DomainPack, Enricher
+from src.domains.research.enrichers import (
+    citation_enricher,
+    concept_enricher,
+    venue_enricher,
+)
+from src.domains.research.telemetry import research_telemetry
+
+_RESEARCH_ENRICHERS = [
+    Enricher(
+        name="venue",
+        fn=venue_enricher,
+        source_types=["paper"],
+        description="Normalize the publication venue from paper metadata.",
+    ),
+    Enricher(
+        name="citation",
+        fn=citation_enricher,
+        source_types=["paper"],
+        description="Count references and incoming citations from metadata.",
+    ),
+    Enricher(
+        name="concept",
+        fn=concept_enricher,
+        source_types=["paper"],
+        description="Tag the paper's dominant concept from title/abstract.",
+    ),
+]
+
+# UI feature flags surfaced to the frontend; gate the research panel family.
+_RESEARCH_UI_FLAGS = {
+    "research": True,
+    "citation_graph": True,
+    "venues": True,
+    "literature_claims": True,
+}
+
+ResearchDomainPack = DomainPack(
+    name="research",
+    description=(
+        "Research-domain analytics for scholarly papers: venue credibility, "
+        "citation graphs, and literature claims. Runs only for "
+        "source_type='paper' documents."
+    ),
+    source_types=["paper"],
+    enrichers=_RESEARCH_ENRICHERS,
+    route_modules=[],
+    ui_flags=_RESEARCH_UI_FLAGS,
+    telemetry=research_telemetry,
+)

--- a/src/domains/research/telemetry.py
+++ b/src/domains/research/telemetry.py
@@ -1,0 +1,71 @@
+"""
+Research-pack ambient telemetry (R7 / #605).
+
+When the research pack dominates the corpus, the empty canvas shifts from
+news movers to research signal: recently ingested papers (ticker), emerging
+concepts by volume (movers), and headline counts. Registered on the pack via
+``DomainPack.telemetry`` so it only shows while research is enabled; the
+genui collector swallows any failure here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+MAX_MOVERS = 5
+MAX_TICKER = 6
+
+
+def research_telemetry() -> Dict[str, Any]:
+    """Emerging concepts, recent papers and counts from the paper corpus."""
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    conn = get_shared_connection()
+    with _LOCK:
+        exists = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = 'documents'"
+        ).fetchall()
+        if not exists:
+            return {}
+        total = conn.execute(
+            "SELECT COUNT(*) FROM documents WHERE source_type = 'paper'"
+        ).fetchone()[0]
+        venues = conn.execute(
+            "SELECT COUNT(DISTINCT venue) FROM documents "
+            "WHERE source_type = 'paper' AND venue IS NOT NULL"
+        ).fetchone()[0]
+        concepts = conn.execute(
+            "SELECT concept, COUNT(*) FROM documents "
+            "WHERE source_type = 'paper' AND concept IS NOT NULL "
+            "GROUP BY concept ORDER BY COUNT(*) DESC LIMIT ?",
+            [MAX_MOVERS],
+        ).fetchall()
+        recent = conn.execute(
+            "SELECT title FROM documents WHERE source_type = 'paper' "
+            "ORDER BY created_at DESC NULLS LAST LIMIT ?",
+            [MAX_TICKER],
+        ).fetchall()
+
+    if not total:
+        return {}
+    movers = [
+        {
+            "label": str(concept),
+            "intent": f"literature on {str(concept).lower()}",
+            "change": int(count),
+        }
+        for concept, count in concepts
+        if concept
+    ]
+    return {
+        "signals": [
+            {"label": "PAPERS", "value": int(total)},
+            {"label": "VENUES", "value": int(venues)},
+            {"label": "EMERGING", "value": len(movers)},
+        ],
+        "movers": movers,
+        "ticker": {
+            "label": "NEW PAPERS",
+            "items": [str(r[0]) for r in recent if r[0]],
+        },
+    }

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -320,6 +320,39 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="topic",
     ),
+    # Research-pack panels (R7 / Track N1), gated by the research ui_flags.
+    PanelDef(
+        type="venues",
+        title="Venue credibility",
+        description="Publication venues scored by concept diversity, attribution and citation impact, generalizing the outlet transparency ranking.",
+        endpoint=None,
+        facets=("sources", "library"),
+        tables=("documents",),
+        ui_flag="venues",
+        default_span=6,
+    ),
+    PanelDef(
+        type="citation_graph",
+        title="Citation graph",
+        description="The paper citation network: papers linked by their references, sized by citation count.",
+        endpoint=None,
+        facets=("entities", "library"),
+        tables=("documents",),
+        ui_flag="citation_graph",
+        default_span=6,
+        topic_param="topic",
+    ),
+    PanelDef(
+        type="literature_claims",
+        title="Literature claims",
+        description="Claims mined from papers with fact-check verdicts and attribution, from the shared claim layer.",
+        endpoint=None,
+        facets=("claims", "library"),
+        tables=("argument_claims",),
+        ui_flag="literature_claims",
+        default_span=6,
+        topic_param="topic",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)

--- a/src/genui/planner.py
+++ b/src/genui/planner.py
@@ -78,6 +78,9 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
     "library": (
         "library", "document", "documents", "docs", "archive", "reading",
         "publications", "ingested", "corpus",
+        "paper", "papers", "research", "scholarly", "academic", "literature",
+        "citation", "citations", "cite", "cited", "venue", "venues", "journal",
+        "journals", "peer-reviewed", "preprint", "study", "studies",
     ),
 }
 

--- a/tests/unit/domains/conftest.py
+++ b/tests/unit/domains/conftest.py
@@ -1,0 +1,72 @@
+"""In-memory warehouse builders for the research-pack tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    yield c
+    c.close()
+
+
+def seed_documents(conn, rows):
+    """rows: list of dicts (id/title/source_type/venue/concept/citations/refs/created_at)."""
+    conn.execute(
+        "CREATE TABLE documents ("
+        "id VARCHAR, title VARCHAR, source_type VARCHAR, venue VARCHAR, "
+        "concept VARCHAR, citations INTEGER, refs VARCHAR, created_at TIMESTAMP)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO documents (id, title, source_type, venue, concept, citations, refs, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    r.get("id"),
+                    r.get("title", ""),
+                    r.get("source_type", "paper"),
+                    r.get("venue"),
+                    r.get("concept"),
+                    r.get("citations", 0),
+                    r.get("refs", ""),
+                    r.get("created_at", "2025-06-01"),
+                )
+                for r in rows
+            ],
+        )
+
+
+def seed_claims(conn, rows):
+    """rows: list of dicts (claim_id/claim_text/document_id/source_type/attributed/verdict/confidence)."""
+    conn.execute(
+        "CREATE TABLE argument_claims ("
+        "claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, source_type VARCHAR, "
+        "confidence DOUBLE, factcheck_verdict VARCHAR, attributed BOOLEAN)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO argument_claims (claim_id, claim_text, document_id, source_type, "
+            "confidence, factcheck_verdict, attributed) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    r.get("claim_id"),
+                    r.get("claim_text", ""),
+                    r.get("document_id"),
+                    r.get("source_type", "paper"),
+                    r.get("confidence", 0.5),
+                    r.get("factcheck_verdict"),
+                    r.get("attributed", False),
+                )
+                for r in rows
+            ],
+        )
+
+
+@pytest.fixture
+def seed():
+    return SimpleNamespace(documents=seed_documents, claims=seed_claims)

--- a/tests/unit/domains/test_research.py
+++ b/tests/unit/domains/test_research.py
@@ -1,0 +1,139 @@
+"""Unit tests for the research domain pack (R7 / Track N1)."""
+
+import pytest
+
+from src.analytics.honesty import validate_analytic_output
+from src.domains.research.analytics import (
+    citation_graph,
+    literature_claims,
+    venue_credibility,
+)
+from src.domains.research.enrichers import (
+    citation_enricher,
+    concept_enricher,
+    venue_enricher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enrichers (#603)
+# ---------------------------------------------------------------------------
+
+
+def test_venue_enricher_normalizes():
+    doc = {"metadata": {"journal": "  Nature Climate Change  "}}
+    assert venue_enricher(doc) == {"venue": "Nature Climate Change", "enricher": "venue"}
+    assert venue_enricher({"metadata": {}}) is None
+
+
+def test_citation_enricher_counts_refs_and_citations():
+    doc = {"metadata": {"references": ["p1", "p2", "p3"], "citations": 42}}
+    out = citation_enricher(doc)
+    assert out["citations"] == 42
+    assert out["reference_count"] == 3
+    assert out["refs"] == "p1,p2,p3"
+    # References-only falls back to a ref count.
+    assert citation_enricher({"metadata": {"references": ["a"]}})["citations"] == 1
+    assert citation_enricher({"metadata": {}}) is None
+
+
+def test_concept_enricher_picks_dominant_term():
+    doc = {"title": "Solar subsidy grid renewable", "metadata": {"abstract": "renewable renewable grid"}}
+    out = concept_enricher(doc)
+    assert out["concept"] in {"renewable", "grid", "solar", "subsidy"}
+    assert concept_enricher({"title": "", "metadata": {}}) is None
+
+
+def test_enrichers_read_dataclass_like_objects():
+    from types import SimpleNamespace
+
+    doc = SimpleNamespace(title="AI safety", metadata={"venue": "NeurIPS"})
+    assert venue_enricher(doc)["venue"] == "NeurIPS"
+
+
+# ---------------------------------------------------------------------------
+# venue_credibility (#604) — generalized transparency scoring
+# ---------------------------------------------------------------------------
+
+
+def test_venue_credibility_scores_and_is_honesty_valid(seed, conn):
+    seed.documents(
+        conn,
+        [
+            {"id": "a", "venue": "Nature", "concept": "climate", "citations": 100},
+            {"id": "b", "venue": "Nature", "concept": "energy", "citations": 80},
+            {"id": "c", "venue": "Nature", "concept": "policy", "citations": 60},
+            {"id": "d", "venue": "arXiv", "concept": "ml", "citations": 5},
+            {"id": "e", "venue": "arXiv", "concept": "ml", "citations": 3},
+        ],
+    )
+    seed.claims(
+        conn,
+        [
+            {"claim_id": "c1", "document_id": "a", "attributed": True},
+            {"claim_id": "c2", "document_id": "d", "attributed": False},
+        ],
+    )
+    payload = venue_credibility(conn)
+    assert validate_analytic_output(payload) == []
+    venues = {v["venue"]: v for v in payload["venues"]}
+    # Nature: diverse concepts + high citations + attributed -> beats arXiv.
+    assert venues["Nature"]["credibility"]["value"] > venues["arXiv"]["credibility"]["value"]
+    ci = venues["Nature"]["credibility"]
+    assert ci["lo"] <= ci["value"] <= ci["hi"]
+    assert payload["n"] == 5
+
+
+def test_venue_credibility_no_corpus(conn):
+    payload = venue_credibility(conn)  # no documents table
+    assert payload["n"] == 0
+    assert "note" in payload
+    assert validate_analytic_output(payload) == []
+
+
+# ---------------------------------------------------------------------------
+# citation_graph (#604)
+# ---------------------------------------------------------------------------
+
+
+def test_citation_graph_builds_edges(seed, conn):
+    seed.documents(
+        conn,
+        [
+            {"id": "p1", "title": "root", "concept": "climate", "citations": 50, "refs": ""},
+            {"id": "p2", "title": "cites p1", "concept": "climate", "citations": 10, "refs": "p1"},
+            {"id": "p3", "title": "cites p1,p2", "concept": "climate", "citations": 5, "refs": "p1,p2"},
+        ],
+    )
+    graph = citation_graph(conn, topic="climate")
+    assert graph["node_count"] == 3
+    assert {"from": "p2", "to": "p1"} in graph["edges"]
+    assert graph["edge_count"] == 3  # p2->p1, p3->p1, p3->p2
+
+
+def test_citation_graph_no_corpus(conn):
+    graph = citation_graph(conn)
+    assert graph == {"nodes": [], "edges": [], "note": "no document corpus ingested"}
+
+
+# ---------------------------------------------------------------------------
+# literature_claims (#604)
+# ---------------------------------------------------------------------------
+
+
+def test_literature_claims_scopes_to_papers(seed, conn):
+    seed.claims(
+        conn,
+        [
+            {"claim_id": "c1", "claim_text": "AI scales", "source_type": "paper", "attributed": True, "confidence": 0.9},
+            {"claim_id": "c2", "claim_text": "news claim", "source_type": "news", "confidence": 0.8},
+        ],
+    )
+    out = literature_claims(conn)
+    assert out["count"] == 1
+    assert out["claims"][0]["claim_id"] == "c1"
+    assert out["claims"][0]["attributed"] is True
+
+
+def test_literature_claims_no_layer(conn):
+    assert literature_claims(conn) == {"claims": [], "note": "no claim layer available"}

--- a/tests/unit/domains/test_research_acceptance.py
+++ b/tests/unit/domains/test_research_acceptance.py
@@ -1,0 +1,92 @@
+"""R7 #605 acceptance: with research on and news off, the canvas is fully
+functional on research panels and shows research telemetry.
+
+Exercises the registry + adaptivity + telemetry + planner together, the way
+the running app wires them, so "research is a first-class domain" is proven
+end-to-end (minus the live panel data path, which lands at R12)."""
+
+import threading
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+import src.domains.news  # noqa: F401  (registers the news pack)
+import src.domains.research  # noqa: F401  (registers the research pack)
+from src.domains import registry
+from src.domains.news.pack import NewsDomainPack
+from src.domains.research.pack import ResearchDomainPack
+from src.genui.adaptivity import merged_ui_flags
+from src.genui.planner import plan
+from src.genui.telemetry import pack_telemetry
+
+
+@pytest.fixture
+def research_only():
+    """Enable research, disable news (the acceptance scenario). reset() clears
+    the registry, so both packs are re-registered before enabling research."""
+    registry.reset()
+    registry.register_pack(NewsDomainPack)
+    registry.register_pack(ResearchDomainPack)
+    registry.enable_pack("research")
+    yield
+    registry.reset()
+    registry.register_pack(NewsDomainPack)
+    registry.register_pack(ResearchDomainPack)
+    registry.enable_pack("news")
+
+
+def test_only_research_flags_are_active(research_only):
+    flags = merged_ui_flags()
+    # Research panel flags present...
+    assert flags.get("research") is True
+    assert flags.get("citation_graph") is True
+    assert flags.get("venues") is True
+    assert flags.get("literature_claims") is True
+    # ...and no news flags leak in.
+    assert "sentiment_dashboard" not in flags
+    assert "trending" not in flags
+
+
+def test_research_intents_plan_research_panels(research_only):
+    flags = merged_ui_flags()
+    types = {p.type for p in plan("citation graph and venues for papers", ui_flags=flags).panels}
+    assert {"citation_graph", "venues"} & types
+    # News-gated panels are hidden because their ui_flags are off.
+    assert "trending" not in types
+    assert "sentiment_heatmap" not in types
+
+
+def test_overview_still_works_with_news_off(research_only):
+    flags = merged_ui_flags()
+    # A generic briefing still yields a live overview canvas (documents anchor).
+    types = {p.type for p in plan("daily briefing", ui_flags=flags).panels}
+    assert types & {"kpi_row", "articles", "documents"}
+    assert len(types) > 1  # never an empty canvas
+
+
+def test_research_telemetry_when_news_off(research_only, monkeypatch):
+    # Point the shared warehouse at an in-memory paper corpus.
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE documents (id VARCHAR, title VARCHAR, source_type VARCHAR, "
+        "venue VARCHAR, concept VARCHAR, created_at TIMESTAMP)"
+    )
+    conn.execute(
+        "INSERT INTO documents VALUES "
+        "('p1','Attention is all you need','paper','NeurIPS','ml','2025-06-02'),"
+        "('p2','Diffusion models','paper','ICML','ml','2025-06-03'),"
+        "('p3','Grid storage limits','paper','Energy Policy','energy','2025-06-01')"
+    )
+    import src.database.local_analytics_connector as connector
+
+    monkeypatch.setattr(connector, "get_shared_connection", lambda: conn)
+    monkeypatch.setattr(connector, "_LOCK", threading.Lock())
+
+    telemetry = pack_telemetry()
+    # Research pack supplied the ambient signal, not the news pack or library.
+    assert telemetry["packs"] == ["research"]
+    assert telemetry["ticker"]["label"] == "NEW PAPERS"
+    assert any(m["intent"].startswith("literature on") for m in telemetry["movers"])
+    labels = {s["label"] for s in telemetry["signals"]}
+    assert "PAPERS" in labels and "VENUES" in labels

--- a/tests/unit/genui/test_genui_annotations.py
+++ b/tests/unit/genui/test_genui_annotations.py
@@ -33,6 +33,7 @@ ANNOTATED_SERVERS = {
     "neuronews-kg": REPO / "tools/kg_mcp/server.py",
     "neuronews-blog-feeds": REPO / "tools/blog_mcp/server.py",
     "neuronews-pipeline": REPO / "tools/pipeline_mcp/server.py",
+    "neuronews-research": REPO / "tools/research_mcp/server.py",
 }
 
 COMPOSED_PANELS = {"note", "timeline"}  # ADR-001 exemptions

--- a/tests/unit/genui/test_genui_discovery.py
+++ b/tests/unit/genui/test_genui_discovery.py
@@ -30,7 +30,7 @@ def make_tool(panel=None, name="some_tool", has_output_schema=True, meta=None):
 
 
 GOOD = {
-    "type": "citation_graph",
+    "type": "custom_widget",
     "title": "Citation graph",
     "description": "Paper citation network.",
     "endpoint": "/api/v1/research/citations",
@@ -77,7 +77,7 @@ def no_host(monkeypatch):
 def test_valid_annotation_builds_panel_def():
     panel = panel_def_from_annotation("research", make_tool(GOOD))
     assert panel is not None
-    assert panel.type == "citation_graph"
+    assert panel.type == "custom_widget"
     assert panel.title == "Citation graph"
     assert panel.endpoint == "/api/v1/research/citations"
     assert panel.facets == ("entities", "library")
@@ -158,8 +158,8 @@ def test_duplicate_type_first_server_wins(fake_host):
         }
     )
     defs = discovered_panel_defs()
-    assert defs["citation_graph"][0].title == "From A"
-    assert defs["citation_graph"][1] == "a-server"
+    assert defs["custom_widget"][0].title == "From A"
+    assert defs["custom_widget"][1] == "a-server"
 
 
 def test_merge_overrides_in_place_and_appends_new(fake_host):
@@ -175,12 +175,12 @@ def test_merge_overrides_in_place_and_appends_new(fake_host):
     types = [p.type for p, _ in merged]
     static_types = [p.type for p in PANEL_CATALOG]
     # Same order as static, with the new type appended at the end.
-    assert types == static_types + ["citation_graph"]
+    assert types == static_types + ["custom_widget"]
 
     by_type = {p.type: (p, src) for p, src in merged}
     assert by_type["claims"][0].title == "Discovered claims"
     assert by_type["claims"][1] == "srv"
-    assert by_type["citation_graph"][1] == "srv"
+    assert by_type["custom_widget"][1] == "srv"
     # Untouched static entries carry no source server.
     assert by_type["kpi_row"][1] is None
 
@@ -189,7 +189,7 @@ def test_merged_dict_carries_source_only_when_discovery_contributes(fake_host):
     fake_host({"srv": [make_tool(GOOD)]})
     panels = merged_catalog_dict()
     by_type = {p["type"]: p for p in panels}
-    assert by_type["citation_graph"]["source"] == "srv"
+    assert by_type["custom_widget"]["source"] == "srv"
     assert by_type["claims"]["source"] == "static"
     # Every static field is still present alongside source.
     assert set(panel_catalog_dict()[0]) | {"source"} == set(by_type["claims"])

--- a/tests/unit/mcp_host/test_mcp_host_config.py
+++ b/tests/unit/mcp_host/test_mcp_host_config.py
@@ -12,8 +12,8 @@ def test_real_mcp_json_yields_only_project_servers():
     specs = load_server_specs()
     assert DEFAULT_MCP_JSON.exists()
     names = {s.name for s in specs}
-    # All 12 tools/*_mcp servers, and nothing npx-launched.
-    assert len(specs) == 12
+    # All 13 tools/*_mcp servers, and nothing npx-launched.
+    assert len(specs) == 13
     assert "neuronews-kg" in names
     assert "neuronews-pipeline" in names
     assert "memory" not in names

--- a/tools/domain_packs_mcp/server.py
+++ b/tools/domain_packs_mcp/server.py
@@ -70,6 +70,7 @@ CONTENT_PREVIEW = 300
 def _registry():
     """Lazy-import the domain registry after ensuring built-in packs are registered."""
     import src.domains.news  # noqa: F401 — triggers register_pack(NewsDomainPack)
+    import src.domains.research  # noqa: F401 — triggers register_pack(ResearchDomainPack)
     from src.domains import registry
     return registry
 

--- a/tools/research_mcp/server.py
+++ b/tools/research_mcp/server.py
@@ -1,0 +1,179 @@
+"""
+NeuroNews Research-domain inspector — MCP server (R7 / Track N1).
+
+Panel-facing read tools for the research pack: venue credibility (transparency
+scoring generalized to publication venues), the paper citation graph, and
+literature claims (SUPPORTS/CONTRADICTS scoped to papers). Annotated for R2
+discovery so the `venues`, `citation_graph` and `literature_claims` panels
+surface automatically when the research pack is enabled.
+
+Design constraints (same as the other tool servers):
+  * Lazy imports inside tools; the top of this module imports only stdlib +
+    fastmcp (plus the stdlib-only honesty helper) so the server starts fast.
+  * The DuckDB warehouse is opened READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.analytics.honesty import INTERVAL_SCHEMA, honesty_output_schema  # noqa: E402
+
+mcp = FastMCP("neuronews-research")
+
+
+def _warehouse_ro():
+    """Open the DuckDB warehouse read-only, honouring NEURONEWS_DB_PATH."""
+    import duckdb
+
+    path = os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"warehouse not found at {path}")
+    return duckdb.connect(path, read_only=True)
+
+
+@mcp.tool(
+    output_schema=honesty_output_schema(
+        {
+            "venue_count": {"type": "integer"},
+            "venues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "venue": {"type": "string"},
+                        "papers": {"type": "integer"},
+                        "credibility": INTERVAL_SCHEMA,
+                        "components": {"type": "object"},
+                    },
+                },
+            },
+        }
+    ),
+    meta={"panel": {
+        "type": "venues",
+        "title": "Venue credibility",
+        "description": "Publication venues scored by concept diversity, attribution and citation impact, generalizing the outlet transparency ranking.",
+        "endpoint": None,
+        "facets": ["sources", "library"],
+        "tables": ["documents"],
+        "ui_flag": "venues",
+        "default_span": 6,
+    }},
+)
+def venues() -> dict:
+    """Per-venue credibility over the ingested paper corpus, reusing the
+    transparency-scoring machinery. Each venue carries a credibility interval
+    and its component scores.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.domains.research.analytics import venue_credibility
+
+        return venue_credibility(con)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "nodes": {"type": "array"},
+            "edges": {"type": "array"},
+            "node_count": {"type": "integer"},
+            "edge_count": {"type": "integer"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "citation_graph",
+        "title": "Citation graph",
+        "description": "The paper citation network: papers linked by their references, sized by citation count.",
+        "endpoint": None,
+        "facets": ["entities", "library"],
+        "tables": ["documents"],
+        "ui_flag": "citation_graph",
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def citation_graph(topic: Optional[str] = None) -> dict:
+    """The paper citation network (nodes = papers, edges = citations) from the
+    document corpus, optionally scoped to a topic/concept.
+
+    Args:
+        topic: optional concept or title filter.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.domains.research.analytics import citation_graph as _cg
+
+        return _cg(con, topic)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "claims": {"type": "array"},
+            "count": {"type": "integer"},
+            "topic": {"type": ["string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "literature_claims",
+        "title": "Literature claims",
+        "description": "Claims mined from papers with fact-check verdicts and attribution, from the shared claim layer.",
+        "endpoint": None,
+        "facets": ["claims", "library"],
+        "tables": ["argument_claims"],
+        "ui_flag": "literature_claims",
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def literature_claims(topic: Optional[str] = None) -> dict:
+    """SUPPORTS/CONTRADICTS-style claims scoped to papers, from the claim layer.
+
+    Args:
+        topic: optional substring filter on the claim text.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.domains.research.analytics import literature_claims as _lc
+
+        return _lc(con, topic)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
# Pull Request: Research pack (milestone R7)

## Overview

Implements milestone **R7** of the MCP rearchitecture plan (Track N1): the research pack, Noesis's second first-class domain. It is built exactly like the news pack (enrichers, ui_flags, telemetry, an MCP server, discovery-surfaced panels), which is the point: it proves the engine is domain-general, not news-shaped. With research on and news off, the canvas is fully functional on research panels.

Closes #603. Closes #604. Closes #605.

## Changes Summary

**Research pack and MCP server (#603)**

- `src/domains/research/`: a `DomainPack` with paper-metadata enrichers (venue normalization, citation/reference counts, dominant-concept tagging), `ui_flags` gating the research panel family, and a telemetry provider. Registered at API startup and in the domain-packs server alongside news.
- `tools/research_mcp/server.py` registered in `.mcp.json`, so the R1 host supervises it and R2 discovery surfaces its panels.
- Enable with `NEURONEWS_ENABLED_PACKS=research` (or `config/domain_packs.json`).

**Panels (#604)**

- `venues`: per-venue credibility as a composite of concept diversity (Shannon entropy of the venue's topic mix, mirroring outlet frame diversity), claim-attribution rate, and normalized citation impact. This generalizes the outlet transparency scoring to publication venues, honesty-wrapped so each venue carries a credibility interval, not a bare number.
- `citation_graph`: the paper citation network (papers linked by references, sized by citation count).
- `literature_claims`: SUPPORTS/CONTRADICTS-style claims scoped to papers from the shared claim layer.
- Three catalog panel types with codegen regenerated; the research_mcp tools annotate them for discovery; frontend renderers (venue error bars reuse the R5 CI bar, citation graph reuses the entity-graph chart); planner keywords for paper/citation/venue/literature/scholarly. The annotation-parity suite now lists the research server.

**Telemetry and acceptance (#605)**

- `research_telemetry` surfaces recently ingested papers (ticker) and emerging concepts (movers) when the pack dominates the corpus.
- An acceptance test proves the R7 exit criterion end-to-end: with research on and news off, `merged_ui_flags` is research-only (no news flags leak), research intents plan the research panels while news-gated panels stay hidden, a generic briefing still yields a live overview (never an empty canvas), and the ambient signal becomes NEW PAPERS.

## Testing Status

- [x] 30 new tests (research analytics incl. generalized venue scoring, enrichers over dict and dataclass documents, telemetry, the news-off acceptance scenario)
- [x] 417 genui/domains/host/analytics/route tests pass, including the parity suite accepting the 3 new panels and the research server
- [x] `tsc --noEmit` and `vite build` clean; codegen staleness gate clean; `TESTING=true` app import unaffected
- [x] Adjusted two existing tests for the wider surface: the `.mcp.json` server count (12 to 13) and the discovery test's example new-type (which collided with the now-real `citation_graph`)

## Live verification (R7 exit criterion)

On a temp warehouse seeded with a paper corpus and `NEURONEWS_ENABLED_PACKS=research` (news off):

- `venues` returned honesty-valid credibility with NeurIPS on top; `citation_graph` built edges from references; `literature_claims` returned only the two paper claims (not the news claim)
- Research on and news off: `merged_ui_flags` was research-only; a citation/venue intent planned `venues`, `citation_graph` and `literature_claims`
- Telemetry became `NEW PAPERS`; discovery surfaced all three research panels from `neuronews-research`