### PR TITLE
R10: OSINT composition, corroboration, source reliability, contradiction scan

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -101,6 +101,14 @@
       ],
       "env": {}
     },
+    "neuronews-osint": {
+      "type": "stdio",
+      "command": "python3",
+      "args": [
+        "tools/osint_mcp/server.py"
+      ],
+      "env": {}
+    },
     "neuronews-dataset": {
       "type": "stdio",
       "command": "python3",

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -34,7 +34,10 @@ export type PanelType =
   | "venues"
   | "citation_graph"
   | "literature_claims"
-  | "provisioned_kg";
+  | "provisioned_kg"
+  | "corroboration"
+  | "reliability_card"
+  | "contradiction_ledger";
 
 export type Facet =
   | "overview"
@@ -94,6 +97,9 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "citation_graph", title: "Citation graph", facets: ["entities", "library"], defaultSpan: 6, topicParam: true },
   { type: "literature_claims", title: "Literature claims", facets: ["claims", "library"], defaultSpan: 6, topicParam: true },
   { type: "provisioned_kg", title: "Provisioned knowledge graphs", facets: ["entities", "overview", "library"], defaultSpan: 6, topicParam: true },
+  { type: "corroboration", title: "Claim corroboration", facets: ["claims", "sources", "conflict"], defaultSpan: 6 },
+  { type: "reliability_card", title: "Source reliability", facets: ["sources"], defaultSpan: 6 },
+  { type: "contradiction_ledger", title: "Contradiction ledger", facets: ["conflict", "claims"], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/planner.ts
+++ b/apps/web/src/genui/planner.ts
@@ -12,7 +12,7 @@ const FACET_KEYWORDS: Record<Facet, string[]> = {
   overview: [],
   trend: ["trend", "trends", "trending", "over time", "shift", "shifted", "evolution", "evolve", "evolved", "changing", "changed", "history", "momentum", "trajectory", "drift", "unusual", "anomaly", "anomalies", "anomalous", "spike", "spikes", "surge", "abnormal", "outlier", "outliers", "semantic", "meaning", "forecast", "forecasts", "predict", "prediction", "projection", "outlook", "future", "expected"],
   sentiment: ["sentiment", "tone", "mood", "feeling", "positive", "negative", "emotion", "optimism", "pessimism"],
-  claims: ["claim", "claims", "fact", "facts", "factcheck", "fact-check", "verify", "verified", "unverified", "true", "false", "misinformation", "disinformation", "evidence", "assertion", "unsourced"],
+  claims: ["claim", "claims", "fact", "facts", "factcheck", "fact-check", "verify", "verified", "unverified", "true", "false", "misinformation", "disinformation", "evidence", "assertion", "unsourced", "corroborate", "corroboration", "corroborated", "independent", "osint"],
   stance: ["stance", "stances", "support", "supports", "supportive", "oppose", "opposes", "opposition", "critical", "position", "positions", "agree", "agrees", "disagree", "disagrees", "pro", "against"],
   actors: ["who", "actor", "actors", "stakeholder", "stakeholders", "politician", "politicians", "speaker", "speakers", "people", "person", "says", "said", "voices"],
   conflict: ["conflict", "conflicts", "controversy", "controversial", "contradict", "contradicts", "contradiction", "contradictions", "dispute", "disputes", "disagreement", "clash", "debate"],

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1070,6 +1070,127 @@ function ProvisionedKgPanel(props: PanelProps) {
   );
 }
 
+const DEMO_CORROBORATION = {
+  claim: { text: "The new emissions rule cuts sector output by 12 percent by 2030.", source: "Alpha Wire", credibility: 0.78 },
+  support: [
+    { source: "Beta Journal", credibility: 0.81, via: "evidence" },
+    { source: "Gamma Review", credibility: 0.66, via: "evidence" },
+  ],
+  contradict: [{ source: "Delta Post", credibility: 0.42, via: "conflict" }],
+  independent_support_count: 2,
+  independent_contradict_count: 1,
+  single_sourced: false,
+};
+
+function CorroborationPanel(props: PanelProps) {
+  const c = DEMO_CORROBORATION;
+  const Row = ({ s, kind }: { s: { source: string; credibility: number; via: string }; kind: "for" | "against" }) => (
+    <div key={s.source} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+      <span style={{ ...chip(kind === "for" ? palette.pos : palette.neg) }}>{kind}</span>
+      <span style={{ flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.source}</span>
+      <span style={{ ...mono }}>{s.via}</span>
+      <ScoreBar value={s.credibility} />
+      <span style={{ fontFamily: fonts.mono, fontSize: 11, color: palette.teal, width: 30, textAlign: "right" }}>{s.credibility.toFixed(2)}</span>
+    </div>
+  );
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ fontSize: 12.5, lineHeight: 1.35, marginBottom: 6 }}>{c.claim.text}</div>
+      <div style={{ ...mono, marginBottom: 8 }}>claimed by {c.claim.source} (credibility {c.claim.credibility.toFixed(2)})</div>
+      {c.single_sourced ? (
+        <div style={{ ...chip(palette.amber) }}>single-sourced, not corroborated</div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+          <div style={{ ...mono }}>{c.independent_support_count} independent for, {c.independent_contradict_count} against</div>
+          {c.support.map((s) => <Row key={s.source} s={s} kind="for" />)}
+          {c.contradict.map((s) => <Row key={s.source} s={s} kind="against" />)}
+        </div>
+      )}
+      <div style={{ ...mono, marginTop: 6 }}>independent-source counts weighted by credibility, never one confidence number</div>
+    </GenPanel>
+  );
+}
+
+const DEMO_RELIABILITY = {
+  source: "Grid Policy Weekly",
+  reliability: { value: 0.71, lo: 0.6, hi: 0.82 },
+  components: { transparency: 0.74, corroboration_hit_rate: 0.68, clean_record_rate: 0.92 },
+  track_record: { documents: 214, claims: 88 },
+  corrections: { disputed_claims: 7 },
+  scored_as_outlet: true,
+};
+
+function ReliabilityCardPanel(props: PanelProps) {
+  const r = DEMO_RELIABILITY;
+  const rows: [string, number][] = [
+    ["transparency", r.components.transparency],
+    ["corroboration hit-rate", r.components.corroboration_hit_rate],
+    ["clean record rate", r.components.clean_record_rate],
+  ];
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 6 }}>
+        <span style={{ fontSize: 14, fontWeight: 600 }}>{r.source}</span>
+        <span style={{ ...mono }}>{r.track_record.documents} docs, {r.track_record.claims} claims</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <span style={{ ...mono, width: 64 }}>reliability</span>
+        <ScoreBar value={r.reliability.value} ci={{ lo: r.reliability.lo, hi: r.reliability.hi, level: 0.95, n: r.track_record.documents }} />
+        <span style={{ fontFamily: fonts.mono, fontSize: 12, color: palette.teal }}>{r.reliability.value.toFixed(2)}</span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {rows.map(([label, v]) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11.5 }}>
+            <span style={{ width: 118, color: palette.dim }}>{label}</span>
+            <ScoreBar value={v} />
+            <span style={{ fontFamily: fonts.mono, fontSize: 11, width: 30, textAlign: "right" }}>{v.toFixed(2)}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 6 }}>
+        {r.corrections.disputed_claims} disputed claims{r.scored_as_outlet ? " ; scored on the outlet transparency path" : ""}
+      </div>
+    </GenPanel>
+  );
+}
+
+const DEMO_CONTRADICTIONS = [
+  {
+    claim_a: { text: "Storage costs fell 40 percent since 2022.", source: "Alpha Wire", cited: true },
+    claim_b: { text: "Storage costs are essentially flat since 2022.", source: "Delta Post", cited: true },
+    topic: "energy storage",
+  },
+  {
+    claim_a: { text: "The rule takes effect in 90 days.", source: "Federal Register", cited: true },
+    claim_b: { text: "The rule is delayed indefinitely.", source: "Unattributed brief", cited: false },
+    topic: "emissions rule",
+  },
+];
+
+function ContradictionLedgerPanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {DEMO_CONTRADICTIONS.map((c, i) => (
+          <div key={i} style={{ borderLeft: `2px solid ${palette.neg}`, paddingLeft: 10 }}>
+            <div style={{ ...mono, color: palette.amber }}>{c.topic}</div>
+            {[c.claim_a, c.claim_b].map((cl, j) => (
+              <div key={j} style={{ display: "flex", gap: 6, alignItems: "flex-start", fontSize: 11.5, marginTop: 2 }}>
+                <span style={{ ...chip(j === 0 ? ACCENT : palette.teal), marginTop: 2 }}>{cl.source}</span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  {cl.text}
+                  {!cl.cited ? <span style={{ ...mono, color: palette.amber, marginLeft: 6 }}>uncited</span> : null}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>where the record disagrees with itself; uncited entries flagged, never hidden</div>
+    </GenPanel>
+  );
+}
+
 function UnknownPanel(props: PanelProps) {
   return (
     <GenPanel {...props}>
@@ -1108,6 +1229,9 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   citation_graph: CitationGraphPanel,
   literature_claims: LiteratureClaimsPanel,
   provisioned_kg: ProvisionedKgPanel,
+  corroboration: CorroborationPanel,
+  reliability_card: ReliabilityCardPanel,
+  contradiction_ledger: ContradictionLedgerPanel,
 };
 
 export function panelComponent(type: string): ComponentType<PanelProps> {

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -641,6 +641,23 @@ calibrated confidence).
 by credibility; uncited assertions render visibly flagged, never
 hidden.
 
+*Delivered.* The OSINT plane lives in `src/osint/` (stdlib-only, pure
+composition of the claim / evidence / conflict / outlet-score layers; the
+connection is injected read-only): `corroboration.py` is `corroborate(claim_id)`,
+counting the independent sources that support or contradict a claim (by
+distinct outlet, excluding the claim's own source) each weighted by its
+transparency composite, flagging a claim as `single_sourced` rather than
+inventing a confidence number; `reliability.py` is `source_reliability(source)`,
+the outlet transparency score generalized to any source_type plus a
+corroboration hit-rate and a disputed-claim rate, honesty-wrapped with a
+track-record-weighted interval; `contradictions.py` is
+`contradiction_scan(topic|entity)` over the CONTRADICTS edges, every pair
+joined back to both sources and citations with uncited entries flagged, never
+dropped. Served by `tools/osint_mcp/` (read-only, 15 project servers), each
+tool annotated for the `corroboration` / `reliability_card` /
+`contradiction_ledger` panels surfaced via R2 discovery under the `osint`
+`ui_flag`.
+
 **R11 — OSINT investigation surface** *(Track OSINT, phase 2)*
 `entity_dossier`, `relationship_path`, `timeline_reconstruct`;
 "investigation" formalized as a provisioned KG with audit trail;

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -140,6 +140,27 @@ The harness is `scripts/provisioning/acceptance.py`, the regression is
 `tests/unit/provisioning/test_acceptance.py`, and the write-up (with the
 friction fed back into R8) is `docs/provisioning-acceptance.md`.
 
+### OSINT composition (`src/osint/`, R10)
+
+Defensive, analytical primitives over already-ingested public documents, each a
+pure composition of layers Noesis already builds (M6 claims, the RAG evidence
+links, the semantic conflict edges, the outlet/source scores). Nothing crawls,
+targets or de-anonymizes; the tools only read the warehouse.
+`corroborate(claim_id)` counts the independent sources (by distinct outlet,
+excluding the claim's own source) that support or contradict a claim, each
+weighted by its transparency composite, and flags a claim as `single_sourced`
+rather than emitting a single confidence number. `source_reliability(source)`
+generalizes the outlet transparency score to any source_type (blogs, papers,
+filings) and adds a corroboration hit-rate and a disputed-claim rate,
+honesty-wrapped with a track-record-weighted interval. `contradiction_scan(topic
+| entity)` reads the CONTRADICTS edges and joins each pair back to both sources
+and citations, flagging uncited entries rather than hiding them. Served by
+`tools/osint_mcp/` (read-only) and surfaced through R2 discovery under the
+`osint` `ui_flag` as the `corroboration`, `reliability_card` and
+`contradiction_ledger` panels. The panels render the uncertainty and
+citation fields from demo data today; live panel data arrives with the MCP
+data proxy (R12).
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -365,6 +365,40 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="kg",
     ),
+    # OSINT composition (R10 / Track OSINT), gated by the `osint` ui_flag;
+    # pure-composition reads over the existing claim / evidence / conflict
+    # layers.
+    PanelDef(
+        type="corroboration",
+        title="Claim corroboration",
+        description="Independent sources supporting or contradicting a claim, weighted by source credibility; single-sourced claims are flagged, never given a false confidence.",
+        endpoint=None,
+        facets=("claims", "sources", "conflict"),
+        tables=("argument_claims",),
+        ui_flag="osint",
+        default_span=6,
+    ),
+    PanelDef(
+        type="reliability_card",
+        title="Source reliability",
+        description="OSINT source vetting: the outlet transparency score generalized to any source type, with corroboration hit-rate and correction history.",
+        endpoint=None,
+        facets=("sources",),
+        tables=("outlet_scores",),
+        ui_flag="osint",
+        default_span=6,
+    ),
+    PanelDef(
+        type="contradiction_ledger",
+        title="Contradiction ledger",
+        description="Where the public record disagrees with itself: contradicting claim pairs with both sources and citations; uncited entries are flagged, never hidden.",
+        endpoint=None,
+        facets=("conflict", "claims"),
+        tables=("claim_conflicts",),
+        ui_flag="osint",
+        default_span=6,
+        topic_param="topic",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)

--- a/src/genui/planner.py
+++ b/src/genui/planner.py
@@ -42,6 +42,7 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
         "verify", "verified", "unverified", "true", "false",
         "misinformation", "disinformation", "evidence", "assertion",
         "unsourced",
+        "corroborate", "corroboration", "corroborated", "independent", "osint",
     ),
     "stance": (
         "stance", "stances", "support", "supports", "supportive", "oppose",
@@ -64,6 +65,7 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
         "transparency", "media", "publisher", "publishers",
         "leads", "lead", "leader", "leaders", "follows", "follow",
         "followers", "agenda", "first", "earliest", "sets",
+        "reliability", "reliable", "vetting", "credibility", "trustworthiness",
     ),
     "entities": (
         "entity", "entities", "network", "graph", "connection",

--- a/src/osint/__init__.py
+++ b/src/osint/__init__.py
@@ -1,0 +1,27 @@
+"""
+OSINT composition plane (MCP rearchitecture plan, R10 / Track OSINT phase 1).
+
+Defensive, analytical primitives over already-ingested public documents. Pure
+composition of the layers Noesis already builds (M6 claims, the RAG
+evidence-link table, the semantic conflict table, and outlet/source scores):
+nothing here crawls, targets, or de-anonymizes anyone.
+
+Modules:
+  * :mod:`~src.osint.corroboration` - ``corroborate(claim_id)``: how many
+    *independent* sources support or contradict a claim, weighted by source
+    credibility. Never collapses to a single confidence number.
+  * :mod:`~src.osint.reliability` - ``source_reliability(source)``: the outlet
+    transparency scoring generalized to any ``source_type``, plus a
+    corroboration hit-rate and correction history.
+  * :mod:`~src.osint.contradictions` - ``contradiction_scan(entity|topic)``:
+    where the public record disagrees with itself, from the CONTRADICTS edges,
+    every entry cited (uncited flagged, never hidden).
+
+Stdlib-only; the caller injects a read-only DuckDB connection.
+"""
+
+from src.osint.contradictions import contradiction_scan
+from src.osint.corroboration import corroborate
+from src.osint.reliability import source_reliability
+
+__all__ = ["corroborate", "source_reliability", "contradiction_scan"]

--- a/src/osint/common.py
+++ b/src/osint/common.py
@@ -1,0 +1,103 @@
+"""
+Shared read helpers for the OSINT composition tools.
+
+All three tools need the same two joins: from a claim to the *source* that
+carried it (``argument_claims.document_id`` to ``news_articles.source``), and
+from a source to its *credibility* (the latest ``outlet_scores.composite_score``).
+Kept in one place so corroboration, reliability and contradiction-scan agree on
+what "source" and "credibility" mean.
+
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+# Credibility assumed for a source with no transparency score yet. Neutral, so
+# an unscored source neither helps nor hurts a corroboration tally.
+DEFAULT_CREDIBILITY = 0.5
+
+
+def table_exists(conn, table: str) -> bool:
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def claim_sources(conn, claim_ids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Map each claim_id to its carrying source: ``{source, source_type, url,
+    document_id}``. Resolves the outlet name via ``news_articles`` when the
+    claim's document is a news article, else falls back to the claim's
+    ``source_type`` as the source label."""
+    if not claim_ids or not table_exists(conn, "argument_claims"):
+        return {}
+    ph = ", ".join("?" for _ in claim_ids)
+    has_articles = table_exists(conn, "news_articles")
+    if has_articles:
+        rows = conn.execute(
+            f"""
+            SELECT c.claim_id, c.source_type, c.document_id,
+                   a.source, a.url
+            FROM argument_claims c
+            LEFT JOIN news_articles a ON c.document_id = a.id
+            WHERE c.claim_id IN ({ph})
+            """,
+            list(claim_ids),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT claim_id, source_type, document_id, NULL, NULL "
+            f"FROM argument_claims WHERE claim_id IN ({ph})",
+            list(claim_ids),
+        ).fetchall()
+    out: Dict[str, Dict[str, Any]] = {}
+    for r in rows:
+        claim_id, source_type, document_id, source, url = r
+        out[claim_id] = {
+            "source": source or source_type or "unknown",
+            "source_type": source_type,
+            "document_id": document_id,
+            "url": url,
+            # True only when the claim's document resolved to a real corpus
+            # article; a dangling document_id does not count as a citation.
+            "resolved": source is not None,
+        }
+    return out
+
+
+def source_credibility(conn, sources: Sequence[str]) -> Dict[str, Optional[float]]:
+    """Latest ``composite_score`` per source from ``outlet_scores`` (None when
+    the source has never been scored)."""
+    uniq = [s for s in dict.fromkeys(sources) if s]
+    if not uniq or not table_exists(conn, "outlet_scores"):
+        return {s: None for s in uniq}
+    ph = ", ".join("?" for _ in uniq)
+    rows = conn.execute(
+        f"""
+        SELECT source, composite_score
+        FROM outlet_scores o
+        WHERE source IN ({ph})
+          AND score_date = (
+            SELECT MAX(score_date) FROM outlet_scores i WHERE i.source = o.source
+          )
+        """,
+        uniq,
+    ).fetchall()
+    scored = {r[0]: (float(r[1]) if r[1] is not None else None) for r in rows}
+    return {s: scored.get(s) for s in uniq}
+
+
+def credibility_or_default(value: Optional[float]) -> float:
+    """A usable credibility weight for tallies (neutral default when unscored)."""
+    return DEFAULT_CREDIBILITY if value is None else value
+
+
+def dedupe_sources(entries: List[Dict[str, Any]]) -> List[str]:
+    """Distinct source names in a list of ``{source: ...}`` rows."""
+    return list(dict.fromkeys(e["source"] for e in entries if e.get("source")))

--- a/src/osint/contradictions.py
+++ b/src/osint/contradictions.py
@@ -1,0 +1,118 @@
+"""
+``contradiction_scan(entity|topic)`` - the public record vs itself (R10 #613).
+
+Surfaces where already-ingested public documents disagree, from the semantic
+conflict edges (``claim_conflicts``, the CONTRADICTS relation). Pure
+composition: it joins each conflicting claim back to its text, source and
+document so every entry is cited. An entry whose document cannot be resolved to
+a citation is *flagged* ``cited: false``, never dropped, so gaps are visible
+rather than hidden.
+
+Scoped by ``topic`` (the conflict table's topic column, or a substring of the
+claim text) or by ``entity`` (a substring of either claim's text). Stdlib-only;
+the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.osint import common
+
+
+def contradiction_scan(
+    conn,
+    topic: Optional[str] = None,
+    entity: Optional[str] = None,
+    limit: int = 40,
+) -> Dict[str, Any]:
+    """A cited contradiction ledger for a topic or entity.
+
+    Returns each contradiction pair with both claims (text, source, citation)
+    and whether it is cited. ``uncited_count`` reports how many entries lack a
+    resolvable citation, so the gap is legible.
+    """
+    if not common.table_exists(conn, "claim_conflicts"):
+        return {"contradictions": [], "count": 0, "topic": topic, "entity": entity,
+                "note": "no conflict layer available"}
+
+    where: List[str] = ["lower(conflict_type) LIKE '%contradict%'"]
+    params: List[Any] = []
+    if topic:
+        where.append("topic ILIKE ?")
+        params.append(f"%{topic}%")
+    params.append(int(limit))
+    rows = conn.execute(
+        f"""
+        SELECT claim_id_a, claim_id_b, conflict_type, topic, similarity_score
+        FROM claim_conflicts
+        WHERE {' AND '.join(where)}
+        ORDER BY similarity_score DESC NULLS LAST
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+
+    all_ids = list({r[0] for r in rows} | {r[1] for r in rows})
+    texts = _claim_texts(conn, all_ids)
+    sources = common.claim_sources(conn, all_ids)
+
+    contradictions = []
+    uncited = 0
+    for r in rows:
+        a = _claim_view(r[0], texts, sources)
+        b = _claim_view(r[1], texts, sources)
+        # Entity filter: keep pairs where either claim mentions the entity.
+        if entity:
+            hay = f"{a['text']} {b['text']}".lower()
+            if entity.lower() not in hay:
+                continue
+        cited = bool(a["cited"] and b["cited"])
+        if not cited:
+            uncited += 1
+        contradictions.append(
+            {
+                "claim_a": a,
+                "claim_b": b,
+                "conflict_type": r[2],
+                "topic": r[3],
+                "similarity": float(r[4]) if r[4] is not None else None,
+                "cited": cited,
+            }
+        )
+
+    return {
+        "contradictions": contradictions,
+        "count": len(contradictions),
+        "uncited_count": uncited,
+        "topic": topic,
+        "entity": entity,
+    }
+
+
+def _claim_texts(conn, claim_ids: List[str]) -> Dict[str, str]:
+    if not claim_ids or not common.table_exists(conn, "argument_claims"):
+        return {}
+    ph = ", ".join("?" for _ in claim_ids)
+    rows = conn.execute(
+        f"SELECT claim_id, claim_text FROM argument_claims WHERE claim_id IN ({ph})",
+        claim_ids,
+    ).fetchall()
+    return {r[0]: r[1] or "" for r in rows}
+
+
+def _claim_view(claim_id: str, texts: Dict[str, str], sources: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    src = sources.get(claim_id, {})
+    document_id = src.get("document_id")
+    url = src.get("url")
+    return {
+        "claim_id": claim_id,
+        "text": (texts.get(claim_id, "") or "")[:220],
+        "source": src.get("source", "unknown"),
+        "source_type": src.get("source_type"),
+        "document_id": document_id,
+        "url": url,
+        # An entry is cited when its claim resolves to a real corpus document;
+        # a dangling document_id is flagged, not hidden.
+        "cited": bool(src.get("resolved")),
+    }

--- a/src/osint/corroboration.py
+++ b/src/osint/corroboration.py
@@ -1,0 +1,210 @@
+"""
+``corroborate(claim_id)`` - the core OSINT primitive (R10 #611).
+
+How many *independent* sources support or contradict a claim, and how good are
+those sources. Pure composition of three layers Noesis already builds:
+
+* the claim itself (``argument_claims``) and its carrying source,
+* the RAG evidence links (``claim_evidence``: SUPPORTS / CONTRADICTS to other
+  documents), and
+* the semantic conflict edges (``claim_conflicts``: another claim contradicts
+  this one),
+
+each source weighted by its credibility (``outlet_scores.composite_score``).
+
+The output is deliberately **not** a single confidence number: it is the count
+of independent supporting and contradicting sources, each with its own
+credibility, plus credibility-weighted tallies. A claim with only its own
+source is flagged ``single_sourced`` so the panel can mark it clearly rather
+than implying corroboration that does not exist.
+
+Honesty-wrapped (``n`` = number of independent corroborating sources).
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.analytics.honesty import analytic_envelope
+from src.osint import common
+
+METHOD = "independent-source corroboration over RAG evidence and conflict edges"
+ASSUMPTIONS = [
+    "independence is by distinct source (outlet); two claims from one source count once",
+    "source credibility is the latest outlet transparency composite (0.5 when unscored)",
+    "absence of evidence is not evidence: a single-sourced claim is flagged, not scored",
+    "reads only already-ingested public documents; no crawling or targeting",
+]
+
+
+def _support_contradict_from_evidence(
+    conn, claim_id: str
+) -> List[Dict[str, Any]]:
+    """Evidence links for this claim: each references an evidence document,
+    whose source and credibility we resolve."""
+    if not common.table_exists(conn, "claim_evidence"):
+        return []
+    has_articles = common.table_exists(conn, "news_articles")
+    if has_articles:
+        rows = conn.execute(
+            """
+            SELECT e.relation, e.evidence_source_type, e.similarity_score,
+                   a.source
+            FROM claim_evidence e
+            LEFT JOIN news_articles a ON e.evidence_document_id = a.id
+            WHERE e.claim_id = ?
+              AND lower(e.relation) IN ('supports', 'contradicts')
+            """,
+            [claim_id],
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT relation, evidence_source_type, similarity_score, NULL "
+            "FROM claim_evidence WHERE claim_id = ? "
+            "AND lower(relation) IN ('supports', 'contradicts')",
+            [claim_id],
+        ).fetchall()
+    out = []
+    for relation, source_type, sim, source in rows:
+        out.append(
+            {
+                "relation": relation.lower(),
+                "source": source or source_type or "unknown",
+                "source_type": source_type,
+                "similarity": float(sim) if sim is not None else None,
+                "via": "evidence",
+            }
+        )
+    return out
+
+
+def _contradict_from_conflicts(conn, claim_id: str) -> List[Dict[str, Any]]:
+    """Semantic conflict edges naming this claim: the other claim contradicts
+    it, so its source is a contradicting source."""
+    if not common.table_exists(conn, "claim_conflicts"):
+        return []
+    rows = conn.execute(
+        """
+        SELECT CASE WHEN claim_id_a = ? THEN claim_id_b ELSE claim_id_a END
+        FROM claim_conflicts
+        WHERE claim_id_a = ? OR claim_id_b = ?
+        """,
+        [claim_id, claim_id, claim_id],
+    ).fetchall()
+    other_ids = [r[0] for r in rows if r[0]]
+    if not other_ids:
+        return []
+    src_map = common.claim_sources(conn, other_ids)
+    out = []
+    for oid in other_ids:
+        info = src_map.get(oid, {})
+        out.append(
+            {
+                "relation": "contradicts",
+                "source": info.get("source", "unknown"),
+                "source_type": info.get("source_type"),
+                "similarity": None,
+                "via": "conflict",
+                "claim_id": oid,
+            }
+        )
+    return out
+
+
+def corroborate(conn, claim_id: str) -> Dict[str, Any]:
+    """Independent-source corroboration for one claim.
+
+    Returns the claim, its own source, the supporting and contradicting
+    sources (each with credibility), the independent-source counts and
+    credibility-weighted tallies, and ``single_sourced`` when nothing
+    independent corroborates it.
+    """
+    if not common.table_exists(conn, "argument_claims"):
+        return {"error": "no claim layer available"}
+    row = conn.execute(
+        "SELECT claim_id, claim_text, document_id, source_type, "
+        "COALESCE(factcheck_verdict, 'unverified') "
+        "FROM argument_claims WHERE claim_id = ?",
+        [claim_id],
+    ).fetchone()
+    if row is None:
+        return {"error": f"claim {claim_id!r} not found"}
+
+    own = common.claim_sources(conn, [claim_id]).get(claim_id, {})
+    own_source = own.get("source", row[3] or "unknown")
+
+    entries = _support_contradict_from_evidence(conn, claim_id)
+    entries += _contradict_from_conflicts(conn, claim_id)
+
+    # A source only counts as independent corroboration if it is not the
+    # claim's own carrying source.
+    support = [
+        e for e in entries if e["relation"] == "supports" and e["source"] != own_source
+    ]
+    contradict = [
+        e for e in entries if e["relation"] == "contradicts" and e["source"] != own_source
+    ]
+
+    cred = common.source_credibility(
+        conn, [e["source"] for e in support + contradict] + [own_source]
+    )
+    for e in support + contradict:
+        e["credibility"] = cred.get(e["source"])
+
+    support_sources = common.dedupe_sources(support)
+    contradict_sources = common.dedupe_sources(contradict)
+
+    def _weighted(sources: List[str]) -> float:
+        return round(
+            sum(common.credibility_or_default(cred.get(s)) for s in sources), 3
+        )
+
+    independent_total = len(set(support_sources) | set(contradict_sources))
+    single_sourced = independent_total == 0
+
+    return analytic_envelope(
+        n=independent_total,
+        method=METHOD,
+        assumptions=ASSUMPTIONS,
+        claim={
+            "claim_id": row[0],
+            "text": (row[1] or "")[:280],
+            "source": own_source,
+            "source_type": row[3],
+            "verdict": row[4],
+            "credibility": cred.get(own_source),
+        },
+        support=_collapse(support, cred),
+        contradict=_collapse(contradict, cred),
+        independent_support_count=len(support_sources),
+        independent_contradict_count=len(contradict_sources),
+        weighted_support=_weighted(support_sources),
+        weighted_contradict=_weighted(contradict_sources),
+        single_sourced=single_sourced,
+    )
+
+
+def _collapse(entries: List[Dict[str, Any]], cred: Dict[str, Optional[float]]) -> List[Dict[str, Any]]:
+    """One row per distinct source, keeping the strongest similarity seen and
+    how the corroboration was found."""
+    by_source: Dict[str, Dict[str, Any]] = {}
+    for e in entries:
+        cur = by_source.get(e["source"])
+        if cur is None:
+            by_source[e["source"]] = {
+                "source": e["source"],
+                "source_type": e.get("source_type"),
+                "credibility": cred.get(e["source"]),
+                "via": e["via"],
+                "similarity": e.get("similarity"),
+            }
+        else:
+            if (e.get("similarity") or 0) > (cur.get("similarity") or 0):
+                cur["similarity"] = e.get("similarity")
+    # Highest-credibility sources first (None sorts last).
+    return sorted(
+        by_source.values(),
+        key=lambda r: (r["credibility"] is not None, r["credibility"] or 0),
+        reverse=True,
+    )

--- a/src/osint/reliability.py
+++ b/src/osint/reliability.py
@@ -1,0 +1,145 @@
+"""
+``source_reliability(source)`` - OSINT source vetting (R10 #612).
+
+The outlet transparency machinery generalized to any ``source_type`` (blogs,
+papers, transcripts, filings), so a source can be vetted the same way an outlet
+is. Composes three signals:
+
+* **transparency**: the latest ``outlet_scores`` composite for the source (the
+  same score path outlets use; it keys on ``source``, not on being news), plus
+  its attribution / frame-diversity / neutrality components,
+* **corroboration hit-rate**: of this source's claims, the fraction that at
+  least one independent source supports (from ``claim_evidence``), and
+* **correction history**: how often the source's claims were later disputed
+  (``factcheck_verdict``), a cheap stand-in for a formal correction log.
+
+The reliability figure is honesty-wrapped and always carries an interval whose
+width shrinks with the source's track-record size, so a thinly-evidenced
+source reads as uncertain rather than authoritative.
+
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict
+
+from src.analytics.honesty import analytic_envelope, interval
+from src.osint import common
+
+METHOD = "outlet transparency scoring generalized to any source_type"
+ASSUMPTIONS = [
+    "reliability blends transparency, corroboration hit-rate and a clean-record rate",
+    "transparency reuses the outlet composite score, which keys on source not on being news",
+    "corroboration hit-rate needs claims with evidence; sparse sources carry wide intervals",
+    "correction history approximated by disputed fact-check verdicts on the source's claims",
+]
+
+
+def _track_record(conn, source: str) -> Dict[str, Any]:
+    if not common.table_exists(conn, "news_articles"):
+        return {"documents": 0, "last_seen": None}
+    row = conn.execute(
+        "SELECT COUNT(*), MAX(publish_date) FROM news_articles WHERE source = ?",
+        [source],
+    ).fetchone()
+    return {
+        "documents": int(row[0] or 0),
+        "last_seen": str(row[1]) if row and row[1] is not None else None,
+    }
+
+
+def _claim_record(conn, source: str) -> Dict[str, Any]:
+    """Corroboration hit-rate and disputed-rate over the source's claims."""
+    if not (
+        common.table_exists(conn, "argument_claims")
+        and common.table_exists(conn, "news_articles")
+    ):
+        return {"claims": 0, "corroborated": 0, "disputed": 0}
+    claim_rows = conn.execute(
+        """
+        SELECT c.claim_id, COALESCE(c.factcheck_verdict, '')
+        FROM argument_claims c
+        JOIN news_articles a ON c.document_id = a.id
+        WHERE a.source = ?
+        """,
+        [source],
+    ).fetchall()
+    claim_ids = [r[0] for r in claim_rows]
+    disputed = sum(1 for r in claim_rows if r[1].lower() in ("disputed", "false", "refuted"))
+    corroborated = 0
+    if claim_ids and common.table_exists(conn, "claim_evidence"):
+        ph = ", ".join("?" for _ in claim_ids)
+        supported = {
+            r[0]
+            for r in conn.execute(
+                f"SELECT DISTINCT claim_id FROM claim_evidence "
+                f"WHERE claim_id IN ({ph}) AND lower(relation) = 'supports'",
+                claim_ids,
+            ).fetchall()
+        }
+        corroborated = len(supported)
+    return {"claims": len(claim_ids), "corroborated": corroborated, "disputed": disputed}
+
+
+def source_reliability(conn, source: str) -> Dict[str, Any]:
+    """Reliability card for any source: transparency, corroboration hit-rate,
+    correction history, and a track-record-weighted reliability interval."""
+    track = _track_record(conn, source)
+    claims = _claim_record(conn, source)
+
+    # Transparency component (the outlet composite), if the source has been scored.
+    components: Dict[str, Any] = {}
+    transparency = None
+    if common.table_exists(conn, "outlet_scores"):
+        row = conn.execute(
+            """
+            SELECT composite_score, attribution_rate, frame_diversity, stance_neutrality
+            FROM outlet_scores o
+            WHERE source = ?
+              AND score_date = (SELECT MAX(score_date) FROM outlet_scores i WHERE i.source = o.source)
+            """,
+            [source],
+        ).fetchone()
+        if row is not None:
+            transparency = float(row[0]) if row[0] is not None else None
+            components = {
+                "transparency": round(transparency, 3) if transparency is not None else None,
+                "attribution_rate": round(float(row[1]), 3) if row[1] is not None else None,
+                "frame_diversity": round(float(row[2]), 3) if row[2] is not None else None,
+                "stance_neutrality": round(float(row[3]), 3) if row[3] is not None else None,
+            }
+
+    total_claims = claims["claims"]
+    hit_rate = (claims["corroborated"] / total_claims) if total_claims else 0.0
+    clean_rate = (1.0 - claims["disputed"] / total_claims) if total_claims else 1.0
+    components["corroboration_hit_rate"] = round(hit_rate, 3)
+    components["clean_record_rate"] = round(clean_rate, 3)
+
+    parts = [p for p in (transparency, hit_rate, clean_rate) if p is not None]
+    composite = sum(parts) / len(parts) if parts else common.DEFAULT_CREDIBILITY
+
+    # Interval width shrinks with evidence: more documents, tighter band.
+    evidence = max(track["documents"], total_claims, 1)
+    half = 0.3 / math.sqrt(evidence)
+
+    return analytic_envelope(
+        n=evidence,
+        method=METHOD,
+        assumptions=ASSUMPTIONS,
+        source=source,
+        found=track["documents"] > 0 or total_claims > 0,
+        reliability=interval(
+            composite, max(0.0, composite - half), min(1.0, composite + half)
+        ),
+        components=components,
+        track_record={
+            "documents": track["documents"],
+            "claims": total_claims,
+            "last_seen": track["last_seen"],
+        },
+        corroboration={"corroborated_claims": claims["corroborated"], "total_claims": total_claims},
+        corrections={"disputed_claims": claims["disputed"]},
+        scored_as_outlet=transparency is not None,
+    )

--- a/tests/unit/genui/test_genui_annotations.py
+++ b/tests/unit/genui/test_genui_annotations.py
@@ -35,6 +35,7 @@ ANNOTATED_SERVERS = {
     "neuronews-pipeline": REPO / "tools/pipeline_mcp/server.py",
     "neuronews-research": REPO / "tools/research_mcp/server.py",
     "neuronews-provisioning": REPO / "tools/provisioning_mcp/server.py",
+    "neuronews-osint": REPO / "tools/osint_mcp/server.py",
 }
 
 COMPOSED_PANELS = {"note", "timeline"}  # ADR-001 exemptions

--- a/tests/unit/mcp_host/test_mcp_host_config.py
+++ b/tests/unit/mcp_host/test_mcp_host_config.py
@@ -12,8 +12,8 @@ def test_real_mcp_json_yields_only_project_servers():
     specs = load_server_specs()
     assert DEFAULT_MCP_JSON.exists()
     names = {s.name for s in specs}
-    # All 14 tools/*_mcp servers, and nothing npx-launched.
-    assert len(specs) == 14
+    # All 15 tools/*_mcp servers, and nothing npx-launched.
+    assert len(specs) == 15
     assert "neuronews-kg" in names
     assert "neuronews-pipeline" in names
     assert "memory" not in names

--- a/tests/unit/osint/conftest.py
+++ b/tests/unit/osint/conftest.py
@@ -1,0 +1,103 @@
+"""Fixtures for the OSINT composition tests: a temp DuckDB warehouse seeded
+with the layers the tools compose (news_articles, argument_claims,
+claim_evidence, claim_conflicts, outlet_scores)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _articles(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS news_articles ("
+        "id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO news_articles (id, title, url, source, publish_date) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _claims(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS argument_claims ("
+        "claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO argument_claims (claim_id, claim_text, document_id, "
+            "source_type, confidence, factcheck_verdict) VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _evidence(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS claim_evidence ("
+        "evidence_id VARCHAR, claim_id VARCHAR, evidence_text VARCHAR, "
+        "evidence_document_id VARCHAR, evidence_source_type VARCHAR, "
+        "relation VARCHAR, similarity_score DOUBLE, found_at VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO claim_evidence (evidence_id, claim_id, evidence_document_id, "
+            "evidence_source_type, relation, similarity_score) VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _conflicts(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS claim_conflicts ("
+        "claim_id_a VARCHAR, claim_id_b VARCHAR, conflict_type VARCHAR, "
+        "similarity_score DOUBLE, source_type_a VARCHAR, source_type_b VARCHAR, "
+        "topic VARCHAR, computed_at VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO claim_conflicts (claim_id_a, claim_id_b, conflict_type, "
+            "similarity_score, topic) VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _outlet_scores(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS outlet_scores ("
+        "source VARCHAR, source_type VARCHAR, score_date VARCHAR, "
+        "frame_diversity DOUBLE, attribution_rate DOUBLE, stance_neutrality DOUBLE, "
+        "composite_score DOUBLE, doc_count INTEGER, claim_count INTEGER, computed_at VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO outlet_scores (source, source_type, score_date, "
+            "frame_diversity, attribution_rate, stance_neutrality, composite_score) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+@pytest.fixture
+def conn(tmp_path):
+    c = duckdb.connect(str(tmp_path / "wh.duckdb"))
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def seed(conn):
+    return SimpleNamespace(
+        conn=conn,
+        articles=lambda rows: _articles(conn, rows),
+        claims=lambda rows: _claims(conn, rows),
+        evidence=lambda rows: _evidence(conn, rows),
+        conflicts=lambda rows: _conflicts(conn, rows),
+        outlet_scores=lambda rows: _outlet_scores(conn, rows),
+    )

--- a/tests/unit/osint/test_contradictions.py
+++ b/tests/unit/osint/test_contradictions.py
@@ -1,0 +1,77 @@
+"""Tests for contradiction_scan() (R10 #613)."""
+
+from src.osint import contradiction_scan
+
+
+def _base(seed):
+    seed.articles(
+        [
+            ("d1", "cost fell", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "cost flat", "http://d/1", "Delta Post", "2026-06-01"),
+            ("d3", "rule effective", "http://f/1", "Federal Register", "2026-06-01"),
+        ]
+    )
+    seed.claims(
+        [
+            ("k1", "Storage costs fell 40 percent.", "d1", "news", 0.9, None),
+            ("k2", "Storage costs are flat.", "d2", "news", 0.8, None),
+            ("k3", "The rule takes effect in 90 days.", "d3", "news", 0.9, None),
+            # k4 has no document -> uncited, must be flagged not hidden.
+            ("k4", "The rule is delayed indefinitely.", "missing_doc", "news", 0.5, None),
+        ]
+    )
+
+
+def test_scan_renders_cited_contradiction_ledger(seed):
+    _base(seed)
+    seed.conflicts([("k1", "k2", "contradicts", 0.8, "energy storage")])
+    out = contradiction_scan(seed.conn, topic="storage")
+    assert out["count"] == 1
+    pair = out["contradictions"][0]
+    assert pair["cited"] is True
+    assert {pair["claim_a"]["source"], pair["claim_b"]["source"]} == {"Alpha Wire", "Delta Post"}
+    assert pair["claim_a"]["url"] and pair["claim_b"]["url"]
+
+
+def test_uncited_entry_is_flagged_not_hidden(seed):
+    _base(seed)
+    seed.conflicts([("k3", "k4", "contradicts", 0.7, "emissions rule")])
+    out = contradiction_scan(seed.conn, topic="emissions")
+    assert out["count"] == 1  # not dropped
+    assert out["uncited_count"] == 1
+    pair = out["contradictions"][0]
+    assert pair["cited"] is False
+    # The uncited claim resolves to no document.
+    uncited = pair["claim_b"] if not pair["claim_b"]["cited"] else pair["claim_a"]
+    assert uncited["document_id"] in (None, "missing_doc") and uncited["url"] is None
+
+
+def test_topic_filter_scopes_results(seed):
+    _base(seed)
+    seed.conflicts(
+        [
+            ("k1", "k2", "contradicts", 0.8, "energy storage"),
+            ("k3", "k4", "contradicts", 0.7, "emissions rule"),
+        ]
+    )
+    assert contradiction_scan(seed.conn, topic="storage")["count"] == 1
+    assert contradiction_scan(seed.conn)["count"] == 2  # unscoped: both
+
+
+def test_entity_filter_matches_claim_text(seed):
+    _base(seed)
+    seed.conflicts(
+        [
+            ("k1", "k2", "contradicts", 0.8, "energy storage"),
+            ("k3", "k4", "contradicts", 0.7, "emissions rule"),
+        ]
+    )
+    out = contradiction_scan(seed.conn, entity="rule")
+    assert out["count"] == 1
+    assert "rule" in (out["contradictions"][0]["claim_a"]["text"] + out["contradictions"][0]["claim_b"]["text"]).lower()
+
+
+def test_no_conflicts_table_is_graceful(seed):
+    seed.claims([("k1", "x", "d1", "news", 0.5, None)])
+    out = contradiction_scan(seed.conn, topic="anything")
+    assert out["count"] == 0 and out["contradictions"] == []

--- a/tests/unit/osint/test_corroboration.py
+++ b/tests/unit/osint/test_corroboration.py
@@ -1,0 +1,87 @@
+"""Tests for corroborate() (R10 #611)."""
+
+from src.analytics.honesty import validate_analytic_output
+from src.osint import corroborate
+
+
+def _base(seed):
+    seed.articles(
+        [
+            ("d1", "Alpha claim doc", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Beta support doc", "http://b/1", "Beta Journal", "2026-06-01"),
+            ("d3", "Gamma support doc", "http://g/1", "Gamma Review", "2026-06-01"),
+            ("d4", "Delta counter doc", "http://d/1", "Delta Post", "2026-06-01"),
+        ]
+    )
+    seed.claims(
+        [
+            ("k1", "Emissions rule cuts output 12 percent.", "d1", "news", 0.9, "unverified"),
+            ("k2", "Emissions rule has no measurable effect.", "d4", "news", 0.8, "disputed"),
+            ("lonely", "A claim nobody else touches.", "d1", "news", 0.5, None),
+        ]
+    )
+    seed.outlet_scores(
+        [
+            ("Alpha Wire", "news", "2026-06-01", 0.7, 0.8, 0.7, 0.78),
+            ("Beta Journal", "news", "2026-06-01", 0.8, 0.85, 0.75, 0.81),
+            ("Gamma Review", "news", "2026-06-01", 0.6, 0.6, 0.6, 0.66),
+            ("Delta Post", "news", "2026-06-01", 0.4, 0.4, 0.5, 0.42),
+        ]
+    )
+
+
+def test_counts_independent_sources_for_and_against(seed):
+    _base(seed)
+    # Two independent sources support k1 via evidence; Delta contradicts via a
+    # conflict edge (k2 from Delta Post contradicts k1).
+    seed.evidence(
+        [
+            ("e1", "k1", "d2", "news", "supports", 0.9),
+            ("e2", "k1", "d3", "news", "supports", 0.7),
+        ]
+    )
+    seed.conflicts([("k1", "k2", "contradicts", 0.8, "emissions")])
+
+    out = corroborate(seed.conn, "k1")
+    assert validate_analytic_output(out) == []
+    assert out["independent_support_count"] == 2
+    assert out["independent_contradict_count"] == 1
+    assert {s["source"] for s in out["support"]} == {"Beta Journal", "Gamma Review"}
+    assert out["contradict"][0]["source"] == "Delta Post"
+    assert out["single_sourced"] is False
+    # No single confidence number: weighted tallies, not one score.
+    assert out["weighted_support"] > out["weighted_contradict"]
+    assert "confidence" not in out
+
+
+def test_single_sourced_claim_is_flagged(seed):
+    _base(seed)
+    out = corroborate(seed.conn, "lonely")
+    assert out["single_sourced"] is True
+    assert out["independent_support_count"] == 0
+    assert out["independent_contradict_count"] == 0
+    assert out["n"] == 0
+
+
+def test_same_source_does_not_self_corroborate(seed):
+    _base(seed)
+    # Evidence pointing back at the claim's OWN source (Alpha Wire) must not
+    # count as independent support.
+    seed.evidence([("e1", "k1", "d1", "news", "supports", 0.95)])
+    out = corroborate(seed.conn, "k1")
+    assert out["independent_support_count"] == 0
+    assert out["single_sourced"] is True
+
+
+def test_credibility_weighting_uses_outlet_scores(seed):
+    _base(seed)
+    seed.evidence([("e1", "k1", "d2", "news", "supports", 0.9)])
+    out = corroborate(seed.conn, "k1")
+    support = out["support"][0]
+    assert support["source"] == "Beta Journal"
+    assert abs(support["credibility"] - 0.81) < 1e-6
+
+
+def test_unknown_claim_errors(seed):
+    _base(seed)
+    assert "error" in corroborate(seed.conn, "nope")

--- a/tests/unit/osint/test_reliability.py
+++ b/tests/unit/osint/test_reliability.py
@@ -1,0 +1,60 @@
+"""Tests for source_reliability() (R10 #612)."""
+
+import math
+
+from src.analytics.honesty import validate_analytic_output
+from src.osint import source_reliability
+
+
+def test_reliability_renders_for_a_non_news_source(seed):
+    # A blog venue, scored the same way an outlet is (outlet_scores keys on
+    # source, not on being news).
+    seed.articles(
+        [
+            ("b1", "post one", "http://x/1", "Indie Energy Blog", "2026-06-01"),
+            ("b2", "post two", "http://x/2", "Indie Energy Blog", "2026-06-02"),
+            ("b3", "post three", "http://x/3", "Indie Energy Blog", "2026-06-03"),
+        ]
+    )
+    seed.claims(
+        [
+            ("c1", "Solar beats gas on cost.", "b1", "blog", 0.9, "supported"),
+            ("c2", "Grid can absorb 80 percent renewables.", "b2", "blog", 0.7, "unverified"),
+            ("c3", "A later-disputed claim.", "b3", "blog", 0.6, "disputed"),
+        ]
+    )
+    seed.evidence([("e1", "c1", "z1", "news", "supports", 0.8)])
+    seed.outlet_scores(
+        [("Indie Energy Blog", "blog", "2026-06-03", 0.7, 0.8, 0.7, 0.75)]
+    )
+
+    out = source_reliability(seed.conn, "Indie Energy Blog")
+    assert validate_analytic_output(out, interval_fields=("reliability",)) == []
+    assert out["found"] is True
+    assert out["scored_as_outlet"] is True
+    assert out["track_record"]["documents"] == 3
+    assert out["corroboration"]["corroborated_claims"] == 1  # only c1 has support
+    assert out["corrections"]["disputed_claims"] == 1  # c3
+    assert 0.0 <= out["reliability"]["value"] <= 1.0
+
+
+def test_sparse_source_has_a_wider_interval(seed):
+    seed.articles([("a1", "one doc", "http://y/1", "Thin Source", "2026-06-01")])
+    seed.claims([("c1", "A lone claim.", "a1", "news", 0.5, None)])
+    thin = source_reliability(seed.conn, "Thin Source")
+
+    seed.articles(
+        [(f"m{i}", "doc", f"http://z/{i}", "Rich Source", "2026-06-01") for i in range(20)]
+    )
+    rich = source_reliability(seed.conn, "Rich Source")
+
+    thin_width = thin["reliability"]["hi"] - thin["reliability"]["lo"]
+    rich_width = rich["reliability"]["hi"] - rich["reliability"]["lo"]
+    assert thin_width > rich_width
+
+
+def test_unknown_source_is_not_found_but_still_valid(seed):
+    seed.articles([("a1", "doc", "http://y/1", "Known", "2026-06-01")])
+    out = source_reliability(seed.conn, "Never Heard Of It")
+    assert out["found"] is False
+    assert validate_analytic_output(out, interval_fields=("reliability",)) == []

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -1,0 +1,187 @@
+"""
+NeuroNews OSINT composition - MCP server (R10 / Track OSINT phase 1).
+
+Defensive, analytical primitives over already-ingested public documents, each a
+pure composition of layers Noesis already builds. Nothing here crawls, targets
+or de-anonymizes; the tools only read the warehouse.
+
+Tools (all annotated for R2 discovery under the `osint` ui_flag):
+  corroborate(claim_id)              -> corroboration panel: independent sources
+                                        for/against, weighted by credibility
+  source_reliability(source)         -> reliability card: transparency,
+                                        corroboration hit-rate, corrections
+  contradiction_scan(topic?, entity?)-> contradiction ledger: cited CONTRADICTS
+                                        pairs, uncited flagged not hidden
+
+Design constraints (as for every tool server): stdlib + fastmcp (plus the
+stdlib-only honesty helper) at import time, lazy imports inside tools, the
+warehouse opened READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.analytics.honesty import INTERVAL_SCHEMA, honesty_output_schema  # noqa: E402
+
+mcp = FastMCP("neuronews-osint")
+
+
+def _warehouse_ro():
+    import duckdb
+
+    path = os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"warehouse not found at {path}")
+    return duckdb.connect(path, read_only=True)
+
+
+@mcp.tool(
+    output_schema=honesty_output_schema(
+        {
+            "claim": {"type": "object"},
+            "support": {"type": "array"},
+            "contradict": {"type": "array"},
+            "independent_support_count": {"type": "integer"},
+            "independent_contradict_count": {"type": "integer"},
+            "weighted_support": {"type": "number"},
+            "weighted_contradict": {"type": "number"},
+            "single_sourced": {"type": "boolean"},
+        }
+    ),
+    meta={"panel": {
+        "type": "corroboration",
+        "title": "Claim corroboration",
+        "description": "Independent sources supporting or contradicting a claim, weighted by source credibility; single-sourced claims are flagged, never given a false confidence.",
+        "endpoint": None,
+        "facets": ["claims", "sources", "conflict"],
+        "tables": ["argument_claims"],
+        "ui_flag": "osint",
+        "default_span": 6,
+    }},
+)
+def corroborate(claim_id: str) -> dict:
+    """How many independent sources support or contradict a claim, and how
+    credible they are. Never collapses to a single confidence number.
+
+    Args:
+        claim_id: the claim to corroborate (see argument_mcp.list_claims).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import corroborate as _corroborate
+
+        return _corroborate(con, claim_id)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema=honesty_output_schema(
+        {
+            "source": {"type": "string"},
+            "found": {"type": "boolean"},
+            "reliability": INTERVAL_SCHEMA,
+            "components": {"type": "object"},
+            "track_record": {"type": "object"},
+            "corroboration": {"type": "object"},
+            "corrections": {"type": "object"},
+            "scored_as_outlet": {"type": "boolean"},
+        }
+    ),
+    meta={"panel": {
+        "type": "reliability_card",
+        "title": "Source reliability",
+        "description": "OSINT source vetting: the outlet transparency score generalized to any source type, with corroboration hit-rate and correction history.",
+        "endpoint": None,
+        "facets": ["sources"],
+        "tables": ["outlet_scores"],
+        "ui_flag": "osint",
+        "default_span": 6,
+    }},
+)
+def source_reliability(source: str) -> dict:
+    """Reliability card for any source (blog, paper venue, filing, outlet),
+    scored the same way outlets are.
+
+    Args:
+        source: the source name to vet (see sources_mcp.list_sources).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import source_reliability as _reliability
+
+        return _reliability(con, source)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "contradictions": {"type": "array"},
+            "count": {"type": "integer"},
+            "uncited_count": {"type": "integer"},
+            "topic": {"type": ["string", "null"]},
+            "entity": {"type": ["string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "contradiction_ledger",
+        "title": "Contradiction ledger",
+        "description": "Where the public record disagrees with itself: contradicting claim pairs with both sources and citations; uncited entries are flagged, never hidden.",
+        "endpoint": None,
+        "facets": ["conflict", "claims"],
+        "tables": ["claim_conflicts"],
+        "ui_flag": "osint",
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def contradiction_scan(
+    topic: Optional[str] = None, entity: Optional[str] = None
+) -> dict:
+    """Contradiction pairs on a topic or entity, each cited back to its source
+    document. Uncited entries are flagged, not dropped.
+
+    Args:
+        topic: optional topic filter (conflict topic or claim-text substring).
+        entity: optional entity filter (substring of either claim's text).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import contradiction_scan as _scan
+
+        return _scan(con, topic=topic, entity=entity)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

R10 opens the OSINT plane (Track OSINT, phase 1): defensive, analytical primitives over already-ingested public documents, each a pure composition of layers Noesis already builds (M6 claims, the RAG evidence links, the semantic conflict edges, the outlet/source scores). Nothing here crawls, targets, or de-anonymizes; the tools only read the warehouse.

Closes #611, #612, #613.

## What landed

New `src/osint/` package (stdlib-only; the connection is injected read-only):

- `corroboration.py`: `corroborate(claim_id)` counts the independent sources that support or contradict a claim (by distinct outlet, excluding the claim's own source), each weighted by its transparency composite. It flags a claim as `single_sourced` rather than inventing a single confidence number, and returns credibility-weighted support and contradict tallies instead.
- `reliability.py`: `source_reliability(source)` generalizes the outlet transparency score to any `source_type` (blogs, paper venues, filings), adding a corroboration hit-rate and a disputed-claim rate. Honesty-wrapped with a track-record-weighted interval, so a thin source reads as uncertain rather than authoritative.
- `contradictions.py`: `contradiction_scan(topic | entity)` reads the CONTRADICTS edges and joins each pair back to both sources and their citations. Uncited entries are flagged (`cited: false`, counted in `uncited_count`), never dropped.

Served by `tools/osint_mcp/server.py` (read-only), registered in `.mcp.json` (15 project servers). Each tool is annotated for R2 discovery under the `osint` `ui_flag`, surfacing the `corroboration`, `reliability_card` and `contradiction_ledger` panels (catalog, codegen, frontend renderers, planner keywords).

## Verification

- `tests/unit/osint` (13 tests) plus `tests/unit/provisioning tests/unit/genui tests/unit/mcp_host tests/unit/analytics`: 414 passed, and the genui route smoke/coverage suite passes. Frontend `tsc --noEmit` clean. `codegen.py --check` reports artifacts current.
- Live run over the real OSINT MCP server on a temp warehouse:

```
STEP 1 corroborate(k1): 2 for, 2 against, weighted_support=1.47, single_sourced=False
STEP 2 source_reliability(Beta Journal): reliability=0.60 [0.30,0.90] scored_as_outlet=True
STEP 3 contradiction_scan(emissions): count=2 uncited=1
STEP 4 discovery: corroboration / reliability_card / contradiction_ledger all sourced from neuronews-osint
RESULT: OK
```

## Exit criteria

- #611: a corroboration panel shows independent-source counts weighted by credibility; single-source claims are marked; never a single confidence number.
- #612: a reliability card renders for a non-news source (a blog venue) using the same scoring path as outlets.
- #613: scanning a topic with contradictory claims renders a cited contradiction ledger, with uncited entries flagged rather than hidden.