### PR TITLE
R12: Data-plane proxy prototype, Stage 3 benchmark and go/no-go ADR

### DIFF
--- a/apps/web/src/genui/GenPanel.tsx
+++ b/apps/web/src/genui/GenPanel.tsx
@@ -44,8 +44,8 @@ export default function GenPanel({
           {panel.title}
         </div>
         {source ? (
-          <Badge variant={isLoading ? "sync" : source === "live" ? "live" : "demo"}>
-            {isLoading ? "SYNC" : source === "live" ? "LIVE" : "DEMO"}
+          <Badge variant={isLoading ? "sync" : source === "live" || source === "mcp" ? "live" : "demo"}>
+            {isLoading ? "SYNC" : source === "mcp" ? "MCP" : source === "live" ? "LIVE" : "DEMO"}
           </Badge>
         ) : null}
         {adjustable ? (

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -8,6 +8,7 @@ import { ACCENT, palette, fonts } from "../theme";
 import { sentColor, sentLabel } from "../lib/sentiment";
 import {
   useArticles,
+  useDataPlaneArticles,
   useClusters,
   useDocuments,
   useTrending,
@@ -129,7 +130,14 @@ function KpiRowPanel(props: PanelProps) {
 }
 
 function ArticlesPanel(props: PanelProps) {
-  const { data: articles, source, isLoading } = useArticles();
+  // R12: prefer the data-plane proxy when it is enabled and serving the
+  // articles family; otherwise fall back to the REST/demo path.
+  const proxy = useDataPlaneArticles();
+  const rest = useArticles();
+  const usingProxy = proxy.proxied && proxy.data.length > 0;
+  const articles = usingProxy ? proxy.data : rest.data;
+  const source = usingProxy ? proxy.source : rest.source;
+  const isLoading = usingProxy ? proxy.isLoading : rest.isLoading;
   const topic = props.panel.params?.topic;
   const matched = articles.filter((a) => topicMatch(topic, `${a.title} ${a.summary} ${a.entities.join(" ")}`));
   const rows = (matched.length ? matched : articles).slice(0, 5);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -381,6 +381,37 @@ export interface RawUiTelemetry {
   packs: string[];
 }
 
+// Data-plane proxy (R12): the allowlist and a data-mode tool invocation.
+export interface RawDataTool {
+  server: string;
+  tool: string;
+  panel?: string;
+  rest_route?: string;
+}
+
+export interface RawDataTools {
+  enabled: boolean;
+  tools: RawDataTool[];
+  count?: number;
+}
+
+export interface RawDataArticle {
+  id: string | null;
+  title: string | null;
+  url: string | null;
+  publish_date: string | null;
+  source: string | null;
+  category: string | null;
+  sentiment_score: number | null;
+  sentiment_label: string | null;
+}
+
+export interface RawDataResponse {
+  server: string;
+  tool: string;
+  data: { count: number; articles: RawDataArticle[] };
+}
+
 // ---------- endpoint calls ----------
 
 export const api = {
@@ -395,6 +426,13 @@ export const api = {
   uiContext: () => request<RawUiContext>("/api/v1/ui/context"),
 
   uiTelemetry: () => request<RawUiTelemetry>("/api/v1/ui/telemetry"),
+
+  // Data-plane proxy prototype (R12): the allowlist, and invoking a data-mode
+  // tool. Both no-op safely when the NOESIS_GENUI_DATA_PROXY flag is off.
+  uiDataTools: () => request<RawDataTools>("/api/v1/ui/data/tools"),
+
+  uiData: (body: { server: string; tool: string; arguments?: Record<string, unknown> }) =>
+    requestPost<RawDataResponse>("/api/v1/ui/data", body),
 
   articles: (params?: { category?: string; source?: string }) =>
     request<RawArticle[]>("/api/v1/news/articles", params),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -32,7 +32,7 @@ import {
   mockOutletRanking,
   mockOutletClusters,
 } from "../data/mock";
-import type { RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActorSummary, RawOutletCluster, RawOutletScore } from "./api";
+import type { RawArticle, RawClaim, RawStanceSummary, RawActorPosition, RawPositionUpdate, RawSourceStance, RawDriftEvent, RawFrameSource, RawActorSummary, RawOutletCluster, RawOutletScore } from "./api";
 import { palette, ACCENT } from "../theme";
 import type {
   Article,
@@ -57,7 +57,7 @@ import type {
   OutletScore,
 } from "../types";
 
-export type Source = "live" | "demo";
+export type Source = "live" | "demo" | "mcp";
 export interface Result<T> {
   data: T;
   source: Source;
@@ -113,6 +113,40 @@ function useWithFallback<T>(key: string, fn: () => Promise<T>, fallback: T): Res
 
 export function useArticles(): Result<Article[]> {
   return useWithFallback("articles", async () => adaptArticles(await api.articles()), mockArticles);
+}
+
+// Data-plane proxy path (R12): when NOESIS_GENUI_DATA_PROXY is on and an
+// `articles` data-mode tool is allowlisted, the articles panel can render its
+// rows through POST /api/v1/ui/data instead of the REST route. Off by default,
+// so `proxied` is false and the panel keeps its REST/demo path.
+export function useDataPlaneArticles(): Result<Article[]> & { proxied: boolean } {
+  const q = useQuery({
+    queryKey: ["dataplane-articles"],
+    queryFn: async (): Promise<{ data: Article[]; source: Source; proxied: boolean }> => {
+      const tools = await api.uiDataTools();
+      const tool = tools.enabled ? tools.tools.find((t) => t.panel === "articles") : undefined;
+      if (!tool) return { data: [], source: "demo", proxied: false };
+      const res = await api.uiData({ server: tool.server, tool: tool.tool, arguments: { limit: 20 } });
+      const raw: RawArticle[] = (res.data.articles ?? []).map((a) => ({
+        id: a.id ?? "",
+        title: a.title ?? "",
+        url: a.url ?? "",
+        publish_date: a.publish_date,
+        source: a.source ?? "",
+        category: a.category ?? "",
+        sentiment: { score: a.sentiment_score, label: a.sentiment_label },
+      }));
+      return { data: adaptArticles(raw), source: "mcp", proxied: true };
+    },
+    staleTime: STALE,
+    retry: false,
+  });
+  return {
+    data: q.data?.data ?? [],
+    source: q.data?.source ?? "demo",
+    isLoading: q.isLoading,
+    proxied: q.data?.proxied ?? false,
+  };
 }
 
 export function useClusters(): Result<Cluster[]> {

--- a/docs/architecture/ADR-002-data-plane-stage3.md
+++ b/docs/architecture/ADR-002-data-plane-stage3.md
@@ -1,0 +1,88 @@
+# ADR-002: Data-plane (Stage 3) go/no-go
+
+Status: accepted. Part of R12 (Data-plane benchmark and Stage 3 decision) in
+`MCP_REARCHITECTURE_PLAN.md`; records the Stage 3 gate with numbers.
+
+## Context
+
+Stage 1 made MCP the read/compose plane for the canvas: tools describe panels
+(R2 discovery), and panels render from the REST routes and demo fallbacks.
+Stage 3 asks a further question: should panel *data* also flow through MCP,
+served to the browser by an API proxy (`POST /api/v1/ui/data`) that invokes a
+data-mode tool, instead of the browser calling the REST route directly?
+
+The case for it: one data path, one allowlist, one place to cache, and panels
+that follow discovery all the way down to their rows. The case against it: the
+MCP stdio hop and FastMCP serialization sit between the API and the warehouse,
+and a fanned-out canvas is latency-sensitive.
+
+R12 built the prototype to measure the tradeoff, not argue it:
+
+- `articles_data` (pipeline server): a data-mode tool returning the full
+  `articles` payload, field-for-field equivalent to `/api/v1/news/articles`.
+- `POST /api/v1/ui/data`: an allowlist-gated, rate-limited, size-capped proxy,
+  behind the `NOESIS_GENUI_DATA_PROXY` flag.
+- `scripts/genui/dataplane_benchmark.py`: the benchmark transcribed below.
+
+## Benchmark
+
+200-row articles payload, 60 iterations, same warehouse, warm process. The
+three paths run the identical query and return byte-identical payloads
+(50,743 bytes each, which confirms the #619 equivalence contract). Latency:
+
+| path | p50 (ms) | p95 (ms) | mean (ms) | payload (B) |
+|---|---|---|---|---|
+| `rest_direct` (in-process SQL the REST route runs) | 13.32 | 15.47 | 13.70 | 50,743 |
+| `mcp_tool` (raw FastMCP client to `articles_data`) | 46.14 | 55.47 | 47.04 | 50,743 |
+| `proxy_cold` (`/ui/data` handler, cache invalidated each call) | 50.38 | 64.75 | 51.82 | 50,743 |
+| `proxy_cached` (`/ui/data` handler, shared TTL cache hit) | 0.36 | 0.44 | 0.37 | (cached) |
+
+Reading the numbers:
+
+- **Payloads are equivalent.** Same bytes on every path; data mode is a faithful
+  full-payload variant, not a summary.
+- **The cold MCP path costs ~3.8x REST**: +37 ms p50, +49 ms p95 per uncached
+  call. That cost is the process boundary and FastMCP stdio serialization
+  (`mcp_tool` alone is 46 ms), not the query. For a canvas fanning out many
+  cold panels, that overhead compounds.
+- **The cached path is ~37x faster than REST** (0.36 ms vs 13.32 ms), because
+  the R4 shared `call_tool_cached` TTL cache serves repeat loads without
+  reopening the warehouse. Repeat panel loads and multi-panel canvases that
+  reuse a tool result land here.
+
+## Decision
+
+**Conditional GO.** Promote exactly one panel family, `articles`, to serve
+through the proxy behind the `NOESIS_GENUI_DATA_PROXY` flag, cache-served. The
+prototype ships enabled-off; a deployment that turns the flag on gets the
+articles panel end-to-end through MCP, at parity on payload and at better than
+REST latency once the TTL cache is warm.
+
+We do **not** replace REST wholesale, and we do not move latency-sensitive
+first loads onto the cold proxy path. The gating metric for a broader Stage 3
+rollout is the cold-path overhead: bringing `proxy_cold` p95 within ~1.5x of
+`rest_direct` (today it is ~4.2x). The overhead is transport, not
+architecture, so the levers are known: a persistent warm session pool (R1
+already supervises one in-process), a lighter result encoding than JSON-over-
+stdio, and pre-warming the cache on generate. Until that metric is met, the
+flag stays off by default and only the articles family is promoted.
+
+### Retirement criteria for the prototype
+
+If, by the next data-plane review, none of the cold-path levers has closed the
+gap and no second panel family has a cache-friendly access pattern that
+benefits, retire the proxy: delete `src/genui/dataplane.py`, the
+`genui_data_routes` router, and the `articles_data` data block, and keep panels
+on REST. The prototype is cheap to remove precisely because it is one flag, one
+route, one tool.
+
+## Consequences
+
+- The browser still never speaks MCP; the proxy is the only door, and it is
+  allowlist-gated (data-mode tools only), rate-limited per client, and
+  size-capped both ways.
+- Data-mode tools are a distinct annotation (`meta.data`) from panel tools
+  (`meta.panel`), so planner-facing stats tools are untouched and a data tool
+  can never be mistaken for a panel definition.
+- The decision is reproducible: re-run `scripts/genui/dataplane_benchmark.py`
+  to refresh the table.

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -697,6 +697,22 @@ as an ADR.
 *Exit:* the decision is written down with numbers; if go, one panel
 family serves via the proxy at production parity.
 
+*Delivered.* The `articles_data` data-mode tool (pipeline server, `meta.data`
+block) returns the full `articles` payload, byte-identical to
+`/api/v1/news/articles`. The `POST /api/v1/ui/data` proxy
+(`src/genui/dataplane.py` + `src/api/routes/genui_data_routes.py`, behind the
+`NOESIS_GENUI_DATA_PROXY` flag) invokes only allowlisted data-mode tools,
+rate-limited per client and size-capped both ways. The benchmark
+(`scripts/genui/dataplane_benchmark.py`) measured, on a 200-row payload:
+`rest_direct` 13.3 ms p50, `mcp_tool` 46.1 ms, `proxy_cold` 50.4 ms,
+`proxy_cached` 0.36 ms, all at the same 50,743-byte payload. Decision (recorded
+in `docs/architecture/ADR-002-data-plane-stage3.md`): **conditional go**,
+promote the `articles` family behind the flag cache-served (proxy_cached beats
+REST), do not move cold first-loads onto the proxy until the transport overhead
+(~3.8x today) closes; retirement criteria documented. The frontend renders the
+articles panel through the proxy when the flag reports enabled, falling back to
+demo otherwise.
+
 **R13 — Noesis as MCP server + naming sweep** *(Stage 4 + N4)*
 `noesis_generate_view` over Streamable HTTP for external hosts;
 `NOESIS_*` env aliases (`NEURONEWS_*` fallbacks), package/server/API

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -179,6 +179,26 @@ corroborated / newly contradicted. The most abusable tools
 These surface as the `entity_dossier`, `relationship_path` and
 `evidence_timeline` panels.
 
+### Data-plane proxy (`src/genui/dataplane.py`, R12)
+
+A prototype answer to the Stage 3 question, "should panel data flow through MCP
+too?", behind the `NOESIS_GENUI_DATA_PROXY` flag (off by default). A data-mode
+tool carries a `meta.data` block (distinct from the `meta.panel` block, so
+planner-facing stats tools are untouched) and returns a full panel payload;
+`articles_data` on the pipeline server is the first, byte-identical to the
+`/api/v1/news/articles` REST route. `POST /api/v1/ui/data` lets the browser have
+the API invoke an allowlisted data-mode tool (the browser never speaks MCP);
+`GET /api/v1/ui/data/tools` exposes the allowlist. The proxy is allowlist-gated
+(data-mode tools only), rate-limited per client, and size-capped both ways, and
+serves through the R4 shared tool cache. The benchmark
+(`scripts/genui/dataplane_benchmark.py`) drove the Stage 3 go/no-go recorded in
+`docs/architecture/ADR-002-data-plane-stage3.md`: same 50,743-byte payload on
+every path; `rest_direct` 13.3 ms p50, `proxy_cold` 50.4 ms, `proxy_cached`
+0.36 ms. Decision: conditional go, promote the `articles` family behind the
+flag cache-served (the frontend `useDataPlaneArticles` hook renders it through
+the proxy when enabled, badged `MCP`, falling back to REST/demo otherwise); do
+not move cold first-loads onto the proxy until the transport overhead closes.
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/scripts/genui/dataplane_benchmark.py
+++ b/scripts/genui/dataplane_benchmark.py
@@ -1,0 +1,227 @@
+"""
+Data-plane latency benchmark (MCP rearchitecture plan, R12 #621 / Stage 3 gate).
+
+Measures the cost of serving one panel family's data through the MCP layer
+versus the direct in-process warehouse read the REST route uses. Three paths,
+same query, same warehouse:
+
+  rest_direct   the SQL the /api/v1/news/articles route runs, in-process
+                (the REST baseline, minus HTTP framing common to both)
+  mcp_tool      the articles_data data-mode tool over a live FastMCP client
+                (the raw MCP transport + tool cost)
+  proxy         invoke_data_tool(), the /api/v1/ui/data proxy handler path
+                (allowlist + host cache + tool), through the same host
+
+Reports p50 / p95 / mean latency and payload size for each, and the proxy
+overhead versus the REST baseline. The numbers printed here are transcribed
+into docs/architecture/ADR-002-data-plane-stage3.md.
+
+Run:  python scripts/genui/dataplane_benchmark.py [iterations]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+os.chdir(REPO_ROOT)
+os.environ.pop("TESTING", None)
+os.environ["NOESIS_GENUI_DATA_PROXY"] = "on"
+
+N_ROWS = 200
+
+
+def _seed(db: str) -> None:
+    import duckdb
+
+    con = duckdb.connect(db)
+    con.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    con.executemany(
+        "INSERT INTO news_articles (id, title, url, publish_date, source, category, "
+        "sentiment_score, sentiment_label) VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (
+                f"a{i}",
+                f"Article {i} on grid policy and market dynamics",
+                f"http://example.com/{i}",
+                "2026-06-%02d" % ((i % 28) + 1),
+                ["Alpha Wire", "Beta Journal", "Gamma Review"][i % 3],
+                ["energy", "tech", "policy"][i % 3],
+                (i % 10) / 10.0 - 0.5,
+                ["positive", "neutral", "negative"][i % 3],
+            )
+            for i in range(N_ROWS)
+        ],
+    )
+    con.close()
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _rest_direct(db: str) -> dict:
+    """The SQL the REST articles route runs, in-process."""
+    import duckdb
+
+    con = duckdb.connect(db, read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT id, title, url, publish_date, source, category, "
+            "sentiment_score, sentiment_label FROM news_articles "
+            "ORDER BY publish_date DESC NULLS LAST LIMIT 200"
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "articles": [
+                {
+                    "id": r[0], "title": r[1], "url": r[2],
+                    "publish_date": r[3].isoformat() if r[3] else None,
+                    "source": r[4], "category": r[5],
+                    "sentiment_score": r[6], "sentiment_label": r[7],
+                }
+                for r in rows
+            ],
+        }
+    finally:
+        con.close()
+
+
+def _stats(samples_ms):
+    s = sorted(samples_ms)
+    n = len(s)
+    p50 = s[n // 2]
+    p95 = s[min(n - 1, int(n * 0.95))]
+    return {"p50": p50, "p95": p95, "mean": sum(s) / n, "n": n}
+
+
+def _time_it(fn, iterations):
+    # Warm up (connect, cache, JIT of the query plan).
+    for _ in range(3):
+        fn()
+    samples = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - t0) * 1000.0)
+    return samples
+
+
+async def _run(db: str, iterations: int):
+    from fastmcp.client import Client
+
+    from src.genui import dataplane
+    import src.mcp_host.host as host_mod
+    from src.mcp_host import MCPHost
+    from src.mcp_host.config import load_server_specs
+
+    pipeline = _load("pl_srv", REPO_ROOT / "tools/pipeline_mcp/server.py")
+
+    # rest_direct
+    rest_samples = _time_it(lambda: _rest_direct(db), iterations)
+    rest_payload = len(json.dumps(_rest_direct(db)).encode())
+
+    # mcp_tool: raw FastMCP client call to the data-mode tool.
+    async with Client(pipeline.mcp) as client:
+        async def call():
+            return (await client.call_tool("articles_data", {"limit": 200})).structured_content
+
+        await call()
+        mcp_payload = len(json.dumps(await call()).encode())
+        mcp_samples = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            await call()
+            mcp_samples.append((time.perf_counter() - t0) * 1000.0)
+
+    # proxy: the /api/v1/ui/data handler path over a supervised host.
+    specs = [s for s in load_server_specs() if s.name == "neuronews-pipeline"]
+    host = MCPHost(specs=specs)
+    host.start()
+    host_mod._host = host
+    deadline = time.monotonic() + 40
+    while time.monotonic() < deadline and host.status()["connected"] != 1:
+        time.sleep(0.5)
+    proxy_samples, proxy_payload = [], 0
+    try:
+        host.invalidate_cached_calls()
+        proxy_payload = len(
+            json.dumps(
+                dataplane.invoke_data_tool("neuronews-pipeline", "articles_data", {"limit": 200})
+            ).encode()
+        )
+        for _ in range(iterations):
+            host.invalidate_cached_calls()  # measure the live path, not the cache
+            t0 = time.perf_counter()
+            dataplane.invoke_data_tool("neuronews-pipeline", "articles_data", {"limit": 200})
+            proxy_samples.append((time.perf_counter() - t0) * 1000.0)
+        # And the warm cache path (what repeat panel loads actually hit).
+        dataplane.invoke_data_tool("neuronews-pipeline", "articles_data", {"limit": 200})
+        cached_samples = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            dataplane.invoke_data_tool("neuronews-pipeline", "articles_data", {"limit": 200})
+            cached_samples.append((time.perf_counter() - t0) * 1000.0)
+    finally:
+        host.stop()
+        host_mod._host = None
+
+    return {
+        "rows": N_ROWS,
+        "iterations": iterations,
+        "rest_direct": {**_stats(rest_samples), "payload_bytes": rest_payload},
+        "mcp_tool": {**_stats(mcp_samples), "payload_bytes": mcp_payload},
+        "proxy_cold": {**_stats(proxy_samples), "payload_bytes": proxy_payload},
+        "proxy_cached": _stats(cached_samples),
+    }
+
+
+def main() -> None:
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 60
+    tmp = tempfile.mkdtemp()
+    db = os.path.join(tmp, "wh.duckdb")
+    os.environ["NEURONEWS_DB_PATH"] = db
+    _seed(db)
+    result = asyncio.run(_run(db, iterations))
+
+    print(f"\nData-plane benchmark ({result['rows']} rows, {result['iterations']} iterations)\n")
+    header = f"{'path':<14}{'p50 ms':>9}{'p95 ms':>9}{'mean ms':>9}{'payload B':>11}"
+    print(header)
+    print("-" * len(header))
+    for path in ("rest_direct", "mcp_tool", "proxy_cold", "proxy_cached"):
+        s = result[path]
+        pb = s.get("payload_bytes", "")
+        print(f"{path:<14}{s['p50']:>9.2f}{s['p95']:>9.2f}{s['mean']:>9.2f}{str(pb):>11}")
+
+    rest_p50 = result["rest_direct"]["p50"]
+    print(
+        f"\nproxy_cold p50 overhead vs rest_direct: "
+        f"+{result['proxy_cold']['p50'] - rest_p50:.2f} ms "
+        f"({result['proxy_cold']['p50'] / rest_p50:.1f}x)"
+    )
+    print(
+        f"proxy_cached p50 overhead vs rest_direct: "
+        f"+{result['proxy_cached']['p50'] - rest_p50:.2f} ms "
+        f"({result['proxy_cached']['p50'] / rest_p50:.1f}x)"
+    )
+    print("\nJSON:\n" + json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -30,6 +30,7 @@ METRICS_ROUTES_AVAILABLE = False
 PRIVACY_ROUTES_AVAILABLE = False
 SECURITY_ROUTES_AVAILABLE = False
 GENUI_ROUTES_AVAILABLE = False
+GENUI_DATA_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -378,6 +379,19 @@ def try_import_genui_routes():
         return False
 
 
+def try_import_genui_data_routes():
+    """Try to import the data-plane proxy routes (R12, behind a feature flag)."""
+    global GENUI_DATA_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import genui_data_routes
+        _imported_modules['genui_data_routes'] = genui_data_routes
+        GENUI_DATA_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        GENUI_DATA_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -436,6 +450,7 @@ def check_all_imports():
     try_import_privacy_routes()
     try_import_security_routes()
     try_import_genui_routes()
+    try_import_genui_data_routes()
     _load_domain_packs()
 
 
@@ -764,6 +779,14 @@ def include_optional_routers(app):
             app.include_router(genui_routes.router)
             routers_included += 1
 
+    # Include the data-plane proxy routes (R12 prototype; behind a flag at
+    # request time, but always mounted so /data/tools can report enabled=false)
+    if GENUI_DATA_ROUTES_AVAILABLE:
+        genui_data_routes = _imported_modules.get('genui_data_routes')
+        if genui_data_routes:
+            app.include_router(genui_data_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -882,6 +905,7 @@ async def root():
             "privacy": PRIVACY_ROUTES_AVAILABLE,
             "local_storage_security": SECURITY_ROUTES_AVAILABLE,
             "generative_ui": GENUI_ROUTES_AVAILABLE,
+            "generative_ui_data": GENUI_DATA_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/genui_data_routes.py
+++ b/src/api/routes/genui_data_routes.py
@@ -1,0 +1,83 @@
+"""Data-plane proxy route (MCP rearchitecture plan, R12 / Stage 3 gate).
+
+``POST /api/v1/ui/data`` lets the browser have the API invoke a data-mode MCP
+tool on its behalf (the browser never speaks MCP). It is a *prototype behind a
+feature flag*: with ``NOESIS_GENUI_DATA_PROXY`` off, every request is refused.
+
+Guardrails (R12 #620): only tools on the discovered data-mode allowlist are
+callable; each client is rate-limited; request and response sizes are capped.
+``GET /api/v1/ui/data/tools`` exposes the allowlist so the frontend knows which
+panels can be served through the proxy.
+"""
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from src.genui.dataplane import (
+    DataPlaneError,
+    check_rate,
+    check_request_size,
+    data_mode_tools,
+    data_proxy_enabled,
+    invoke_data_tool,
+)
+
+router = APIRouter(prefix="/api/v1/ui", tags=["generative_ui_data"])
+
+
+class DataRequest(BaseModel):
+    """Body for POST /api/v1/ui/data."""
+
+    server: str = Field(..., max_length=128, description="MCP server name")
+    tool: str = Field(..., max_length=128, description="Data-mode tool name")
+    arguments: Optional[Dict[str, Any]] = Field(
+        default=None, description="Tool arguments"
+    )
+
+
+def _client_key(request: Request) -> str:
+    client = request.client.host if request.client else "unknown"
+    return client
+
+
+@router.get("/data/tools")
+def data_tools() -> Dict[str, Any]:
+    """The data-mode allowlist the proxy will serve (empty when the flag is off
+    or the host is down), so the frontend can decide which panels to fetch
+    live."""
+    if not data_proxy_enabled():
+        return {"enabled": False, "tools": []}
+    tools = [
+        {"server": server, "tool": tool, **meta}
+        for (server, tool), meta in sorted(data_mode_tools().items())
+    ]
+    return {"enabled": True, "tools": tools, "count": len(tools)}
+
+
+@router.post("/data")
+def ui_data(request: DataRequest, http_request: Request) -> Dict[str, Any]:
+    """Invoke an allowlisted data-mode MCP tool and return its payload.
+
+    Refuses when the flag is off (404), when the tool is not allowlisted (403),
+    when the client is over its rate limit (429), or when a size cap is
+    exceeded (413). Sync on purpose: the blocking MCP call runs in the
+    threadpool.
+    """
+    if not data_proxy_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail="data-plane proxy is disabled (set NOESIS_GENUI_DATA_PROXY=on)",
+        )
+    try:
+        check_rate(_client_key(http_request))
+        check_request_size(request.arguments)
+        payload = invoke_data_tool(request.server, request.tool, request.arguments)
+    except DataPlaneError as err:
+        raise HTTPException(status_code=err.status, detail=err.message)
+    return {
+        "server": request.server,
+        "tool": request.tool,
+        "data": payload,
+    }

--- a/src/genui/dataplane.py
+++ b/src/genui/dataplane.py
@@ -1,0 +1,180 @@
+"""
+Data-plane proxy support (MCP rearchitecture plan, R12 / Stage 3 gate).
+
+Stage 1 turned MCP tools into panels; Stage 3 asks whether panel *data* should
+flow through MCP too. This module is the backend for a prototype answer: a
+narrow, guardrailed way for the browser to have the API invoke a **data-mode**
+MCP tool on its behalf (the browser never speaks MCP).
+
+* :func:`data_mode_tools` discovers the data-mode allowlist from the R1 tool
+  cache: a tool is data-mode when its ``meta`` carries a ``data`` block (format
+  mirrors the ADR-001 ``panel`` block). Only allowlisted tools are callable.
+* :class:`RateLimiter` is a per-client token bucket.
+* :func:`invoke_data_tool` enforces the allowlist and the response-size cap and
+  calls the tool through the host's shared cache.
+
+Everything is behind the ``NOESIS_GENUI_DATA_PROXY`` feature flag; the whole
+prototype is off by default. Import-safe (stdlib + src.mcp_host only).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Dict, Optional, Tuple
+
+DATA_ANNOTATION_KEY = "data"
+
+# Caps (bytes). Requests/responses beyond these are rejected, not truncated.
+MAX_REQUEST_BYTES = 16 * 1024
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+# Per-client rate limit defaults (token bucket).
+DEFAULT_RATE_PER_MIN = 120
+
+
+class DataPlaneError(Exception):
+    """A data-plane request was refused. ``status`` is the HTTP code to map to."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+def data_proxy_enabled() -> bool:
+    """True when the data-plane proxy prototype is switched on."""
+    return os.getenv("NOESIS_GENUI_DATA_PROXY", "off").lower() in ("on", "1", "true")
+
+
+def data_mode_tools() -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """The data-mode allowlist: ``{(server, tool): {panel, rest_route}}`` from
+    the host's tool cache. Empty when the host is down or nothing is annotated,
+    so an empty allowlist safely rejects everything."""
+    try:
+        from src.mcp_host import get_host
+
+        host = get_host()
+    except Exception:  # pragma: no cover - defensive import guard
+        return {}
+    if host is None:
+        return {}
+
+    out: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for server in sorted(host.tools()):
+        for tool in host.tools(server).get(server, []):
+            meta = tool.get("meta")
+            block = meta.get(DATA_ANNOTATION_KEY) if isinstance(meta, dict) else None
+            if not isinstance(block, dict):
+                continue
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            if not tool.get("has_output_schema", False):
+                # Data-mode tools must declare a schema, same discipline as panels.
+                continue
+            out[(server, name)] = {
+                "panel": block.get("panel"),
+                "rest_route": block.get("rest_route"),
+            }
+    return out
+
+
+def is_allowed(server: str, tool: str) -> bool:
+    """Whether ``(server, tool)`` is an allowlisted data-mode tool."""
+    return (server, tool) in data_mode_tools()
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    updated: float
+
+
+class RateLimiter:
+    """A per-client token bucket: ``rate`` requests per minute, burst = rate."""
+
+    def __init__(self, rate_per_min: int = DEFAULT_RATE_PER_MIN):
+        self.rate = max(1, int(rate_per_min))
+        self._buckets: Dict[str, _Bucket] = {}
+        self._lock = Lock()
+
+    def allow(self, client: str, now: Optional[float] = None) -> bool:
+        now = time.time() if now is None else now
+        refill_per_sec = self.rate / 60.0
+        with self._lock:
+            bucket = self._buckets.get(client)
+            if bucket is None:
+                self._buckets[client] = _Bucket(tokens=self.rate - 1, updated=now)
+                return True
+            elapsed = max(0.0, now - bucket.updated)
+            bucket.tokens = min(self.rate, bucket.tokens + elapsed * refill_per_sec)
+            bucket.updated = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True
+            return False
+
+
+# One shared limiter for the process; the rate is read once at import.
+_LIMITER = RateLimiter(
+    int(os.getenv("NOESIS_GENUI_DATA_RATE_PER_MIN", str(DEFAULT_RATE_PER_MIN)))
+)
+
+
+def check_rate(client: str) -> None:
+    """Raise :class:`DataPlaneError` (429) when ``client`` is over its limit."""
+    if not _LIMITER.allow(client):
+        raise DataPlaneError(429, "rate_limited", "data-plane rate limit exceeded")
+
+
+def check_request_size(arguments: Any) -> None:
+    """Raise (413) when the argument payload exceeds the request cap."""
+    import json
+
+    try:
+        size = len(json.dumps(arguments or {}, default=str).encode("utf-8"))
+    except Exception:
+        raise DataPlaneError(400, "bad_request", "arguments are not JSON-serializable")
+    if size > MAX_REQUEST_BYTES:
+        raise DataPlaneError(413, "request_too_large",
+                             f"request {size} bytes over {MAX_REQUEST_BYTES} cap")
+
+
+def invoke_data_tool(
+    server: str, tool: str, arguments: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Invoke an allowlisted data-mode tool through the host cache, enforcing
+    the allowlist and the response-size cap. Raises :class:`DataPlaneError`."""
+    import json
+
+    if not is_allowed(server, tool):
+        raise DataPlaneError(403, "not_allowed",
+                             f"tool {server}:{tool} is not an allowlisted data-mode tool")
+    try:
+        from src.mcp_host import get_host
+
+        host = get_host()
+    except Exception:
+        host = None
+    if host is None:
+        raise DataPlaneError(503, "host_unavailable", "MCP host is not available")
+
+    try:
+        result = host.call_tool_cached(server, tool, arguments or {})
+    except Exception as exc:
+        raise DataPlaneError(502, "tool_error", f"tool call failed: {exc}")
+
+    if not isinstance(result, dict):
+        raise DataPlaneError(502, "bad_result", "tool returned a non-object result")
+    if "error" in result:
+        raise DataPlaneError(502, "tool_error", str(result["error"]))
+
+    size = len(json.dumps(result, default=str).encode("utf-8"))
+    if size > MAX_RESPONSE_BYTES:
+        raise DataPlaneError(413, "response_too_large",
+                             f"response {size} bytes over {MAX_RESPONSE_BYTES} cap")
+    return result

--- a/tests/unit/api/routes/test_genui_data_routes.py
+++ b/tests/unit/api/routes/test_genui_data_routes.py
@@ -1,0 +1,122 @@
+"""Route tests for src/api/routes/genui_data_routes.py (R12 data-plane proxy).
+
+Loads the route module BY PATH (never via src.api.routes, whose __init__
+eagerly imports heavy ML modules), mounts only that router, and drives it with
+a fake host so no MCP session is needed. Covers the flag gate, the allowlist,
+and the rate-limit / size-cap rejections.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.genui import dataplane  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "genui_data_routes_under_test", REPO / "src/api/routes/genui_data_routes.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class FakeHost:
+    def __init__(self, tools, results):
+        self._tools = tools
+        self._results = results
+
+    def tools(self, server=None):
+        if server is not None:
+            return {server: self._tools.get(server, [])}
+        return dict(self._tools)
+
+    def call_tool_cached(self, server, tool, arguments=None, **kw):
+        return self._results[(server, tool)]
+
+
+def _data_tool(name):
+    return {
+        "name": name,
+        "meta": {"data": {"panel": "articles", "rest_route": "/api/v1/news/articles"}},
+        "has_output_schema": True,
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("NOESIS_GENUI_DATA_PROXY", "on")
+    # Fresh limiter each test so bursts do not leak across tests.
+    monkeypatch.setattr(dataplane, "_LIMITER", dataplane.RateLimiter(1000))
+    host = FakeHost(
+        {"neuronews-pipeline": [_data_tool("articles_data")]},
+        {("neuronews-pipeline", "articles_data"): {"count": 1, "articles": [{"id": "a1"}]}},
+    )
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: host)
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app)
+
+
+def test_disabled_returns_404(monkeypatch):
+    monkeypatch.setenv("NOESIS_GENUI_DATA_PROXY", "off")
+    app = FastAPI()
+    app.include_router(mod.router)
+    c = TestClient(app)
+    assert c.post("/api/v1/ui/data", json={"server": "x", "tool": "y"}).status_code == 404
+    tools = c.get("/api/v1/ui/data/tools").json()
+    assert tools["enabled"] is False and tools["tools"] == []
+
+
+def test_allowlist_is_exposed(client):
+    body = client.get("/api/v1/ui/data/tools").json()
+    assert body["enabled"] is True
+    assert body["count"] == 1
+    assert body["tools"][0]["tool"] == "articles_data"
+    assert body["tools"][0]["panel"] == "articles"
+
+
+def test_allowed_tool_returns_payload(client):
+    resp = client.post(
+        "/api/v1/ui/data",
+        json={"server": "neuronews-pipeline", "tool": "articles_data", "arguments": {"limit": 1}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tool"] == "articles_data"
+    assert body["data"]["count"] == 1
+
+
+def test_non_allowlisted_tool_is_forbidden(client):
+    resp = client.post(
+        "/api/v1/ui/data",
+        json={"server": "neuronews-pipeline", "tool": "trigger_delete_everything"},
+    )
+    assert resp.status_code == 403
+
+
+def test_rate_limit_returns_429(client, monkeypatch):
+    monkeypatch.setattr(dataplane, "_LIMITER", dataplane.RateLimiter(2))
+    ok1 = client.post("/api/v1/ui/data", json={"server": "neuronews-pipeline", "tool": "articles_data"})
+    ok2 = client.post("/api/v1/ui/data", json={"server": "neuronews-pipeline", "tool": "articles_data"})
+    blocked = client.post("/api/v1/ui/data", json={"server": "neuronews-pipeline", "tool": "articles_data"})
+    assert ok1.status_code == 200 and ok2.status_code == 200
+    assert blocked.status_code == 429
+
+
+def test_oversized_request_returns_413(client, monkeypatch):
+    monkeypatch.setattr(dataplane, "MAX_REQUEST_BYTES", 40)
+    resp = client.post(
+        "/api/v1/ui/data",
+        json={"server": "neuronews-pipeline", "tool": "articles_data", "arguments": {"blob": "x" * 200}},
+    )
+    assert resp.status_code == 413

--- a/tests/unit/genui/test_dataplane.py
+++ b/tests/unit/genui/test_dataplane.py
@@ -1,0 +1,169 @@
+"""Unit tests for the data-plane proxy support (src/genui/dataplane.py, R12).
+
+Covers the data-mode allowlist discovery, the rate limiter, the size caps and
+the invoke guardrails. All host access goes through a fake.
+"""
+
+import pytest
+
+from src.genui import dataplane
+from src.genui.dataplane import (
+    DataPlaneError,
+    RateLimiter,
+    check_request_size,
+    data_mode_tools,
+    invoke_data_tool,
+    is_allowed,
+)
+
+
+class FakeHost:
+    def __init__(self, tools_by_server, results=None):
+        self._tools = tools_by_server
+        self._results = results or {}
+
+    def tools(self, server=None):
+        if server is not None:
+            return {server: self._tools.get(server, [])}
+        return dict(self._tools)
+
+    def call_tool_cached(self, server, tool, arguments=None, **kw):
+        return self._results[(server, tool)]
+
+
+def _data_tool(name, panel="articles", has_schema=True):
+    return {
+        "name": name,
+        "meta": {"data": {"panel": panel, "rest_route": "/api/v1/news/articles"}},
+        "has_output_schema": has_schema,
+    }
+
+
+def _panel_tool(name):
+    return {"name": name, "meta": {"panel": {"type": "articles"}}, "has_output_schema": True}
+
+
+@pytest.fixture
+def fake_host(monkeypatch):
+    def _install(tools_by_server, results=None):
+        host = FakeHost(tools_by_server, results)
+        monkeypatch.setattr("src.mcp_host.get_host", lambda: host)
+        return host
+
+    return _install
+
+
+@pytest.fixture
+def no_host(monkeypatch):
+    monkeypatch.setattr("src.mcp_host.get_host", lambda: None)
+
+
+# --- allowlist discovery ----------------------------------------------------
+
+
+def test_data_mode_tools_discovers_only_data_blocks(fake_host):
+    fake_host({"srv": [_data_tool("articles_data"), _panel_tool("latest_articles")]})
+    tools = data_mode_tools()
+    assert list(tools) == [("srv", "articles_data")]
+    assert tools[("srv", "articles_data")]["panel"] == "articles"
+
+
+def test_data_mode_tool_requires_output_schema(fake_host):
+    fake_host({"srv": [_data_tool("articles_data", has_schema=False)]})
+    assert data_mode_tools() == {}
+
+
+def test_no_host_means_empty_allowlist(no_host):
+    assert data_mode_tools() == {}
+    assert is_allowed("srv", "articles_data") is False
+
+
+def test_is_allowed(fake_host):
+    fake_host({"srv": [_data_tool("articles_data")]})
+    assert is_allowed("srv", "articles_data") is True
+    assert is_allowed("srv", "not_a_tool") is False
+
+
+# --- rate limiter -----------------------------------------------------------
+
+
+def test_rate_limiter_allows_burst_then_blocks():
+    limiter = RateLimiter(rate_per_min=3)
+    assert [limiter.allow("c", now=1000) for _ in range(3)] == [True, True, True]
+    assert limiter.allow("c", now=1000) is False  # bucket empty
+
+
+def test_rate_limiter_refills_over_time():
+    limiter = RateLimiter(rate_per_min=60)  # 1 token/sec
+    for _ in range(60):
+        limiter.allow("c", now=1000)
+    assert limiter.allow("c", now=1000) is False
+    assert limiter.allow("c", now=1002) is True  # ~2 tokens refilled
+
+
+def test_rate_limiter_is_per_client():
+    limiter = RateLimiter(rate_per_min=1)
+    assert limiter.allow("a", now=1000) is True
+    assert limiter.allow("a", now=1000) is False
+    assert limiter.allow("b", now=1000) is True  # separate bucket
+
+
+# --- size caps --------------------------------------------------------------
+
+
+def test_request_size_cap(monkeypatch):
+    monkeypatch.setattr(dataplane, "MAX_REQUEST_BYTES", 50)
+    with pytest.raises(DataPlaneError) as exc:
+        check_request_size({"x": "y" * 100})
+    assert exc.value.status == 413
+
+
+def test_request_size_ok():
+    check_request_size({"topic": "energy"})  # no raise
+
+
+# --- invoke guardrails ------------------------------------------------------
+
+
+def test_invoke_rejects_non_allowlisted(fake_host):
+    fake_host({"srv": [_data_tool("articles_data")]})
+    with pytest.raises(DataPlaneError) as exc:
+        invoke_data_tool("srv", "evil_tool", {})
+    assert exc.value.status == 403 and exc.value.code == "not_allowed"
+
+
+def test_invoke_returns_payload(fake_host):
+    fake_host(
+        {"srv": [_data_tool("articles_data")]},
+        results={("srv", "articles_data"): {"count": 2, "articles": [{"id": "a"}, {"id": "b"}]}},
+    )
+    out = invoke_data_tool("srv", "articles_data", {"limit": 2})
+    assert out["count"] == 2
+
+
+def test_invoke_maps_tool_error(fake_host):
+    fake_host(
+        {"srv": [_data_tool("articles_data")]},
+        results={("srv", "articles_data"): {"error": "warehouse locked"}},
+    )
+    with pytest.raises(DataPlaneError) as exc:
+        invoke_data_tool("srv", "articles_data", {})
+    assert exc.value.status == 502 and exc.value.code == "tool_error"
+
+
+def test_invoke_response_size_cap(fake_host, monkeypatch):
+    monkeypatch.setattr(dataplane, "MAX_RESPONSE_BYTES", 20)
+    fake_host(
+        {"srv": [_data_tool("articles_data")]},
+        results={("srv", "articles_data"): {"articles": [{"title": "x" * 100}]}},
+    )
+    with pytest.raises(DataPlaneError) as exc:
+        invoke_data_tool("srv", "articles_data", {})
+    assert exc.value.status == 413 and exc.value.code == "response_too_large"
+
+
+def test_invoke_without_host(no_host):
+    with pytest.raises(DataPlaneError) as exc:
+        invoke_data_tool("srv", "articles_data", {})
+    # not allowlisted (no host -> empty allowlist) is checked first.
+    assert exc.value.status == 403

--- a/tests/unit/genui/test_dataplane_equivalence.py
+++ b/tests/unit/genui/test_dataplane_equivalence.py
@@ -1,0 +1,94 @@
+"""R12 #619 equivalence: the articles_data data-mode tool returns payloads
+equivalent to the /api/v1/news/articles REST route for the articles family.
+
+Loads the pipeline server by path, calls articles_data over an in-memory
+FastMCP client on a temp warehouse, and asserts each row carries exactly the
+REST route's fields. Skips where fastmcp/duckdb are unavailable.
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp")
+duckdb = pytest.importorskip("duckdb")
+
+REPO = Path(__file__).resolve().parents[3]
+
+# The exact field set the /api/v1/news/articles route selects (src/api/routes/
+# news_routes.py get_articles): id, title, url, publish_date, source, category,
+# sentiment_score, sentiment_label.
+REST_FIELDS = {
+    "id", "title", "url", "publish_date", "source", "category",
+    "sentiment_score", "sentiment_label",
+}
+
+
+def _load_pipeline():
+    path = REPO / "tools/pipeline_mcp/server.py"
+    spec = importlib.util.spec_from_file_location("pl_equiv_srv", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def warehouse(tmp_path, monkeypatch):
+    db = tmp_path / "wh.duckdb"
+    con = duckdb.connect(str(db))
+    con.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    con.executemany(
+        "INSERT INTO news_articles (id, title, url, publish_date, source, category, "
+        "sentiment_score, sentiment_label) VALUES (?,?,?,?,?,?,?,?)",
+        [
+            ("a1", "Grid policy shifts", "http://x/1", "2026-06-02", "Alpha Wire", "energy", 0.4, "positive"),
+            ("a2", "Market reaction muted", "http://x/2", "2026-06-01", "Beta Journal", "markets", -0.2, "negative"),
+        ],
+    )
+    con.close()
+    monkeypatch.setenv("NEURONEWS_DB_PATH", str(db))
+    return db
+
+
+def _call_articles_data(pipeline):
+    from fastmcp.client import Client
+
+    async def run():
+        async with Client(pipeline.mcp) as c:
+            return (await c.call_tool("articles_data", {"limit": 50})).structured_content
+
+    return asyncio.run(run())
+
+
+def test_articles_data_matches_rest_fields(warehouse):
+    pipeline = _load_pipeline()
+    out = _call_articles_data(pipeline)
+    assert out["count"] == 2
+    for article in out["articles"]:
+        assert set(article) == REST_FIELDS, f"field drift vs REST route: {set(article)}"
+    # Full-payload (not a summary): url and sentiment_score are present, which
+    # the compact latest_articles summary omits.
+    first = out["articles"][0]
+    assert first["url"] and first["sentiment_score"] is not None
+
+
+def test_articles_data_filters_like_the_route(warehouse):
+    pipeline = _load_pipeline()
+    from fastmcp.client import Client
+
+    async def run():
+        async with Client(pipeline.mcp) as c:
+            return (
+                await c.call_tool("articles_data", {"source": "Alpha Wire"})
+            ).structured_content
+
+    out = asyncio.run(run())
+    assert out["count"] == 1 and out["articles"][0]["source"] == "Alpha Wire"

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1100,6 +1100,99 @@ def latest_articles(topic: Optional[str] = None, limit: int = 10) -> dict:
 @mcp.tool(
     output_schema={
         "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "articles": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "title": {"type": ["string", "null"]},
+                        "url": {"type": ["string", "null"]},
+                        "publish_date": {"type": ["string", "null"]},
+                        "source": {"type": ["string", "null"]},
+                        "category": {"type": ["string", "null"]},
+                        "sentiment_score": {"type": ["number", "null"]},
+                        "sentiment_label": {"type": ["string", "null"]},
+                    },
+                },
+            },
+        },
+        "additionalProperties": True,
+    },
+    # Data-mode (R12 #619): a full-payload variant of the `articles` panel,
+    # equivalent to the /api/v1/news/articles REST route. The `data` meta block
+    # marks it callable through the /api/v1/ui/data proxy allowlist; it is not a
+    # planner-facing stats tool.
+    meta={"data": {
+        "panel": "articles",
+        "rest_route": "/api/v1/news/articles",
+    }},
+)
+def articles_data(
+    source: Optional[str] = None,
+    category: Optional[str] = None,
+    limit: int = 50,
+) -> dict:
+    """Full article rows for the `articles` panel (data mode): the same fields
+    the /api/v1/news/articles REST route returns, served through the MCP layer.
+
+    Args:
+        source: optional exact source filter.
+        category: optional exact category filter.
+        limit: max rows (default 50, max 200).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    limit = min(max(1, limit), 200)
+    where, params = [], []
+    if source:
+        where.append("source = ?")
+        params.append(source)
+    if category:
+        where.append("category = ?")
+        params.append(category)
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params.append(limit)
+    try:
+        rows = con.execute(
+            f"""
+            SELECT id, title, url, publish_date, source, category,
+                   sentiment_score, sentiment_label
+            FROM news_articles {clause}
+            ORDER BY publish_date DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return {
+            "count": len(rows),
+            "articles": [
+                {
+                    "id": r[0],
+                    "title": r[1],
+                    "url": r[2],
+                    "publish_date": r[3].isoformat() if r[3] else None,
+                    "source": r[4],
+                    "category": r[5],
+                    "sentiment_score": float(r[6]) if r[6] is not None else None,
+                    "sentiment_label": r[7],
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
         "properties": {"total_documents": {"type": "integer"}, "by_source_type": {"type": "array"}},
         "additionalProperties": True,
     },


### PR DESCRIPTION
## Summary

R12 is the Stage 3 gate: build a prototype for serving panel *data* through MCP, benchmark it against the equivalent REST route, and record the go/no-go decision with numbers.

Closes #619, #620, #621.

## What landed

- Data-mode tool (#619): `articles_data` on the pipeline server returns the full `articles` payload, byte-identical to the `/api/v1/news/articles` REST route. It carries a `meta.data` annotation, distinct from the `meta.panel` block, so planner-facing stats tools are untouched and a data tool is never mistaken for a panel definition.
- Proxy (#620): `POST /api/v1/ui/data` lets the browser have the API invoke an allowlisted data-mode tool (the browser never speaks MCP); `GET /api/v1/ui/data/tools` exposes the allowlist. `src/genui/dataplane.py` enforces the allowlist (discovered from `meta.data` over the R1 tool cache), a per-client token bucket, and request/response size caps, and serves through the R4 shared tool cache. It is behind the `NOESIS_GENUI_DATA_PROXY` flag (off by default), registered in `app.py` via the standard feature-flag pattern.
- Benchmark + ADR (#621): `scripts/genui/dataplane_benchmark.py` and `docs/architecture/ADR-002-data-plane-stage3.md`.
- Frontend: the `useDataPlaneArticles` hook renders the articles panel through the proxy when the flag reports it enabled (badged `MCP`), falling back to REST/demo otherwise.

## Benchmark (200-row payload, 60 iterations)

Same 50,743-byte payload on every path (confirms the #619 equivalence):

| path | p50 (ms) | p95 (ms) | payload (B) |
|---|---|---|---|
| `rest_direct` | 13.3 | 15.5 | 50,743 |
| `mcp_tool` | 46.1 | 55.5 | 50,743 |
| `proxy_cold` | 50.4 | 64.7 | 50,743 |
| `proxy_cached` | 0.36 | 0.44 | (cached) |

## Decision (ADR-002)

**Conditional go.** Promote the `articles` family through the proxy behind the flag, cache-served: `proxy_cached` beats REST because the R4 TTL cache skips the warehouse open on repeat loads. Do not move cold first-loads onto the proxy until the transport overhead (~3.8x today, all process-boundary + FastMCP serialization) closes; the gating metric and the prototype's retirement criteria are documented.

## Verification

- `tests/unit/genui` (incl. dataplane + equivalence), `tests/unit/api/routes/test_genui_data_routes.py`, plus the osint/provisioning sweep: 370+ passed. Frontend `tsc --noEmit` clean. `codegen.py --check` current.
- Live over the real supervised host: the allowlist includes only `articles_data` (the `meta.data` tool) and excludes `latest_articles` (a `meta.panel` tool); the proxy invokes and returns the full REST-equivalent fields; a non-allowlisted tool is rejected with 403.

```
STEP 1 allowlist has articles_data: True
STEP 2 latest_articles (meta.panel) NOT allowlisted: True
STEP 3 proxy invoke: count=2 fields=[category, id, publish_date, sentiment_label, sentiment_score, source, title, url]
STEP 4 non-allowlisted rejected: 403 not_allowed
RESULT: OK
```

## Exit criteria

- #619: data-mode calls return payloads equivalent to the REST route for the articles family (byte-identical in the benchmark, field-set asserted in a test).
- #620: one panel family renders end-to-end through the proxy behind the flag; disallowed tools, rate-limit and size-cap rejections are tested.
- #621: the ADR exists with benchmark numbers and a clear decision.