### PR TITLE
R8: Provisioning plane, agent-deployed namespaced knowledge graphs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -93,6 +93,14 @@
       ],
       "env": {}
     },
+    "neuronews-provisioning": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/provisioning_mcp/server.py"
+      ],
+      "env": {}
+    },
     "neuronews-dataset": {
       "type": "stdio",
       "command": "python3",

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -33,7 +33,8 @@ export type PanelType =
   | "forecast"
   | "venues"
   | "citation_graph"
-  | "literature_claims";
+  | "literature_claims"
+  | "provisioned_kg";
 
 export type Facet =
   | "overview"
@@ -92,6 +93,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "venues", title: "Venue credibility", facets: ["sources", "library"], defaultSpan: 6 },
   { type: "citation_graph", title: "Citation graph", facets: ["entities", "library"], defaultSpan: 6, topicParam: true },
   { type: "literature_claims", title: "Literature claims", facets: ["claims", "library"], defaultSpan: 6, topicParam: true },
+  { type: "provisioned_kg", title: "Provisioned knowledge graphs", facets: ["entities", "overview", "library"], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/planner.ts
+++ b/apps/web/src/genui/planner.ts
@@ -17,7 +17,7 @@ const FACET_KEYWORDS: Record<Facet, string[]> = {
   actors: ["who", "actor", "actors", "stakeholder", "stakeholders", "politician", "politicians", "speaker", "speakers", "people", "person", "says", "said", "voices"],
   conflict: ["conflict", "conflicts", "controversy", "controversial", "contradict", "contradicts", "contradiction", "contradictions", "dispute", "disputes", "disagreement", "clash", "debate"],
   sources: ["outlet", "outlets", "source", "sources", "bias", "biased", "framing", "frame", "frames", "coverage", "compare", "comparison", "transparency", "media", "publisher", "publishers", "leads", "lead", "leader", "leaders", "follows", "follow", "followers", "agenda", "first", "earliest", "sets"],
-  entities: ["entity", "entities", "network", "graph", "connection", "connections", "related", "relationship", "relationships", "influence"],
+  entities: ["entity", "entities", "network", "graph", "connection", "connections", "related", "relationship", "relationships", "influence", "knowledge graph", "provisioned", "provisioning", "namespace", "namespaces", "deployed kg"],
   events: ["event", "events", "cluster", "clusters", "story", "stories", "breaking", "timeline", "happening", "developments", "watchlist", "watchlists", "alert", "alerts"],
   library: ["library", "document", "documents", "docs", "archive", "reading", "publications", "ingested", "corpus", "paper", "papers", "research", "scholarly", "academic", "literature", "citation", "citations", "cite", "cited", "venue", "venues", "journal", "journals", "peer-reviewed", "preprint", "study", "studies"],
 };

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -967,6 +967,57 @@ function LiteratureClaimsPanel(props: PanelProps) {
   );
 }
 
