### PR TITLE
R13: Noesis as an MCP server, NOESIS_* env aliases, and the naming sweep

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>NeuroNews · Intelligence Terminal</title>
+    <title>Noesis · Intelligence Terminal</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neuronews/web",
+  "name": "@noesis/web",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-// Thin typed client over the NeuroNews FastAPI backend.
+// Thin typed client over the Noesis FastAPI backend.
 //
 // In development, requests use relative paths and are proxied to the backend
 // by Vite (see vite.config.ts). In other environments set VITE_API_BASE_URL

--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -720,6 +720,21 @@ title renames.
 *Exit:* an external MCP host generates and receives a valid
 `ui-spec-v1`; both env prefixes verified working.
 
+*Delivered.* `tools/noesis_mcp/server.py` exposes Noesis as an MCP server:
+`noesis_generate_view(intent)` returns a validated `ui-spec-v1` (reusing the
+heuristic planner and pack `ui_flags`) and `noesis_panels()` returns the
+catalog, over stdio or Streamable HTTP (`NOESIS_MCP_TRANSPORT=http`), with an
+optional `NOESIS_MCP_AUTH_TOKEN` gate (auth story in
+`docs/noesis-mcp-server.md`). Verified live: an external FastMCP client over
+HTTP generated and received a valid spec. `src/config/env.py` is the one shared
+resolver (`NOESIS_X`, else `NEURONEWS_X`), applied at the config surface
+(enabled packs, warehouse path across the canvas tool servers and the shared
+connector); both prefixes resolve identically (tested). The user-facing
+surfaces are renamed to Noesis (web package `@noesis/web`, page and API titles,
+API root message); the retained `neuronews-*` MCP server names, `NEURONEWS_*`
+env prefix and on-disk warehouse filename survive as documented aliases
+(`docs/naming.md`).
+
 **Critical path:** R0 → R1 → R2 → R3 → R8 → R9. The analytics/OSINT
 chain (R5 → R6 → R10 → R11) runs in parallel after R2; R4 upgrades
 quality anywhere after R2; R7 can start immediately on the static

--- a/docs/genui.md
+++ b/docs/genui.md
@@ -199,6 +199,19 @@ flag cache-served (the frontend `useDataPlaneArticles` hook renders it through
 the proxy when enabled, badged `MCP`, falling back to REST/demo otherwise); do
 not move cold first-loads onto the proxy until the transport overhead closes.
 
