### PR TITLE
Track P2: provisioning MCP orchestrates databases and pipelines (#640-#645)

### DIFF
--- a/docs/architecture/MCP_REARCHITECTURE_PLAN.md
+++ b/docs/architecture/MCP_REARCHITECTURE_PLAN.md
@@ -203,6 +203,20 @@ approval). It does not depend on Stage 3.
 *Effort: large (namespacing + routing are the real work). Risk: RW agent
 surface — mitigated by the guardrail table above.*
 
+*Delivered (phase 1, R8/R9): table-prefix namespacing, routing, and the
+`kg_*` tool surface with guardrails, on a two-domain acceptance. Phase 2 (P2,
+issues #640-#644) extends the same surface to orchestrate databases and
+pipelines: a KG can deploy into its own attached DuckDB database (`backend`:
+`table-prefix` or `attached`), bind a pipeline with `kg_attach_pipeline`
+(contract-validated at attach), and `kg_ingest` runs the bound connectors
+before routing (connector to contract to enrich to route), with quotas on
+databases and pipelines and a teardown that detaches the database and unbinds
+the connectors, never cascading to the shared corpus. Two domains stand up
+with their own database and pipeline via provisioning alone;
+`docs/provisioning-p2-acceptance.md` is the write-up. The one remaining
+integration point is wiring the ingest runner to the real `pipeline_mcp`
+connector execution.*
+
 ## Track DS — the analytics plane: data-science techniques as MCP tools
 
 The same discovery pattern that turns servers into panels turns

--- a/docs/provisioning-p2-acceptance.md
+++ b/docs/provisioning-p2-acceptance.md
@@ -1,0 +1,79 @@
+# Provisioning phase 2 acceptance: databases and pipelines (Track P2)
+
+R8/R9 made the provisioning MCP orchestrate the knowledge-graph slice: deploy a
+namespaced KG (a table prefix in the shared warehouse), bind already-ingested
+sources, route their documents in, tear down. Track P2 (issues #640-#644)
+extends it to orchestrate **everything**: a KG can deploy into its own database,
+bind and run its own pipeline, and the whole domain reconstructs from its audit
+trail.
+
+The executable form of this report is
+[`scripts/provisioning/p2_acceptance.py`](../scripts/provisioning/p2_acceptance.py);
+the regression is
+[`tests/unit/provisioning/test_p2_backends_pipelines.py`](../tests/unit/provisioning/test_p2_backends_pipelines.py).
+
+## What changed
+
+- **Isolation backends (#640).** A KG's `backend` is `table-prefix` (default,
+  R8) or `attached`. An `attached` KG gets its own DuckDB file, attached under
+  the alias `kg_<name>`, so its documents/entities/claims live in a separate
+  database entirely (`kg_<name>.documents`, ...), not `kg_<name>_documents` in
+  the shared warehouse. Routing reads the shared corpus and writes across into
+  the KG's database. Teardown detaches the database and leaves the file on disk.
+- **`kg_attach_pipeline` (#641).** Binds a connector or feed to a KG,
+  contract-validated at attach (a feed with no url, or a config that fails its
+  ingest contract, is refused), idempotent by `(kg, connector)`, recorded in
+  lineage.
+- **Orchestrated `kg_ingest` (#642).** With bound pipelines and a runner, each
+  connector runs first (connector to contract to enrich), then routing copies
+  the matching documents into the namespace; per-pipeline progress is in the
+  ingest lineage event. With no runner it degrades to routing already-ingested
+  documents (R8 behaviour).
+- **Guardrails (#643).** New quotas: max provisioned databases and max
+  pipelines per KG. Deploying a database backend and attaching a pipeline are
+  approval-gated. Teardown detaches the database and unbinds pipelines, and
+  never cascades to the shared corpus. Each has a failing-path test.
+
+## Result (live run)
+
+```
+Standing up two domains, each with its own database and pipeline:
+  [energy]  deploy(attached) -> attach_pipeline -> attach_source -> ingest: pipeline ran (3 ingested), routed 3 docs into its own database
+  [markets] deploy(attached) -> attach_pipeline -> attach_source -> ingest: pipeline ran (2 ingested), routed 2 docs into its own database
+isolation: kg_energy.documents=3, kg_markets.documents=2, separate databases ['kg_energy', 'kg_markets']
+  [energy]  audit trail: ['deploy', 'attach_pipeline', 'attach', 'ingest']
+  [markets] audit trail: ['deploy', 'attach_pipeline', 'attach', 'ingest']
+teardown energy: database detached, file kept
+RESULT: OK - two domains live via provisioning alone, each with its own database and pipeline
+```
+
+- **Own database.** Each KG's rows live in its own attached DuckDB
+  (`kg_energy`, `kg_markets`), separate databases in `duckdb_databases()`, not
+  a prefix in the shared warehouse.
+- **Own pipeline.** The connector ran on ingest (writing fresh rows into the
+  shared corpus, as a real connector to contract to enrich step would), then
+  routing copied the matching rows into the KG's database, the full connector
+  to route path.
+- **Reconstructable.** Each domain replays from its lineage: deploy,
+  attach_pipeline, attach, ingest.
+- **Clean teardown.** Detaches the database (file kept, never deleted) and
+  unbinds the pipeline; the shared corpus is untouched.
+
+The same flow runs over the real `provisioning_mcp` server:
+`kg_deploy(backend="attached")`, `kg_attach_pipeline` (preview then approve, a
+bad config refused with `contract_invalid`), `kg_ingest`, `kg_status`
+(reporting `backend` and `pipeline_count`), and `kg_teardown` (detaching the
+database and the pipeline).
+
+## Answer to "does it orchestrate everything?"
+
+Yes, now: databases (own DuckDB per KG), knowledge graphs (R8 namespacing), and
+pipelines (bind a connector, run it on ingest, route the results), all from the
+one guardrailed, audited provisioning surface.
+
+Note on the live connector: in this harness the pipeline runner simulates a
+connector by writing to the shared corpus, so the run-to-route path is proven
+without a live external feed. Wiring the runner to the real `pipeline_mcp`
+connector execution (so `kg_ingest` pulls from an actual RSS/document source) is
+the one remaining integration point; the orchestration, guardrails and audit
+around it are complete and tested.

--- a/scripts/provisioning/p2_acceptance.py
+++ b/scripts/provisioning/p2_acceptance.py
@@ -1,0 +1,122 @@
+"""
+Track P2 acceptance: two domains, each with its own database and its own live
+pipeline, stood up by provisioning alone (issues #640-#644).
+
+This is the phase-2 counterpart to `acceptance.py` (R9). It provisions two
+domains through the provisioning plane, each deployed into its own attached
+DuckDB database (not a table prefix in the shared warehouse) and fed by its own
+bound pipeline. The pipeline runner here simulates a connector: on ingest it
+writes fresh rows into the shared corpus (as a real connector would), and
+routing then copies the matching rows into the KG's own database, proving the
+connector to route path end to end. Each domain is reconstructed from its audit
+trail at the end.
+
+Run:  python scripts/provisioning/p2_acceptance.py
+
+The executable form of docs/provisioning-p2-acceptance.md.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+sys.path.insert(0, str(REPO_ROOT))
+os.chdir(REPO_ROOT)
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def main() -> None:
+    import duckdb
+
+    from src.provisioning import namespaces, store
+    from src.provisioning.provisioner import Provisioner
+
+    tmp = tempfile.mkdtemp()
+    db = os.path.join(tmp, "wh.duckdb")
+    os.environ["NOESIS_DB_PATH"] = db
+    conn = duckdb.connect(db)
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    print("seeded empty shared warehouse (connectors will fill it on ingest)")
+
+    # A connector simulator: each run appends fresh articles for its source,
+    # exactly as a real connector -> contract -> enrich step would land them in
+    # the shared corpus. Routing then copies them into the KG's own database.
+    def make_runner(source: str, ids):
+        def runner(spec):
+            n = 0
+            for i in ids:
+                exists = conn.execute("SELECT 1 FROM news_articles WHERE id = ?", [i]).fetchone()
+                if not exists:
+                    conn.execute(
+                        "INSERT INTO news_articles (id, title, url, publish_date, source, category) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        [i, f"{source} item {i}", f"http://x/{i}", _now(), source, "topic"],
+                    )
+                    n += 1
+            return {"connector": spec["connector"], "documents_ingested": n}
+        return runner
+
+    def stand_up(name, source, ids):
+        prov = Provisioner(
+            conn, clock=_now, pipeline_runner=make_runner(source, ids)
+        )
+        dep = prov.deploy(name, f"{name} domain", approve=True, backend="attached")
+        assert dep["backend"] == "attached", dep
+        at = prov.attach_pipeline(
+            name, f"{name}-feed", "rss", {"url": f"http://{name}/feed.xml"}, approve=True
+        )
+        assert at["attached"], at
+        prov.attach_sources(name, sources=[source])
+        ing = prov.ingest(name)
+        assert ing["ingested"] and ing["backend"] == "attached", ing
+        print(
+            f"  [{name}] deploy(attached) -> attach_pipeline -> attach_source -> ingest: "
+            f"pipeline ran ({ing['pipeline_runs'][0]['result']['documents_ingested']} ingested), "
+            f"routed {ing['routed']['documents']} docs into its own database"
+        )
+        return prov
+
+    print("Standing up two domains, each with its own database and pipeline:")
+    prov = stand_up("energy", "Energy Feed", ["e1", "e2", "e3"])
+    stand_up("markets", "Markets Feed", ["m1", "m2"])
+
+    # Each KG's rows live in its OWN attached database, isolated from the other.
+    dbs = {r[0] for r in conn.execute("SELECT database_name FROM duckdb_databases()").fetchall()}
+    assert {"kg_energy", "kg_markets"} <= dbs, dbs
+    e = conn.execute("SELECT COUNT(*) FROM kg_energy.documents").fetchone()[0]
+    m = conn.execute("SELECT COUNT(*) FROM kg_markets.documents").fetchone()[0]
+    print(f"isolation: kg_energy.documents={e}, kg_markets.documents={m}, separate databases {sorted(d for d in dbs if d.startswith('kg_'))}")
+    assert e == 3 and m == 2
+
+    # Reconstruct each from its audit trail.
+    for name in ("energy", "markets"):
+        events = [ev["event"] for ev in reversed(store.list_events(conn, name, limit=50))]
+        print(f"  [{name}] audit trail: {events}")
+        assert events[:4] == ["deploy", "attach_pipeline", "attach", "ingest"], events
+
+    # Teardown detaches the database and keeps the file.
+    energy_file = namespaces.attached_db_path("energy")
+    prov.teardown("energy", confirm=True)
+    dbs2 = {r[0] for r in conn.execute("SELECT database_name FROM duckdb_databases()").fetchall()}
+    assert "kg_energy" not in dbs2 and os.path.exists(energy_file)
+    print(f"teardown energy: database detached, file kept at {os.path.basename(energy_file)}")
+
+    conn.close()
+    print("RESULT: OK - two domains live via provisioning alone, each with its own database and pipeline")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/provisioning/guardrails.py
+++ b/src/provisioning/guardrails.py
@@ -51,6 +51,9 @@ class Quotas:
     max_kgs: int = 8
     max_sources_per_kg: int = 20
     ingest_min_interval_s: int = 0
+    # P2 (#643): blast radius for provisioned databases and pipelines.
+    max_databases: int = 4
+    max_pipelines_per_kg: int = 8
 
     @classmethod
     def from_env(cls) -> "Quotas":
@@ -58,7 +61,27 @@ class Quotas:
             max_kgs=_env_int("NOESIS_PROV_MAX_KGS", 8),
             max_sources_per_kg=_env_int("NOESIS_PROV_MAX_SOURCES", 20),
             ingest_min_interval_s=_env_int("NOESIS_PROV_INGEST_MIN_INTERVAL_S", 0),
+            max_databases=_env_int("NOESIS_PROV_MAX_DATABASES", 4),
+            max_pipelines_per_kg=_env_int("NOESIS_PROV_MAX_PIPELINES", 8),
         )
+
+    def check_database_quota(self, deployed_db_count: int, is_new_db: bool) -> None:
+        """Refuse a *new* attached-database deploy past the max-databases quota."""
+        if is_new_db and deployed_db_count >= self.max_databases:
+            raise GuardrailError(
+                "quota_max_databases",
+                f"database quota reached: {deployed_db_count}/{self.max_databases} "
+                f"provisioned. Tear one down or raise NOESIS_PROV_MAX_DATABASES.",
+            )
+
+    def check_pipelines_quota(self, current: int, adding: int) -> None:
+        """Refuse a pipeline attach past the max-pipelines-per-KG quota."""
+        if current + adding > self.max_pipelines_per_kg:
+            raise GuardrailError(
+                "quota_max_pipelines",
+                f"pipeline quota exceeded: {current} bound + {adding} requested "
+                f"> {self.max_pipelines_per_kg} per KG.",
+            )
 
     def check_deploy_quota(self, deployed_count: int, is_new: bool) -> None:
         """Refuse a *new* deploy that would exceed the max-KGs quota. Re-deploy

--- a/src/provisioning/namespaces.py
+++ b/src/provisioning/namespaces.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import re
 from collections import Counter
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]{1,30}$")
@@ -55,35 +56,115 @@ def require_valid_name(name: str) -> str:
     return name
 
 
+# Isolation backends (P2 / #640). ``table-prefix`` keeps a KG's tables in the
+# shared warehouse (R8 default); ``attached`` gives a KG its own DuckDB file,
+# attached under the alias ``kg_<name>`` so its data lives in a separate
+# database entirely.
+BACKEND_TABLE_PREFIX = "table-prefix"
+BACKEND_ATTACHED = "attached"
+_ROLES = ("documents", "entities", "claims")
+
+
 def namespace_prefix(name: str) -> str:
     """The table prefix for a KG, e.g. ``kg_climate_`` for ``climate``."""
     return f"kg_{require_valid_name(name)}_"
 
 
-def namespace_tables(name: str) -> Dict[str, str]:
-    """The three namespaced table names for a KG, keyed by role."""
-    prefix = namespace_prefix(name)
-    return {
-        "documents": f"{prefix}documents",
-        "entities": f"{prefix}entities",
-        "claims": f"{prefix}claims",
-    }
+def attached_alias(name: str) -> str:
+    """The attached-database alias for a KG (its own DuckDB), e.g. ``kg_climate``."""
+    return f"kg_{require_valid_name(name)}"
 
 
-def _table_exists(conn, table: str) -> bool:
+def attached_db_path(name: str, base_dir: Optional[str] = None) -> str:
+    """The on-disk file for a KG's attached database. Defaults to a
+    ``provisioned/`` directory beside the shared warehouse."""
+    require_valid_name(name)
+    if base_dir is None:
+        try:
+            from src.config.env import warehouse_path
+
+            base_dir = str(Path(warehouse_path()).resolve().parent / "provisioned")
+        except Exception:
+            base_dir = str(Path.cwd() / "data" / "provisioned")
+    return str(Path(base_dir) / f"kg_{name}.duckdb")
+
+
+def _is_attached(conn, alias: str) -> bool:
     try:
         rows = conn.execute(
-            "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
-            [table],
+            "SELECT 1 FROM duckdb_databases() WHERE database_name = ?", [alias]
         ).fetchall()
         return bool(rows)
     except Exception:
         return False
 
 
-def create_namespace(conn, name: str) -> Dict[str, str]:
-    """Create the three namespaced tables for a KG if absent (idempotent)."""
-    tables = namespace_tables(name)
+def ensure_attached(conn, name: str, db_path: Optional[str] = None) -> str:
+    """Attach a KG's own DuckDB file under its alias if not already attached
+    in this connection. Returns the alias. The file is created on first attach."""
+    alias = attached_alias(name)
+    if _is_attached(conn, alias):
+        return alias
+    path = db_path or attached_db_path(name)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    # The alias is derived from a validated name, and the path is quoted; no
+    # untrusted input reaches the ATTACH statement.
+    conn.execute(f"ATTACH '{path}' AS {alias}")
+    return alias
+
+
+def detach(conn, name: str) -> None:
+    """Detach a KG's database if attached (the file is left on disk)."""
+    alias = attached_alias(name)
+    if _is_attached(conn, alias):
+        conn.execute(f"DETACH {alias}")
+
+
+def namespace_tables(name: str, backend: str = BACKEND_TABLE_PREFIX) -> Dict[str, str]:
+    """The three namespaced table references for a KG, keyed by role. For the
+    ``attached`` backend these are qualified by the KG's database alias."""
+    if backend == BACKEND_ATTACHED:
+        alias = attached_alias(name)
+        return {role: f"{alias}.{role}" for role in _ROLES}
+    prefix = namespace_prefix(name)
+    return {role: f"{prefix}{role}" for role in _ROLES}
+
+
+def _prepare(conn, name: str, backend: str, db_path: Optional[str]) -> Dict[str, str]:
+    """Ensure the backend is ready (attach the DB for ``attached``) and return
+    the table refs."""
+    if backend == BACKEND_ATTACHED:
+        ensure_attached(conn, name, db_path)
+    return namespace_tables(name, backend)
+
+
+def _table_exists(conn, table: str) -> bool:
+    """Whether a table exists. Handles a bare name (shared warehouse) and a
+    ``db.table`` reference (an attached backend), which information_schema does
+    not see from the main catalog."""
+    try:
+        if "." in table:
+            db, tbl = table.split(".", 1)
+            rows = conn.execute(
+                "SELECT 1 FROM duckdb_tables() WHERE database_name = ? AND table_name = ?",
+                [db, tbl],
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
+                [table],
+            ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def create_namespace(
+    conn, name: str, backend: str = BACKEND_TABLE_PREFIX, db_path: Optional[str] = None
+) -> Dict[str, str]:
+    """Create the three namespaced tables for a KG if absent (idempotent). For
+    the ``attached`` backend, attaches the KG's own database first."""
+    tables = _prepare(conn, name, backend, db_path)
     conn.execute(
         f"CREATE TABLE IF NOT EXISTS {tables['documents']} ("
         "id VARCHAR, title VARCHAR, source VARCHAR, source_type VARCHAR, "
@@ -101,17 +182,24 @@ def create_namespace(conn, name: str) -> Dict[str, str]:
     return tables
 
 
-def drop_namespace(conn, name: str) -> None:
+def drop_namespace(conn, name: str, backend: str = BACKEND_TABLE_PREFIX) -> None:
     """Drop the three namespaced tables for a KG (used only after archival)."""
-    for table in namespace_tables(name).values():
+    for table in namespace_tables(name, backend).values():
         conn.execute(f"DROP TABLE IF EXISTS {table}")
 
 
-def archive_namespace(conn, name: str) -> Dict[str, str]:
-    """Rename the namespace tables to a ``zz_archived__`` prefix so they stop
-    reading as live but are never silently deleted (the teardown guarantee).
-    Returns the archived table names."""
+def archive_namespace(
+    conn, name: str, backend: str = BACKEND_TABLE_PREFIX, db_path: Optional[str] = None
+) -> Dict[str, str]:
+    """Archive a KG's namespace without deleting it (the teardown guarantee).
+
+    For ``table-prefix`` the tables are renamed aside under ``zz_archived__``;
+    for ``attached`` the database is detached and its file left on disk."""
     require_valid_name(name)
+    if backend == BACKEND_ATTACHED:
+        path = db_path or attached_db_path(name)
+        detach(conn, name)
+        return {"detached_db": path}
     archived: Dict[str, str] = {}
     for role, table in namespace_tables(name).items():
         target = f"zz_archived__{table}"
@@ -146,16 +234,20 @@ def route_documents(
     sources: Sequence[str],
     now: Any,
     backfill_days: Optional[int] = None,
+    backend: str = BACKEND_TABLE_PREFIX,
+    db_path: Optional[str] = None,
 ) -> Dict[str, int]:
     """Route documents (and their claims and derived entities) from the shared
     corpus into the KG's namespace tables.
 
     Only rows whose ``source`` is one of ``sources`` are copied, and a document
     already present in the namespace is skipped, so re-running ingest converges
-    rather than duplicating. Returns the counts newly added.
+    rather than duplicating. Returns the counts newly added. For the
+    ``attached`` backend the rows land in the KG's own database, while the read
+    of the shared corpus stays in the main warehouse (a cross-database copy).
     """
     require_valid_name(name)
-    tables = create_namespace(conn, name)
+    tables = create_namespace(conn, name, backend, db_path)
     if not sources:
         return {"documents": 0, "claims": 0, "entities": 0}
 
@@ -247,12 +339,16 @@ def namespace_sample(
     docs: int = 6,
     entities: int = 12,
     claims: int = 6,
+    backend: str = BACKEND_TABLE_PREFIX,
+    db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """The scoped panel family for a KG namespace: a sample of routed
     documents, the top derived entities, and a sample of scoped claims. This
     is what a per-namespace ``documents`` / ``entity_graph`` / ``claims`` view
     reads (the R9 scoped family)."""
-    tables = namespace_tables(name)
+    if backend == BACKEND_ATTACHED:
+        ensure_attached(conn, name, db_path)
+    tables = namespace_tables(name, backend)
     out: Dict[str, Any] = {"documents": [], "entities": [], "claims": []}
     if _table_exists(conn, tables["documents"]):
         rows = conn.execute(
@@ -291,9 +387,13 @@ def namespace_sample(
     return out
 
 
-def namespace_counts(conn, name: str) -> Dict[str, int]:
+def namespace_counts(
+    conn, name: str, backend: str = BACKEND_TABLE_PREFIX, db_path: Optional[str] = None
+) -> Dict[str, int]:
     """Live row counts for a KG's three namespace tables (0 when absent)."""
-    tables = namespace_tables(name)
+    if backend == BACKEND_ATTACHED:
+        ensure_attached(conn, name, db_path)
+    tables = namespace_tables(name, backend)
     out: Dict[str, int] = {}
     for role, table in tables.items():
         if _table_exists(conn, table):

--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -55,11 +55,20 @@ class Provisioner:
         quotas: Optional[Quotas] = None,
         clock: Callable[[], datetime] = _utcnow,
         ensure: bool = True,
+        pipeline_runner: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        contract_validator: Optional[Callable[[str, Dict[str, Any]], Dict[str, Any]]] = None,
     ):
         self._conn = conn
         self._lock = lock if lock is not None else _NullLock()
         self._quotas = quotas if quotas is not None else Quotas.from_env()
         self._clock = clock
+        # P2: how a bound pipeline actually runs (injected so the server wires
+        # it to the MCP pipeline server and tests inject a fake); and how a
+        # pipeline config is contract-validated at attach. Both optional: with
+        # no runner, ingest degrades to routing already-ingested documents, and
+        # with no validator a local sanity check is used.
+        self._pipeline_runner = pipeline_runner
+        self._contract_validator = contract_validator
         # Read-only callers pass ensure=False: the schema is created lazily on
         # the first write path, so a read tool never needs DDL rights.
         if ensure:
@@ -74,46 +83,77 @@ class Provisioner:
         description: str = "",
         ontology: Any = None,
         approve: bool = False,
+        backend: str = namespaces.BACKEND_TABLE_PREFIX,
     ) -> Dict[str, Any]:
         """Deploy (or converge onto) a namespaced KG. Approval-gated: without
-        ``approve`` it returns a free dry-run preview and writes nothing."""
+        ``approve`` it returns a free dry-run preview and writes nothing.
+
+        ``backend`` selects the isolation: ``table-prefix`` (default; tables in
+        the shared warehouse) or ``attached`` (the KG gets its own DuckDB file)."""
         try:
             namespaces.require_valid_name(name)
         except ValueError as exc:
             return {"error": str(exc), "code": "invalid_name"}
+        if backend not in (namespaces.BACKEND_TABLE_PREFIX, namespaces.BACKEND_ATTACHED):
+            return {"error": f"unknown backend {backend!r}", "code": "bad_backend"}
 
         existing = store.get_kg(self._conn, name)
         is_new = existing is None or existing.get("status") != store.STATUS_DEPLOYED
+        # A converging re-deploy keeps the original backend.
+        if existing is not None and existing.get("backend"):
+            backend = existing["backend"]
+        is_attached = backend == namespaces.BACKEND_ATTACHED
+        db_path = (
+            (existing or {}).get("db_path")
+            or (namespaces.attached_db_path(name) if is_attached else None)
+        )
 
         if not approve:
             try:
                 self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+                if is_attached:
+                    self._quotas.check_database_quota(self._count_databases(), is_new)
             except GuardrailError as exc:
                 return {"error": exc.message, "code": exc.code}
             return {
                 "preview": True,
                 "kg": name,
                 "would": "deploy" if is_new else "update",
-                "namespace_tables": namespaces.namespace_tables(name),
+                "backend": backend,
+                "db_path": db_path,
+                "namespace_tables": namespaces.namespace_tables(name, backend),
                 "note": "approval-gated; re-run with approve=true to execute",
             }
 
         try:
             with self._lock:
                 self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+                if is_attached:
+                    self._quotas.check_database_quota(self._count_databases(), is_new)
                 now = self._clock()
-                namespaces.create_namespace(self._conn, name)
-                kg = store.upsert_kg(self._conn, name, description, ontology, now)
+                namespaces.create_namespace(self._conn, name, backend, db_path)
+                kg = store.upsert_kg(
+                    self._conn, name, description, ontology, now,
+                    backend=backend, db_path=db_path,
+                )
                 store.record_event(
                     self._conn,
                     name,
                     "deploy",
-                    {"new": is_new, "namespace": namespaces.namespace_prefix(name)},
+                    {"new": is_new, "backend": backend, "db_path": db_path},
                     now,
                 )
         except GuardrailError as exc:
             return {"error": exc.message, "code": exc.code}
-        return {"deployed": True, "created": is_new, "kg": kg}
+        return {"deployed": True, "created": is_new, "backend": backend, "kg": kg}
+
+    def _count_databases(self) -> int:
+        """How many deployed KGs use the attached-database backend."""
+        return sum(
+            1
+            for kg in store.list_kgs(self._conn, include_archived=False)
+            if kg.get("backend") == namespaces.BACKEND_ATTACHED
+        )
 
     # ----------------------------------------------------------------- attach
 
@@ -238,17 +278,126 @@ class Provisioner:
             )
         return out
 
+    # --------------------------------------------------------------- pipelines
+
+    def attach_pipeline(
+        self,
+        name: str,
+        connector: str,
+        connector_type: str,
+        config: Optional[Dict[str, Any]] = None,
+        contract: Optional[str] = None,
+        approve: bool = False,
+    ) -> Dict[str, Any]:
+        """Bind a pipeline (a connector or feed) to a KG, contract-validated at
+        attach. Approval-gated (it binds a connector that will run on ingest);
+        idempotent by ``(kg, connector)``."""
+        kg = store.get_kg(self._conn, name)
+        if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
+            return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
+        if not connector or not connector_type:
+            return {"error": "connector and connector_type are required", "code": "no_input"}
+        config = config or {}
+
+        # Contract-validate the config before it can ever run.
+        validation = self._validate_pipeline(connector_type, config, contract)
+        if not validation.get("valid", False):
+            return {
+                "error": f"pipeline failed contract validation: {validation.get('reason')}",
+                "code": "contract_invalid",
+                "validation": validation,
+            }
+
+        already = any(
+            p["connector"] == connector for p in store.list_pipelines(self._conn, name)
+        )
+        if not approve:
+            return {
+                "preview": True,
+                "kg": name,
+                "would": "update" if already else "attach",
+                "connector": connector,
+                "connector_type": connector_type,
+                "validation": validation,
+                "note": "approval-gated; re-run with approve=true to bind",
+            }
+
+        try:
+            with self._lock:
+                current = store.count_pipelines(self._conn, name)
+                self._quotas.check_pipelines_quota(current, 0 if already else 1)
+                now = self._clock()
+                newly = store.upsert_pipeline(
+                    self._conn, name, connector, connector_type, config,
+                    validation.get("contract"), now,
+                )
+                store.record_event(
+                    self._conn,
+                    name,
+                    "attach_pipeline",
+                    {"connector": connector, "connector_type": connector_type,
+                     "newly_bound": newly, "contract": validation.get("contract")},
+                    now,
+                )
+        except GuardrailError as exc:
+            return {"error": exc.message, "code": exc.code}
+        return {
+            "attached": newly,
+            "kg": name,
+            "connector": connector,
+            "pipelines": store.list_pipelines(self._conn, name),
+        }
+
+    def _validate_pipeline(
+        self, connector_type: str, config: Dict[str, Any], contract: Optional[str]
+    ) -> Dict[str, Any]:
+        """Validate a pipeline config against its ingest contract. Uses the
+        injected validator (the contracts server) when present, else a local
+        sanity check that the connector type and required config are present."""
+        if self._contract_validator is not None:
+            try:
+                result = self._contract_validator(connector_type, config)
+                if isinstance(result, dict):
+                    result.setdefault("valid", True)
+                    result.setdefault("contract", contract or result.get("contract"))
+                    return result
+            except Exception as exc:
+                return {"valid": False, "reason": f"validator error: {exc}"}
+        # Local fallback: a connector must name its type and, for a feed, a url.
+        if not isinstance(config, dict):
+            return {"valid": False, "reason": "config must be an object"}
+        if connector_type in ("rss", "feed", "blog") and not config.get("url"):
+            return {"valid": False, "reason": "a feed connector requires a 'url'"}
+        default_contract = (
+            "document-ingest-v1"
+            if connector_type in ("document", "paper", "book", "transcript")
+            else "article-ingest-v1"
+        )
+        return {"valid": True, "contract": contract or default_contract,
+                "checked_by": "local"}
+
     # ----------------------------------------------------------------- ingest
 
     def ingest(self, name: str, backfill_days: Optional[int] = None) -> Dict[str, Any]:
-        """Route the bound sources' documents (and claims / derived entities)
-        into the KG namespace. Rate-capped, idempotent (re-ingest converges)."""
+        """Run the KG's bound pipelines, then route the bound sources' documents
+        into the KG namespace. Rate-capped, idempotent (re-ingest converges).
+
+        With bound pipelines and a runner (the MCP pipeline server), each
+        connector runs first (connector to contract to enrich), then routing
+        copies the matching documents into the namespace. With no pipeline or
+        runner, it degrades to routing already-ingested documents (R8 behaviour).
+        """
         kg = store.get_kg(self._conn, name)
         if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
             return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
         bound = [r["source"] for r in store.list_sources(self._conn, name)]
-        if not bound:
-            return {"error": "no sources bound; attach first", "code": "no_sources"}
+        pipelines = store.list_pipelines(self._conn, name)
+        if not bound and not pipelines:
+            return {"error": "no sources or pipelines bound; attach first",
+                    "code": "no_sources"}
+
+        backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
+        db_path = kg.get("db_path")
 
         try:
             with self._lock:
@@ -256,21 +405,51 @@ class Provisioner:
                 self._quotas.check_ingest_rate(
                     self._seconds_since_last_ingest(kg, now)
                 )
+                # Stage 1: run the bound pipelines (connector -> contract ->
+                # enrich), collecting per-pipeline progress.
+                pipeline_runs = self._run_pipelines(pipelines)
+                # Stage 2: route the matching documents into the namespace.
                 routed = namespaces.route_documents(
-                    self._conn, name, bound, now, backfill_days
+                    self._conn, name, bound, now, backfill_days, backend, db_path
                 )
                 store.mark_ingested(self._conn, name, now)
                 store.record_event(
                     self._conn,
                     name,
                     "ingest",
-                    {"routed": routed, "sources": bound, "backfill_days": backfill_days},
+                    {"routed": routed, "sources": bound,
+                     "pipeline_runs": pipeline_runs, "backfill_days": backfill_days},
                     now,
                 )
         except GuardrailError as exc:
             return {"error": exc.message, "code": exc.code}
-        return {"ingested": True, "kg": name, "routed": routed,
-                "totals": namespaces.namespace_counts(self._conn, name)}
+        return {
+            "ingested": True,
+            "kg": name,
+            "backend": backend,
+            "routed": routed,
+            "pipeline_runs": pipeline_runs,
+            "totals": namespaces.namespace_counts(self._conn, name, backend, db_path),
+        }
+
+    def _run_pipelines(self, pipelines: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Run each bound pipeline through the injected runner, returning
+        per-pipeline progress. No runner (or none bound) yields an empty list,
+        so ingest degrades to pure routing."""
+        if not pipelines or self._pipeline_runner is None:
+            return []
+        runs = []
+        for p in pipelines:
+            try:
+                result = self._pipeline_runner(
+                    {"connector": p["connector"], "connector_type": p["connector_type"],
+                     "config": p.get("config", {})}
+                )
+                runs.append({"connector": p["connector"], "ok": True,
+                             "result": result if isinstance(result, dict) else {}})
+            except Exception as exc:
+                runs.append({"connector": p["connector"], "ok": False, "error": str(exc)})
+        return runs
 
     @staticmethod
     def _seconds_since_last_ingest(kg: Dict[str, Any], now: datetime) -> Optional[float]:
@@ -294,12 +473,17 @@ class Provisioner:
         if kg is None:
             return {"error": f"KG {name!r} not found", "code": "not_found"}
         sources = store.list_sources(self._conn, name)
-        counts = namespaces.namespace_counts(self._conn, name)
+        pipelines = store.list_pipelines(self._conn, name)
+        backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
+        counts = namespaces.namespace_counts(self._conn, name, backend, kg.get("db_path"))
         health = self._source_health([s["source"] for s in sources])
         return {
             "kg": kg,
+            "backend": backend,
             "sources": sources,
             "source_count": len(sources),
+            "pipelines": pipelines,
+            "pipeline_count": len(pipelines),
             "counts": counts,
             "source_health": health,
             "lineage": store.list_events(self._conn, name, limit=20),
@@ -331,11 +515,15 @@ class Provisioner:
         kgs = store.list_kgs(self._conn, include_archived=include_archived)
         out = []
         for kg in kgs:
+            backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
             out.append(
                 {
                     **kg,
                     "source_count": store.count_sources(self._conn, kg["name"]),
-                    "counts": namespaces.namespace_counts(self._conn, kg["name"]),
+                    "pipeline_count": store.count_pipelines(self._conn, kg["name"]),
+                    "counts": namespaces.namespace_counts(
+                        self._conn, kg["name"], backend, kg.get("db_path")
+                    ),
                 }
             )
         return {"kgs": out, "count": len(out)}
@@ -350,13 +538,19 @@ class Provisioner:
             kgs = [k for k in kgs if k["name"] == name]
         out = []
         for kg in kgs:
-            sample = namespaces.namespace_sample(self._conn, kg["name"])
+            backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
+            sample = namespaces.namespace_sample(
+                self._conn, kg["name"], backend=backend, db_path=kg.get("db_path")
+            )
             out.append(
                 {
                     **kg,
                     "source_count": store.count_sources(self._conn, kg["name"]),
-                    "counts": namespaces.namespace_counts(self._conn, kg["name"]),
+                    "counts": namespaces.namespace_counts(
+                        self._conn, kg["name"], backend, kg.get("db_path")
+                    ),
                     "sources": store.list_sources(self._conn, kg["name"]),
+                    "pipelines": store.list_pipelines(self._conn, kg["name"]),
                     "sample": sample,
                 }
             )
@@ -369,14 +563,17 @@ class Provisioner:
     # --------------------------------------------------------------- teardown
 
     def teardown(self, name: str, confirm: bool = False) -> Dict[str, Any]:
-        """Archive a KG: rename its namespace tables aside (never delete),
-        detach its sources, mark it archived. Confirm-gated; never touches the
-        shared corpus."""
+        """Archive a KG: for ``table-prefix`` rename its tables aside, for
+        ``attached`` detach its database (the file is left on disk); detach its
+        sources and pipelines; mark it archived. Confirm-gated; never touches
+        the shared corpus."""
         kg = store.get_kg(self._conn, name)
         if kg is None:
             return {"error": f"KG {name!r} not found", "code": "not_found"}
         if kg.get("status") == store.STATUS_ARCHIVED:
             return {"error": f"KG {name!r} already archived", "code": "already_archived"}
+        backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
+        db_path = kg.get("db_path")
         try:
             require_confirm(confirm, "teardown")
         except GuardrailError as exc:
@@ -384,29 +581,35 @@ class Provisioner:
                 "error": exc.message,
                 "code": exc.code,
                 "preview": True,
-                "would_archive": namespaces.namespace_tables(name),
+                "backend": backend,
+                "would_archive": namespaces.namespace_tables(name, backend),
             }
         with self._lock:
             now = self._clock()
-            counts = namespaces.namespace_counts(self._conn, name)
-            archived_tables = namespaces.archive_namespace(self._conn, name)
+            counts = namespaces.namespace_counts(self._conn, name, backend, db_path)
+            archived = namespaces.archive_namespace(self._conn, name, backend, db_path)
             detached = store.detach_all_sources(self._conn, name)
+            pipelines_detached = store.detach_all_pipelines(self._conn, name)
             store.set_status(self._conn, name, store.STATUS_ARCHIVED, now)
             store.record_event(
                 self._conn,
                 name,
                 "teardown",
                 {
+                    "backend": backend,
                     "archived_counts": counts,
-                    "archived_tables": archived_tables,
+                    "archived": archived,
                     "sources_detached": detached,
+                    "pipelines_detached": pipelines_detached,
                 },
                 now,
             )
         return {
             "archived": True,
             "kg": name,
-            "archived_tables": archived_tables,
+            "backend": backend,
+            "archived_location": archived,
             "archived_counts": counts,
             "sources_detached": detached,
+            "pipelines_detached": pipelines_detached,
         }

--- a/src/provisioning/store.py
+++ b/src/provisioning/store.py
@@ -32,12 +32,25 @@ def ensure_schema(conn) -> None:
         "CREATE TABLE IF NOT EXISTS provisioned_kgs ("
         "name VARCHAR PRIMARY KEY, description VARCHAR, ontology VARCHAR, "
         "status VARCHAR, created_at TIMESTAMP, updated_at TIMESTAMP, "
-        "last_ingest_at TIMESTAMP)"
+        "last_ingest_at TIMESTAMP, backend VARCHAR, db_path VARCHAR)"
     )
+    # Migrate an R8/R9 registry that predates the backend columns (P2 / #640).
+    for col, decl in (("backend", "VARCHAR"), ("db_path", "VARCHAR")):
+        try:
+            conn.execute(f"ALTER TABLE provisioned_kgs ADD COLUMN IF NOT EXISTS {col} {decl}")
+        except Exception:
+            pass
     conn.execute(
         "CREATE TABLE IF NOT EXISTS provisioned_kg_sources ("
         "kg_name VARCHAR, source VARCHAR, source_type VARCHAR, reason VARCHAR, "
         "attached_at TIMESTAMP, PRIMARY KEY (kg_name, source))"
+    )
+    # Bound pipelines (connectors/feeds) per KG (P2 / #641).
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS provisioned_kg_pipelines ("
+        "kg_name VARCHAR, connector VARCHAR, connector_type VARCHAR, "
+        "config VARCHAR, contract VARCHAR, attached_at TIMESTAMP, "
+        "PRIMARY KEY (kg_name, connector))"
     )
     conn.execute(
         "CREATE TABLE IF NOT EXISTS provisioning_events ("
@@ -74,7 +87,15 @@ def _row_to_kg(row) -> Dict[str, Any]:
         "created_at": str(row[4]) if row[4] is not None else None,
         "updated_at": str(row[5]) if row[5] is not None else None,
         "last_ingest_at": str(row[6]) if row[6] is not None else None,
+        "backend": (row[7] if len(row) > 7 and row[7] else "table-prefix"),
+        "db_path": (row[8] if len(row) > 8 else None),
     }
+
+
+_KG_COLUMNS = (
+    "name, description, ontology, status, created_at, updated_at, "
+    "last_ingest_at, backend, db_path"
+)
 
 
 def get_kg(conn, name: str) -> Optional[Dict[str, Any]]:
@@ -82,8 +103,7 @@ def get_kg(conn, name: str) -> Optional[Dict[str, Any]]:
     if not schema_ready(conn):
         return None
     row = conn.execute(
-        "SELECT name, description, ontology, status, created_at, updated_at, "
-        "last_ingest_at FROM provisioned_kgs WHERE name = ?",
+        f"SELECT {_KG_COLUMNS} FROM provisioned_kgs WHERE name = ?",
         [name],
     ).fetchone()
     return _row_to_kg(row) if row else None
@@ -93,10 +113,7 @@ def list_kgs(conn, include_archived: bool = False) -> List[Dict[str, Any]]:
     """List KGs, deployed-only by default."""
     if not schema_ready(conn):
         return []
-    sql = (
-        "SELECT name, description, ontology, status, created_at, updated_at, "
-        "last_ingest_at FROM provisioned_kgs"
-    )
+    sql = f"SELECT {_KG_COLUMNS} FROM provisioned_kgs"
     params: List[Any] = []
     if not include_archived:
         sql += " WHERE status = ?"
@@ -124,17 +141,21 @@ def upsert_kg(
     ontology: Any,
     now: Any,
     status: str = STATUS_DEPLOYED,
+    backend: str = "table-prefix",
+    db_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Insert or update a KG keyed by name (idempotent). Preserves the original
-    ``created_at`` on re-deploy so a converging re-run does not reset it."""
+    ``created_at`` and the ``backend``/``db_path`` on re-deploy so a converging
+    re-run does not reset them."""
     ontology_json = json.dumps(ontology) if ontology is not None else None
     existing = get_kg(conn, name)
     if existing is None:
         conn.execute(
             "INSERT INTO provisioned_kgs "
             "(name, description, ontology, status, created_at, updated_at, "
-            "last_ingest_at) VALUES (?, ?, ?, ?, ?, ?, NULL)",
-            [name, description, ontology_json, status, now, now],
+            "last_ingest_at, backend, db_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+            [name, description, ontology_json, status, now, now, backend, db_path],
         )
     else:
         conn.execute(
@@ -228,6 +249,89 @@ def detach_all_sources(conn, name: str) -> int:
     """Unbind every source from a KG (teardown). Returns the count removed."""
     n = count_sources(conn, name)
     conn.execute("DELETE FROM provisioned_kg_sources WHERE kg_name = ?", [name])
+    return n
+
+
+# --------------------------------------------------------------------------- #
+# Bound pipelines (P2 / #641)
+# --------------------------------------------------------------------------- #
+
+def count_pipelines(conn, name: str) -> int:
+    """How many pipelines are bound to a KG (for the max-pipelines quota)."""
+    if not schema_ready(conn):
+        return 0
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM provisioned_kg_pipelines WHERE kg_name = ?",
+            [name],
+        ).fetchone()[0]
+    )
+
+
+def upsert_pipeline(
+    conn,
+    name: str,
+    connector: str,
+    connector_type: str,
+    config: Any,
+    contract: Optional[str],
+    now: Any,
+) -> bool:
+    """Bind a pipeline (connector/feed) to a KG (idempotent by ``(kg,
+    connector)``). Returns True if newly bound, False if it was already bound
+    (updated)."""
+    config_json = json.dumps(config, default=str) if config is not None else None
+    row = conn.execute(
+        "SELECT 1 FROM provisioned_kg_pipelines WHERE kg_name = ? AND connector = ?",
+        [name, connector],
+    ).fetchone()
+    if row is None:
+        conn.execute(
+            "INSERT INTO provisioned_kg_pipelines "
+            "(kg_name, connector, connector_type, config, contract, attached_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [name, connector, connector_type, config_json, contract, now],
+        )
+        return True
+    conn.execute(
+        "UPDATE provisioned_kg_pipelines SET connector_type = ?, config = ?, "
+        "contract = ? WHERE kg_name = ? AND connector = ?",
+        [connector_type, config_json, contract, name, connector],
+    )
+    return False
+
+
+def list_pipelines(conn, name: str) -> List[Dict[str, Any]]:
+    """The pipelines bound to a KG."""
+    if not schema_ready(conn):
+        return []
+    rows = conn.execute(
+        "SELECT connector, connector_type, config, contract, attached_at "
+        "FROM provisioned_kg_pipelines WHERE kg_name = ? ORDER BY connector",
+        [name],
+    ).fetchall()
+    out = []
+    for r in rows:
+        try:
+            config = json.loads(r[2]) if r[2] else {}
+        except Exception:
+            config = {}
+        out.append(
+            {
+                "connector": r[0],
+                "connector_type": r[1],
+                "config": config,
+                "contract": r[3],
+                "attached_at": str(r[4]) if r[4] is not None else None,
+            }
+        )
+    return out
+
+
+def detach_all_pipelines(conn, name: str) -> int:
+    """Unbind every pipeline from a KG (teardown). Returns the count removed."""
+    n = count_pipelines(conn, name)
+    conn.execute("DELETE FROM provisioned_kg_pipelines WHERE kg_name = ?", [name])
     return n
 
 

--- a/tests/unit/provisioning/test_p2_backends_pipelines.py
+++ b/tests/unit/provisioning/test_p2_backends_pipelines.py
@@ -1,0 +1,166 @@
+"""Track P2 tests: attached-database backend (#640), kg_attach_pipeline (#641),
+orchestrated ingest (#642), and the new guardrails (#643)."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.provisioning import namespaces, store
+from src.provisioning.guardrails import Quotas
+from src.provisioning.provisioner import Provisioner
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _seed(seed):
+    seed.articles(
+        [
+            ("a1", "Solar record", "u1", "c", _now(), "Alpha Wire", "energy"),
+            ("a2", "Storage limits", "u2", "c", _now(), "Alpha Wire", "energy"),
+            ("b1", "Chip fabs", "u3", "c", _now(), "Beta Wire", "tech"),
+        ]
+    )
+    seed.claims([("c1", "Solar is cheap.", "a1", "news", 0.9, "supported")])
+
+
+@pytest.fixture(autouse=True)
+def _attached_db_dir(monkeypatch, tmp_path):
+    # Keep attached DBs inside the test's tmp dir; monkeypatch so the env var
+    # never leaks into other tests (NOESIS_DB_PATH overrides NEURONEWS_DB_PATH).
+    monkeypatch.setenv("NOESIS_DB_PATH", str(tmp_path / "wh.duckdb"))
+
+
+def _prov(seed, tmp_path, **kw):
+    return Provisioner(seed.conn, quotas=kw.pop("quotas", Quotas()), clock=_now, **kw)
+
+
+# ------------------------------------------------------------- attached backend
+
+
+def test_attached_backend_gives_a_kg_its_own_database(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)
+    dep = prov.deploy("energy", "Energy", approve=True, backend="attached")
+    assert dep["backend"] == "attached"
+    prov.attach_sources("energy", sources=["Alpha Wire"])
+    ing = prov.ingest("energy")
+    assert ing["backend"] == "attached"
+    assert ing["routed"]["documents"] == 2
+
+    # The routed rows live in the KG's own attached database, not the shared one.
+    dbs = {r[0] for r in seed.conn.execute("SELECT database_name FROM duckdb_databases()").fetchall()}
+    assert "kg_energy" in dbs
+    n = seed.conn.execute("SELECT COUNT(*) FROM kg_energy.documents").fetchone()[0]
+    assert n == 2
+    # The shared warehouse has no table-prefix table for this KG.
+    assert not namespaces._table_exists(seed.conn, "kg_energy_documents")
+
+
+def test_attached_teardown_detaches_and_keeps_the_file(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)
+    prov.deploy("energy", approve=True, backend="attached")
+    prov.attach_sources("energy", sources=["Alpha Wire"])
+    prov.ingest("energy")
+    db_file = namespaces.attached_db_path("energy")
+
+    torn = prov.teardown("energy", confirm=True)
+    assert torn["backend"] == "attached"
+    dbs = {r[0] for r in seed.conn.execute("SELECT database_name FROM duckdb_databases()").fetchall()}
+    assert "kg_energy" not in dbs  # detached
+    import os
+
+    assert os.path.exists(db_file)  # file kept, never deleted
+    # Shared corpus untouched.
+    assert seed.conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 3
+
+
+def test_database_quota_blocks_a_new_attached_deploy(seed, tmp_path):
+    prov = _prov(seed, tmp_path, quotas=Quotas(max_databases=1))
+    assert prov.deploy("one", approve=True, backend="attached")["deployed"] is True
+    blocked = prov.deploy("two", approve=True, backend="attached")
+    assert blocked.get("code") == "quota_max_databases"
+    # A table-prefix KG is not counted against the database quota.
+    assert prov.deploy("three", approve=True)["deployed"] is True
+
+
+# --------------------------------------------------------------- pipelines
+
+
+def test_attach_pipeline_is_approval_gated_and_contract_validated(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)
+    prov.deploy("energy", approve=True)
+
+    preview = prov.attach_pipeline("energy", "energy-rss", "rss", {"url": "http://x/f.xml"})
+    assert preview.get("preview") is True
+    assert store.count_pipelines(seed.conn, "energy") == 0  # nothing bound yet
+
+    done = prov.attach_pipeline("energy", "energy-rss", "rss", {"url": "http://x/f.xml"}, approve=True)
+    assert done["attached"] is True
+    pipes = store.list_pipelines(seed.conn, "energy")
+    assert pipes[0]["connector"] == "energy-rss" and pipes[0]["contract"] == "article-ingest-v1"
+
+
+def test_attach_pipeline_refuses_a_config_that_fails_the_contract(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)
+    prov.deploy("energy", approve=True)
+    # A feed connector with no url fails the local contract check.
+    bad = prov.attach_pipeline("energy", "energy-rss", "rss", {}, approve=True)
+    assert bad.get("code") == "contract_invalid"
+
+
+def test_pipeline_quota_enforced(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path, quotas=Quotas(max_pipelines_per_kg=1))
+    prov.deploy("energy", approve=True)
+    assert prov.attach_pipeline("energy", "p1", "rss", {"url": "http://x/1"}, approve=True)["attached"]
+    blocked = prov.attach_pipeline("energy", "p2", "rss", {"url": "http://x/2"}, approve=True)
+    assert blocked.get("code") == "quota_max_pipelines"
+
+
+def test_orchestrated_ingest_runs_bound_pipelines_then_routes(seed, tmp_path):
+    _seed(seed)
+    ran = []
+
+    def runner(spec):
+        ran.append(spec["connector"])
+        return {"connector": spec["connector"], "documents_ingested": 1}
+
+    prov = _prov(seed, tmp_path, pipeline_runner=runner)
+    prov.deploy("energy", approve=True)
+    prov.attach_sources("energy", sources=["Alpha Wire"])
+    prov.attach_pipeline("energy", "energy-rss", "rss", {"url": "http://x/f"}, approve=True)
+
+    out = prov.ingest("energy")
+    assert ran == ["energy-rss"]  # the connector ran before routing
+    assert out["pipeline_runs"][0]["ok"] is True
+    assert out["routed"]["documents"] == 2  # then routing copied the docs
+    # Progress is visible in status/lineage.
+    st = prov.status("energy")
+    assert st["pipeline_count"] == 1
+    assert any(e["event"] == "attach_pipeline" for e in st["lineage"])
+
+
+def test_ingest_degrades_without_a_runner(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)  # no runner
+    prov.deploy("energy", approve=True)
+    prov.attach_pipeline("energy", "energy-rss", "rss", {"url": "http://x/f"}, approve=True)
+    prov.attach_sources("energy", sources=["Alpha Wire"])
+    out = prov.ingest("energy")
+    assert out["pipeline_runs"] == []  # no runner -> pure routing
+    assert out["routed"]["documents"] == 2
+
+
+def test_teardown_detaches_pipelines(seed, tmp_path):
+    _seed(seed)
+    prov = _prov(seed, tmp_path)
+    prov.deploy("energy", approve=True)
+    prov.attach_pipeline("energy", "p1", "rss", {"url": "http://x/1"}, approve=True)
+    torn = prov.teardown("energy", confirm=True)
+    assert torn["pipelines_detached"] == 1
+    assert store.count_pipelines(seed.conn, "energy") == 0

--- a/tools/provisioning_mcp/server.py
+++ b/tools/provisioning_mcp/server.py
@@ -84,6 +84,7 @@ def kg_deploy(
     description: str = "",
     ontology: Optional[dict] = None,
     approve: bool = False,
+    backend: str = "table-prefix",
 ) -> dict:
     """Deploy a namespaced knowledge graph (approval-gated).
 
@@ -92,10 +93,12 @@ def kg_deploy(
     converges (idempotent upsert) rather than duplicating.
 
     Args:
-        name: KG identifier, lowercase ``[a-z][a-z0-9_]*`` (becomes the table prefix).
+        name: KG identifier, lowercase ``[a-z][a-z0-9_]*``.
         description: human-readable summary.
         ontology: optional ontology hint (stored as JSON).
         approve: must be true to actually deploy.
+        backend: ``table-prefix`` (default; tables in the shared warehouse) or
+            ``attached`` (the KG gets its own DuckDB database file).
     """
     from src.provisioning import Provisioner
 
@@ -106,7 +109,7 @@ def kg_deploy(
             return {"error": str(exc)}
         try:
             return Provisioner(con, ensure=False).deploy(
-                name, description, ontology, approve=False
+                name, description, ontology, approve=False, backend=backend
             )
         finally:
             con.close()
@@ -116,7 +119,56 @@ def kg_deploy(
         return {"error": str(exc)}
     try:
         prov = Provisioner(con, lock=_WRITE_LOCK)
-        return prov.deploy(name, description, ontology, approve=True)
+        return prov.deploy(name, description, ontology, approve=True, backend=backend)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def kg_attach_pipeline(
+    kg: str,
+    connector: str,
+    connector_type: str,
+    config: Optional[dict] = None,
+    contract: Optional[str] = None,
+    approve: bool = False,
+) -> dict:
+    """Bind a pipeline (a connector or feed) to a deployed KG, contract-validated
+    at attach. Approval-gated (the connector will run on ingest); idempotent by
+    ``(kg, connector)``.
+
+    Args:
+        kg: the deployed KG name.
+        connector: a name for this binding (e.g. "energy-rss").
+        connector_type: the connector kind (e.g. "rss", "document").
+        config: connector config (e.g. {"url": "http://.../feed.xml"}).
+        contract: optional ingest contract id override.
+        approve: must be true to bind (a preview is returned otherwise).
+    """
+    from src.provisioning import Provisioner
+
+    if not approve:
+        try:
+            con = _warehouse_ro()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            return Provisioner(con, ensure=False).attach_pipeline(
+                kg, connector, connector_type, config=config, contract=contract, approve=False
+            )
+        finally:
+            con.close()
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        prov = Provisioner(con, lock=_WRITE_LOCK)
+        return prov.attach_pipeline(
+            kg, connector, connector_type, config=config, contract=contract, approve=True
+        )
     except Exception as exc:
         return {"error": str(exc)}
     finally:


### PR DESCRIPTION
## Summary

Extends the provisioning plane (R8/R9) from orchestrating knowledge graphs to orchestrating databases and pipelines too, from the same guardrailed, audited surface. This is the "make it orchestrate everything" work.

Closes #640, #641, #642, #643, #644, #645.

## What landed

- **Isolation backends (#640).** A KG's `backend` is `table-prefix` (R8 default) or `attached`. An `attached` KG gets its own DuckDB file (`ATTACH` under alias `kg_<name>`), so its documents/entities/claims live in a separate database, not a prefix in the shared warehouse. `namespaces.py` threads `backend`/`db_path` through create/route/count/sample/archive; `store.py` persists them (with a migration for R8/R9 registries); teardown detaches the database and leaves the file on disk.
- **`kg_attach_pipeline` (#641).** Bind a connector or feed to a KG, contract-validated at attach (a feed with no url, or a config failing its ingest contract, is refused), idempotent by `(kg, connector)`, in lineage. New `provisioned_kg_pipelines` table.
- **Orchestrated `kg_ingest` (#642).** With bound pipelines and an injected runner, each connector runs first (connector to contract to enrich), then routing copies the matching documents into the namespace; per-pipeline progress is in the ingest lineage event. Degrades to pure routing with no runner.
- **Guardrails (#643).** Quotas for max databases and max pipelines per KG; deploy of a database backend and attach of a pipeline are approval-gated; teardown detaches the database and unbinds pipelines, never cascading to shared tables. Failing-path test per guardrail.

## Verification

- `tests/unit/provisioning/test_p2_backends_pipelines.py` (9 tests) plus the full osint/genui/mcp_host/config sweep: 405 passed. Existing R8/R9 provisioning tests unchanged (backend defaults to `table-prefix`).
- Acceptance harness `scripts/provisioning/p2_acceptance.py`, two domains each with own database and pipeline:

```
  [energy]  deploy(attached) -> attach_pipeline -> attach_source -> ingest: pipeline ran (3 ingested), routed 3 docs into its own database
  [markets] deploy(attached) -> attach_pipeline -> attach_source -> ingest: pipeline ran (2 ingested), routed 2 docs into its own database
isolation: kg_energy.documents=3, kg_markets.documents=2, separate databases ['kg_energy', 'kg_markets']
teardown energy: database detached, file kept
RESULT: OK
```

- Live over the real provisioning MCP server: `kg_deploy(backend="attached")`, `kg_attach_pipeline` (preview then approve, a bad config refused with `contract_invalid`), `kg_ingest` (routing into the attached DB), `kg_status` (reporting `backend` and `pipeline_count`), `kg_teardown` (detaching the database and pipeline), shared corpus untouched.

## Exit criterion

Two domains stand up end-to-end via provisioning alone, each with its own database backend and its own live pipeline, both reconstructable from their audit trail, with a failing-path test for every new guardrail. The one remaining integration point (documented in `docs/provisioning-p2-acceptance.md`): wiring the ingest runner to the real `pipeline_mcp` connector execution so `kg_ingest` pulls from an actual external feed. The orchestration, guardrails, and audit around it are complete and tested.