+const DEMO_KGS = [
+  {
+    name: "semiconductors",
+    description: "Chip supply-chain and fab coverage",
+    counts: { documents: 148, entities: 32, claims: 27 },
+    sources: [
+      { source: "Reuters Tech", reason: "selected because transparency 0.82 >= 0.70" },
+      { source: "The Verge", reason: "selected because transparency 0.74 >= 0.70" },
+    ],
+  },
+  {
+    name: "climate_policy",
+    description: "Emissions targets and grid transition",
+    counts: { documents: 91, entities: 21, claims: 18 },
+    sources: [{ source: "Carbon Brief", reason: "explicitly listed" }],
+  },
+];
+
+function ProvisionedKgPanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {DEMO_KGS.map((kg) => (
+          <div key={kg.name} style={{ borderLeft: `2px solid ${palette.teal}`, paddingLeft: 10 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>{kg.name}</span>
+              <span style={{ ...mono }}>kg_{kg.name}_*</span>
+            </div>
+            <div style={{ fontSize: 12, color: palette.dim, margin: "2px 0 4px" }}>{kg.description}</div>
+            <div style={{ display: "flex", gap: 12, ...mono }}>
+              <span>{kg.counts.documents} docs</span>
+              <span>{kg.counts.entities} entities</span>
+              <span>{kg.counts.claims} claims</span>
+              <span>{kg.sources.length} sources</span>
+            </div>
+            <div style={{ marginTop: 4, display: "flex", flexDirection: "column", gap: 2 }}>
+              {kg.sources.map((s) => (
+                <div key={s.source} style={{ fontSize: 11.5 }}>
+                  <span style={{ color: palette.teal }}>{s.source}</span>
+                  <span style={{ color: palette.dim }}> - {s.reason}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>agent-deployed knowledge graphs, fed by selected sources</div>
+    </GenPanel>
+  );
+}
+
 function UnknownPanel(props: PanelProps) {
   return (
     <GenPanel {...props}>
@@ -1004,6 +1055,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   venues: VenuesPanel,
   citation_graph: CitationGraphPanel,
   literature_claims: LiteratureClaimsPanel,
+  provisioned_kg: ProvisionedKgPanel,
 };
 
 export function panelComponent(type: string): ComponentType<PanelProps> {

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -594,6 +594,25 @@ quotas, approval gates, idempotent upserts.
 *Exit:* deploy → attach by criteria → ingest → scoped panels appear via
 discovery; teardown archives; every step visible in lineage.
 
+*Delivered.* The provisioning plane lives in `src/provisioning/` (stdlib-only;
+the caller injects the DuckDB connection, so nothing here opens the warehouse
+itself): `namespaces.py` is the table-prefix namespacing (`kg_<name>_documents`
+/ `_entities` / `_claims`, name validated to `[a-z][a-z0-9_]*` before it ever
+reaches a table identifier) plus the routing that copies only the rows whose
+source is bound to a KG out of the shared corpus, leaving the shared tables
+untouched; `store.py` is the registry and an append-only lineage event log,
+every write an idempotent upsert keyed by name; `guardrails.py` is the quotas
+(max KGs, max sources per KG, ingest rate cap), the deploy/teardown approval
+gate and the confirm gate; `provisioner.py` ties them into deploy / attach /
+ingest / status / list / teardown, resolving quality criteria (transparency,
+attribution, type) against `outlet_scores`. Served by
+`tools/provisioning_mcp/` (write tools hold a process lock over a read-write
+warehouse, mirroring the pipeline server's trigger tools; read tools open
+read-only). The `provisioned_kg` panel type surfaces the plane on the canvas
+via R2 discovery (the `kg_view` tool is annotated). Teardown archives (renames
+the namespace tables aside, never deletes) and detaches sources; re-running a
+failed provision converges without duplicating.
+
 **R9 — Provisioned-domain proof** *(Track N3 = Track P acceptance)*
 Stand up finance (earnings-call transcripts) as a provisioned domain,
 writing no pack code; repeat with a second domain to prove it wasn't a

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -104,6 +104,33 @@ telemetry (recent papers, emerging concepts) takes over the empty canvas
 when the pack dominates. Enable with `NEURONEWS_ENABLED_PACKS=research`;
 with news off the canvas is fully functional on research panels.
 
+### Provisioning plane (`src/provisioning/`, R8)
+
+Turns MCP from the read/compose plane into one that can *provision* knowledge
+domains: an agent deploys a namespaced knowledge graph, binds the sources that
+feed it (explicitly or by a quality criterion), routes matching documents into
+the namespace, and the canvas grows a `provisioned_kg` panel for it via R2
+discovery. A per-KG namespace is a table prefix (`kg_<name>_documents` /
+`_entities` / `_claims`); routing copies only the rows whose `source` is bound
+to the KG out of the shared corpus, so a namespace holds only routed documents
+and the shared tables are read, never mutated. `namespaces.py` owns the prefix
+DDL and routing (the KG name is validated to `[a-z][a-z0-9_]*` before it ever
+reaches a table identifier); `store.py` is the registry plus an append-only
+lineage event log, every write an idempotent upsert keyed by name; `guardrails.py`
+enforces the RW guardrails (max KGs, max sources per KG, an ingest rate cap,
+a deploy approval gate, a teardown confirm gate); `provisioner.py` ties them
+into `deploy` / `attach_sources` / `ingest` / `status` / `list` / `teardown`,
+resolving criteria (transparency, attribution, type) against `outlet_scores`.
+Served by `tools/provisioning_mcp/`: the write tools (`kg_deploy`,
+`kg_attach_sources`, `kg_ingest`, `kg_teardown`) hold a process lock over a
+read-write warehouse, mirroring the pipeline server's trigger tools; the read
+tools (`kg_status`, `kg_list`, `kg_lineage`, `kg_view`) open it read-only.
+Deploy and teardown are approval-gated by default (a free dry-run preview
+otherwise); teardown archives (renames the namespace tables aside, never
+deletes) and detaches sources; re-running a failed provision converges without
+duplicating. Every deploy/attach/ingest/teardown is in the lineage log, so each
+step is visible.
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -353,6 +353,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="topic",
     ),
+    # Provisioning plane (R8 / Track P): agent-deployed namespaced KGs surface
+    # as a scoped panel via R2 discovery from the provisioning server.
+    PanelDef(
+        type="provisioned_kg",
+        title="Provisioned knowledge graphs",
+        description="Agent-deployed namespaced knowledge graphs: entity and document counts, the sources feeding each and why they were selected.",
+        endpoint=None,
+        facets=("entities", "overview", "library"),
+        tables=("provisioned_kgs",),
+        default_span=6,
+        topic_param="kg",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)

--- a/src/genui/planner.py
+++ b/src/genui/planner.py
@@ -69,6 +69,8 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
         "entity", "entities", "network", "graph", "connection",
         "connections", "related", "relationship", "relationships",
         "influence",
+        "knowledge graph", "provisioned", "provisioning", "namespace",
+        "namespaces", "deployed kg",
     ),
     "events": (
         "event", "events", "cluster", "clusters", "story", "stories",

--- a/src/provisioning/__init__.py
+++ b/src/provisioning/__init__.py
@@ -1,0 +1,30 @@
+"""
+Provisioning plane (MCP rearchitecture plan, R8 / Track P).
+
+Turns MCP from the read/compose plane into one that can *provision knowledge
+domains*: an agent deploys a namespaced knowledge graph, binds the sources
+that feed it (explicitly or by a quality criterion), routes matching
+documents into the namespace, and the generative canvas grows a scoped panel
+for it via R2 discovery. No code change, no deploy.
+
+Modules:
+  * :mod:`~src.provisioning.namespaces` - table-prefix namespacing
+    (``kg_<name>_documents`` / ``_entities`` / ``_claims``) plus the routing
+    that copies only matching rows out of the shared corpus. Shared tables are
+    read, never written.
+  * :mod:`~src.provisioning.store` - the registry (deployed KGs, bound
+    sources) and the append-only lineage event log; every write is an
+    idempotent upsert keyed by name.
+  * :mod:`~src.provisioning.guardrails` - quotas, the deploy/teardown approval
+    gate, and the ingest rate cap (the non-negotiable RW guardrails).
+  * :mod:`~src.provisioning.provisioner` - the lifecycle orchestration
+    (deploy / attach / ingest / status / list / teardown) the MCP tools call.
+
+Stdlib-only; the caller injects the DuckDB connection (the API process owns
+the single warehouse writer), so nothing here opens the warehouse itself.
+"""
+
+from src.provisioning.guardrails import GuardrailError, Quotas
+from src.provisioning.provisioner import Provisioner
+
+__all__ = ["Provisioner", "GuardrailError", "Quotas"]

--- a/src/provisioning/guardrails.py
+++ b/src/provisioning/guardrails.py
@@ -1,0 +1,113 @@
+"""
+Provisioning guardrails (R8 #608): the non-negotiable rules for a RW agent
+surface. Each is enforced here and has a failing-path test.
+
+    Blast radius     max KGs, max sources per KG, an ingest rate cap.
+    Human-in-loop    deploy and teardown are approval-gated by default
+                     (``approve`` / ``confirm`` must be passed); status and
+                     dry-run previews are free.
+    Idempotency      enforced in the store (upserts keyed by name); the
+                     provisioner never creates a second row for the same name.
+
+A breach raises :class:`GuardrailError` with a machine-readable ``code`` so the
+MCP tool can return a clean ``{"error": ..., "code": ...}`` rather than a
+stack trace. Limits are read from the environment once per :class:`Quotas`
+instance so tests can tighten them.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+class GuardrailError(Exception):
+    """A provisioning guardrail refused the operation."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _env_int(key: str, default: int) -> int:
+    try:
+        return int(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class Quotas:
+    """The provisioning blast-radius limits.
+
+    ``ingest_min_interval_s`` of 0 disables the rate cap (the default, so
+    normal use and idempotent re-runs are never throttled); a positive value
+    rejects a second ingest of the same KG within that many seconds.
+    """
+
+    max_kgs: int = 8
+    max_sources_per_kg: int = 20
+    ingest_min_interval_s: int = 0
+
+    @classmethod
+    def from_env(cls) -> "Quotas":
+        return cls(
+            max_kgs=_env_int("NOESIS_PROV_MAX_KGS", 8),
+            max_sources_per_kg=_env_int("NOESIS_PROV_MAX_SOURCES", 20),
+            ingest_min_interval_s=_env_int("NOESIS_PROV_INGEST_MIN_INTERVAL_S", 0),
+        )
+
+    def check_deploy_quota(self, deployed_count: int, is_new: bool) -> None:
+        """Refuse a *new* deploy that would exceed the max-KGs quota. Re-deploy
+        of an existing name (``is_new`` False) converges and never counts."""
+        if is_new and deployed_count >= self.max_kgs:
+            raise GuardrailError(
+                "quota_max_kgs",
+                f"KG quota reached: {deployed_count}/{self.max_kgs} deployed. "
+                f"Tear one down or raise NOESIS_PROV_MAX_KGS.",
+            )
+
+    def check_sources_quota(self, current: int, adding: int) -> None:
+        """Refuse an attach that would push a KG past the max-sources quota."""
+        if current + adding > self.max_sources_per_kg:
+            raise GuardrailError(
+                "quota_max_sources",
+                f"source quota exceeded: {current} bound + {adding} requested "
+                f"> {self.max_sources_per_kg} per KG.",
+            )
+
+    def check_ingest_rate(self, seconds_since_last: float | None) -> None:
+        """Refuse an ingest that arrives inside the rate-cap window."""
+        if (
+            self.ingest_min_interval_s > 0
+            and seconds_since_last is not None
+            and seconds_since_last < self.ingest_min_interval_s
+        ):
+            raise GuardrailError(
+                "rate_capped",
+                f"ingest rate-capped: last ingest {seconds_since_last:.0f}s ago, "
+                f"minimum interval {self.ingest_min_interval_s}s.",
+            )
+
+
+def require_approval(approve: bool, action: str) -> None:
+    """Gate deploy: refuse unless the caller explicitly approved."""
+    if not approve:
+        raise GuardrailError(
+            "approval_required",
+            f"{action} is approval-gated: re-run with approve=true to execute "
+            f"(dry-run previews are free).",
+        )
+
+
+def require_confirm(confirm: bool, action: str) -> None:
+    """Gate teardown: refuse unless the caller explicitly confirmed."""
+    if not confirm:
+        raise GuardrailError(
+            "confirm_required",
+            f"{action} archives the KG and requires confirm=true "
+            f"(it never silently deletes).",
+        )

--- a/src/provisioning/namespaces.py
+++ b/src/provisioning/namespaces.py
@@ -1,0 +1,267 @@
+"""
+KG namespacing by table prefix, plus per-namespace document routing (R8 #606).
+
+Decision (from the plan's Track P): a per-KG namespace is a *table prefix*,
+``kg_<name>_``. Each deployed KG owns three namespaced tables:
+
+    kg_<name>_documents   routed documents (a copy of the matching corpus rows)
+    kg_<name>_entities    entities derived from the routed documents
+    kg_<name>_claims      claims scoped to the routed documents
+
+Routing copies only the rows whose ``source`` is bound to the KG out of the
+shared corpus (``news_articles``) and the shared ``argument_claims`` layer.
+The shared tables are read, never mutated, so a namespace holds *only* routed
+documents and the shared corpus is untouched (the #606 exit criterion).
+
+The KG name is validated to a strict ``[a-z][a-z0-9_]*`` shape before it ever
+reaches a table identifier, so the prefix can be interpolated into DDL without
+opening an injection hole (DuckDB has no bind parameters for identifiers).
+
+Stdlib-only. The connection is injected read-write by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional, Sequence
+
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{1,30}$")
+
+# Words never counted as entities when deriving them from document titles.
+_STOPWORDS = frozenset(
+    """a an and are as at be but by for from has have how in into is it its of
+    on or that the their them then there these this to us was were what when
+    where which will with would new say says said report reports amid over
+    after before about""".split()
+)
+
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9'\-]+")
+
+
+def valid_name(name: str) -> bool:
+    """True if ``name`` is a legal KG namespace identifier."""
+    return bool(isinstance(name, str) and _NAME_RE.match(name))
+
+
+def require_valid_name(name: str) -> str:
+    """Return ``name`` if legal, else raise ``ValueError`` (no table prefix is
+    ever built from an unvalidated string)."""
+    if not valid_name(name):
+        raise ValueError(
+            f"invalid KG name {name!r}: must match [a-z][a-z0-9_]{{1,30}} "
+            f"(lowercase letter first, then letters/digits/underscore)"
+        )
+    return name
+
+
+def namespace_prefix(name: str) -> str:
+    """The table prefix for a KG, e.g. ``kg_climate_`` for ``climate``."""
+    return f"kg_{require_valid_name(name)}_"
+
+
+def namespace_tables(name: str) -> Dict[str, str]:
+    """The three namespaced table names for a KG, keyed by role."""
+    prefix = namespace_prefix(name)
+    return {
+        "documents": f"{prefix}documents",
+        "entities": f"{prefix}entities",
+        "claims": f"{prefix}claims",
+    }
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def create_namespace(conn, name: str) -> Dict[str, str]:
+    """Create the three namespaced tables for a KG if absent (idempotent)."""
+    tables = namespace_tables(name)
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {tables['documents']} ("
+        "id VARCHAR, title VARCHAR, source VARCHAR, source_type VARCHAR, "
+        "url VARCHAR, published_at TIMESTAMP, routed_at TIMESTAMP)"
+    )
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {tables['entities']} ("
+        "entity VARCHAR, mentions INTEGER, routed_at TIMESTAMP)"
+    )
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {tables['claims']} ("
+        "claim_id VARCHAR, claim_text VARCHAR, verdict VARCHAR, "
+        "document_id VARCHAR, routed_at TIMESTAMP)"
+    )
+    return tables
+
+
+def drop_namespace(conn, name: str) -> None:
+    """Drop the three namespaced tables for a KG (used only after archival)."""
+    for table in namespace_tables(name).values():
+        conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+
+def archive_namespace(conn, name: str) -> Dict[str, str]:
+    """Rename the namespace tables to a ``zz_archived__`` prefix so they stop
+    reading as live but are never silently deleted (the teardown guarantee).
+    Returns the archived table names."""
+    require_valid_name(name)
+    archived: Dict[str, str] = {}
+    for role, table in namespace_tables(name).items():
+        target = f"zz_archived__{table}"
+        conn.execute(f"DROP TABLE IF EXISTS {target}")
+        if _table_exists(conn, table):
+            conn.execute(f"ALTER TABLE {table} RENAME TO {target}")
+        archived[role] = target
+    return archived
+
+
+def _derive_entities(titles: Sequence[str], top: int = 25) -> List[Dict[str, Any]]:
+    """Cheap entity signal from routed titles: stopword-filtered token
+    frequency. Deterministic, dependency-free; the real KG builder replaces
+    this once the routing path is wired to it."""
+    counter: Counter = Counter()
+    for title in titles:
+        for word in _WORD_RE.findall(title or ""):
+            token = word.lower()
+            if len(token) < 3 or token in _STOPWORDS:
+                continue
+            counter[token] += 1
+    return [
+        {"entity": token, "mentions": count}
+        for token, count in counter.most_common(top)
+        if count > 1
+    ]
+
+
+def route_documents(
+    conn,
+    name: str,
+    sources: Sequence[str],
+    now: Any,
+    backfill_days: Optional[int] = None,
+) -> Dict[str, int]:
+    """Route documents (and their claims and derived entities) from the shared
+    corpus into the KG's namespace tables.
+
+    Only rows whose ``source`` is one of ``sources`` are copied, and a document
+    already present in the namespace is skipped, so re-running ingest converges
+    rather than duplicating. Returns the counts newly added.
+    """
+    require_valid_name(name)
+    tables = create_namespace(conn, name)
+    if not sources:
+        return {"documents": 0, "claims": 0, "entities": 0}
+
+    placeholders = ", ".join("?" for _ in sources)
+    where = [f"source IN ({placeholders})"]
+    params: List[Any] = list(sources)
+    if backfill_days and backfill_days > 0 and _has_column(conn, "news_articles", "publish_date"):
+        where.append("publish_date >= (CURRENT_TIMESTAMP - INTERVAL (?) DAY)")
+        params.append(int(backfill_days))
+
+    existing = {
+        r[0]
+        for r in conn.execute(f"SELECT id FROM {tables['documents']}").fetchall()
+    }
+    rows = []
+    if _table_exists(conn, "news_articles"):
+        rows = conn.execute(
+            "SELECT id, title, source, url, publish_date FROM news_articles "
+            f"WHERE {' AND '.join(where)}",
+            params,
+        ).fetchall()
+
+    new_docs = [r for r in rows if r[0] not in existing]
+    for r in new_docs:
+        conn.execute(
+            f"INSERT INTO {tables['documents']} "
+            "(id, title, source, source_type, url, published_at, routed_at) "
+            "VALUES (?, ?, ?, 'news', ?, ?, ?)",
+            [r[0], r[1], r[2], r[3], r[4], now],
+        )
+
+    # Claims scoped to the routed documents, from the shared claim layer.
+    routed_ids = [r[0] for r in new_docs]
+    claim_count = 0
+    if routed_ids and _table_exists(conn, "argument_claims"):
+        existing_claims = {
+            r[0]
+            for r in conn.execute(
+                f"SELECT claim_id FROM {tables['claims']}"
+            ).fetchall()
+        }
+        cph = ", ".join("?" for _ in routed_ids)
+        crows = conn.execute(
+            "SELECT claim_id, claim_text, "
+            "COALESCE(factcheck_verdict, 'unverified'), document_id "
+            f"FROM argument_claims WHERE document_id IN ({cph})",
+            routed_ids,
+        ).fetchall()
+        for cr in crows:
+            if cr[0] in existing_claims:
+                continue
+            conn.execute(
+                f"INSERT INTO {tables['claims']} "
+                "(claim_id, claim_text, verdict, document_id, routed_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [cr[0], cr[1], cr[2], cr[3], now],
+            )
+            claim_count += 1
+
+    # Rebuild the derived-entity table from the full routed corpus (cheap,
+    # keeps the namespace self-consistent after each ingest).
+    entity_count = 0
+    if new_docs:
+        conn.execute(f"DELETE FROM {tables['entities']}")
+        all_titles = [
+            r[0]
+            for r in conn.execute(
+                f"SELECT title FROM {tables['documents']}"
+            ).fetchall()
+        ]
+        for ent in _derive_entities(all_titles):
+            conn.execute(
+                f"INSERT INTO {tables['entities']} (entity, mentions, routed_at) "
+                "VALUES (?, ?, ?)",
+                [ent["entity"], ent["mentions"], now],
+            )
+            entity_count += 1
+
+    return {
+        "documents": len(new_docs),
+        "claims": claim_count,
+        "entities": entity_count,
+    }
+
+
+def namespace_counts(conn, name: str) -> Dict[str, int]:
+    """Live row counts for a KG's three namespace tables (0 when absent)."""
+    tables = namespace_tables(name)
+    out: Dict[str, int] = {}
+    for role, table in tables.items():
+        if _table_exists(conn, table):
+            out[role] = int(
+                conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            )
+        else:
+            out[role] = 0
+    return out
+
+
+def _has_column(conn, table: str, column: str) -> bool:
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = ? AND column_name = ?",
+            [table, column],
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False

--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -1,0 +1,390 @@
+"""
+Provisioning lifecycle orchestration (R8 #607): the object the MCP tools call.
+
+One :class:`Provisioner` wraps an injected read-write DuckDB connection and a
+serialising lock (the API process owns the single warehouse writer). It ties
+together the namespace DDL/routing (:mod:`~src.provisioning.namespaces`), the
+registry and lineage log (:mod:`~src.provisioning.store`) and the guardrails
+(:mod:`~src.provisioning.guardrails`) into the five verbs:
+
+    deploy(name, description, ontology?, approve)   -> namespaced KG + lineage
+    attach_sources(name, sources? | criteria?)      -> bind feeds (quality-driven
+                                                       criteria resolved via
+                                                       outlet_scores)
+    ingest(name, backfill_days?)                     -> route matching documents
+    status(name) / list_kgs()                        -> counts, source health, lag
+    teardown(name, confirm)                          -> archive + detach
+
+Every write registers a lineage event, so each step is visible in lineage. All
+writes hold the lock for their duration; reads (status/list/preview) are free.
+
+Stdlib-only; the caller injects the connection, the lock, and the clock.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from src.provisioning import namespaces, store
+from src.provisioning.guardrails import (
+    GuardrailError,
+    Quotas,
+    require_approval,
+    require_confirm,
+)
+
+
+class _NullLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Provisioner:
+    def __init__(
+        self,
+        conn,
+        lock: Any = None,
+        quotas: Optional[Quotas] = None,
+        clock: Callable[[], datetime] = _utcnow,
+        ensure: bool = True,
+    ):
+        self._conn = conn
+        self._lock = lock if lock is not None else _NullLock()
+        self._quotas = quotas if quotas is not None else Quotas.from_env()
+        self._clock = clock
+        # Read-only callers pass ensure=False: the schema is created lazily on
+        # the first write path, so a read tool never needs DDL rights.
+        if ensure:
+            with self._lock:
+                store.ensure_schema(conn)
+
+    # ------------------------------------------------------------------ deploy
+
+    def deploy(
+        self,
+        name: str,
+        description: str = "",
+        ontology: Any = None,
+        approve: bool = False,
+    ) -> Dict[str, Any]:
+        """Deploy (or converge onto) a namespaced KG. Approval-gated: without
+        ``approve`` it returns a free dry-run preview and writes nothing."""
+        try:
+            namespaces.require_valid_name(name)
+        except ValueError as exc:
+            return {"error": str(exc), "code": "invalid_name"}
+
+        existing = store.get_kg(self._conn, name)
+        is_new = existing is None or existing.get("status") != store.STATUS_DEPLOYED
+
+        if not approve:
+            try:
+                self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+            except GuardrailError as exc:
+                return {"error": exc.message, "code": exc.code}
+            return {
+                "preview": True,
+                "kg": name,
+                "would": "deploy" if is_new else "update",
+                "namespace_tables": namespaces.namespace_tables(name),
+                "note": "approval-gated; re-run with approve=true to execute",
+            }
+
+        try:
+            with self._lock:
+                self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+                now = self._clock()
+                namespaces.create_namespace(self._conn, name)
+                kg = store.upsert_kg(self._conn, name, description, ontology, now)
+                store.record_event(
+                    self._conn,
+                    name,
+                    "deploy",
+                    {"new": is_new, "namespace": namespaces.namespace_prefix(name)},
+                    now,
+                )
+        except GuardrailError as exc:
+            return {"error": exc.message, "code": exc.code}
+        return {"deployed": True, "created": is_new, "kg": kg}
+
+    # ----------------------------------------------------------------- attach
+
+    def attach_sources(
+        self,
+        name: str,
+        sources: Optional[Sequence[str]] = None,
+        criteria: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Bind sources to a KG, explicitly or by a quality criterion resolved
+        against the outlet transparency scores. Idempotent by ``(kg, source)``.
+        """
+        kg = store.get_kg(self._conn, name)
+        if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
+            return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
+
+        resolved: List[Dict[str, Any]]
+        if criteria:
+            resolved = self._resolve_criteria(criteria)
+            if not resolved:
+                return {
+                    "attached": 0,
+                    "kg": name,
+                    "note": "no sources matched the criteria",
+                    "criteria": criteria,
+                }
+        elif sources:
+            resolved = [
+                {"source": s, "source_type": None, "reason": "explicitly listed"}
+                for s in sources
+            ]
+        else:
+            return {"error": "provide sources or criteria", "code": "no_input"}
+
+        try:
+            with self._lock:
+                current = store.count_sources(self._conn, name)
+                # Count only sources not already bound toward the quota.
+                already = {r["source"] for r in store.list_sources(self._conn, name)}
+                adding = sum(1 for r in resolved if r["source"] not in already)
+                self._quotas.check_sources_quota(current, adding)
+                now = self._clock()
+                newly = 0
+                for r in resolved:
+                    if store.upsert_source(
+                        self._conn,
+                        name,
+                        r["source"],
+                        r.get("source_type"),
+                        r.get("reason", ""),
+                        now,
+                    ):
+                        newly += 1
+                store.record_event(
+                    self._conn,
+                    name,
+                    "attach",
+                    {
+                        "requested": len(resolved),
+                        "newly_bound": newly,
+                        "criteria": criteria,
+                        "sources": [r["source"] for r in resolved],
+                    },
+                    now,
+                )
+        except GuardrailError as exc:
+            return {"error": exc.message, "code": exc.code}
+        return {
+            "attached": newly,
+            "already_bound": len(resolved) - newly,
+            "kg": name,
+            "sources": store.list_sources(self._conn, name),
+        }
+
+    def _resolve_criteria(self, criteria: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Resolve a quality criterion into a source list from ``outlet_scores``
+        (the transparency ranking). Supported keys: ``min_transparency`` (on
+        composite_score), ``min_attribution`` (attribution_rate), ``type``
+        (source_type)."""
+        if not namespaces._table_exists(self._conn, "outlet_scores"):
+            return []
+        where = ["1 = 1"]
+        params: List[Any] = []
+        if criteria.get("type"):
+            where.append("source_type = ?")
+            params.append(criteria["type"])
+        min_transparency = criteria.get("min_transparency")
+        if min_transparency is not None:
+            where.append("composite_score >= ?")
+            params.append(float(min_transparency))
+        min_attribution = criteria.get("min_attribution")
+        if min_attribution is not None:
+            where.append("attribution_rate >= ?")
+            params.append(float(min_attribution))
+        # Latest score per (source, source_type).
+        rows = self._conn.execute(
+            "SELECT source, source_type, composite_score, attribution_rate "
+            "FROM outlet_scores o WHERE "
+            + " AND ".join(where)
+            + " AND score_date = (SELECT MAX(score_date) FROM outlet_scores i "
+            "WHERE i.source = o.source AND i.source_type = o.source_type) "
+            "ORDER BY composite_score DESC NULLS LAST",
+            params,
+        ).fetchall()
+        out = []
+        for r in rows:
+            bits = []
+            if min_transparency is not None:
+                bits.append(f"transparency {float(r[2] or 0):.2f} >= {float(min_transparency):.2f}")
+            if min_attribution is not None:
+                bits.append(f"attribution {float(r[3] or 0):.2f} >= {float(min_attribution):.2f}")
+            if criteria.get("type"):
+                bits.append(f"type={criteria['type']}")
+            out.append(
+                {
+                    "source": r[0],
+                    "source_type": r[1],
+                    "reason": "selected because " + ", ".join(bits)
+                    if bits
+                    else "matched criteria",
+                }
+            )
+        return out
+
+    # ----------------------------------------------------------------- ingest
+
+    def ingest(self, name: str, backfill_days: Optional[int] = None) -> Dict[str, Any]:
+        """Route the bound sources' documents (and claims / derived entities)
+        into the KG namespace. Rate-capped, idempotent (re-ingest converges)."""
+        kg = store.get_kg(self._conn, name)
+        if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
+            return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
+        bound = [r["source"] for r in store.list_sources(self._conn, name)]
+        if not bound:
+            return {"error": "no sources bound; attach first", "code": "no_sources"}
+
+        try:
+            with self._lock:
+                now = self._clock()
+                self._quotas.check_ingest_rate(
+                    self._seconds_since_last_ingest(kg, now)
+                )
+                routed = namespaces.route_documents(
+                    self._conn, name, bound, now, backfill_days
+                )
+                store.mark_ingested(self._conn, name, now)
+                store.record_event(
+                    self._conn,
+                    name,
+                    "ingest",
+                    {"routed": routed, "sources": bound, "backfill_days": backfill_days},
+                    now,
+                )
+        except GuardrailError as exc:
+            return {"error": exc.message, "code": exc.code}
+        return {"ingested": True, "kg": name, "routed": routed,
+                "totals": namespaces.namespace_counts(self._conn, name)}
+
+    @staticmethod
+    def _seconds_since_last_ingest(kg: Dict[str, Any], now: datetime) -> Optional[float]:
+        last = kg.get("last_ingest_at")
+        if not last:
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(last))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return (now - parsed).total_seconds()
+        except Exception:
+            return None
+
+    # -------------------------------------------------------- status / list
+
+    def status(self, name: str) -> Dict[str, Any]:
+        """Entity/document/claim counts, bound-source health and ingest lag for
+        a KG. Read-only and free (no approval needed)."""
+        kg = store.get_kg(self._conn, name)
+        if kg is None:
+            return {"error": f"KG {name!r} not found", "code": "not_found"}
+        sources = store.list_sources(self._conn, name)
+        counts = namespaces.namespace_counts(self._conn, name)
+        health = self._source_health([s["source"] for s in sources])
+        return {
+            "kg": kg,
+            "sources": sources,
+            "source_count": len(sources),
+            "counts": counts,
+            "source_health": health,
+            "lineage": store.list_events(self._conn, name, limit=20),
+        }
+
+    def _source_health(self, sources: Sequence[str]) -> List[Dict[str, Any]]:
+        if not sources or not namespaces._table_exists(self._conn, "news_articles"):
+            return [{"source": s, "documents": 0, "last_seen": None} for s in sources]
+        ph = ", ".join("?" for _ in sources)
+        has_date = namespaces._has_column(self._conn, "news_articles", "publish_date")
+        date_expr = "MAX(publish_date)" if has_date else "NULL"
+        rows = self._conn.execute(
+            f"SELECT source, COUNT(*), {date_expr} FROM news_articles "
+            f"WHERE source IN ({ph}) GROUP BY source",
+            list(sources),
+        ).fetchall()
+        seen = {r[0]: (int(r[1]), str(r[2]) if r[2] is not None else None) for r in rows}
+        return [
+            {
+                "source": s,
+                "documents": seen.get(s, (0, None))[0],
+                "last_seen": seen.get(s, (0, None))[1],
+            }
+            for s in sources
+        ]
+
+    def list_kgs(self, include_archived: bool = False) -> Dict[str, Any]:
+        """List KGs with their namespace counts."""
+        kgs = store.list_kgs(self._conn, include_archived=include_archived)
+        out = []
+        for kg in kgs:
+            out.append(
+                {
+                    **kg,
+                    "source_count": store.count_sources(self._conn, kg["name"]),
+                    "counts": namespaces.namespace_counts(self._conn, kg["name"]),
+                }
+            )
+        return {"kgs": out, "count": len(out)}
+
+    def lineage(self, name: Optional[str] = None, limit: int = 50) -> Dict[str, Any]:
+        """The provisioning lineage event log (all KGs, or one)."""
+        return {"events": store.list_events(self._conn, name, limit=limit)}
+
+    # --------------------------------------------------------------- teardown
+
+    def teardown(self, name: str, confirm: bool = False) -> Dict[str, Any]:
+        """Archive a KG: rename its namespace tables aside (never delete),
+        detach its sources, mark it archived. Confirm-gated; never touches the
+        shared corpus."""
+        kg = store.get_kg(self._conn, name)
+        if kg is None:
+            return {"error": f"KG {name!r} not found", "code": "not_found"}
+        if kg.get("status") == store.STATUS_ARCHIVED:
+            return {"error": f"KG {name!r} already archived", "code": "already_archived"}
+        try:
+            require_confirm(confirm, "teardown")
+        except GuardrailError as exc:
+            return {
+                "error": exc.message,
+                "code": exc.code,
+                "preview": True,
+                "would_archive": namespaces.namespace_tables(name),
+            }
+        with self._lock:
+            now = self._clock()
+            counts = namespaces.namespace_counts(self._conn, name)
+            archived_tables = namespaces.archive_namespace(self._conn, name)
+            detached = store.detach_all_sources(self._conn, name)
+            store.set_status(self._conn, name, store.STATUS_ARCHIVED, now)
+            store.record_event(
+                self._conn,
+                name,
+                "teardown",
+                {
+                    "archived_counts": counts,
+                    "archived_tables": archived_tables,
+                    "sources_detached": detached,
+                },
+                now,
+            )
+        return {
+            "archived": True,
+            "kg": name,
+            "archived_tables": archived_tables,
+            "archived_counts": counts,
+            "sources_detached": detached,
+        }

--- a/src/provisioning/store.py
+++ b/src/provisioning/store.py
@@ -1,0 +1,277 @@
+"""
+The provisioning registry and lineage event log (R8 #606 / #608).
+
+Three warehouse-side tables, all outside the shared corpus:
+
+    provisioned_kgs         one row per deployed KG (name, description, status)
+    provisioned_kg_sources  the sources bound to each KG, with why they were
+                            selected
+    provisioning_events     an append-only lineage log: every deploy / attach /
+                            ingest / teardown, so each step is visible in
+                            lineage (the R8 provenance guardrail)
+
+All writes are idempotent upserts keyed by name (or by ``(kg, source)``), so
+re-running a failed provision converges instead of duplicating. Writes run
+under the caller's serialising lock and the API's single warehouse writer.
+
+Stdlib-only; the connection is injected.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+STATUS_DEPLOYED = "deployed"
+STATUS_ARCHIVED = "archived"
+
+
+def ensure_schema(conn) -> None:
+    """Create the registry and lineage tables if absent (idempotent)."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS provisioned_kgs ("
+        "name VARCHAR PRIMARY KEY, description VARCHAR, ontology VARCHAR, "
+        "status VARCHAR, created_at TIMESTAMP, updated_at TIMESTAMP, "
+        "last_ingest_at TIMESTAMP)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS provisioned_kg_sources ("
+        "kg_name VARCHAR, source VARCHAR, source_type VARCHAR, reason VARCHAR, "
+        "attached_at TIMESTAMP, PRIMARY KEY (kg_name, source))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS provisioning_events ("
+        "seq BIGINT, kg_name VARCHAR, event VARCHAR, detail VARCHAR, "
+        "created_at TIMESTAMP)"
+    )
+
+
+def schema_ready(conn) -> bool:
+    """True once the registry tables exist (read tools may run before any
+    deploy has created them)."""
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_name = 'provisioned_kgs'"
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def _row_to_kg(row) -> Dict[str, Any]:
+    ontology: Any = None
+    if row[2]:
+        try:
+            ontology = json.loads(row[2])
+        except Exception:
+            ontology = None
+    return {
+        "name": row[0],
+        "description": row[1],
+        "ontology": ontology,
+        "status": row[3],
+        "created_at": str(row[4]) if row[4] is not None else None,
+        "updated_at": str(row[5]) if row[5] is not None else None,
+        "last_ingest_at": str(row[6]) if row[6] is not None else None,
+    }
+
+
+def get_kg(conn, name: str) -> Optional[Dict[str, Any]]:
+    """Return the KG record for ``name``, or None."""
+    if not schema_ready(conn):
+        return None
+    row = conn.execute(
+        "SELECT name, description, ontology, status, created_at, updated_at, "
+        "last_ingest_at FROM provisioned_kgs WHERE name = ?",
+        [name],
+    ).fetchone()
+    return _row_to_kg(row) if row else None
+
+
+def list_kgs(conn, include_archived: bool = False) -> List[Dict[str, Any]]:
+    """List KGs, deployed-only by default."""
+    if not schema_ready(conn):
+        return []
+    sql = (
+        "SELECT name, description, ontology, status, created_at, updated_at, "
+        "last_ingest_at FROM provisioned_kgs"
+    )
+    params: List[Any] = []
+    if not include_archived:
+        sql += " WHERE status = ?"
+        params.append(STATUS_DEPLOYED)
+    sql += " ORDER BY created_at NULLS LAST, name"
+    return [_row_to_kg(r) for r in conn.execute(sql, params).fetchall()]
+
+
+def count_deployed(conn) -> int:
+    """How many KGs are currently deployed (for the max-KGs quota)."""
+    if not schema_ready(conn):
+        return 0
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM provisioned_kgs WHERE status = ?",
+            [STATUS_DEPLOYED],
+        ).fetchone()[0]
+    )
+
+
+def upsert_kg(
+    conn,
+    name: str,
+    description: str,
+    ontology: Any,
+    now: Any,
+    status: str = STATUS_DEPLOYED,
+) -> Dict[str, Any]:
+    """Insert or update a KG keyed by name (idempotent). Preserves the original
+    ``created_at`` on re-deploy so a converging re-run does not reset it."""
+    ontology_json = json.dumps(ontology) if ontology is not None else None
+    existing = get_kg(conn, name)
+    if existing is None:
+        conn.execute(
+            "INSERT INTO provisioned_kgs "
+            "(name, description, ontology, status, created_at, updated_at, "
+            "last_ingest_at) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            [name, description, ontology_json, status, now, now],
+        )
+    else:
+        conn.execute(
+            "UPDATE provisioned_kgs SET description = ?, ontology = ?, "
+            "status = ?, updated_at = ? WHERE name = ?",
+            [description, ontology_json, status, now, name],
+        )
+    return get_kg(conn, name)
+
+
+def set_status(conn, name: str, status: str, now: Any) -> None:
+    """Set a KG's lifecycle status."""
+    conn.execute(
+        "UPDATE provisioned_kgs SET status = ?, updated_at = ? WHERE name = ?",
+        [status, now, name],
+    )
+
+
+def mark_ingested(conn, name: str, now: Any) -> None:
+    """Stamp the last-ingest time (feeds the ingest rate-cap guardrail)."""
+    conn.execute(
+        "UPDATE provisioned_kgs SET last_ingest_at = ?, updated_at = ? "
+        "WHERE name = ?",
+        [now, now, name],
+    )
+
+
+def count_sources(conn, name: str) -> int:
+    """How many sources are bound to a KG (for the max-sources quota)."""
+    if not schema_ready(conn):
+        return 0
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM provisioned_kg_sources WHERE kg_name = ?",
+            [name],
+        ).fetchone()[0]
+    )
+
+
+def upsert_source(
+    conn,
+    name: str,
+    source: str,
+    source_type: Optional[str],
+    reason: str,
+    now: Any,
+) -> bool:
+    """Bind a source to a KG (idempotent by ``(kg, source)``). Returns True if
+    the source was newly added, False if it was already bound (updated)."""
+    row = conn.execute(
+        "SELECT 1 FROM provisioned_kg_sources WHERE kg_name = ? AND source = ?",
+        [name, source],
+    ).fetchone()
+    if row is None:
+        conn.execute(
+            "INSERT INTO provisioned_kg_sources "
+            "(kg_name, source, source_type, reason, attached_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [name, source, source_type, reason, now],
+        )
+        return True
+    conn.execute(
+        "UPDATE provisioned_kg_sources SET source_type = ?, reason = ? "
+        "WHERE kg_name = ? AND source = ?",
+        [source_type, reason, name, source],
+    )
+    return False
+
+
+def list_sources(conn, name: str) -> List[Dict[str, Any]]:
+    """The sources bound to a KG, with why each was selected."""
+    if not schema_ready(conn):
+        return []
+    rows = conn.execute(
+        "SELECT source, source_type, reason, attached_at "
+        "FROM provisioned_kg_sources WHERE kg_name = ? ORDER BY source",
+        [name],
+    ).fetchall()
+    return [
+        {
+            "source": r[0],
+            "source_type": r[1],
+            "reason": r[2],
+            "attached_at": str(r[3]) if r[3] is not None else None,
+        }
+        for r in rows
+    ]
+
+
+def detach_all_sources(conn, name: str) -> int:
+    """Unbind every source from a KG (teardown). Returns the count removed."""
+    n = count_sources(conn, name)
+    conn.execute("DELETE FROM provisioned_kg_sources WHERE kg_name = ?", [name])
+    return n
+
+
+def record_event(conn, name: str, event: str, detail: Dict[str, Any], now: Any) -> int:
+    """Append a lineage event and return its sequence number."""
+    seq = int(
+        conn.execute(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM provisioning_events"
+        ).fetchone()[0]
+    )
+    conn.execute(
+        "INSERT INTO provisioning_events (seq, kg_name, event, detail, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [seq, name, event, json.dumps(detail, default=str), now],
+    )
+    return seq
+
+
+def list_events(
+    conn, name: Optional[str] = None, limit: int = 50
+) -> List[Dict[str, Any]]:
+    """The lineage event log, newest first, optionally scoped to one KG."""
+    if not schema_ready(conn):
+        return []
+    sql = "SELECT seq, kg_name, event, detail, created_at FROM provisioning_events"
+    params: List[Any] = []
+    if name is not None:
+        sql += " WHERE kg_name = ?"
+        params.append(name)
+    sql += " ORDER BY seq DESC LIMIT ?"
+    params.append(int(limit))
+    out = []
+    for r in conn.execute(sql, params).fetchall():
+        try:
+            detail = json.loads(r[3]) if r[3] else {}
+        except Exception:
+            detail = {}
+        out.append(
+            {
+                "seq": int(r[0]),
+                "kg": r[1],
+                "event": r[2],
+                "detail": detail,
+                "at": str(r[4]) if r[4] is not None else None,
+            }
+        )
+    return out

--- a/tests/unit/genui/test_genui_annotations.py
+++ b/tests/unit/genui/test_genui_annotations.py
@@ -34,6 +34,7 @@ ANNOTATED_SERVERS = {
     "neuronews-blog-feeds": REPO / "tools/blog_mcp/server.py",
     "neuronews-pipeline": REPO / "tools/pipeline_mcp/server.py",
     "neuronews-research": REPO / "tools/research_mcp/server.py",
+    "neuronews-provisioning": REPO / "tools/provisioning_mcp/server.py",
 }
 
 COMPOSED_PANELS = {"note", "timeline"}  # ADR-001 exemptions

--- a/tests/unit/mcp_host/test_mcp_host_config.py
+++ b/tests/unit/mcp_host/test_mcp_host_config.py
@@ -12,8 +12,8 @@ def test_real_mcp_json_yields_only_project_servers():
     specs = load_server_specs()
     assert DEFAULT_MCP_JSON.exists()
     names = {s.name for s in specs}
-    # All 13 tools/*_mcp servers, and nothing npx-launched.
-    assert len(specs) == 13
+    # All 14 tools/*_mcp servers, and nothing npx-launched.
+    assert len(specs) == 14
     assert "neuronews-kg" in names
     assert "neuronews-pipeline" in names
     assert "memory" not in names

--- a/tests/unit/provisioning/conftest.py
+++ b/tests/unit/provisioning/conftest.py
@@ -1,0 +1,75 @@
+"""Fixtures for the provisioning-plane tests: a temp DuckDB warehouse seeded
+with a shared corpus (news_articles), a claim layer (argument_claims) and
+outlet transparency scores (outlet_scores) so criteria-attach and routing have
+something to resolve against."""
+
+from types import SimpleNamespace
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _seed_articles(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS news_articles ("
+        "id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO news_articles (id, title, url, content, publish_date, "
+            "source, category) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _seed_claims(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS argument_claims ("
+        "claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO argument_claims (claim_id, claim_text, document_id, "
+            "source_type, confidence, factcheck_verdict) VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _seed_outlet_scores(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS outlet_scores ("
+        "source VARCHAR, source_type VARCHAR, score_date VARCHAR, "
+        "frame_diversity DOUBLE, attribution_rate DOUBLE, "
+        "stance_neutrality DOUBLE, composite_score DOUBLE, "
+        "doc_count INTEGER, claim_count INTEGER, computed_at VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO outlet_scores (source, source_type, score_date, "
+            "frame_diversity, attribution_rate, stance_neutrality, "
+            "composite_score, doc_count, claim_count, computed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+@pytest.fixture
+def conn(tmp_path):
+    db = tmp_path / "wh.duckdb"
+    c = duckdb.connect(str(db))
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def seed(conn):
+    return SimpleNamespace(
+        conn=conn,
+        articles=lambda rows: _seed_articles(conn, rows),
+        claims=lambda rows: _seed_claims(conn, rows),
+        outlet_scores=lambda rows: _seed_outlet_scores(conn, rows),
+    )

--- a/tests/unit/provisioning/test_guardrails.py
+++ b/tests/unit/provisioning/test_guardrails.py
@@ -1,0 +1,123 @@
+"""Guardrail failing-path tests (R8 #608).
+
+Each guardrail has a test that proves enforcement, plus the convergence test:
+a re-run of a failed provision converges without duplicates.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.provisioning import store
+from src.provisioning.guardrails import Quotas
+from src.provisioning.provisioner import Provisioner
+
+
+class _Clock:
+    def __init__(self, start=None):
+        self.t = start or datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def advance(self, seconds):
+        self.t = self.t + timedelta(seconds=seconds)
+
+    def __call__(self):
+        return self.t
+
+
+def _seed(seed):
+    seed.articles(
+        [
+            ("a1", "Solar record", "u1", "c", datetime(2026, 6, 1, tzinfo=timezone.utc), "Alpha", "energy"),
+            ("a2", "Storage limits", "u2", "c", datetime(2026, 6, 1, tzinfo=timezone.utc), "Alpha", "energy"),
+        ]
+    )
+
+
+def test_max_kgs_quota_blocks_new_deploy(seed):
+    prov = Provisioner(seed.conn, quotas=Quotas(max_kgs=1), clock=_Clock())
+    assert prov.deploy("one", approve=True)["deployed"] is True
+    blocked = prov.deploy("two", approve=True)
+    assert blocked.get("code") == "quota_max_kgs"
+    assert store.get_kg(seed.conn, "two") is None
+
+
+def test_redeploy_of_existing_name_ignores_quota(seed):
+    prov = Provisioner(seed.conn, quotas=Quotas(max_kgs=1), clock=_Clock())
+    prov.deploy("one", "first", approve=True)
+    # Re-deploying the same name converges even at the quota ceiling.
+    again = prov.deploy("one", "updated", approve=True)
+    assert again["deployed"] is True and again["created"] is False
+    assert store.count_deployed(seed.conn) == 1
+
+
+def test_max_sources_quota_blocks_attach(seed):
+    prov = Provisioner(seed.conn, quotas=Quotas(max_sources_per_kg=1), clock=_Clock())
+    prov.deploy("kg", approve=True)
+    res = prov.attach_sources("kg", sources=["Alpha", "Beta"])
+    assert res.get("code") == "quota_max_sources"
+    assert store.count_sources(seed.conn, "kg") == 0
+
+
+def test_ingest_rate_cap_blocks_second_ingest(seed):
+    _seed(seed)
+    clock = _Clock()
+    prov = Provisioner(
+        seed.conn, quotas=Quotas(ingest_min_interval_s=3600), clock=clock
+    )
+    prov.deploy("kg", approve=True)
+    prov.attach_sources("kg", sources=["Alpha"])
+    first = prov.ingest("kg")
+    assert first["ingested"] is True
+    clock.advance(60)  # 1 minute later, well inside the 1h cap
+    second = prov.ingest("kg")
+    assert second.get("code") == "rate_capped"
+
+
+def test_deploy_requires_approval(seed):
+    prov = Provisioner(seed.conn, clock=_Clock())
+    preview = prov.deploy("kg")
+    assert preview.get("preview") is True
+    assert store.get_kg(seed.conn, "kg") is None
+
+
+def test_teardown_requires_confirm(seed):
+    prov = Provisioner(seed.conn, clock=_Clock())
+    prov.deploy("kg", approve=True)
+    res = prov.teardown("kg")
+    assert res.get("code") == "confirm_required"
+    assert store.get_kg(seed.conn, "kg")["status"] == "deployed"
+
+
+def test_invalid_name_is_refused(seed):
+    prov = Provisioner(seed.conn, clock=_Clock())
+    res = prov.deploy("Bad Name", approve=True)
+    assert res.get("code") == "invalid_name"
+
+
+def test_rerun_of_failed_provision_converges_without_duplicates(seed):
+    """Simulate a provision that fails partway (attach hits the source quota),
+    then re-run the whole sequence with room: it converges to a single clean
+    KG with no duplicated rows."""
+    _seed(seed)
+    clock = _Clock()
+    # First attempt: quota too small, attach fails after deploy succeeds.
+    tight = Provisioner(seed.conn, quotas=Quotas(max_sources_per_kg=0), clock=clock)
+    tight.deploy("energy", "Energy", approve=True)
+    failed = tight.attach_sources("energy", sources=["Alpha"])
+    assert failed.get("code") == "quota_max_sources"
+
+    # Re-run with a healthy quota: deploy converges (no duplicate KG), attach
+    # and ingest complete.
+    ok = Provisioner(seed.conn, quotas=Quotas(), clock=clock)
+    ok.deploy("energy", "Energy", approve=True)
+    ok.attach_sources("energy", sources=["Alpha"])
+    ok.attach_sources("energy", sources=["Alpha"])  # duplicate attach
+    ok.ingest("energy")
+    ok.ingest("energy")  # duplicate ingest
+
+    assert store.count_deployed(seed.conn) == 1
+    assert store.count_sources(seed.conn, "energy") == 1  # no duplicate source
+    from src.provisioning import namespaces
+
+    counts = namespaces.namespace_counts(seed.conn, "energy")
+    assert counts["documents"] == 2  # routed once, not four times

--- a/tests/unit/provisioning/test_namespaces.py
+++ b/tests/unit/provisioning/test_namespaces.py
@@ -1,0 +1,103 @@
+"""Namespacing + routing tests (R8 #606).
+
+The exit criterion: a namespaced KG holds only routed documents; shared tables
+are untouched; the namespace is visible in the registry/lineage.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.provisioning import namespaces
+
+
+def _now():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def test_name_validation_rejects_injection_and_shapes():
+    for bad in ["Bad", "1kg", "kg-name", "kg name", "kg;drop", "", "x" * 40, None]:
+        assert not namespaces.valid_name(bad)
+    for good in ["climate", "kg2", "semi_conductors", "a1"]:
+        assert namespaces.valid_name(good)
+
+
+def test_namespace_tables_are_prefixed():
+    tables = namespaces.namespace_tables("climate")
+    assert tables == {
+        "documents": "kg_climate_documents",
+        "entities": "kg_climate_entities",
+        "claims": "kg_climate_claims",
+    }
+
+
+def test_require_valid_name_raises():
+    with pytest.raises(ValueError):
+        namespaces.namespace_prefix("Bad Name")
+
+
+def _seed(seed):
+    seed.articles(
+        [
+            ("a1", "Solar power sets new record", "u1", "c", _now(), "Alpha", "energy"),
+            ("a2", "Grid storage limits growth", "u2", "c", _now(), "Alpha", "energy"),
+            ("a3", "Chip fabs expand capacity", "u3", "c", _now(), "Beta", "tech"),
+            ("a4", "Unrelated sports result", "u4", "c", _now(), "Gamma", "sport"),
+        ]
+    )
+    seed.claims(
+        [
+            ("c1", "Solar is cheapest.", "a1", "news", 0.9, "supported"),
+            ("c2", "Storage is the constraint.", "a2", "news", 0.8, "disputed"),
+            ("c3", "Sports claim.", "a4", "news", 0.7, None),
+        ]
+    )
+
+
+def test_routing_holds_only_routed_documents(seed):
+    _seed(seed)
+    conn = seed.conn
+    # Route only Alpha's documents into the KG namespace.
+    counts = namespaces.route_documents(conn, "energy", ["Alpha"], _now())
+    assert counts["documents"] == 2
+    assert counts["claims"] == 2  # only a1/a2 claims, not the sports claim
+
+    ns = namespaces.namespace_tables("energy")
+    routed_ids = {r[0] for r in conn.execute(f"SELECT id FROM {ns['documents']}").fetchall()}
+    assert routed_ids == {"a1", "a2"}
+    # The Beta/Gamma documents never entered the namespace.
+    assert "a3" not in routed_ids and "a4" not in routed_ids
+
+
+def test_routing_leaves_shared_tables_untouched(seed):
+    _seed(seed)
+    conn = seed.conn
+    before = conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
+    before_claims = conn.execute("SELECT COUNT(*) FROM argument_claims").fetchone()[0]
+    namespaces.route_documents(conn, "energy", ["Alpha"], _now())
+    after = conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
+    after_claims = conn.execute("SELECT COUNT(*) FROM argument_claims").fetchone()[0]
+    assert (before, before_claims) == (after, after_claims) == (4, 3)
+
+
+def test_routing_is_idempotent(seed):
+    _seed(seed)
+    conn = seed.conn
+    first = namespaces.route_documents(conn, "energy", ["Alpha"], _now())
+    second = namespaces.route_documents(conn, "energy", ["Alpha"], _now())
+    assert first["documents"] == 2
+    assert second["documents"] == 0  # nothing new on re-run
+    ns = namespaces.namespace_tables("energy")
+    total = conn.execute(f"SELECT COUNT(*) FROM {ns['documents']}").fetchone()[0]
+    assert total == 2  # no duplication
+
+
+def test_archive_renames_without_deleting(seed):
+    _seed(seed)
+    conn = seed.conn
+    namespaces.route_documents(conn, "energy", ["Alpha"], _now())
+    archived = namespaces.archive_namespace(conn, "energy")
+    # Live tables are gone, archived copies remain with the data.
+    assert namespaces.namespace_counts(conn, "energy")["documents"] == 0
+    kept = conn.execute(f"SELECT COUNT(*) FROM {archived['documents']}").fetchone()[0]
+    assert kept == 2

--- a/tests/unit/provisioning/test_provisioner.py
+++ b/tests/unit/provisioning/test_provisioner.py
@@ -1,0 +1,130 @@
+"""End-to-end lifecycle tests for the Provisioner (R8 #607).
+
+The exit criterion: deploy, then attach by criteria, then ingest, and the
+scoped view has data; teardown archives; every step is visible in lineage.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.provisioning import store
+from src.provisioning.guardrails import Quotas
+from src.provisioning.provisioner import Provisioner
+
+
+class _Clock:
+    def __init__(self):
+        self.t = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def __call__(self):
+        return self.t
+
+
+def _prov(conn, **kw):
+    return Provisioner(conn, quotas=kw.pop("quotas", Quotas()), clock=_Clock(), **kw)
+
+
+def _seed(seed):
+    seed.articles(
+        [
+            ("a1", "Solar power record", "u1", "c", _Clock()(), "Alpha", "energy"),
+            ("a2", "Storage limits growth", "u2", "c", _Clock()(), "Alpha", "energy"),
+            ("a3", "Chip fabs expand", "u3", "c", _Clock()(), "Beta", "tech"),
+        ]
+    )
+    seed.claims(
+        [
+            ("c1", "Solar is cheapest.", "a1", "news", 0.9, "supported"),
+            ("c2", "Storage is the constraint.", "a2", "news", 0.8, "disputed"),
+        ]
+    )
+    seed.outlet_scores(
+        [
+            ("Alpha", "news", "2026-06-01", 0.8, 0.9, 0.7, 0.85, 40, 30, "2026-06-01"),
+            ("Beta", "news", "2026-06-01", 0.5, 0.4, 0.5, 0.45, 20, 10, "2026-06-01"),
+        ]
+    )
+
+
+def test_deploy_is_approval_gated(seed):
+    prov = _prov(seed.conn)
+    preview = prov.deploy("energy", "Energy KG")
+    assert preview.get("preview") is True
+    assert store.get_kg(seed.conn, "energy") is None  # nothing written
+
+    done = prov.deploy("energy", "Energy KG", approve=True)
+    assert done["deployed"] is True and done["created"] is True
+    assert store.get_kg(seed.conn, "energy")["status"] == "deployed"
+
+
+def test_full_lifecycle_deploy_attach_criteria_ingest_status(seed):
+    _seed(seed)
+    prov = _prov(seed.conn)
+
+    prov.deploy("energy", "Energy KG", approve=True)
+
+    # Attach by a quality criterion resolved via outlet_scores: only Alpha
+    # clears transparency >= 0.7.
+    attach = prov.attach_sources("energy", criteria={"min_transparency": 0.7, "type": "news"})
+    assert attach["attached"] == 1
+    bound = [s["source"] for s in attach["sources"]]
+    assert bound == ["Alpha"]
+    assert "selected because" in attach["sources"][0]["reason"]
+
+    ingest = prov.ingest("energy")
+    assert ingest["ingested"] is True
+    assert ingest["routed"]["documents"] == 2
+    assert ingest["totals"]["claims"] == 2
+
+    status = prov.status("energy")
+    assert status["counts"]["documents"] == 2
+    assert status["source_count"] == 1
+    assert status["source_health"][0]["documents"] == 2
+
+    # Every step is in the lineage log.
+    events = [e["event"] for e in status["lineage"]]
+    assert {"deploy", "attach", "ingest"} <= set(events)
+
+
+def test_teardown_archives_and_is_confirm_gated(seed):
+    _seed(seed)
+    prov = _prov(seed.conn)
+    prov.deploy("energy", approve=True)
+    prov.attach_sources("energy", sources=["Alpha"])
+    prov.ingest("energy")
+
+    # Without confirm: preview only, still deployed.
+    preview = prov.teardown("energy")
+    assert preview.get("code") == "confirm_required"
+    assert store.get_kg(seed.conn, "energy")["status"] == "deployed"
+
+    torn = prov.teardown("energy", confirm=True)
+    assert torn["archived"] is True
+    assert torn["archived_counts"]["documents"] == 2
+    assert store.get_kg(seed.conn, "energy")["status"] == "archived"
+    # Shared corpus untouched.
+    assert seed.conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 3
+    # Teardown is in lineage.
+    assert prov.lineage("energy")["events"][0]["event"] == "teardown"
+
+
+def test_criteria_with_no_match_binds_nothing(seed):
+    _seed(seed)
+    prov = _prov(seed.conn)
+    prov.deploy("energy", approve=True)
+    res = prov.attach_sources("energy", criteria={"min_transparency": 0.99})
+    assert res["attached"] == 0
+    assert "no sources matched" in res["note"]
+
+
+def test_list_kgs_excludes_archived_by_default(seed):
+    _seed(seed)
+    prov = _prov(seed.conn)
+    prov.deploy("energy", approve=True)
+    prov.deploy("tech", approve=True)
+    prov.teardown("tech", confirm=True)
+    names = [k["name"] for k in prov.list_kgs()["kgs"]]
+    assert names == ["energy"]
+    all_names = {k["name"] for k in prov.list_kgs(include_archived=True)["kgs"]}
+    assert all_names == {"energy", "tech"}

--- a/tools/provisioning_mcp/server.py
+++ b/tools/provisioning_mcp/server.py
@@ -1,0 +1,351 @@
+"""
+NeuroNews Provisioning plane - MCP server (R8 / Track P).
+
+The read/write surface over the provisioning plane: an agent deploys a
+namespaced knowledge graph, binds the sources that feed it (explicitly or by a
+quality criterion), routes matching documents into the namespace, and the
+canvas grows a scoped panel for it via R2 discovery. Teardown archives, never
+silently deletes. Every step is registered in an append-only lineage log.
+
+Tool surface:
+  kg_deploy(name, description?, ontology?, approve=False)   deploy (approval-gated)
+  kg_attach_sources(kg, sources?, criteria?)                bind feeds/connectors
+  kg_ingest(kg, backfill_days?)                             route matching docs
+  kg_status(kg)                                             counts / health / lag
+  kg_list(include_archived=False)                           deployed KGs
+  kg_lineage(kg?, limit=50)                                 provisioning event log
+  kg_teardown(kg, confirm=False)                            archive + detach
+  kg_view(kg?)                                              annotated `provisioned_kg` panel
+
+Write authority: the write tools open the DuckDB warehouse read-write and hold
+a process-level lock for the operation, mirroring the pipeline server's
+trigger tools; in the deployed system the write path is the API process that
+owns the single warehouse writer. Read tools open the warehouse read-only.
+
+Design constraints (as for every tool server): stdlib + fastmcp at import
+time, lazy imports inside tools, guardrails enforced in
+:mod:`src.provisioning`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Any, List, Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+mcp = FastMCP("neuronews-provisioning")
+
+# Serialises every provisioning write in this process (the warehouse is a
+# single-writer store; provisioning never runs two writes at once).
+_WRITE_LOCK = threading.Lock()
+
+
+def _db_path() -> str:
+    return os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+
+
+def _warehouse_ro():
+    import duckdb
+
+    path = _db_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"warehouse not found at {path}")
+    return duckdb.connect(path, read_only=True)
+
+
+def _warehouse_rw():
+    import duckdb
+
+    path = _db_path()
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"warehouse not found at {path} - start the API once to seed it, "
+            f"or set NEURONEWS_DB_PATH"
+        )
+    return duckdb.connect(path, read_only=False)
+
+
+# --------------------------------------------------------------------------- #
+# Write tools (guardrailed; hold the write lock for the operation)
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def kg_deploy(
+    name: str,
+    description: str = "",
+    ontology: Optional[dict] = None,
+    approve: bool = False,
+) -> dict:
+    """Deploy a namespaced knowledge graph (approval-gated).
+
+    Without ``approve`` this returns a free dry-run preview and writes nothing;
+    re-run with ``approve=true`` to execute. Re-deploying an existing name
+    converges (idempotent upsert) rather than duplicating.
+
+    Args:
+        name: KG identifier, lowercase ``[a-z][a-z0-9_]*`` (becomes the table prefix).
+        description: human-readable summary.
+        ontology: optional ontology hint (stored as JSON).
+        approve: must be true to actually deploy.
+    """
+    from src.provisioning import Provisioner
+
+    if not approve:
+        try:
+            con = _warehouse_ro()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            return Provisioner(con, ensure=False).deploy(
+                name, description, ontology, approve=False
+            )
+        finally:
+            con.close()
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, lock=_WRITE_LOCK)
+        return prov.deploy(name, description, ontology, approve=True)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_attach_sources(
+    kg: str,
+    sources: Optional[List[str]] = None,
+    criteria: Optional[dict] = None,
+) -> dict:
+    """Bind sources to a deployed KG, explicitly or by a quality criterion.
+
+    ``criteria`` is resolved against the outlet transparency scores; supported
+    keys: ``min_transparency`` (composite score), ``min_attribution``,
+    ``type`` (source_type). Idempotent by ``(kg, source)``.
+
+    Args:
+        kg: the deployed KG name.
+        sources: explicit source names to bind.
+        criteria: quality criterion, e.g. {"min_transparency": 0.7, "type": "news"}.
+    """
+    from src.provisioning import Provisioner
+
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, lock=_WRITE_LOCK)
+        return prov.attach_sources(kg, sources=sources, criteria=criteria)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_ingest(kg: str, backfill_days: Optional[int] = None) -> dict:
+    """Route the bound sources' documents (and claims / derived entities) into
+    the KG namespace. Rate-capped and idempotent (re-ingest converges).
+
+    Args:
+        kg: the deployed KG name.
+        backfill_days: optional lookback window for the routed corpus.
+    """
+    from src.provisioning import Provisioner
+
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, lock=_WRITE_LOCK)
+        return prov.ingest(kg, backfill_days=backfill_days)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_teardown(kg: str, confirm: bool = False) -> dict:
+    """Archive a KG: rename its namespace tables aside (never delete), detach
+    its sources, mark it archived. Confirm-gated; never touches shared tables.
+
+    Args:
+        kg: the KG name.
+        confirm: must be true to archive (a preview is returned otherwise).
+    """
+    from src.provisioning import Provisioner
+
+    if not confirm:
+        try:
+            con = _warehouse_ro()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            return Provisioner(con, ensure=False).teardown(kg, confirm=False)
+        finally:
+            con.close()
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, lock=_WRITE_LOCK)
+        return prov.teardown(kg, confirm=True)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+# --------------------------------------------------------------------------- #
+# Read tools (free; read-only warehouse)
+# --------------------------------------------------------------------------- #
+
+@mcp.tool
+def kg_status(kg: str) -> dict:
+    """Entity/document/claim counts, bound-source health and ingest lag for a
+    deployed KG, plus its recent lineage. Read-only and free.
+
+    Args:
+        kg: the KG name.
+    """
+    from src.provisioning import Provisioner
+
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        return Provisioner(con, ensure=False).status(kg)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_list(include_archived: bool = False) -> dict:
+    """List provisioned KGs with their namespace counts.
+
+    Args:
+        include_archived: include torn-down (archived) KGs.
+    """
+    from src.provisioning import Provisioner
+
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        return Provisioner(con, ensure=False).list_kgs(include_archived=include_archived)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_lineage(kg: Optional[str] = None, limit: int = 50) -> dict:
+    """The provisioning lineage event log (deploy / attach / ingest / teardown),
+    newest first, for all KGs or one.
+
+    Args:
+        kg: optional KG name to scope to.
+        limit: max events (1-200).
+    """
+    from src.provisioning import Provisioner
+
+    limit = max(1, min(int(limit), 200))
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        return Provisioner(con, ensure=False).lineage(kg, limit=limit)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "kgs": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": ["string", "null"]},
+                        "status": {"type": "string"},
+                        "source_count": {"type": "integer"},
+                        "counts": {"type": "object"},
+                        "sources": {"type": "array"},
+                    },
+                },
+            },
+            "count": {"type": "integer"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "provisioned_kg",
+        "title": "Provisioned knowledge graphs",
+        "description": "Agent-deployed namespaced knowledge graphs: entity and document counts, the sources feeding each and why they were selected.",
+        "endpoint": None,
+        "facets": ["entities", "overview", "library"],
+        "tables": ["provisioned_kgs"],
+        "ui_flag": None,
+        "default_span": 6,
+        "topic_param": "kg",
+    }},
+)
+def kg_view(kg: Optional[str] = None) -> dict:
+    """The `provisioned_kg` panel view: deployed KGs with their namespace
+    counts and the sources feeding each (with the selection rationale). With a
+    ``kg`` argument, scopes to that one KG.
+
+    Args:
+        kg: optional KG name to scope the view.
+    """
+    from src.provisioning import Provisioner
+
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, ensure=False)
+        listing = prov.list_kgs(include_archived=False)
+        kgs = listing["kgs"]
+        if kg is not None:
+            kgs = [k for k in kgs if k["name"] == kg]
+        from src.provisioning import store
+
+        for k in kgs:
+            k["sources"] = store.list_sources(con, k["name"])
+        return {"kgs": kgs, "count": len(kgs)}
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