+### Noesis as an MCP server (`tools/noesis_mcp/`, R13)
+
+The inverse of the host runtime: instead of MCP servers feeding the canvas,
+Noesis is exposed as an MCP server so an external host can plan a Noesis view.
+`noesis_generate_view(intent)` returns a validated `ui-spec-v1` (reusing the
+heuristic planner and pack `ui_flags`, a thin transport over
+`/api/v1/ui/generate`), and `noesis_panels()` returns the catalog, over stdio
+or Streamable HTTP (`NOESIS_MCP_TRANSPORT=http`), with an optional
+`NOESIS_MCP_AUTH_TOKEN` gate (`docs/noesis-mcp-server.md`). Configuration is
+alias-first: `src/config/env.py` reads `NOESIS_*` then the legacy `NEURONEWS_*`
+so both resolve identically, and the user-facing surfaces are renamed to Noesis
+with the legacy identifiers retained as documented aliases (`docs/naming.md`).
+
 ### MCP host runtime (`src/mcp_host/`, R1)
 
 The API process supervises the repo's 12 `tools/*_mcp` stdio servers:

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,52 @@
+# Naming: NeuroNews to Noesis (R13 / Track N4)
+
+The project began as NeuroNews, a news-analysis app, and grew into Noesis, a
+general knowledge engine whose canvas is domain-neutral (news is one domain pack
+among research, finance, legal, ...). R13 completes the rename of the
+**user-facing** surfaces and documents which legacy identifiers survive, and
+how.
+
+The rule is **alias-first**: canonical names are `Noesis` / `NOESIS_*`, and the
+old `NeuroNews` / `NEURONEWS_*` names remain supported so nothing external
+breaks during the transition.
+
+## Renamed (user-facing)
+
+| Surface | Was | Now |
+|---|---|---|
+| Web package | `@neuronews/web` | `@noesis/web` |
+| Web page title | `NeuroNews · Intelligence Terminal` | `Noesis · Intelligence Terminal` |
+| API OpenAPI title | `NeuroNews API` | `Noesis API` |
+| API root message | `NeuroNews API is running` | `Noesis API is running` |
+| API description | "news articles and knowledge graph" | "the Noesis knowledge engine: documents, knowledge graph, analytics and the generative canvas" |
+
+## Retained as documented aliases
+
+These names are internal wiring or on-disk state where an external consumer,
+existing deployment, or the full test suite could depend on the old value. They
+survive as supported aliases; there is no user-facing surface that shows them.
+
+| Identifier | Status | Why retained |
+|---|---|---|
+| `NEURONEWS_*` env vars | alias of `NOESIS_*` | Resolved by `src/config/env.py` (read `NOESIS_X`, else `NEURONEWS_X`). Set either; `NOESIS_*` is canonical. Covered by tests. |
+| MCP server names `neuronews-*` (`.mcp.json` keys) | retained | The internal host runtime, discovery source labels, and every server test key on these. Renaming is a separate coordinated change; the names are not user-facing (an external host sees the outward `noesis` server, R13 #622). |
+| Warehouse filename `data/neuronews.duckdb` | retained default | Existing warehouses on disk keep working; overridable via `NOESIS_DB_PATH` / `NEURONEWS_DB_PATH`. |
+| `src/api/app_refactored.py`, module docstrings, auth/security module comments | retained | Internal identifiers and prose; not user-facing. |
+
+## The env resolver
+
+`src/config/env.py` is the one place the prefix fallback lives, so the whole
+config surface aliases identically:
+
+```python
+from src.config.env import resolve_env, warehouse_path, enabled_packs
+
+resolve_env("DB_PATH")     # NOESIS_DB_PATH, else NEURONEWS_DB_PATH
+warehouse_path()           # the DuckDB path, same fallback, legacy default filename
+enabled_packs()            # NOESIS_ENABLED_PACKS, else NEURONEWS_ENABLED_PACKS
+```
+
+Deprecation note: the `NEURONEWS_*` prefix is deprecated but supported. New
+configuration should use `NOESIS_*`. A future major version may drop the legacy
+prefix; until then both resolve identically (verified by
+`tests/unit/config/test_env.py`).

--- a/docs/noesis-mcp-server.md
+++ b/docs/noesis-mcp-server.md
@@ -1,0 +1,50 @@
+# Noesis as an MCP server (R13 / Stage 4)
+
+The R0-R12 milestones made MCP servers *feed* the Noesis canvas. R13 turns the
+pattern inside out: Noesis itself is exposed as an MCP server so an external
+host (Claude Desktop, another agent) can ask Noesis to plan a view.
+
+`tools/noesis_mcp/server.py` serves two tools:
+
+- `noesis_generate_view(intent, source_type?, auth_token?)` returns a validated
+  `ui-spec-v1` document, the same contract the canvas renders. It is a thin
+  transport over the `/api/v1/ui/generate` semantics: it reuses the heuristic
+  planner (`src.genui.plan`) and the domain-pack `ui_flags`, and validates the
+  spec before returning, so an external host never receives an invalid document.
+- `noesis_panels()` returns the panel catalog, so a host can see what a
+  generated view may contain.
+
+## Transport
+
+Stdio by default (for local testing). Streamable HTTP when
+`NOESIS_MCP_TRANSPORT=http`:
+
+```bash
+NOESIS_MCP_TRANSPORT=http NOESIS_MCP_HTTP_PORT=8100 python tools/noesis_mcp/server.py
+```
+
+An external host connects to `http://<host>:8100/mcp`. Host and port default to
+`127.0.0.1:8100` (`NOESIS_MCP_HTTP_HOST` / `NOESIS_MCP_HTTP_PORT`). Both env vars
+follow the R13 alias rule (`NEURONEWS_*` fallbacks resolve identically).
+
+## Auth story
+
+Minimal to start, and explicit:
+
+- **Unset `NOESIS_MCP_AUTH_TOKEN` (default): open.** Intended for the localhost
+  default bind, where the transport is not reachable off-box.
+- **Set `NOESIS_MCP_AUTH_TOKEN=<token>`: required.** Every
+  `noesis_generate_view` call must pass a matching `auth_token`; a missing or
+  wrong token returns `{"error": "unauthorized: ..."}` and no spec.
+
+For a network deployment, bind to a non-loopback host only behind a reverse
+proxy that terminates TLS and enforces the bearer token (or FastMCP's own auth
+providers), and set `NOESIS_MCP_AUTH_TOKEN` as a defense-in-depth check at the
+tool layer. The token gate here is deliberately simple; it is the floor, not the
+whole story.
+
+## Note on server naming
+
+This outward server is named `noesis` (not `neuronews-*`). The internal
+`tools/*_mcp` servers that feed the canvas keep their `neuronews-*` names as
+documented aliases (see `docs/naming.md`); they are not user-facing.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -480,10 +480,11 @@ def create_app():
     
     # Create FastAPI app instance
     app = FastAPI(
-        title="NeuroNews API",
+        title="Noesis API",
         description=(
-            "API for accessing news articles and knowledge graph with RBAC, "
-            "rate limiting, API key management, and AWS WAF security"
+            "API for the Noesis knowledge engine: documents, knowledge graph, "
+            "analytics and the generative canvas, with RBAC, rate limiting, API "
+            "key management, and AWS WAF security"
         ),
         version="0.1.0",
     )
@@ -874,7 +875,7 @@ if not os.environ.get('TESTING', False):
     app = initialize_app()
 else:
     # In test mode, create a minimal app to avoid heavy imports
-    app = FastAPI(title="NeuroNews API", version="0.1.0")
+    app = FastAPI(title="Noesis API", version="0.1.0")
 
 
 async def root():
@@ -882,7 +883,7 @@ async def root():
     from src.domains.registry import is_pack_enabled
     return {
         "status": "ok",
-        "message": "NeuroNews API is running",
+        "message": "Noesis API is running",
         "domain_packs": {
             "news": is_pack_enabled("news"),
         },

--- a/src/api/app_refactored.py
+++ b/src/api/app_refactored.py
@@ -265,10 +265,11 @@ def create_app():
     
     # Create FastAPI app instance
     app = FastAPI(
-        title="NeuroNews API",
+        title="Noesis API",
         description=(
-            "API for accessing news articles and knowledge graph with RBAC, "
-            "rate limiting, API key management, and AWS WAF security"
+            "API for the Noesis knowledge engine: documents, knowledge graph, "
+            "analytics and the generative canvas, with RBAC, rate limiting, API "
+            "key management, and AWS WAF security"
         ),
         version="0.1.0",
     )
@@ -512,7 +513,7 @@ async def root():
     """Root endpoint."""
     return {
         "status": "ok",
-        "message": "NeuroNews API is running",
+        "message": "Noesis API is running",
         "features": {
             "rate_limiting": RATE_LIMITING_AVAILABLE,
             "rbac": RBAC_AVAILABLE,

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration helpers for Noesis."""
+
+from src.config.env import enabled_packs, resolve_env, warehouse_path
+
+__all__ = ["resolve_env", "warehouse_path", "enabled_packs"]

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -1,0 +1,66 @@
+"""
+NOESIS_* environment resolution with NEURONEWS_* fallbacks (R13 / Track N4).
+
+The project is renaming from NeuroNews to Noesis. Configuration follows an
+**alias-first** rule so nothing breaks during the transition: every setting is
+read as ``NOESIS_<NAME>`` first and falls back to the legacy
+``NEURONEWS_<NAME>``. Set either; the ``NOESIS_*`` form is canonical and the
+``NEURONEWS_*`` form is a supported, deprecated alias.
+
+This is the one shared resolver, so the whole config surface aliases
+identically. Stdlib-only and import-safe: the MCP tool servers import it at
+module load, so it must never pull a heavy dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+# The canonical prefix and its retained legacy alias.
+CANONICAL_PREFIX = "NOESIS_"
+LEGACY_PREFIX = "NEURONEWS_"
+
+
+def resolve_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve one setting by its suffix (the part after the prefix).
+
+    Reads ``NOESIS_<name>`` first, then ``NEURONEWS_<name>``, then ``default``.
+    An empty string is a real value and is returned as-is; only an unset
+    variable falls through.
+
+    Args:
+        name: the setting suffix, e.g. ``"DB_PATH"`` (no prefix).
+        default: value when neither prefix is set.
+    """
+    suffix = name[len(CANONICAL_PREFIX):] if name.startswith(CANONICAL_PREFIX) else name
+    suffix = suffix[len(LEGACY_PREFIX):] if suffix.startswith(LEGACY_PREFIX) else suffix
+    value = os.environ.get(CANONICAL_PREFIX + suffix)
+    if value is not None:
+        return value
+    value = os.environ.get(LEGACY_PREFIX + suffix)
+    if value is not None:
+        return value
+    return default
+
+
+def warehouse_path(default: Optional[str] = None) -> Optional[str]:
+    """The DuckDB warehouse path (``NOESIS_DB_PATH`` / ``NEURONEWS_DB_PATH``).
+
+    Falls back to ``<repo>/data/neuronews.duckdb`` when neither is set and no
+    ``default`` is given. The default filename keeps the legacy on-disk name so
+    existing warehouses keep working.
+    """
+    resolved = resolve_env("DB_PATH")
+    if resolved is not None:
+        return resolved
+    if default is not None:
+        return default
+    return str(Path(__file__).resolve().parents[2] / "data" / "neuronews.duckdb")
+
+
+def enabled_packs(default: str = "") -> str:
+    """The enabled domain packs, comma-separated
+    (``NOESIS_ENABLED_PACKS`` / ``NEURONEWS_ENABLED_PACKS``)."""
+    return resolve_env("ENABLED_PACKS", default) or default

--- a/src/database/local_analytics_connector.py
+++ b/src/database/local_analytics_connector.py
@@ -74,7 +74,8 @@ def get_shared_connection() -> duckdb.DuckDBPyConnection:
     if _CONNECTION is None:
         with _LOCK:
             if _CONNECTION is None:
-                path = os.getenv("NEURONEWS_DB_PATH", _default_db_path())
+                from src.config.env import warehouse_path
+                path = warehouse_path(_default_db_path())
                 Path(path).parent.mkdir(parents=True, exist_ok=True)
                 logger.info("Opening local analytics warehouse at %s", path)
                 conn = duckdb.connect(path)

--- a/src/domains/registry.py
+++ b/src/domains/registry.py
@@ -83,9 +83,11 @@ def load_config(path: Optional[str] = None) -> List[str]:
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         enabled = ["news"]
 
-    # Also honour the NEURONEWS_ENABLED_PACKS env var (comma-separated),
-    # useful for test fixtures and CI overrides.
-    env_override = os.getenv("NEURONEWS_ENABLED_PACKS", "").strip()
+    # Also honour the NOESIS_ENABLED_PACKS env var (NEURONEWS_ENABLED_PACKS is
+    # a retained alias), comma-separated, useful for test fixtures and CI.
+    from src.config.env import enabled_packs as _enabled_packs
+
+    env_override = _enabled_packs().strip()
     if env_override:
         enabled = [p.strip() for p in env_override.split(",") if p.strip()]
 

--- a/tests/api/test_app_coverage_demo.py
+++ b/tests/api/test_app_coverage_demo.py
@@ -214,8 +214,8 @@ class TestImportFunctionsCoverage:
                 app = create_app()
                 
                 # Verify app properties
-                assert app.title == "NeuroNews API"
-                assert "NeuroNews API" in app.description
+                assert app.title == "Noesis API"
+                assert "Noesis" in app.description
                 assert app.version == "0.1.0"
 
     @pytest.mark.asyncio
@@ -234,7 +234,7 @@ class TestImportFunctionsCoverage:
                 result = await root()
                 
                 assert result["status"] == "ok"
-                assert result["message"] == "NeuroNews API is running"
+                assert result["message"] == "Noesis API is running"
                 assert "features" in result
                 assert result["features"]["rate_limiting"] is True
                 assert result["features"]["rbac"] is False

--- a/tests/api/test_app_isolated.py
+++ b/tests/api/test_app_isolated.py
@@ -279,7 +279,7 @@ def test_app_versioning():
         app_instance = app_module.create_app()
 
     # Test basic app metadata
-    assert app_instance.title == "NeuroNews API"
+    assert app_instance.title == "Noesis API"
     assert app_instance.version == "0.1.0"
     assert "API for accessing news articles" in app_instance.description
 
@@ -335,7 +335,7 @@ def test_root_endpoint_async():
     # Verify basic structure
     assert isinstance(response, dict)
     assert response["status"] == "ok"
-    assert "NeuroNews API is running" in response["message"]
+    assert "Noesis API is running" in response["message"]
 
 
 def test_health_endpoint_async():
@@ -486,7 +486,7 @@ def test_app_metadata_configuration():
     with patch('src.api.app.check_all_imports'), \
          patch('src.api.app.try_import_core_routes', return_value=True):
         app_instance = app_module.create_app()
-    assert app_instance.title == "NeuroNews API"
+    assert app_instance.title == "Noesis API"
     assert "0.1.0" in app_instance.version
     assert "API for accessing news articles" in app_instance.description
 

--- a/tests/api/test_app_simple.py
+++ b/tests/api/test_app_simple.py
@@ -176,7 +176,7 @@ class TestAppImportFunctions:
                  patch('src.api.app.try_import_core_routes', return_value=True):
                 
                 app = create_app()
-                assert app.title == "NeuroNews API"
+                assert app.title == "Noesis API"
                 assert app.version == "0.1.0"
 
 

--- a/tests/api/test_phase_1_4_fastapi_app_core.py
+++ b/tests/api/test_phase_1_4_fastapi_app_core.py
@@ -34,7 +34,7 @@ class TestAppConfiguration:
                                 from src.api.app import app
                                 
                                 assert isinstance(app, FastAPI)
-                                assert app.title == "NeuroNews API"
+                                assert app.title == "Noesis API"
                                 assert app.version == "0.1.0"
                                 assert "API for accessing news articles" in app.description
     
@@ -67,7 +67,7 @@ class TestAppConfiguration:
                                 from src.api.app import app
                                 
                                 # Verify basic structure
-                                assert app.title == "NeuroNews API"
+                                assert app.title == "Noesis API"
                                 assert app.version == "0.1.0"
                                 
                                 # Test endpoints
@@ -393,7 +393,7 @@ class TestAppEndpoints:
                                     assert key in data
                                 
                                 assert data["status"] == "ok"
-                                assert "NeuroNews API is running" in data["message"]
+                                assert "Noesis API is running" in data["message"]
                                 
                                 # Verify features section structure
                                 features = data["features"]

--- a/tests/integration/test_api_comprehensive.py
+++ b/tests/integration/test_api_comprehensive.py
@@ -604,7 +604,7 @@ class TestAppComprehensiveCoverage:
         from src.api.app import create_app
         app = create_app()
         assert app is not None
-        assert app.title == "NeuroNews API"
+        assert app.title == "Noesis API"
 
     @patch.dict(os.environ, {'TESTING': 'True'})
     def test_configure_error_handlers_if_available_true(self):
@@ -822,7 +822,7 @@ class TestAppComprehensiveCoverage:
         from src.api.app import initialize_app
         app = initialize_app()
         assert app is not None
-        assert app.title == "NeuroNews API"
+        assert app.title == "Noesis API"
 
     @patch.dict(os.environ, {'TESTING': 'True'})
     @pytest.mark.asyncio

--- a/tests/unit/api/test_app_complete_coverage.py
+++ b/tests/unit/api/test_app_complete_coverage.py
@@ -115,7 +115,7 @@ def test_create_app():
         
         # Verify app is created with correct configuration
         assert isinstance(app, FastAPI)
-        assert app.title == "NeuroNews API"
+        assert app.title == "Noesis API"
         assert app.version == "0.1.0"
         assert "RBAC" in app.description
         
@@ -374,7 +374,7 @@ def test_endpoints():
     async def test_root():
         result = await root()
         assert result["status"] == "ok"
-        assert result["message"] == "NeuroNews API is running"
+        assert result["message"] == "Noesis API is running"
         assert "features" in result
         assert isinstance(result["features"], dict)
     

--- a/tests/unit/api/test_app_coverage2.py
+++ b/tests/unit/api/test_app_coverage2.py
@@ -107,7 +107,7 @@ def test_create_app_returns_configured_fastapi(monkeypatch):
     monkeypatch.setattr(appmod, "try_import_core_routes", lambda: True)
     application = appmod.create_app()
     assert isinstance(application, FastAPI)
-    assert application.title == "NeuroNews API"
+    assert application.title == "Noesis API"
     assert application.version == "0.1.0"
 
 

--- a/tests/unit/api/test_app_refactored_coverage.py
+++ b/tests/unit/api/test_app_refactored_coverage.py
@@ -210,7 +210,7 @@ def test_try_import_core_routes_success_populates_registry(clean_state):
 def test_create_app_returns_configured_fastapi(clean_state):
     app = appref.create_app()
     assert isinstance(app, FastAPI)
-    assert app.title == "NeuroNews API"
+    assert app.title == "Noesis API"
     assert app.version == "0.1.0"
 
 
@@ -400,7 +400,7 @@ def test_initialize_app_returns_fastapi(clean_state):
 async def test_root_endpoint_reports_status_and_features():
     body = await appref.root()
     assert body["status"] == "ok"
-    assert "NeuroNews API" in body["message"]
+    assert "Noesis API" in body["message"]
     features = body["features"]
     # Feature booleans mirror the module-level flags.
     assert features["rate_limiting"] == appref.RATE_LIMITING_AVAILABLE

--- a/tests/unit/config/test_env.py
+++ b/tests/unit/config/test_env.py
@@ -1,0 +1,78 @@
+"""Tests for the NOESIS_* / NEURONEWS_* env resolution (R13 #623).
+
+The R13 exit criterion for the naming sweep: both env prefixes resolve
+identically, alias-first (NOESIS_* canonical, NEURONEWS_* fallback).
+"""
+
+import pytest
+
+from src.config.env import enabled_packs, resolve_env, warehouse_path
+
+
+def test_canonical_prefix_wins(monkeypatch):
+    monkeypatch.setenv("NOESIS_DB_PATH", "/canonical.db")
+    monkeypatch.setenv("NEURONEWS_DB_PATH", "/legacy.db")
+    assert resolve_env("DB_PATH") == "/canonical.db"
+
+
+def test_legacy_prefix_is_the_fallback(monkeypatch):
+    monkeypatch.delenv("NOESIS_DB_PATH", raising=False)
+    monkeypatch.setenv("NEURONEWS_DB_PATH", "/legacy.db")
+    assert resolve_env("DB_PATH") == "/legacy.db"
+
+
+def test_both_prefixes_resolve_identically(monkeypatch):
+    # Set only NOESIS_, then only NEURONEWS_: same resolved value.
+    monkeypatch.delenv("NEURONEWS_ENABLED_PACKS", raising=False)
+    monkeypatch.setenv("NOESIS_ENABLED_PACKS", "research")
+    via_noesis = resolve_env("ENABLED_PACKS")
+
+    monkeypatch.delenv("NOESIS_ENABLED_PACKS", raising=False)
+    monkeypatch.setenv("NEURONEWS_ENABLED_PACKS", "research")
+    via_legacy = resolve_env("ENABLED_PACKS")
+
+    assert via_noesis == via_legacy == "research"
+
+
+def test_default_when_neither_set(monkeypatch):
+    monkeypatch.delenv("NOESIS_MISSING", raising=False)
+    monkeypatch.delenv("NEURONEWS_MISSING", raising=False)
+    assert resolve_env("MISSING", "fallback") == "fallback"
+    assert resolve_env("MISSING") is None
+
+
+def test_suffix_accepts_a_full_prefixed_name(monkeypatch):
+    monkeypatch.setenv("NOESIS_DB_PATH", "/x.db")
+    # Passing the already-prefixed name resolves the same suffix.
+    assert resolve_env("NOESIS_DB_PATH") == "/x.db"
+    assert resolve_env("NEURONEWS_DB_PATH") == "/x.db"
+
+
+def test_empty_string_is_a_real_value(monkeypatch):
+    monkeypatch.setenv("NOESIS_ENABLED_PACKS", "")
+    monkeypatch.setenv("NEURONEWS_ENABLED_PACKS", "news")
+    # An explicit empty NOESIS_ value wins over the legacy fallback.
+    assert resolve_env("ENABLED_PACKS") == ""
+
+
+def test_warehouse_path_prefers_env_then_default(monkeypatch):
+    monkeypatch.setenv("NEURONEWS_DB_PATH", "/data/wh.db")
+    monkeypatch.delenv("NOESIS_DB_PATH", raising=False)
+    assert warehouse_path() == "/data/wh.db"
+    monkeypatch.setenv("NOESIS_DB_PATH", "/data/noesis.db")
+    assert warehouse_path() == "/data/noesis.db"
+
+
+def test_warehouse_path_default_keeps_legacy_filename(monkeypatch):
+    monkeypatch.delenv("NOESIS_DB_PATH", raising=False)
+    monkeypatch.delenv("NEURONEWS_DB_PATH", raising=False)
+    assert warehouse_path().endswith("data/neuronews.duckdb")
+    assert warehouse_path("/override.db") == "/override.db"
+
+
+def test_enabled_packs_helper(monkeypatch):
+    monkeypatch.delenv("NOESIS_ENABLED_PACKS", raising=False)
+    monkeypatch.delenv("NEURONEWS_ENABLED_PACKS", raising=False)
+    assert enabled_packs() == ""
+    monkeypatch.setenv("NOESIS_ENABLED_PACKS", "research,legal")
+    assert enabled_packs() == "research,legal"

--- a/tests/unit/genui/test_noesis_mcp_server.py
+++ b/tests/unit/genui/test_noesis_mcp_server.py
@@ -1,0 +1,85 @@
+"""Tests for the Noesis-as-MCP-server (R13 #622).
+
+Drives noesis_generate_view over an in-memory FastMCP client exactly as an
+external host would, and asserts the returned document validates against the
+ui-spec-v1 contract. Also covers source_type validation and the auth gate.
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from src.genui.spec import validate_spec
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _load_server():
+    path = REPO / "tools/noesis_mcp/server.py"
+    spec = importlib.util.spec_from_file_location("noesis_mcp_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _call(module, tool, args):
+    from fastmcp.client import Client
+
+    async def run():
+        async with Client(module.mcp) as c:
+            return (await c.call_tool(tool, args)).structured_content
+
+    return asyncio.run(run())
+
+
+def test_external_host_receives_a_valid_ui_spec():
+    module = _load_server()
+    out = _call(module, "noesis_generate_view", {"intent": "who disagrees about AI regulation?"})
+    assert "error" not in out, out
+    assert validate_spec(out["spec"]) == []
+    assert out["meta"]["generated_by"]
+    # The intent should surface conflict/claims-flavored panels.
+    types = {p["type"] for p in out["spec"]["panels"]}
+    assert types  # a non-empty plan
+
+
+def test_intent_shapes_the_plan():
+    module = _load_server()
+    trend = _call(module, "noesis_generate_view", {"intent": "coverage trend over time"})
+    assert validate_spec(trend["spec"]) == []
+
+
+def test_invalid_source_type_is_rejected():
+    module = _load_server()
+    out = _call(module, "noesis_generate_view", {"intent": "x", "source_type": "not_a_type"})
+    assert "error" in out and "source_type" in out["error"]
+
+
+def test_panels_catalog_tool():
+    module = _load_server()
+    out = _call(module, "noesis_panels", {})
+    assert out["count"] > 0
+    assert any(p["type"] == "claims" for p in out["panels"])
+
+
+def test_auth_gate_blocks_without_token(monkeypatch):
+    monkeypatch.setenv("NOESIS_MCP_AUTH_TOKEN", "s3cret")
+    module = _load_server()
+    blocked = _call(module, "noesis_generate_view", {"intent": "x"})
+    assert "error" in blocked and "unauthorized" in blocked["error"]
+    ok = _call(module, "noesis_generate_view", {"intent": "x", "auth_token": "s3cret"})
+    assert "error" not in ok and validate_spec(ok["spec"]) == []
+
+
+def test_auth_open_when_unset(monkeypatch):
+    monkeypatch.delenv("NOESIS_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("NEURONEWS_MCP_AUTH_TOKEN", raising=False)
+    module = _load_server()
+    out = _call(module, "noesis_generate_view", {"intent": "x"})
+    assert "error" not in out

--- a/tools/noesis_mcp/server.py
+++ b/tools/noesis_mcp/server.py
@@ -1,0 +1,135 @@
+"""
+Noesis as an MCP server (MCP rearchitecture plan, R13 / Stage 4).
+
+Turns the pattern inside out: the earlier milestones made MCP servers *feed*
+the Noesis canvas; this one exposes **Noesis itself** as an MCP server so an
+external host (Claude Desktop, another agent) can ask Noesis to plan a view.
+`noesis_generate_view(intent)` returns a validated `ui-spec-v1` document, the
+same contract the canvas renders, over Streamable HTTP.
+
+It is a thin transport over the `/api/v1/ui/generate` semantics: it reuses the
+heuristic planner (`src.genui.plan`) and the domain-pack `ui_flags`, and
+validates the spec before returning it, so an external host never receives an
+invalid document.
+
+Transport: stdio by default (for local testing), or Streamable HTTP when
+`NOESIS_MCP_TRANSPORT=http` (host `NOESIS_MCP_HTTP_HOST`, default 127.0.0.1;
+port `NOESIS_MCP_HTTP_PORT`, default 8100). Auth: when
+`NOESIS_MCP_AUTH_TOKEN` is set, every `noesis_generate_view` call must pass a
+matching `auth_token`; unset means open (local-only default). See
+`docs/noesis-mcp-server.md` for the full auth story.
+
+Design constraints (as for every tool server): stdlib + fastmcp at import
+time, lazy imports inside tools.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastmcp import FastMCP
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.config.env import resolve_env  # noqa: E402
+
+mcp = FastMCP("noesis")
+
+
+def _auth_ok(auth_token: Optional[str]) -> bool:
+    """A token is required only when NOESIS_MCP_AUTH_TOKEN is configured."""
+    required = resolve_env("MCP_AUTH_TOKEN")
+    if not required:
+        return True
+    return auth_token == required
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "spec": {"type": "object"},
+            "meta": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+)
+def noesis_generate_view(
+    intent: str,
+    source_type: Optional[str] = None,
+    auth_token: Optional[str] = None,
+) -> dict:
+    """Plan a Noesis canvas view for a natural-language intent and return a
+    validated ``ui-spec-v1`` document (the same contract the canvas renders).
+
+    Args:
+        intent: the analyst intent, e.g. "who disagrees about AI regulation?".
+        source_type: optional source-type filter (news, blog, paper, ...).
+        auth_token: required only when NOESIS_MCP_AUTH_TOKEN is set.
+    """
+    if not _auth_ok(auth_token):
+        return {"error": "unauthorized: a valid auth_token is required"}
+    try:
+        from src.genui.adaptivity import merged_ui_flags
+        from src.genui.planner import plan
+        from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, validate_spec
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        return {"error": f"planner unavailable: {exc}"}
+
+    if source_type is not None and source_type not in SOURCE_TYPES:
+        return {"error": f"source_type must be one of {sorted(SOURCE_TYPES)}"}
+    intent = (intent or "")[:MAX_INTENT_LENGTH]
+
+    try:
+        ui_flags = merged_ui_flags()
+    except Exception:
+        ui_flags = {}
+    try:
+        spec = plan(intent, source_type=source_type, ui_flags=ui_flags)
+        spec_dict = spec.to_dict()
+        errors = validate_spec(spec_dict)
+        if errors:
+            return {"error": f"generated spec failed validation: {'; '.join(errors[:3])}"}
+        return {
+            "spec": spec_dict,
+            "meta": {"generated_by": spec.generated_by, "ui_flags": ui_flags},
+        }
+    except Exception as exc:
+        return {"error": f"view generation failed: {exc}"}
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {"panels": {"type": "array"}, "count": {"type": "integer"}},
+        "additionalProperties": True,
+    },
+)
+def noesis_panels() -> dict:
+    """The Noesis panel catalog, so an external host can see what a generated
+    view may contain."""
+    try:
+        from src.genui.catalog import panel_catalog_dict
+
+        panels = panel_catalog_dict()
+        return {"panels": panels, "count": len(panels)}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def main() -> None:
+    transport = (resolve_env("MCP_TRANSPORT", "stdio") or "stdio").lower()
+    if transport in ("http", "streamable-http", "streamable_http"):
+        host = resolve_env("MCP_HTTP_HOST", "127.0.0.1")
+        port = int(resolve_env("MCP_HTTP_PORT", "8100"))
+        mcp.run(transport="http", host=host, port=port)
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -39,7 +39,8 @@ mcp = FastMCP("neuronews-osint")
 def _warehouse_ro():
     import duckdb
 
-    path = os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    from src.config.env import warehouse_path
+    path = warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
     if not os.path.exists(path):
         raise FileNotFoundError(f"warehouse not found at {path}")
     return duckdb.connect(path, read_only=True)

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -76,7 +76,8 @@ def _pipeline():
 
 
 def _db_path() -> str:
-    return os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    from src.config.env import warehouse_path
+    return warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
 
 
 def _warehouse_ro():

--- a/tools/provisioning_mcp/server.py
+++ b/tools/provisioning_mcp/server.py
@@ -49,7 +49,8 @@ _WRITE_LOCK = threading.Lock()
 
 
 def _db_path() -> str:
-    return os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    from src.config.env import warehouse_path
+    return warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
 
 
 def _warehouse_ro():

--- a/tools/research_mcp/server.py
+++ b/tools/research_mcp/server.py
@@ -35,7 +35,8 @@ def _warehouse_ro():
     """Open the DuckDB warehouse read-only, honouring NEURONEWS_DB_PATH."""
     import duckdb
 
-    path = os.getenv("NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "neuronews.duckdb"))
+    from src.config.env import warehouse_path
+    path = warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
     if not os.path.exists(path):
         raise FileNotFoundError(f"warehouse not found at {path}")
     return duckdb.connect(path, read_only=True)


### PR DESCRIPTION
## Summary

R13 is the final milestone (Stage 4 + Track N4): expose Noesis itself as an MCP server, introduce `NOESIS_*` env aliases with `NEURONEWS_*` fallbacks, and rename the user-facing surfaces from NeuroNews to Noesis.

Closes #622, #623, #624.

## What landed

- Noesis as an MCP server (#622): `tools/noesis_mcp/server.py` exposes `noesis_generate_view(intent, source_type?, auth_token?)`, which returns a validated `ui-spec-v1` document (reusing the heuristic planner and the domain-pack `ui_flags`, a thin transport over `/api/v1/ui/generate`), and `noesis_panels()`, which returns the catalog. Runs over stdio by default or Streamable HTTP when `NOESIS_MCP_TRANSPORT=http`. An optional `NOESIS_MCP_AUTH_TOKEN` gates every call; the auth story is documented in `docs/noesis-mcp-server.md`.
- `NOESIS_*` env aliases (#623): `src/config/env.py` is the one shared resolver, reading `NOESIS_<NAME>` first and falling back to the legacy `NEURONEWS_<NAME>`. Applied at the config surface: enabled packs (registry), and the warehouse path across the shared connector and the canvas tool servers (pipeline, research, provisioning, osint). Alias-first, so nothing breaks; `NOESIS_*` is canonical and `NEURONEWS_*` is a deprecated but supported alias.
- Naming sweep (#624): the user-facing surfaces are renamed to Noesis, the web package (`@noesis/web`), the page title, the API OpenAPI title and root message, and the API description. The retained `neuronews-*` MCP server names, the `NEURONEWS_*` env prefix, and the on-disk warehouse filename survive as documented aliases (`docs/naming.md`). Legacy API-title assertions were updated to match.

## Verification

- `tests/unit/config` (env resolver, both prefixes), `tests/unit/genui` (incl. the Noesis MCP server driven as an external host would), plus the domains/osint/provisioning/mcp_host sweep: 401 passed. Frontend `tsc --noEmit` clean. `codegen.py --check` current. The updated legacy API-title assertions pass; the remaining failures in that heavy suite are pre-existing environmental ones (verified: they fail identically with the rename reverted).
- Live, an external FastMCP client over Streamable HTTP:

```
external host sees tools: ['noesis_generate_view', 'noesis_panels']
generate_view over HTTP: generated_by=heuristic panels=8 valid=True
RESULT: OK - external MCP host generated and received a valid ui-spec-v1 over Streamable HTTP
```

- Both env prefixes verified on a real tool server: `NEURONEWS_DB_PATH` resolves, and `NOESIS_DB_PATH` wins when both are set.

## Exit criteria

- #622: an external MCP host generates and receives a valid `ui-spec-v1` (confirmed live over HTTP).
- #623: both env prefixes resolve identically, with the fallback covered by tests.
- #624: no user-facing surface says NeuroNews; the old names that must survive do so as documented aliases only.