### PR TITLE
R11: OSINT investigation surface, dossier, relationship path, timeline, investigations

### DIFF
--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -37,7 +37,10 @@ export type PanelType =
   | "provisioned_kg"
   | "corroboration"
   | "reliability_card"
-  | "contradiction_ledger";
+  | "contradiction_ledger"
+  | "entity_dossier"
+  | "relationship_path"
+  | "evidence_timeline";
 
 export type Facet =
   | "overview"
@@ -100,6 +103,9 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "corroboration", title: "Claim corroboration", facets: ["claims", "sources", "conflict"], defaultSpan: 6 },
   { type: "reliability_card", title: "Source reliability", facets: ["sources"], defaultSpan: 6 },
   { type: "contradiction_ledger", title: "Contradiction ledger", facets: ["conflict", "claims"], defaultSpan: 6, topicParam: true },
+  { type: "entity_dossier", title: "Entity dossier", facets: ["entities", "actors"], defaultSpan: 6, topicParam: true },
+  { type: "relationship_path", title: "Connection path", facets: ["entities", "actors"], defaultSpan: 6 },
+  { type: "evidence_timeline", title: "Evidence timeline", facets: ["events", "trend", "claims"], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/planner.ts
+++ b/apps/web/src/genui/planner.ts
@@ -14,10 +14,10 @@ const FACET_KEYWORDS: Record<Facet, string[]> = {
   sentiment: ["sentiment", "tone", "mood", "feeling", "positive", "negative", "emotion", "optimism", "pessimism"],
   claims: ["claim", "claims", "fact", "facts", "factcheck", "fact-check", "verify", "verified", "unverified", "true", "false", "misinformation", "disinformation", "evidence", "assertion", "unsourced", "corroborate", "corroboration", "corroborated", "independent", "osint"],
   stance: ["stance", "stances", "support", "supports", "supportive", "oppose", "opposes", "opposition", "critical", "position", "positions", "agree", "agrees", "disagree", "disagrees", "pro", "against"],
-  actors: ["who", "actor", "actors", "stakeholder", "stakeholders", "politician", "politicians", "speaker", "speakers", "people", "person", "says", "said", "voices"],
+  actors: ["who", "actor", "actors", "stakeholder", "stakeholders", "politician", "politicians", "speaker", "speakers", "people", "person", "says", "said", "voices", "dossier", "brief", "investigate", "investigation", "profile"],
   conflict: ["conflict", "conflicts", "controversy", "controversial", "contradict", "contradicts", "contradiction", "contradictions", "dispute", "disputes", "disagreement", "clash", "debate"],
   sources: ["outlet", "outlets", "source", "sources", "bias", "biased", "framing", "frame", "frames", "coverage", "compare", "comparison", "transparency", "media", "publisher", "publishers", "leads", "lead", "leader", "leaders", "follows", "follow", "followers", "agenda", "first", "earliest", "sets"],
-  entities: ["entity", "entities", "network", "graph", "connection", "connections", "related", "relationship", "relationships", "influence", "knowledge graph", "provisioned", "provisioning", "namespace", "namespaces", "deployed kg"],
+  entities: ["entity", "entities", "network", "graph", "connection", "connections", "related", "relationship", "relationships", "influence", "knowledge graph", "provisioned", "provisioning", "namespace", "namespaces", "deployed kg", "path", "dossier", "connected to", "linked"],
   events: ["event", "events", "cluster", "clusters", "story", "stories", "breaking", "timeline", "happening", "developments", "watchlist", "watchlists", "alert", "alerts"],
   library: ["library", "document", "documents", "docs", "archive", "reading", "publications", "ingested", "corpus", "paper", "papers", "research", "scholarly", "academic", "literature", "citation", "citations", "cite", "cited", "venue", "venues", "journal", "journals", "peer-reviewed", "preprint", "study", "studies"],
 };

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1191,6 +1191,121 @@ function ContradictionLedgerPanel(props: PanelProps) {
   );
 }
 