R8 turns MCP from the read/compose plane into one that provisions knowledge domains (Track P). An agent deploys a namespaced knowledge graph, binds the sources that feed it (explicitly or by a quality criterion), routes matching documents into the namespace, and the canvas grows a scoped panel for it via R2 discovery. No code change, no deploy.

Closes #606, #607, #608.

## What landed

New `src/provisioning/` package (stdlib-only; the caller injects the DuckDB connection, so nothing here opens the warehouse itself):

- `namespaces.py`: table-prefix namespacing (`kg_<name>_documents` / `_entities` / `_claims`). The KG name is validated to `[a-z][a-z0-9_]*` before it ever reaches a table identifier, so the prefix is injection-safe. Routing copies only the rows whose `source` is bound to the KG out of the shared corpus, so a namespace holds only routed documents and the shared tables are read, never mutated.
- `store.py`: the registry (deployed KGs, bound sources) plus an append-only lineage event log. Every write is an idempotent upsert keyed by name.
- `guardrails.py`: the RW guardrails. Quotas (max KGs, max sources per KG, an ingest rate cap), the deploy/teardown approval gate and the confirm gate. A breach raises a typed error with a machine-readable code.
- `provisioner.py`: ties them into `deploy` / `attach_sources` / `ingest` / `status` / `list` / `teardown`, resolving quality criteria (transparency, attribution, type) against `outlet_scores`.

New `tools/provisioning_mcp/server.py`, registered in `.mcp.json` (14 project servers):

- Write tools `kg_deploy`, `kg_attach_sources`, `kg_ingest`, `kg_teardown` hold a process lock over a read-write warehouse, mirroring the pipeline server's trigger tools.
- Read tools `kg_status`, `kg_list`, `kg_lineage`, `kg_view` open the warehouse read-only.

Guarantees:

- Deploy and teardown are approval-gated by default (a free dry-run preview otherwise).
- Teardown archives (renames the namespace tables aside, never deletes) and detaches sources; it never cascades to shared tables.
- Re-running a failed provision converges without duplicating.
- Every deploy, attach, ingest and teardown is in the lineage log, so each step is visible.

Canvas surface: the `provisioned_kg` panel type (catalog, codegen, frontend renderer, planner keywords, `kg_view` annotation) makes the plane appear via discovery.

## Verification

- `tests/unit/provisioning/` (20 tests): namespacing and routing, the full deploy/attach-by-criteria/ingest/status/teardown lifecycle, and a failing-path test per guardrail (max-KGs quota, max-sources quota, ingest rate cap, missing approve, missing confirm, invalid name) plus the re-run convergence test.
- Full sweep `tests/unit/provisioning tests/unit/genui tests/unit/mcp_host tests/unit/domains`: 334 passed. Frontend `tsc --noEmit` clean. `codegen.py --check` reports artifacts current.
- Live end-to-end over the real provisioning MCP server on a temp warehouse: deploy is approval-gated (preview writes nothing), approved deploy creates the namespace, attach by `min_transparency >= 0.7` binds only the qualifying outlet, ingest routes two documents and their claims, status shows counts and lineage, the shared corpus stays at four rows, teardown is confirm-gated and archives, and discovery surfaces the `provisioned_kg` panel from `neuronews-provisioning`.

## Exit criteria

- #606: a namespaced KG holds only routed documents; shared tables are untouched; the namespace is visible in the registry and lineage.
- #607: deploy, then attach by criteria, then ingest, and the scoped view has data; teardown archives; every step visible in lineage.
- #608: each guardrail has a failing-path test proving enforcement; a re-run of a failed provision converges without duplicates.