+const DEMO_DOSSIER = {
+  entity: "Jordan Rivera",
+  is_person: true,
+  mention_count: 12,
+  aliases: ["J. Rivera", "Jordan A. Rivera"],
+  first_seen: "2025-11-03",
+  last_seen: "2026-06-21",
+  mentions: [
+    { title: "Rivera testifies on grid resilience", source: "Alpha Wire", role: "speaker", cited: true },
+    { title: "Committee questions Rivera on costs", source: "Beta Journal", role: "subject", cited: true },
+    { title: "Unattributed brief names Rivera", source: "unknown", role: "subject", cited: false },
+  ],
+  connected_entities: [
+    { entity: "Grid Authority", shared_documents: 5 },
+    { entity: "Sen. Park", shared_documents: 3 },
+  ],
+};
+
+function EntityDossierPanel(props: PanelProps) {
+  const d = DEMO_DOSSIER;
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span style={{ fontSize: 14, fontWeight: 600 }}>{d.entity}</span>
+        {d.is_person ? <span style={{ ...chip(palette.amber) }}>person</span> : null}
+        <span style={{ ...mono }}>{d.mention_count} mentions</span>
+      </div>
+      <div style={{ ...mono, marginTop: 2 }}>
+        aka {d.aliases.join(", ")} ; seen {d.first_seen} to {d.last_seen}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 6 }}>
+        {d.mentions.map((m, i) => (
+          <div key={i} style={{ display: "flex", gap: 6, alignItems: "flex-start", fontSize: 11.5 }}>
+            <span style={{ ...chip(m.cited ? palette.teal : palette.amber), marginTop: 2 }}>{m.cited ? m.source : "uncited"}</span>
+            <span style={{ flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{m.title}</span>
+            <span style={{ ...mono }}>{m.role}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 6 }}>
+        <div style={{ ...mono, color: palette.teal }}>connected</div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {d.connected_entities.map((c) => (
+            <span key={c.entity} style={{ ...chip(palette.dim) }}>{c.entity} ({c.shared_documents})</span>
+          ))}
+        </div>
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>every line links to its source document; person facts document-sourced only</div>
+    </GenPanel>
+  );
+}
+
+const DEMO_PATH = {
+  path: ["Jordan Rivera", "Grid Authority", "Delphi Energy"],
+  hops: 2,
+  edges: [
+    { from: "Jordan Rivera", to: "Grid Authority", shared_documents: 5 },
+    { from: "Grid Authority", to: "Delphi Energy", shared_documents: 2 },
+  ],
+};
+
+function RelationshipPathPanel(props: PanelProps) {
+  const p = DEMO_PATH;
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ ...mono, marginBottom: 6 }}>{p.hops} hops</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {p.edges.map((e, i) => (
+          <div key={i}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12.5 }}>
+              <span style={{ fontWeight: 600 }}>{e.from}</span>
+              <span style={{ color: palette.dim }}>to</span>
+              <span style={{ fontWeight: 600 }}>{e.to}</span>
+            </div>
+            <div style={{ ...mono, color: palette.teal }}>{e.shared_documents} shared documents (cited evidence)</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>each edge carries the cited documents that establish it</div>
+    </GenPanel>
+  );
+}
+
+const DEMO_TIMELINE = [
+  { date: "2025-11-03", claim_count: 1, corroboration_density: 1, state: "single_sourced", entries: [{ text: "Rule first proposed.", source: "Alpha Wire", cited: true }] },
+  { date: "2026-02-14", claim_count: 3, corroboration_density: 3, state: "cited", entries: [{ text: "Three outlets confirm the delay.", source: "Beta Journal", cited: true }] },
+  { date: "2026-06-21", claim_count: 1, corroboration_density: 0, state: "uncited", entries: [{ text: "Anonymous brief claims reversal.", source: "unknown", cited: false }] },
+];
+
+const STATE_COLOR: Record<string, string> = { cited: palette.pos, single_sourced: palette.amber, uncited: palette.neg };
+
+function EvidenceTimelinePanel(props: PanelProps) {
+  return (
+    <GenPanel {...props} source="demo">
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {DEMO_TIMELINE.map((ev, i) => (
+          <div key={i} style={{ borderLeft: `2px solid ${STATE_COLOR[ev.state] ?? palette.dim}`, paddingLeft: 10 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+              <span style={{ fontFamily: fonts.mono, fontSize: 12 }}>{ev.date}</span>
+              <span style={{ ...chip(STATE_COLOR[ev.state] ?? palette.dim) }}>{ev.corroboration_density} sources</span>
+            </div>
+            {ev.entries.map((e, j) => (
+              <div key={j} style={{ fontSize: 11.5, marginTop: 2 }}>
+                {e.text}
+                <span style={{ ...mono, marginLeft: 6, color: e.cited ? palette.teal : palette.amber }}>{e.cited ? e.source : "uncited"}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <div style={{ ...mono, marginTop: 4 }}>corroboration density per event; uncited entries flagged, never hidden</div>
+    </GenPanel>
+  );
+}
+
 function UnknownPanel(props: PanelProps) {
   return (
     <GenPanel {...props}>
@@ -1232,6 +1347,9 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   corroboration: CorroborationPanel,
   reliability_card: ReliabilityCardPanel,
   contradiction_ledger: ContradictionLedgerPanel,
+  entity_dossier: EntityDossierPanel,
+  relationship_path: RelationshipPathPanel,
+  evidence_timeline: EvidenceTimelinePanel,
 };
 
 export function panelComponent(type: string): ComponentType<PanelProps> {

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -667,6 +667,27 @@ ship later or not at all.
 *Exit:* an entity brief where every line links to its source document;
 guardrail tests prove person-tools refuse non-document-sourced facts.
 
+*Delivered.* The investigation surface extends `src/osint/` (stdlib-only,
+pure composition over `document_actors` / `argument_claims` /
+`news_articles`; the connection is injected read-only): `evidence.py` is the
+shared evidence discipline (a citation on every line, the cited /
+single_sourced / uncited render states); `dossier.py` is
+`entity_dossier(entity)`, a cited brief (mentions, aliases, first/last seen,
+connected entities) with the person-entity guardrail enforced in code, a
+person with no ingested document is refused rather than described from
+inference; `paths.py` is `relationship_path(a, b)`, the shortest co-mention
+path with the establishing documents cited on every edge and resolution
+ambiguity surfaced; `timeline.py` is `timeline_reconstruct(topic|entity)`,
+dated cited claims bucketed into events each carrying its corroboration
+density. `investigations.py` formalizes an investigation as a Track
+P-provisioned KG reconstructable from its provisioning audit trail
+(`investigation_audit`), supplies the OSINT-dominant empty-canvas telemetry
+(open threads / newly corroborated / newly contradicted), and names the
+review-gated `geolocate_claims` / `narrative_coordination` (absent from the
+served surface, enforced by a test; gate in `docs/osint-review-gate.md`).
+Served by `tools/osint_mcp/` as the `entity_dossier`, `relationship_path` and
+`evidence_timeline` panels via R2 discovery under the `osint` `ui_flag`.
+
 ### Ecosystem
 
 **R12 — Data-plane benchmark and Stage 3 decision** *(Stage 3 gate)*

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -161,6 +161,24 @@ and citations, flagging uncited entries rather than hiding them. Served by
 citation fields from demo data today; live panel data arrives with the MCP
 data proxy (R12).
 
+The investigation surface (R11) extends the same package under one evidence
+discipline (`src/osint/evidence.py`: a citation on every line, the cited /
+single_sourced / uncited render states). `entity_dossier(entity)` is a cited
+brief (mentions, aliases, first/last seen, connected entities) with a
+person-entity guardrail enforced in code: a person with no ingested document
+is refused, never described from inference. `relationship_path(a, b)` is the
+shortest co-mention path between two entities with the establishing documents
+cited on every edge and resolution ambiguity surfaced.
+`timeline_reconstruct(topic | entity)` buckets dated cited claims into events,
+each carrying its corroboration density. An investigation is a Track
+P-provisioned KG reconstructable from its audit trail (`investigation_audit`),
+and the OSINT-dominant empty canvas leads with open threads / newly
+corroborated / newly contradicted. The most abusable tools
+(`geolocate_claims`, `narrative_coordination`) stay behind the review gate in
+`docs/osint-review-gate.md`, absent from the served surface until it passes.
+These surface as the `entity_dossier`, `relationship_path` and
+`evidence_timeline` panels.
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/docs/osint-review-gate.md
+++ b/docs/osint-review-gate.md
@@ -1,0 +1,48 @@
+# OSINT review gate (R11)
+
+Track OSINT is defensive and analytical: it reads already-ingested public
+documents and never crawls, targets, or de-anonymizes. Two tools named in the
+plan are the most abusable and the most false-positive-prone, so they stay
+behind an explicit review gate. They are **absent from the served tool
+surface** until this gate passes, and a test
+(`tests/unit/osint/test_investigations.py::test_gated_tools_are_absent`)
+asserts they are not exposed.
+
+## Gated tools
+
+| Tool | Why gated | Constraint if it ever ships |
+|---|---|---|
+| `geolocate_claims` | Location inference is the most abusable OSINT primitive. | Strictly event-geography derived from document content (where an event is reported to have happened), never person location. |
+| `narrative_coordination` | Coordinated-behavior detection is highly false-positive-prone and can smear coincidental cohorts. | Findings flag a cohort for human review, never accuse; every edge cited; a calibrated null model, not a threshold on raw co-occurrence. |
+
+`src/osint/investigations.py` names them in `GATED_TOOLS`; `is_gated(tool)`
+returns True for both. Neither is registered on `tools/osint_mcp/server.py`.
+
+## Gate criteria (must all pass before either tool is served)
+
+1. **Purpose limitation, in code.** `geolocate_claims` resolves only
+   event-geography from document text; a test proves it never emits a person
+   location. `narrative_coordination` outputs cohorts marked "for review" with
+   no accusatory language and a citation on every edge.
+2. **Calibration.** Both reuse the Track DS calibration/conformal work: a
+   documented false-positive rate on a labeled fixture, not an unvalidated
+   threshold.
+3. **Evidence discipline.** Every output line carries a citation
+   (`src/osint/evidence.py`); uncited findings are flagged, never hidden.
+4. **Abuse review.** A written misuse analysis (who could weaponize this, and
+   the mitigations) is reviewed and attached to the enabling PR.
+5. **Human-in-the-loop.** Both are opt-in behind an explicit flag, off by
+   default, and log every invocation to the provisioning audit trail.
+
+Until all five hold, the tools do not ship. This document is the gate; the
+absence test is its enforcement.
+
+## Why "investigation" is a provisioned KG
+
+An investigation is not a new abstraction. It is a Track P-provisioned,
+namespaced knowledge graph (R8) fed by a chosen source set. Every provisioning
+action (deploy, attach, ingest, teardown) is already written to the
+provisioning lineage log, so an investigation is fully reconstructable from its
+audit trail via `investigation_audit(name)`
+(`src/osint/investigations.py`). That gives investigations their accountability
+for free: nothing happens to an investigation that is not logged and replayable.

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -399,6 +399,39 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="topic",
     ),
+    # OSINT investigation surface (R11 / Track OSINT phase 2), gated by osint.
+    PanelDef(
+        type="entity_dossier",
+        title="Entity dossier",
+        description="A cited brief for an entity from ingested public documents: every mention, aliases, first and last seen, and connected entities, each line linked to its source. Person entities require a document; no inference-only facts.",
+        endpoint=None,
+        facets=("entities", "actors"),
+        tables=("document_actors",),
+        ui_flag="osint",
+        default_span=6,
+        topic_param="entity",
+    ),
+    PanelDef(
+        type="relationship_path",
+        title="Connection path",
+        description="How two entities are connected across the corpus, via the shortest co-mention path; each edge carries the cited documents that establish it. Resolution ambiguity is surfaced, not collapsed.",
+        endpoint=None,
+        facets=("entities", "actors"),
+        tables=("document_actors",),
+        ui_flag="osint",
+        default_span=6,
+    ),
+    PanelDef(
+        type="evidence_timeline",
+        title="Evidence timeline",
+        description="A reconstructed event sequence from dated, cited claims, each event carrying its corroboration density (independent-source count); uncited entries flagged.",
+        endpoint=None,
+        facets=("events", "trend", "claims"),
+        tables=("argument_claims",),
+        ui_flag="osint",
+        default_span=6,
+        topic_param="topic",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)

--- a/src/genui/planner.py
+++ b/src/genui/planner.py
@@ -53,6 +53,7 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
         "who", "actor", "actors", "stakeholder", "stakeholders",
         "politician", "politicians", "speaker", "speakers", "people",
         "person", "says", "said", "voices",
+        "dossier", "brief", "investigate", "investigation", "profile",
     ),
     "conflict": (
         "conflict", "conflicts", "controversy", "controversial",
@@ -73,6 +74,7 @@ FACET_KEYWORDS: Dict[str, Tuple[str, ...]] = {
         "influence",
         "knowledge graph", "provisioned", "provisioning", "namespace",
         "namespaces", "deployed kg",
+        "path", "dossier", "connected to", "linked",
     ),
     "events": (
         "event", "events", "cluster", "clusters", "story", "stories",

--- a/src/genui/telemetry.py
+++ b/src/genui/telemetry.py
@@ -114,6 +114,17 @@ def _library_telemetry() -> Dict[str, Any]:
     }
 
 
+def _osint_telemetry() -> Dict[str, Any]:
+    """OSINT-dominant ambient signal from investigations and the claim layer.
+    Empty when there is no OSINT activity, so the library fallback still runs."""
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+    from src.osint import osint_telemetry
+
+    conn = get_shared_connection()
+    with _LOCK:
+        return osint_telemetry(conn)
+
+
 def pack_telemetry() -> Dict[str, Any]:
     """Collect ambient telemetry from whichever packs are enabled.
 
@@ -151,6 +162,28 @@ def pack_telemetry() -> Dict[str, Any]:
         if ticker is None:
             ticker = pack_ticker
         contributing.append(pack.name)
+
+    # OSINT-dominant ambient signal (R11 / Track OSINT phase 2): when
+    # investigations exist, the empty canvas leads with open threads, newly
+    # corroborated and newly contradicted before the library fallback.
+    if not (signals and movers and ticker):
+        try:
+            osint = _osint_telemetry()
+        except Exception:
+            logger.warning("osint telemetry failed", exc_info=True)
+            osint = {}
+        if osint:
+            osint_signals = _clean_signals(osint.get("signals"))
+            osint_movers = _clean_movers(osint.get("movers"))
+            osint_ticker = _clean_ticker(osint.get("ticker"))
+            if osint_signals or osint_movers or osint_ticker:
+                if not signals:
+                    signals = osint_signals
+                if not movers:
+                    movers = osint_movers
+                if ticker is None:
+                    ticker = osint_ticker
+                contributing.append("osint")
 
     # Engine fallback: fill whatever no pack supplied from the corpus.
     if not (signals and movers and ticker):

--- a/src/osint/__init__.py
+++ b/src/osint/__init__.py
@@ -22,6 +22,30 @@ Stdlib-only; the caller injects a read-only DuckDB connection.
 
 from src.osint.contradictions import contradiction_scan
 from src.osint.corroboration import corroborate
+from src.osint.dossier import entity_dossier
+from src.osint.investigations import (
+    GATED_TOOLS,
+    investigation_audit,
+    is_gated,
+    list_investigations,
+    osint_telemetry,
+)
+from src.osint.paths import relationship_path
 from src.osint.reliability import source_reliability
+from src.osint.timeline import timeline_reconstruct
 
-__all__ = ["corroborate", "source_reliability", "contradiction_scan"]
+__all__ = [
+    # R10 composition
+    "corroborate",
+    "source_reliability",
+    "contradiction_scan",
+    # R11 investigation surface
+    "entity_dossier",
+    "relationship_path",
+    "timeline_reconstruct",
+    "investigation_audit",
+    "list_investigations",
+    "osint_telemetry",
+    "GATED_TOOLS",
+    "is_gated",
+]

--- a/src/osint/dossier.py
+++ b/src/osint/dossier.py
@@ -1,0 +1,166 @@
+"""
+``entity_dossier(entity)`` - a cited entity brief (R11 #615).
+
+A brief assembled *only* from already-ingested public documents: every public
+mention, resolved aliases, first and last seen, and the entities connected to
+it, with a citation on every line. The backbone is ``document_actors``, which
+links an entity (actor) to the document it was mentioned in, so every fact is
+document-sourced by construction.
+
+Person-entity guardrail (enforced here, not just documented): a person entity
+must have at least one ingested public document, and only document-sourced
+facts are surfaced. A person with no ingested documents is refused rather than
+described from inference, so the tool never emits an unsourced claim about an
+individual.
+
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.osint import common, evidence
+
+# Roles that denote a human individual, used to infer person-ness when the
+# caller does not pass an explicit entity_type.
+_PERSON_ROLES = {"speaker", "author", "subject", "person", "spokesperson"}
+
+
+def _is_person(conn, entity: str, entity_type: Optional[str]) -> bool:
+    if entity_type and entity_type.strip().lower() in ("person", "people", "individual"):
+        return True
+    if isinstance(entity, str) and entity.lower().startswith("person:"):
+        return True
+    if not common.table_exists(conn, "document_actors"):
+        return False
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT lower(role) FROM document_actors "
+            "WHERE actor_name = ? OR entity_id = ?",
+            [entity, entity],
+        ).fetchall()
+    except Exception:
+        return False
+    roles = {r[0] for r in rows if r[0]}
+    return bool(roles) and roles.issubset(_PERSON_ROLES)
+
+
+def _mentions(conn, entity: str) -> List[Dict[str, Any]]:
+    if not common.table_exists(conn, "document_actors"):
+        return []
+    rows = conn.execute(
+        "SELECT document_id, actor_name, entity_id, role FROM document_actors "
+        "WHERE actor_name = ? OR entity_id = ?",
+        [entity, entity],
+    ).fetchall()
+    doc_ids = [r[0] for r in rows]
+    cites = evidence.document_citations(conn, doc_ids)
+    out = []
+    for document_id, actor_name, entity_id, role in rows:
+        cite = cites.get(document_id, evidence.citation(document_id, None, None))
+        out.append(
+            {
+                "document_id": document_id,
+                "actor_name": actor_name,
+                "entity_id": entity_id,
+                "role": role,
+                "source": cite["source"],
+                "url": cite["url"],
+                "title": cite.get("title"),
+                "cited": cite["cited"],
+            }
+        )
+    return out
+
+
+def _first_last_seen(conn, document_ids: List[str]) -> Dict[str, Optional[str]]:
+    if not document_ids or not common.table_exists(conn, "news_articles"):
+        return {"first_seen": None, "last_seen": None}
+    ph = ", ".join("?" for _ in document_ids)
+    row = conn.execute(
+        f"SELECT MIN(publish_date), MAX(publish_date) FROM news_articles WHERE id IN ({ph})",
+        document_ids,
+    ).fetchone()
+    return {
+        "first_seen": str(row[0]) if row and row[0] is not None else None,
+        "last_seen": str(row[1]) if row and row[1] is not None else None,
+    }
+
+
+def _connected_entities(conn, entity: str, document_ids: List[str], limit: int = 15) -> List[Dict[str, Any]]:
+    """Entities co-mentioned in the same documents, each with the count of
+    shared documents (its evidence weight)."""
+    if not document_ids or not common.table_exists(conn, "document_actors"):
+        return []
+    ph = ", ".join("?" for _ in document_ids)
+    rows = conn.execute(
+        f"SELECT actor_name, COUNT(DISTINCT document_id) AS shared "
+        f"FROM document_actors WHERE document_id IN ({ph}) AND actor_name <> ? "
+        f"GROUP BY actor_name ORDER BY shared DESC LIMIT ?",
+        [*document_ids, entity, int(limit)],
+    ).fetchall()
+    return [{"entity": r[0], "shared_documents": int(r[1])} for r in rows]
+
+
+def _aliases(conn, entity: str) -> List[str]:
+    """Distinct alias spellings that resolve to the same entity_id."""
+    if not common.table_exists(conn, "document_actors"):
+        return []
+    row = conn.execute(
+        "SELECT entity_id FROM document_actors WHERE actor_name = ? AND entity_id IS NOT NULL LIMIT 1",
+        [entity],
+    ).fetchone()
+    if not row or not row[0]:
+        return []
+    rows = conn.execute(
+        "SELECT DISTINCT actor_name FROM document_actors WHERE entity_id = ? AND actor_name <> ?",
+        [row[0], entity],
+    ).fetchall()
+    return [r[0] for r in rows if r[0]]
+
+
+def entity_dossier(conn, entity: str, entity_type: Optional[str] = None) -> Dict[str, Any]:
+    """A cited brief for one entity from ingested public documents.
+
+    Every mention, alias, and connection carries a citation. A person entity
+    with no ingested document is refused (the person-entity guardrail).
+    """
+    if not common.table_exists(conn, "document_actors"):
+        return {"error": "no entity-mention layer available", "entity": entity}
+
+    is_person = _is_person(conn, entity, entity_type)
+    mentions = _mentions(conn, entity)
+
+    if is_person and not mentions:
+        # Person guardrail: never describe an individual from inference.
+        return {
+            "error": (
+                f"person entity {entity!r} has no ingested public document; "
+                f"refusing to surface non-document-sourced facts about an individual"
+            ),
+            "code": "person_requires_documents",
+            "entity": entity,
+            "is_person": True,
+        }
+
+    doc_ids = [m["document_id"] for m in mentions if m["document_id"]]
+    seen = _first_last_seen(conn, doc_ids)
+    cited_mentions = [m for m in mentions if m["cited"]]
+
+    return {
+        "entity": entity,
+        "is_person": is_person,
+        "found": bool(mentions),
+        "mention_count": len(mentions),
+        "cited_mention_count": len(cited_mentions),
+        "uncited_count": evidence.uncited_count(mentions),
+        "aliases": _aliases(conn, entity),
+        "first_seen": seen["first_seen"],
+        "last_seen": seen["last_seen"],
+        "mentions": mentions[:40],
+        "connected_entities": _connected_entities(conn, entity, doc_ids),
+        # Every surfaced fact is document-sourced; there are no inference-only
+        # lines in this payload.
+        "document_sourced_only": True,
+    }

--- a/src/osint/evidence.py
+++ b/src/osint/evidence.py
@@ -1,0 +1,90 @@
+"""
+The evidence discipline, shared by every OSINT investigation tool (R10 #614,
+enforced across R11 #615-#617).
+
+The non-negotiable rule: no fact renders without a citation to its source
+document, "uncited" is a visible state (flagged, never hidden), and
+corroboration is an explicit independent-source count rather than a single
+asserted confidence number. This module is the one place those rules live, so
+the dossier, path and timeline tools cite identically.
+
+* :func:`citation` builds the ``{document_id, source, url, path, cited}``
+  locator every rendered line carries; ``cited`` is False when the document
+  does not resolve to the corpus (the flagged state).
+* :func:`render_state` maps an independent-source count to ``cited`` /
+  ``single_sourced`` / ``uncited`` for a panel to badge.
+
+Stdlib-only; a read-only connection is injected by callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from src.osint import common
+
+
+def citation(
+    document_id: Optional[str],
+    source: Optional[str],
+    url: Optional[str],
+    chunk: Optional[str] = None,
+    resolved: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """A source locator for one rendered line. ``path`` is the citation path
+    (document id plus optional chunk); ``cited`` is True only when the line
+    resolves to a real corpus document."""
+    is_cited = bool(document_id) if resolved is None else bool(resolved)
+    path = None
+    if document_id:
+        path = f"{document_id}#{chunk}" if chunk else str(document_id)
+    return {
+        "document_id": document_id,
+        "source": source or "unknown",
+        "url": url,
+        "path": path,
+        "cited": is_cited,
+    }
+
+
+def render_state(independent_sources: int) -> str:
+    """The evidence render state for a fact backed by ``independent_sources``
+    distinct sources: none is ``uncited``, one is ``single_sourced``, more is
+    ``cited`` (corroborated)."""
+    if independent_sources <= 0:
+        return "uncited"
+    if independent_sources == 1:
+        return "single_sourced"
+    return "cited"
+
+
+def document_citations(conn, document_ids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Resolve document ids to citations via ``news_articles``. A document id
+    with no matching article yields a citation with ``cited=False`` so the gap
+    is visible."""
+    uniq = [d for d in dict.fromkeys(document_ids) if d]
+    out: Dict[str, Dict[str, Any]] = {}
+    resolved: Dict[str, Any] = {}
+    if uniq and common.table_exists(conn, "news_articles"):
+        ph = ", ".join("?" for _ in uniq)
+        for r in conn.execute(
+            f"SELECT id, source, url, title FROM news_articles WHERE id IN ({ph})",
+            uniq,
+        ).fetchall():
+            resolved[r[0]] = {"source": r[1], "url": r[2], "title": r[3]}
+    for d in uniq:
+        info = resolved.get(d)
+        out[d] = citation(
+            d,
+            (info or {}).get("source"),
+            (info or {}).get("url"),
+            resolved=info is not None,
+        )
+        if info is not None:
+            out[d]["title"] = info.get("title")
+    return out
+
+
+def uncited_count(rows: List[Dict[str, Any]], key: str = "cited") -> int:
+    """How many rows are in the uncited (flagged) state."""
+    return sum(1 for r in rows if not r.get(key))

--- a/src/osint/investigations.py
+++ b/src/osint/investigations.py
@@ -1,0 +1,127 @@
+"""
+Investigations as provisioned KGs, plus the review gate (R11 #618).
+
+An "investigation" is not a new abstraction: it is a Track P-provisioned,
+namespaced knowledge graph (R8) fed by a chosen source set. Because every
+provisioning action (deploy / attach / ingest / teardown) is already written to
+the provisioning lineage log, an investigation is fully reconstructable from
+its audit trail. :func:`investigation_audit` replays that trail.
+
+The review gate: ``geolocate_claims`` and ``narrative_coordination`` are the
+most abusable and false-positive-prone tools. They stay behind an explicit
+review gate: they are **absent** from the served tool surface until the gate
+documented in ``docs/osint-review-gate.md`` passes. :data:`GATED_TOOLS` names
+them so a test can assert they are not exposed.
+
+:func:`osint_telemetry` supplies the empty-canvas ambient signal when the OSINT
+surface dominates: open investigation threads, newly corroborated and newly
+contradicted claims.
+
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.osint import common
+
+# Tools held behind the explicit review gate; absent from the server until the
+# gate passes. Named here so enforcement is testable.
+GATED_TOOLS = ("geolocate_claims", "narrative_coordination")
+
+
+def is_gated(tool_name: str) -> bool:
+    """True if a tool is behind the review gate (must not be served yet)."""
+    return tool_name in GATED_TOOLS
+
+
+def investigation_audit(conn, name: str) -> Dict[str, Any]:
+    """Reconstruct an investigation from its provisioning audit trail: the KG
+    record, its bound sources, and every logged provisioning action in order,
+    so the investigation can be fully replayed."""
+    from src.provisioning import store
+
+    kg = store.get_kg(conn, name)
+    if kg is None:
+        return {"error": f"investigation {name!r} not found", "code": "not_found"}
+    events = list(reversed(store.list_events(conn, name, limit=500)))  # oldest first
+    return {
+        "investigation": name,
+        "kg": kg,
+        "sources": store.list_sources(conn, name),
+        "audit_trail": events,
+        "action_count": len(events),
+        "reconstructable": True,
+    }
+
+
+def list_investigations(conn) -> Dict[str, Any]:
+    """Deployed investigations (provisioned KGs) with their audit-action counts."""
+    from src.provisioning import store
+
+    out = []
+    for kg in store.list_kgs(conn, include_archived=False):
+        events = store.list_events(conn, kg["name"], limit=500)
+        out.append(
+            {
+                "name": kg["name"],
+                "description": kg["description"],
+                "source_count": store.count_sources(conn, kg["name"]),
+                "action_count": len(events),
+            }
+        )
+    return {"investigations": out, "count": len(out)}
+
+
+def osint_telemetry(conn) -> Dict[str, Any]:
+    """Empty-canvas ambient signal for an OSINT-dominant canvas: open threads,
+    newly corroborated, newly contradicted. Returns ``{}`` when there is no
+    OSINT activity so the engine falls back to the library signal."""
+    threads = list_investigations(conn)["investigations"]
+    corroborated = 0
+    if common.table_exists(conn, "claim_evidence"):
+        corroborated = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM claim_evidence WHERE lower(relation) = 'supports'"
+            ).fetchone()[0]
+        )
+    contradicted = 0
+    contradiction_topics: List[str] = []
+    if common.table_exists(conn, "claim_conflicts"):
+        contradicted = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM claim_conflicts WHERE lower(conflict_type) LIKE '%contradict%'"
+            ).fetchone()[0]
+        )
+        contradiction_topics = [
+            r[0]
+            for r in conn.execute(
+                "SELECT DISTINCT topic FROM claim_conflicts "
+                "WHERE topic IS NOT NULL AND lower(conflict_type) LIKE '%contradict%' LIMIT 6"
+            ).fetchall()
+            if r[0]
+        ]
+
+    if not (threads or corroborated or contradicted):
+        return {}
+
+    return {
+        "signals": [
+            {"label": "OPEN THREADS", "value": len(threads)},
+            {"label": "CORROBORATED", "value": corroborated},
+            {"label": "CONTRADICTED", "value": contradicted},
+        ],
+        "movers": [
+            {
+                "label": f"work thread {t['name']}",
+                "intent": f"investigation {t['name']} dossier and timeline",
+                "change": t["action_count"],
+            }
+            for t in threads[:5]
+        ],
+        "ticker": {
+            "label": "NEWLY CONTRADICTED",
+            "items": contradiction_topics,
+        } if contradiction_topics else None,
+    }

--- a/src/osint/paths.py
+++ b/src/osint/paths.py
@@ -1,0 +1,139 @@
+"""
+``relationship_path(a, b)`` - how is A connected to B (R11 #616).
+
+The shortest path between two entities across the corpus, over the co-mention
+graph built from ``document_actors``: two entities are adjacent when they are
+named in the same document, and that edge *carries its evidence*, the shared
+documents (with citations) that establish it. Nothing on the path renders
+without the documents that back it.
+
+Resolution ambiguity is surfaced, not silently collapsed: when a name matches
+several distinct entity ids, the candidates are reported rather than an
+arbitrary one being chosen.
+
+Pure composition, stdlib-only BFS; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.osint import common, evidence
+
+MAX_NODES = 4000
+
+
+def _resolve(conn, name: str) -> Dict[str, Any]:
+    """Resolve a name to the entity used in the graph, surfacing ambiguity."""
+    if not common.table_exists(conn, "document_actors"):
+        return {"entity": name, "candidates": []}
+    rows = conn.execute(
+        "SELECT DISTINCT entity_id FROM document_actors WHERE actor_name = ? AND entity_id IS NOT NULL",
+        [name],
+    ).fetchall()
+    candidates = [r[0] for r in rows if r[0]]
+    return {"entity": name, "candidates": candidates, "ambiguous": len(candidates) > 1}
+
+
+def _adjacency(conn) -> Tuple[Dict[str, set], Dict[Tuple[str, str], List[str]]]:
+    """Co-mention adjacency plus, for each undirected pair, the documents that
+    establish the edge."""
+    adj: Dict[str, set] = {}
+    edge_docs: Dict[Tuple[str, str], List[str]] = {}
+    if not common.table_exists(conn, "document_actors"):
+        return adj, edge_docs
+    rows = conn.execute(
+        "SELECT document_id, actor_name FROM document_actors "
+        "WHERE actor_name IS NOT NULL"
+    ).fetchall()
+    by_doc: Dict[str, List[str]] = {}
+    for document_id, actor in rows:
+        by_doc.setdefault(document_id, [])
+        if actor not in by_doc[document_id]:
+            by_doc[document_id].append(actor)
+    for document_id, actors in by_doc.items():
+        for i in range(len(actors)):
+            for j in range(i + 1, len(actors)):
+                a, b = actors[i], actors[j]
+                adj.setdefault(a, set()).add(b)
+                adj.setdefault(b, set()).add(a)
+                key = (a, b) if a <= b else (b, a)
+                edge_docs.setdefault(key, [])
+                if document_id not in edge_docs[key]:
+                    edge_docs[key].append(document_id)
+    return adj, edge_docs
+
+
+def _bfs(adj: Dict[str, set], start: str, goal: str) -> Optional[List[str]]:
+    if start not in adj or goal not in adj:
+        return None
+    if start == goal:
+        return [start]
+    prev: Dict[str, str] = {start: start}
+    q = deque([start])
+    seen = 0
+    while q and seen < MAX_NODES:
+        cur = q.popleft()
+        seen += 1
+        for nxt in adj.get(cur, ()):  # deterministic order below
+            if nxt not in prev:
+                prev[nxt] = cur
+                if nxt == goal:
+                    path = [goal]
+                    while path[-1] != start:
+                        path.append(prev[path[-1]])
+                    return list(reversed(path))
+                q.append(nxt)
+    return None
+
+
+def relationship_path(conn, a: str, b: str) -> Dict[str, Any]:
+    """The shortest co-mention path from ``a`` to ``b`` with cited evidence on
+    every edge, or a clear "no path" when they are not connected."""
+    if not common.table_exists(conn, "document_actors"):
+        return {"error": "no entity-mention layer available"}
+
+    resolve_a = _resolve(conn, a)
+    resolve_b = _resolve(conn, b)
+
+    adj, edge_docs = _adjacency(conn)
+    # Sort neighbours for deterministic shortest paths.
+    adj = {k: sorted(v) for k, v in adj.items()}
+    path = _bfs(adj, a, b)
+    if path is None:
+        return {
+            "connected": False,
+            "a": a,
+            "b": b,
+            "resolution": {"a": resolve_a, "b": resolve_b},
+            "note": "no co-mention path found in the ingested corpus",
+        }
+
+    edges = []
+    for i in range(len(path) - 1):
+        x, y = path[i], path[i + 1]
+        key = (x, y) if x <= y else (y, x)
+        doc_ids = edge_docs.get(key, [])
+        cites = evidence.document_citations(conn, doc_ids)
+        edge_citations = [cites[d] for d in doc_ids if d in cites]
+        edges.append(
+            {
+                "from": x,
+                "to": y,
+                "shared_documents": len(doc_ids),
+                "evidence": edge_citations[:10],
+                "uncited_count": evidence.uncited_count(edge_citations),
+            }
+        )
+
+    return {
+        "connected": True,
+        "a": a,
+        "b": b,
+        "path": path,
+        "hops": len(path) - 1,
+        "edges": edges,
+        "resolution": {"a": resolve_a, "b": resolve_b},
+        "ambiguous": bool(resolve_a.get("ambiguous") or resolve_b.get("ambiguous")),
+    }

--- a/src/osint/timeline.py
+++ b/src/osint/timeline.py
@@ -1,0 +1,119 @@
+"""
+``timeline_reconstruct(topic|entity)`` - a cited event sequence (R11 #617).
+
+Reconstructs a sequence of events from dated, cited claims (``argument_claims``
+joined to ``news_articles`` for the publish date and citation), scoped by topic
+(a substring of the claim text) or entity (an actor in ``document_actors``).
+Claims are bucketed by day into events; each event reports its **corroboration
+density**, the number of independent sources that back it, so a well-sourced
+event is visibly distinct from a single-sourced one.
+
+Every entry is cited; an entry whose document does not resolve is flagged, not
+hidden. Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.osint import common, evidence
+
+
+def _entity_document_ids(conn, entity: str) -> List[str]:
+    if not common.table_exists(conn, "document_actors"):
+        return []
+    rows = conn.execute(
+        "SELECT DISTINCT document_id FROM document_actors "
+        "WHERE actor_name = ? OR entity_id = ?",
+        [entity, entity],
+    ).fetchall()
+    return [r[0] for r in rows if r[0]]
+
+
+def timeline_reconstruct(
+    conn,
+    topic: Optional[str] = None,
+    entity: Optional[str] = None,
+    limit: int = 200,
+) -> Dict[str, Any]:
+    """A day-bucketed event timeline of cited claims for a topic or entity,
+    each event carrying its corroboration density (independent-source count)."""
+    if not common.table_exists(conn, "argument_claims"):
+        return {"events": [], "count": 0, "topic": topic, "entity": entity,
+                "note": "no claim layer available"}
+
+    where: List[str] = []
+    params: List[Any] = []
+    if topic:
+        where.append("c.claim_text ILIKE ?")
+        params.append(f"%{topic}%")
+    if entity:
+        doc_ids = _entity_document_ids(conn, entity)
+        if not doc_ids:
+            return {"events": [], "count": 0, "topic": topic, "entity": entity,
+                    "note": f"entity {entity!r} not found in the corpus"}
+        where.append("c.document_id IN (" + ", ".join("?" for _ in doc_ids) + ")")
+        params.extend(doc_ids)
+
+    has_articles = common.table_exists(conn, "news_articles")
+    date_expr = "a.publish_date" if has_articles else "CAST(NULL AS TIMESTAMP)"
+    join = "LEFT JOIN news_articles a ON c.document_id = a.id" if has_articles else ""
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params.append(int(limit))
+
+    rows = conn.execute(
+        f"""
+        SELECT c.claim_id, c.claim_text, c.document_id, {date_expr} AS dt,
+               {'a.source' if has_articles else 'NULL'} AS source,
+               {'a.url' if has_articles else 'NULL'} AS url
+        FROM argument_claims c
+        {join}
+        {clause}
+        ORDER BY dt NULLS LAST
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+
+    # Bucket by calendar day; each bucket is one event.
+    buckets: Dict[str, List[Dict[str, Any]]] = {}
+    order: List[str] = []
+    for claim_id, text, document_id, dt, source, url in rows:
+        day = str(dt)[:10] if dt is not None else "undated"
+        if day not in buckets:
+            buckets[day] = []
+            order.append(day)
+        cite = evidence.citation(document_id, source, url, resolved=source is not None)
+        buckets[day].append(
+            {
+                "claim_id": claim_id,
+                "text": (text or "")[:200],
+                "source": cite["source"],
+                "url": cite["url"],
+                "path": cite["path"],
+                "cited": cite["cited"],
+            }
+        )
+
+    events = []
+    for day in order:
+        entries = buckets[day]
+        independent = len({e["source"] for e in entries if e["cited"] and e["source"] != "unknown"})
+        events.append(
+            {
+                "date": day,
+                "entries": entries,
+                "claim_count": len(entries),
+                "corroboration_density": independent,
+                "state": evidence.render_state(independent),
+                "uncited_count": evidence.uncited_count(entries),
+            }
+        )
+
+    return {
+        "events": events,
+        "count": len(events),
+        "claim_count": sum(len(b) for b in buckets.values()),
+        "topic": topic,
+        "entity": entity,
+    }

--- a/tests/unit/osint/conftest.py
+++ b/tests/unit/osint/conftest.py
@@ -84,6 +84,20 @@ def _outlet_scores(conn, rows):
         )
 
 
+def _actors(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS document_actors ("
+        "document_id VARCHAR, source_type VARCHAR, actor_name VARCHAR, "
+        "entity_id VARCHAR, role VARCHAR, confidence DOUBLE, extracted_at VARCHAR)"
+    )
+    if rows:
+        conn.executemany(
+            "INSERT INTO document_actors (document_id, actor_name, entity_id, role) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+
+
 @pytest.fixture
 def conn(tmp_path):
     c = duckdb.connect(str(tmp_path / "wh.duckdb"))
@@ -100,4 +114,5 @@ def seed(conn):
         evidence=lambda rows: _evidence(conn, rows),
         conflicts=lambda rows: _conflicts(conn, rows),
         outlet_scores=lambda rows: _outlet_scores(conn, rows),
+        actors=lambda rows: _actors(conn, rows),
     )

--- a/tests/unit/osint/test_dossier.py
+++ b/tests/unit/osint/test_dossier.py
@@ -1,0 +1,76 @@
+"""Tests for entity_dossier() and the person-entity guardrail (R11 #615)."""
+
+from src.osint import entity_dossier
+
+
+def _corpus(seed):
+    seed.articles(
+        [
+            ("d1", "Rivera testifies on grid", "http://a/1", "Alpha Wire", "2025-11-03"),
+            ("d2", "Committee questions Rivera", "http://b/1", "Beta Journal", "2026-06-21"),
+            ("d3", "Org filing on costs", "http://c/1", "Gamma Review", "2026-01-10"),
+        ]
+    )
+    seed.actors(
+        [
+            ("d1", "Jordan Rivera", "person:jr", "speaker"),
+            ("d2", "Jordan Rivera", "person:jr", "subject"),
+            ("d2", "J. Rivera", "person:jr", "subject"),  # alias
+            ("d1", "Grid Authority", "org:ga", "subject"),
+            ("d2", "Grid Authority", "org:ga", "subject"),
+            ("d3", "Grid Authority", "org:ga", "subject"),
+        ]
+    )
+
+
+def test_dossier_every_line_links_to_a_source(seed):
+    _corpus(seed)
+    out = entity_dossier(seed.conn, "Jordan Rivera")
+    assert out["found"] is True
+    assert out["mention_count"] == 2
+    # Every mention carries a citation with a source and (when resolved) url.
+    for m in out["mentions"]:
+        assert m["cited"] is True
+        assert m["source"] in {"Alpha Wire", "Beta Journal"}
+        assert m["url"]
+    assert "J. Rivera" in out["aliases"]
+    assert out["first_seen"] == "2025-11-03 00:00:00"
+    assert out["last_seen"] == "2026-06-21 00:00:00"
+    assert any(c["entity"] == "Grid Authority" for c in out["connected_entities"])
+
+
+def test_person_with_no_document_is_refused(seed):
+    # Person entity, zero ingested documents -> guardrail refusal.
+    seed.actors([])  # create the table, empty
+    out = entity_dossier(seed.conn, "Ghost Person", entity_type="person")
+    assert out.get("code") == "person_requires_documents"
+    assert out["is_person"] is True
+    assert "mentions" not in out  # no inference-only facts surfaced
+
+
+def test_person_inferred_from_role_is_guardrailed(seed):
+    _corpus(seed)
+    # A person known only by a person-role but with no documents of their own.
+    out = entity_dossier(seed.conn, "Nonexistent Speaker")
+    # Not a person (no rows -> not classified person) so returns not-found, not a crash.
+    assert out["found"] is False
+
+
+def test_non_person_with_no_documents_is_allowed_empty(seed):
+    _corpus(seed)
+    out = entity_dossier(seed.conn, "Unknown Org", entity_type="organization")
+    assert out["found"] is False
+    assert "error" not in out
+
+
+def test_uncited_mention_is_flagged_not_hidden(seed):
+    seed.articles([("d1", "known doc", "http://a/1", "Alpha Wire", "2026-01-01")])
+    seed.actors(
+        [
+            ("d1", "Widget Co", "org:w", "subject"),
+            ("missing", "Widget Co", "org:w", "subject"),  # dangling document
+        ]
+    )
+    out = entity_dossier(seed.conn, "Widget Co", entity_type="organization")
+    assert out["mention_count"] == 2
+    assert out["uncited_count"] == 1  # the dangling mention flagged, not dropped

--- a/tests/unit/osint/test_investigations.py
+++ b/tests/unit/osint/test_investigations.py
@@ -1,0 +1,108 @@
+"""Tests for investigations-as-provisioned-KGs, the audit trail, the OSINT
+telemetry and the review gate (R11 #618)."""
+
+from datetime import datetime, timezone
+
+from src.osint import (
+    GATED_TOOLS,
+    investigation_audit,
+    is_gated,
+    list_investigations,
+    osint_telemetry,
+)
+from src.provisioning.provisioner import Provisioner
+
+
+def _now():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _open_investigation(seed, name):
+    seed.articles(
+        [
+            ("d1", "doc one", "http://a/1", "Alpha Wire", "2026-05-01"),
+            ("d2", "doc two", "http://a/2", "Alpha Wire", "2026-05-02"),
+        ]
+    )
+    prov = Provisioner(seed.conn, clock=_now)
+    prov.deploy(name, "An investigation", approve=True)
+    prov.attach_sources(name, sources=["Alpha Wire"])
+    prov.ingest(name)
+    return prov
+
+
+def test_investigation_reconstructs_from_audit_trail(seed):
+    _open_investigation(seed, "op_daybreak")
+    audit = investigation_audit(seed.conn, "op_daybreak")
+    assert audit["reconstructable"] is True
+    events = [e["event"] for e in audit["audit_trail"]]
+    # Oldest-first, the full provisioning sequence is replayable.
+    assert events == ["deploy", "attach", "ingest"]
+    assert audit["kg"]["name"] == "op_daybreak"
+    assert audit["sources"][0]["source"] == "Alpha Wire"
+
+
+def test_unknown_investigation_errors(seed):
+    from src.provisioning import store
+
+    store.ensure_schema(seed.conn)
+    assert investigation_audit(seed.conn, "nope")["code"] == "not_found"
+
+
+def test_list_investigations_counts_actions(seed):
+    _open_investigation(seed, "op_a")
+    out = list_investigations(seed.conn)
+    assert out["count"] == 1
+    assert out["investigations"][0]["action_count"] == 3
+
+
+def test_osint_telemetry_leads_with_threads_and_contradictions(seed):
+    _open_investigation(seed, "op_a")
+    seed.evidence([("e1", "k1", "d2", "news", "supports", 0.9)])
+    seed.conflicts([("k1", "k2", "contradicts", 0.8, "energy")])
+    tel = osint_telemetry(seed.conn)
+    labels = {s["label"] for s in tel["signals"]}
+    assert labels == {"OPEN THREADS", "CORROBORATED", "CONTRADICTED"}
+    assert tel["signals"][0]["value"] == 1  # one open investigation
+    assert tel["ticker"]["label"] == "NEWLY CONTRADICTED"
+
+
+def test_osint_telemetry_empty_without_activity(seed):
+    from src.provisioning import store
+
+    store.ensure_schema(seed.conn)
+    assert osint_telemetry(seed.conn) == {}
+
+
+def test_gated_tools_are_absent_from_the_server():
+    """Enforcement of the review gate: the two gated tools must not be exposed
+    by the OSINT MCP server until the gate passes."""
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[3]
+    path = repo / "tools/osint_mcp/server.py"
+    spec = importlib.util.spec_from_file_location("osint_gate_check", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    import asyncio
+
+    from fastmcp.client import Client
+
+    async def _names():
+        async with Client(module.mcp) as c:
+            return {t.name for t in await c.list_tools()}
+
+    served = asyncio.run(_names())
+    for gated in GATED_TOOLS:
+        assert is_gated(gated)
+        assert gated not in served, f"gated tool {gated} must not be served"
+
+
+def test_is_gated():
+    assert is_gated("geolocate_claims")
+    assert is_gated("narrative_coordination")
+    assert not is_gated("corroborate")

--- a/tests/unit/osint/test_paths.py
+++ b/tests/unit/osint/test_paths.py
@@ -1,0 +1,65 @@
+"""Tests for relationship_path() (R11 #616)."""
+
+from src.osint import relationship_path
+
+
+def _corpus(seed):
+    seed.articles(
+        [
+            ("d1", "Rivera and Grid Authority", "http://a/1", "Alpha Wire", "2026-01-01"),
+            ("d2", "Grid Authority and Delphi", "http://b/1", "Beta Journal", "2026-01-02"),
+            ("d3", "Unrelated actors", "http://c/1", "Gamma Review", "2026-01-03"),
+        ]
+    )
+    seed.actors(
+        [
+            ("d1", "Jordan Rivera", "person:jr", "speaker"),
+            ("d1", "Grid Authority", "org:ga", "subject"),
+            ("d2", "Grid Authority", "org:ga", "subject"),
+            ("d2", "Delphi Energy", "org:de", "subject"),
+            ("d3", "Faraway Person", "person:fp", "speaker"),
+        ]
+    )
+
+
+def test_path_has_cited_evidence_on_every_edge(seed):
+    _corpus(seed)
+    out = relationship_path(seed.conn, "Jordan Rivera", "Delphi Energy")
+    assert out["connected"] is True
+    assert out["path"] == ["Jordan Rivera", "Grid Authority", "Delphi Energy"]
+    assert out["hops"] == 2
+    for edge in out["edges"]:
+        assert edge["shared_documents"] >= 1
+        assert edge["evidence"]  # cited documents establishing the edge
+        for cite in edge["evidence"]:
+            assert cite["cited"] is True and cite["url"]
+
+
+def test_disconnected_entities_report_no_path(seed):
+    _corpus(seed)
+    out = relationship_path(seed.conn, "Jordan Rivera", "Faraway Person")
+    assert out["connected"] is False
+    assert "no co-mention path" in out["note"]
+
+
+def test_resolution_ambiguity_is_surfaced(seed):
+    seed.articles([("d1", "doc", "http://a/1", "Alpha Wire", "2026-01-01"),
+                   ("d2", "doc", "http://b/1", "Beta Journal", "2026-01-02")])
+    seed.actors(
+        [
+            ("d1", "J. Smith", "person:smith1", "speaker"),
+            ("d2", "J. Smith", "person:smith2", "speaker"),  # same name, two ids
+            ("d1", "Org X", "org:x", "subject"),
+            ("d2", "Org X", "org:x", "subject"),
+        ]
+    )
+    out = relationship_path(seed.conn, "J. Smith", "Org X")
+    assert out["resolution"]["a"]["ambiguous"] is True
+    assert set(out["resolution"]["a"]["candidates"]) == {"person:smith1", "person:smith2"}
+
+
+def test_same_entity_is_trivially_connected(seed):
+    _corpus(seed)
+    out = relationship_path(seed.conn, "Grid Authority", "Grid Authority")
+    assert out["connected"] is True
+    assert out["hops"] == 0

--- a/tests/unit/osint/test_timeline.py
+++ b/tests/unit/osint/test_timeline.py
@@ -1,0 +1,56 @@
+"""Tests for timeline_reconstruct() (R11 #617)."""
+
+from src.osint import timeline_reconstruct
+
+
+def _corpus(seed):
+    seed.articles(
+        [
+            ("d1", "rule proposed", "http://a/1", "Alpha Wire", "2025-11-03"),
+            ("d2", "delay confirmed A", "http://b/1", "Beta Journal", "2026-02-14"),
+            ("d3", "delay confirmed B", "http://c/1", "Gamma Review", "2026-02-14"),
+            ("d4", "anon reversal", None, "unknown", "2026-06-21"),
+        ]
+    )
+    seed.claims(
+        [
+            ("k1", "The emissions rule was proposed.", "d1", "news", 0.9, None),
+            ("k2", "The rule is delayed.", "d2", "news", 0.8, None),
+            ("k3", "The rule is delayed.", "d3", "news", 0.8, None),
+            ("k4", "The rule is reversed.", "missing_doc", "news", 0.4, None),
+        ]
+    )
+
+
+def test_events_carry_corroboration_density(seed):
+    _corpus(seed)
+    out = timeline_reconstruct(seed.conn, topic="rule")
+    by_date = {e["date"]: e for e in out["events"]}
+    # Two independent sources on 2026-02-14 -> density 2, state cited.
+    assert by_date["2026-02-14"]["corroboration_density"] == 2
+    assert by_date["2026-02-14"]["state"] == "cited"
+    # First event single-sourced.
+    assert by_date["2025-11-03"]["state"] == "single_sourced"
+
+
+def test_uncited_entry_is_flagged(seed):
+    _corpus(seed)
+    out = timeline_reconstruct(seed.conn, topic="rule")
+    undated = [e for e in out["events"] if e["date"] == "undated"]
+    assert undated and undated[0]["uncited_count"] == 1  # k4 has no resolvable doc
+    assert undated[0]["state"] == "uncited"
+
+
+def test_entity_scoped_timeline(seed):
+    _corpus(seed)
+    seed.actors([("d1", "Grid Authority", "org:ga", "subject")])
+    out = timeline_reconstruct(seed.conn, entity="Grid Authority")
+    assert out["count"] == 1  # only d1's claim
+    assert out["events"][0]["entries"][0]["claim_id"] == "k1"
+
+
+def test_unknown_entity_is_graceful(seed):
+    _corpus(seed)
+    seed.actors([])
+    out = timeline_reconstruct(seed.conn, entity="Nobody")
+    assert out["count"] == 0

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -183,5 +183,179 @@ def contradiction_scan(
         con.close()
 
 
+# --------------------------------------------------------------------------- #
+# Investigation surface (R11 / Track OSINT phase 2)
+# --------------------------------------------------------------------------- #
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "entity": {"type": "string"},
+            "is_person": {"type": "boolean"},
+            "found": {"type": "boolean"},
+            "mention_count": {"type": "integer"},
+            "uncited_count": {"type": "integer"},
+            "aliases": {"type": "array"},
+            "first_seen": {"type": ["string", "null"]},
+            "last_seen": {"type": ["string", "null"]},
+            "mentions": {"type": "array"},
+            "connected_entities": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "entity_dossier",
+        "title": "Entity dossier",
+        "description": "A cited brief for an entity from ingested public documents: every mention, aliases, first and last seen, and connected entities, each line linked to its source. Person entities require a document; no inference-only facts.",
+        "endpoint": None,
+        "facets": ["entities", "actors"],
+        "tables": ["document_actors"],
+        "ui_flag": "osint",
+        "default_span": 6,
+        "topic_param": "entity",
+    }},
+)
+def entity_dossier(entity: str, entity_type: Optional[str] = None) -> dict:
+    """A cited entity brief from already-ingested public documents only. A
+    person entity with no ingested document is refused (person guardrail).
+
+    Args:
+        entity: the entity name or id (see kg_mcp.list_entities).
+        entity_type: optional type hint (e.g. "person") to enforce the guardrail.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import entity_dossier as _dossier
+
+        return _dossier(con, entity, entity_type=entity_type)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "connected": {"type": "boolean"},
+            "a": {"type": "string"},
+            "b": {"type": "string"},
+            "path": {"type": "array"},
+            "hops": {"type": "integer"},
+            "edges": {"type": "array"},
+            "resolution": {"type": "object"},
+            "ambiguous": {"type": "boolean"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "relationship_path",
+        "title": "Connection path",
+        "description": "How two entities are connected across the corpus, via the shortest co-mention path; each edge carries the cited documents that establish it. Resolution ambiguity is surfaced, not collapsed.",
+        "endpoint": None,
+        "facets": ["entities", "actors"],
+        "tables": ["document_actors"],
+        "ui_flag": "osint",
+        "default_span": 6,
+    }},
+)
+def relationship_path(a: str, b: str) -> dict:
+    """The shortest co-mention path between two entities, with cited evidence
+    on every edge.
+
+    Args:
+        a: the first entity name.
+        b: the second entity name.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import relationship_path as _path
+
+        return _path(con, a, b)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "events": {"type": "array"},
+            "count": {"type": "integer"},
+            "claim_count": {"type": "integer"},
+            "topic": {"type": ["string", "null"]},
+            "entity": {"type": ["string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    meta={"panel": {
+        "type": "evidence_timeline",
+        "title": "Evidence timeline",
+        "description": "A reconstructed event sequence from dated, cited claims, each event carrying its corroboration density (independent-source count); uncited entries flagged.",
+        "endpoint": None,
+        "facets": ["events", "trend", "claims"],
+        "tables": ["argument_claims"],
+        "ui_flag": "osint",
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def timeline_reconstruct(
+    topic: Optional[str] = None, entity: Optional[str] = None
+) -> dict:
+    """A cited event timeline for a topic or entity, each event with its
+    corroboration density.
+
+    Args:
+        topic: optional topic filter (claim-text substring).
+        entity: optional entity filter (an actor in the corpus).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import timeline_reconstruct as _timeline
+
+        return _timeline(con, topic=topic, entity=entity)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def investigation_audit(investigation: str) -> dict:
+    """Reconstruct an investigation from its provisioning audit trail: the KG
+    record, bound sources, and every logged action in order. An investigation
+    is a Track P-provisioned namespaced KG; this replays its trail.
+
+    Args:
+        investigation: the investigation (provisioned KG) name.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.osint import investigation_audit as _audit
+
+        return _audit(con, investigation)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Summary

R11 builds the OSINT investigation surface (Track OSINT, phase 2) on top of the R10 composition plane: cited investigation tools over already-ingested public documents, all under one evidence discipline. Defensive and analytical only; nothing crawls, targets, or de-anonymizes.

Closes #615, #616, #617, #618.

## What landed

New modules in `src/osint/` (stdlib-only; the connection is injected read-only):

- `evidence.py`: the shared evidence discipline. A citation on every line (document plus path), and the `cited` / `single_sourced` / `uncited` render states. Uncited is a flagged state, never hidden.
- `dossier.py`: `entity_dossier(entity)` builds a cited brief (mentions, aliases, first and last seen, connected entities) from `document_actors`. The person-entity guardrail is enforced in code: a person with no ingested document is refused rather than described from inference, so the tool never emits an unsourced claim about an individual.
- `paths.py`: `relationship_path(a, b)` finds the shortest co-mention path between two entities, with the establishing documents cited on every edge. Resolution ambiguity (a name matching several entity ids) is surfaced, not collapsed.
- `timeline.py`: `timeline_reconstruct(topic | entity)` buckets dated, cited claims into events, each carrying its corroboration density (independent-source count).
- `investigations.py`: an investigation is a Track P-provisioned KG, fully reconstructable from its provisioning audit trail (`investigation_audit`). Supplies the OSINT-dominant empty-canvas telemetry (open threads / newly corroborated / newly contradicted). Names the review-gated `geolocate_claims` and `narrative_coordination` and keeps them absent from the served surface.

Served by `tools/osint_mcp/server.py` as the `entity_dossier`, `relationship_path` and `evidence_timeline` panels via R2 discovery under the `osint` `ui_flag` (catalog, codegen, frontend renderers, planner keywords). The review gate is documented in `docs/osint-review-gate.md` and enforced by an absence test.

## Verification

- `tests/unit/osint` (33 tests) plus `tests/unit/provisioning tests/unit/genui tests/unit/mcp_host tests/unit/analytics`: 434 passed. The genui telemetry and route suites pass. Frontend `tsc --noEmit` clean. `codegen.py --check` reports artifacts current.
- Live run over the real OSINT MCP server on a temp warehouse:

```
STEP 0 gated tools absent from server: [contradiction_scan, corroborate, entity_dossier, investigation_audit, relationship_path, source_reliability, timeline_reconstruct]
STEP 1 entity_dossier(Jordan Rivera): mentions=2 cited=2 connected=['Grid Authority']
STEP 2 person guardrail (no docs): code=person_requires_documents
STEP 3 relationship_path: Jordan Rivera -> Grid Authority -> Delphi Energy ; edge evidence cited=True
STEP 4 timeline_reconstruct(rule): events=3 density={'2025-11-03': 1, '2026-02-14': 2, 'undated': 0}
STEP 5 investigation_audit(op_daybreak): trail=['deploy', 'attach', 'ingest'] reconstructable=True
STEP 6 discovery: entity_dossier / relationship_path / evidence_timeline all sourced from neuronews-osint
RESULT: OK
```

## Exit criteria

- #615: an entity brief renders where every line links to its source document; guardrail tests prove person-tools refuse non-document-sourced facts.
- #616: a path between two entities renders with inspectable, cited evidence on every edge.
- #617: a topic timeline renders with per-event corroboration density and per-entry source citations.
- #618: an investigation KG can be provisioned, worked, and fully reconstructed from its audit trail; the review gate for the two gated tools is documented and enforced (tools absent, verified by test).