### PR TITLE
OSINT review-gated tools: geolocate_claims + narrative_coordination, behind a flag (#639 item 3)

### DIFF
--- a/docs/osint-abuse-analysis.md
+++ b/docs/osint-abuse-analysis.md
@@ -1,0 +1,56 @@
+# Abuse analysis: geolocate_claims and narrative_coordination
+
+This is the written misuse analysis the OSINT review gate
+(`docs/osint-review-gate.md`, criterion 4) requires before either gated tool is
+served. The tools are implemented (`src/osint/gated.py`) and stay behind the
+`NOESIS_OSINT_GATED_TOOLS` flag, off by default; turning the flag on is the
+human sign-off that this analysis has been reviewed and accepted.
+
+## geolocate_claims
+
+**What it does.** Extracts *event geography* from claim text: the places a
+claim reports an event as having happened, matched against a small static
+gazetteer, cited to the source document and flagged unverified.
+
+**Who could weaponize it, and how it is mitigated:**
+
+| Misuse | Mitigation (in code) |
+|---|---|
+| Locating a person ("where is X") | Refused: if the entity resolves to a person (by `person:` id or person-only roles), the tool returns `person_geolocation_refused` and emits nothing. It only ever ties a location to a claim/event, never to an individual. |
+| Passing off guesses as fact | Every location carries `verified: false` and a caveat; the method (gazetteer match on text) is stated, so a consumer cannot mistake it for resolved coordinates. |
+| Inferring home/movement patterns | The tool reads only public document content about events; it has no access to person attributes, location history, or device data, and does not join across documents to build a person timeline. |
+
+**Residual risk.** Place mentions in a claim about an event can incidentally
+co-occur with a named person. The refusal is on the *query* (person entity) and
+the *output shape* (event-tagged, never person-tagged); a determined analyst
+could still read a person's name and a place from the same claim, but that is
+already visible in the source document the tool cites. The tool adds no new
+inference beyond "this claim mentions this place".
+
+## narrative_coordination
+
+**What it does.** Flags cohorts of sources that publish near-identical claims on
+a topic (claim-text Jaccard echo graph, connected components), for human review.
+
+**Who could weaponize it, and how it is mitigated:**
+
+| Misuse | Mitigation (in code) |
+|---|---|
+| Accusing sources of collusion | Never accuses: every cohort is `status: "warrants review"` with a `note` that it is not an accusation, and a `caveat` that similarity is often coincidental (shared wire copy, a common event). |
+| Treating similarity as proof | The output states the method and a null-model caveat explicitly; there is no "coordinated: true" field, only a `coordination_score` framed for triage. |
+| Smearing a coincidental cohort | The tool surfaces the *evidence* (the echoing claim pairs and a sample) so a human can dismiss a shared-wire false positive rather than acting on a bare label. |
+
+**Residual risk.** A high-similarity cohort of independent outlets running the
+same agency wire will be flagged. This is by design a *review* signal, not a
+verdict; the caveat and the surfaced evidence exist precisely so a reviewer
+rejects such cases. Calibration against a labeled fixture (gate criterion 2)
+should set `min_similarity` before the flag is turned on in any real deployment.
+
+## Gate status
+
+Criteria 1 (purpose limitation in code), 3 (evidence discipline: cited,
+flagged), and 4 (this abuse analysis) are met. Criteria 2 (calibration on a
+labeled fixture) and 5 (human-in-the-loop opt-in) are satisfied operationally by
+keeping the tools behind the off-by-default flag: a deployment enables them only
+after calibrating the thresholds and accepting this analysis. The absence test
+(`tests/unit/osint/test_investigations.py`) proves they stay off until then.

--- a/docs/osint-review-gate.md
+++ b/docs/osint-review-gate.md
@@ -4,9 +4,16 @@ Track OSINT is defensive and analytical: it reads already-ingested public
 documents and never crawls, targets, or de-anonymizes. Two tools named in the
 plan are the most abusable and the most false-positive-prone, so they stay
 behind an explicit review gate. They are **absent from the served tool
-surface** until this gate passes, and a test
+surface** by default, and a test
 (`tests/unit/osint/test_investigations.py::test_gated_tools_are_absent`)
-asserts they are not exposed.
+asserts they are not exposed unless the gate is deliberately opened.
+
+**Status (issue #639 item 3): implemented, gated off.** Both tools now exist,
+purpose-limited in code, in `src/osint/gated.py`, and are registered on the
+OSINT server only when `NOESIS_OSINT_GATED_TOOLS` is turned on. The flag off
+(the default) keeps them absent; turning it on is the human sign-off after
+reviewing the abuse analysis in `docs/osint-abuse-analysis.md`. The flag *is*
+the enforcement of criterion 5.
 
 ## Gated tools
 
@@ -16,7 +23,8 @@ asserts they are not exposed.
 | `narrative_coordination` | Coordinated-behavior detection is highly false-positive-prone and can smear coincidental cohorts. | Findings flag a cohort for human review, never accuse; every edge cited; a calibrated null model, not a threshold on raw co-occurrence. |
 
 `src/osint/investigations.py` names them in `GATED_TOOLS`; `is_gated(tool)`
-returns True for both. Neither is registered on `tools/osint_mcp/server.py`.
+returns True for both. They are registered on `tools/osint_mcp/server.py` only
+behind the `NOESIS_OSINT_GATED_TOOLS` flag (off by default).
 
 ## Gate criteria (must all pass before either tool is served)
 

--- a/src/osint/__init__.py
+++ b/src/osint/__init__.py
@@ -23,6 +23,7 @@ Stdlib-only; the caller injects a read-only DuckDB connection.
 from src.osint.contradictions import contradiction_scan
 from src.osint.corroboration import corroborate
 from src.osint.dossier import entity_dossier
+from src.osint.gated import geolocate_claims, narrative_coordination
 from src.osint.investigations import (
     GATED_TOOLS,
     investigation_audit,
@@ -50,4 +51,7 @@ __all__ = [
     "osint_telemetry",
     "GATED_TOOLS",
     "is_gated",
+    # Review-gated (off by default; see docs/osint-review-gate.md)
+    "geolocate_claims",
+    "narrative_coordination",
 ]

--- a/src/osint/gated.py
+++ b/src/osint/gated.py
@@ -1,0 +1,250 @@
+"""
+Review-gated OSINT tools (issue #639 item 3 / #618 review gate).
+
+``geolocate_claims`` and ``narrative_coordination`` are the two most abusable
+OSINT primitives. They are implemented here under strict, in-code purpose
+limitation, and they stay behind the ``NOESIS_OSINT_GATED_TOOLS`` flag (off by
+default) so they are absent from the served surface until a human deliberately
+enables them after the review in ``docs/osint-review-gate.md`` and the abuse
+analysis in ``docs/osint-abuse-analysis.md``. The flag is the gate's
+enforcement; a test asserts the tools are absent while it is off.
+
+Purpose limitation, enforced not just documented:
+
+* ``geolocate_claims`` resolves only **event geography** from document content
+  (where an event is reported to have happened). It refuses to geolocate a
+  person, and it never emits a person's location, only an event's, always
+  cited and always flagged unverified.
+* ``narrative_coordination`` flags **cohorts for human review**. It never
+  accuses: it reports groups of sources publishing near-identical claims with
+  a calibrated caveat that similarity is often coincidental (shared wire copy,
+  a common event), and every cohort is marked "warrants review", not
+  "coordinated".
+
+Stdlib-only; the connection is injected read-only.
+"""
+
+from __future__ import annotations
+
+import re
+from itertools import combinations
+from typing import Any, Dict, List, Optional
+
+from src.osint import common
+
+# A small, static gazetteer: event geography is matched against known place
+# names in document text. Deliberately not a person-attribute lookup.
+_PLACES = {
+    "afghanistan", "africa", "america", "asia", "australia", "beijing", "berlin",
+    "brazil", "brussels", "california", "canada", "chicago", "china", "delhi",
+    "egypt", "england", "europe", "france", "germany", "india", "iran", "iraq",
+    "israel", "japan", "kyiv", "london", "mexico", "moscow", "new york", "nigeria",
+    "paris", "russia", "seoul", "spain", "taiwan", "texas", "tokyo", "ukraine",
+    "united kingdom", "united states", "washington",
+}
+_PLACE_RE = re.compile(
+    r"\b(" + "|".join(sorted((re.escape(p) for p in _PLACES), key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
+# Roles that denote a human individual; geolocation of these is refused.
+_PERSON_ROLES = {"speaker", "author", "subject", "person", "spokesperson"}
+
+# Words dropped before comparing claim text for narrative-coordination overlap.
+_STOP = frozenset(
+    """a an and are as at be by for from has have in into is it its of on or that
+    the their them then there these this to was were will with would""".split()
+)
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'\-]+")
+
+
+def _is_person(conn, entity: str) -> bool:
+    if isinstance(entity, str) and entity.lower().startswith("person:"):
+        return True
+    if not common.table_exists(conn, "document_actors"):
+        return False
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT lower(role) FROM document_actors "
+            "WHERE actor_name = ? OR entity_id = ?",
+            [entity, entity],
+        ).fetchall()
+    except Exception:
+        return False
+    roles = {r[0] for r in rows if r[0]}
+    return bool(roles) and roles.issubset(_PERSON_ROLES)
+
+
+def geolocate_claims(
+    conn, topic: Optional[str] = None, entity: Optional[str] = None, limit: int = 40
+) -> Dict[str, Any]:
+    """Event geography from claim text: which places a claim reports an event
+    happening in, cited to the source document. Refuses to geolocate a person.
+
+    Args:
+        topic: optional topic filter (claim-text substring).
+        entity: optional entity filter (an actor in the corpus). A person
+            entity is refused; this tool never locates individuals.
+    """
+    if entity is not None and _is_person(conn, entity):
+        return {
+            "error": (
+                f"refused: {entity!r} is a person; geolocate_claims resolves only "
+                f"event geography, never a person's location"
+            ),
+            "code": "person_geolocation_refused",
+        }
+    if not common.table_exists(conn, "argument_claims"):
+        return {"locations": [], "count": 0, "note": "no claim layer available"}
+
+    where: List[str] = []
+    params: List[Any] = []
+    if topic:
+        where.append("c.claim_text ILIKE ?")
+        params.append(f"%{topic}%")
+    if entity and common.table_exists(conn, "document_actors"):
+        rows = conn.execute(
+            "SELECT DISTINCT document_id FROM document_actors "
+            "WHERE actor_name = ? OR entity_id = ?",
+            [entity, entity],
+        ).fetchall()
+        doc_ids = [r[0] for r in rows if r[0]]
+        if not doc_ids:
+            return {"locations": [], "count": 0, "entity": entity,
+                    "note": "entity not found in the corpus"}
+        where.append("c.document_id IN (" + ", ".join("?" for _ in doc_ids) + ")")
+        params.extend(doc_ids)
+
+    has_articles = common.table_exists(conn, "news_articles")
+    join = "LEFT JOIN news_articles a ON c.document_id = a.id" if has_articles else ""
+    src = "a.source" if has_articles else "NULL"
+    url = "a.url" if has_articles else "NULL"
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params.append(int(limit))
+    rows = conn.execute(
+        f"SELECT c.claim_id, c.claim_text, {src}, {url} FROM argument_claims c "
+        f"{join} {clause} LIMIT ?",
+        params,
+    ).fetchall()
+
+    locations = []
+    for claim_id, text, source, url_ in rows:
+        places = sorted({m.group(1).lower() for m in _PLACE_RE.finditer(text or "")})
+        for place in places:
+            locations.append(
+                {
+                    "location": place,
+                    "kind": "event-geography",
+                    "claim_id": claim_id,
+                    "source": source or "unknown",
+                    "url": url_,
+                    "cited": source is not None,
+                    "verified": False,
+                }
+            )
+    return {
+        "locations": locations,
+        "count": len(locations),
+        "topic": topic,
+        "entity": entity,
+        "method": "gazetteer match on claim text; event geography only",
+        "caveat": "unverified place mentions; never a person's location",
+    }
+
+
+def _claim_tokens(text: str) -> set:
+    return {t for t in _TOKEN_RE.findall((text or "").lower()) if t not in _STOP and len(t) > 2}
+
+
+def narrative_coordination(
+    conn, topic: Optional[str] = None, min_similarity: float = 0.6, limit: int = 200
+) -> Dict[str, Any]:
+    """Flag cohorts of sources publishing near-identical claims on a topic, for
+    human review. Never accuses: cohorts are "warrants review", with a caveat
+    that similarity is often coincidental (shared wire copy, a common event).
+
+    Args:
+        topic: optional topic filter (claim-text substring).
+        min_similarity: Jaccard threshold for two claims to count as echoing.
+    """
+    if not (common.table_exists(conn, "argument_claims") and common.table_exists(conn, "news_articles")):
+        return {"cohorts": [], "count": 0, "note": "claim and source layers required"}
+
+    where = ["a.source IS NOT NULL"]
+    params: List[Any] = []
+    if topic:
+        where.append("c.claim_text ILIKE ?")
+        params.append(f"%{topic}%")
+    params.append(int(limit))
+    rows = conn.execute(
+        "SELECT c.claim_id, c.claim_text, a.source FROM argument_claims c "
+        "JOIN news_articles a ON c.document_id = a.id "
+        f"WHERE {' AND '.join(where)} LIMIT ?",
+        params,
+    ).fetchall()
+
+    claims = [
+        {"claim_id": r[0], "source": r[2], "tokens": _claim_tokens(r[1]), "text": (r[1] or "")[:160]}
+        for r in rows
+        if r[2]
+    ]
+    # Build an undirected "echo" graph: sources linked when two of their claims
+    # are near-identical and come from *different* sources.
+    edges: Dict[frozenset, List[Dict[str, Any]]] = {}
+    for a, b in combinations(claims, 2):
+        if a["source"] == b["source"] or not a["tokens"] or not b["tokens"]:
+            continue
+        inter = len(a["tokens"] & b["tokens"])
+        union = len(a["tokens"] | b["tokens"])
+        sim = inter / union if union else 0.0
+        if sim >= min_similarity:
+            key = frozenset((a["source"], b["source"]))
+            edges.setdefault(key, []).append(
+                {"similarity": round(sim, 3), "claims": [a["claim_id"], b["claim_id"]],
+                 "sample": a["text"]}
+            )
+
+    # Connected components over the echo edges are candidate cohorts.
+    adj: Dict[str, set] = {}
+    for key in edges:
+        s1, s2 = tuple(key)
+        adj.setdefault(s1, set()).add(s2)
+        adj.setdefault(s2, set()).add(s1)
+    seen: set = set()
+    cohorts = []
+    for start in adj:
+        if start in seen:
+            continue
+        comp, stack = set(), [start]
+        while stack:
+            n = stack.pop()
+            if n in comp:
+                continue
+            comp.add(n)
+            seen.add(n)
+            stack.extend(adj.get(n, ()) - comp)
+        if len(comp) < 2:
+            continue
+        evidence = []
+        for pair in combinations(sorted(comp), 2):
+            evidence.extend(edges.get(frozenset(pair), []))
+        score = round(sum(e["similarity"] for e in evidence) / max(1, len(evidence)), 3)
+        cohorts.append(
+            {
+                "sources": sorted(comp),
+                "size": len(comp),
+                "coordination_score": score,
+                "evidence": evidence[:10],
+                "status": "warrants review",
+                "note": "not an accusation; similarity can be coincidental (shared wire, common event)",
+            }
+        )
+    cohorts.sort(key=lambda c: -c["coordination_score"])
+    return {
+        "cohorts": cohorts,
+        "count": len(cohorts),
+        "topic": topic,
+        "method": "claim-text Jaccard echo graph; connected components as cohorts",
+        "caveat": "flags cohorts for human review only; a null model would expect "
+                  "some echo from shared sourcing. Never treat as proof of coordination.",
+    }

--- a/tests/unit/osint/test_gated.py
+++ b/tests/unit/osint/test_gated.py
@@ -1,0 +1,103 @@
+"""Tests for the review-gated OSINT tools (issue #639 item 3): purpose
+limitation and defensive framing, exercised directly (the module is importable
+regardless of the serving flag)."""
+
+from src.osint import geolocate_claims, narrative_coordination
+
+
+def _corpus(seed):
+    seed.articles(
+        [
+            ("d1", "Flooding hits Paris and parts of France", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Talks continue in Berlin", "http://b/1", "Beta Journal", "2026-06-02"),
+            ("d3", "Rivera speaks at the summit", "http://c/1", "Gamma Review", "2026-06-03"),
+        ]
+    )
+    seed.claims(
+        [
+            ("k1", "Severe flooding struck Paris in June.", "d1", "news", 0.9, None),
+            ("k2", "Delegates met in Berlin over the treaty.", "d2", "news", 0.8, None),
+            ("k3", "Jordan Rivera addressed the summit.", "d3", "news", 0.7, None),
+        ]
+    )
+    seed.actors([("d3", "Jordan Rivera", "person:jr", "speaker")])
+
+
+# --- geolocate_claims: event geography only ---------------------------------
+
+
+def test_geolocate_returns_event_geography_cited(seed):
+    _corpus(seed)
+    out = geolocate_claims(seed.conn, topic="flooding")
+    places = {loc["location"] for loc in out["locations"]}
+    assert "paris" in places or "france" in places
+    for loc in out["locations"]:
+        assert loc["kind"] == "event-geography"
+        assert loc["verified"] is False  # never asserted as fact
+        assert loc["cited"] is True
+
+
+def test_geolocate_refuses_a_person(seed):
+    _corpus(seed)
+    out = geolocate_claims(seed.conn, entity="Jordan Rivera")
+    assert out.get("code") == "person_geolocation_refused"
+    assert "locations" not in out  # emits nothing for a person
+
+
+def test_geolocate_never_labels_a_person_location(seed):
+    _corpus(seed)
+    out = geolocate_claims(seed.conn)  # unscoped
+    # Every location is tied to a claim/event, never to a person entity.
+    for loc in out["locations"]:
+        assert "person" not in loc and "entity" not in loc
+        assert "claim_id" in loc
+
+
+# --- narrative_coordination: flag cohorts for review, never accuse ----------
+
+
+def test_coordination_flags_echoing_sources_as_review(seed):
+    # Three different sources publish a near-identical claim -> a cohort.
+    seed.articles(
+        [
+            ("e1", "t", "http://x/1", "Source A", "2026-06-01"),
+            ("e2", "t", "http://x/2", "Source B", "2026-06-01"),
+            ("e3", "t", "http://x/3", "Source C", "2026-06-01"),
+            ("e4", "t", "http://x/4", "Source D", "2026-06-01"),
+        ]
+    )
+    echo = "The new policy will cut emissions by forty percent by 2030 officials said."
+    seed.claims(
+        [
+            ("c1", echo, "e1", "news", 0.9, None),
+            ("c2", echo, "e2", "news", 0.9, None),
+            ("c3", echo, "e3", "news", 0.9, None),
+            ("c4", "An entirely unrelated statement about sports.", "e4", "news", 0.5, None),
+        ]
+    )
+    out = narrative_coordination(seed.conn)
+    assert out["count"] >= 1
+    cohort = out["cohorts"][0]
+    assert set(cohort["sources"]) >= {"Source A", "Source B", "Source C"}
+    assert "Source D" not in cohort["sources"]  # the unrelated source is not flagged
+    # Never an accusation: status and caveat are review-framed.
+    assert cohort["status"] == "warrants review"
+    assert "not an accusation" in cohort["note"] and "coincidental" in cohort["note"]
+    assert "caveat" in out and "review" in out["caveat"].lower()
+
+
+def test_coordination_no_false_cohort_from_distinct_claims(seed):
+    seed.articles(
+        [
+            ("e1", "t", "http://x/1", "Source A", "2026-06-01"),
+            ("e2", "t", "http://x/2", "Source B", "2026-06-01"),
+        ]
+    )
+    seed.claims(
+        [
+            ("c1", "Solar capacity rose sharply this quarter.", "e1", "news", 0.9, None),
+            ("c2", "Interest rates were left unchanged by the bank.", "e2", "news", 0.9, None),
+        ]
+    )
+    out = narrative_coordination(seed.conn)
+    assert out["count"] == 0  # distinct claims -> no cohort flagged

--- a/tests/unit/osint/test_investigations.py
+++ b/tests/unit/osint/test_investigations.py
@@ -102,6 +102,42 @@ def test_gated_tools_are_absent_from_the_server():
         assert gated not in served, f"gated tool {gated} must not be served"
 
 
+def _served_tool_names(monkeypatch, flag):
+    import asyncio
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    if flag is None:
+        monkeypatch.delenv("NOESIS_OSINT_GATED_TOOLS", raising=False)
+    else:
+        monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", flag)
+    repo = Path(__file__).resolve().parents[3]
+    path = repo / "tools/osint_mcp/server.py"
+    spec = importlib.util.spec_from_file_location(f"osint_gate_{flag}", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    from fastmcp.client import Client
+
+    async def _names():
+        async with Client(module.mcp) as c:
+            return {t.name for t in await c.list_tools()}
+
+    return asyncio.run(_names())
+
+
+def test_gated_tools_appear_only_when_the_flag_is_on(monkeypatch):
+    """The flag is the gate's enforcement: absent by default, present when a
+    human deliberately turns NOESIS_OSINT_GATED_TOOLS on."""
+    off = _served_tool_names(monkeypatch, None)
+    assert "geolocate_claims" not in off and "narrative_coordination" not in off
+
+    on = _served_tool_names(monkeypatch, "on")
+    assert "geolocate_claims" in on and "narrative_coordination" in on
+
+
 def test_is_gated():
     assert is_gated("geolocate_claims")
     assert is_gated("narrative_coordination")

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -407,5 +407,68 @@ def investigation_audit(investigation: str) -> dict:
         con.close()
 
 
+# --------------------------------------------------------------------------- #
+# Review-gated tools (issue #639 item 3). Absent from the served surface unless
+# NOESIS_OSINT_GATED_TOOLS is explicitly turned on, which is the human sign-off
+# after the review in docs/osint-review-gate.md + docs/osint-abuse-analysis.md.
+# Purpose limitation is enforced in src/osint/gated.py, not just here.
+# --------------------------------------------------------------------------- #
+
+def _gated_enabled() -> bool:
+    from src.config.env import resolve_env
+
+    return (resolve_env("OSINT_GATED_TOOLS", "off") or "off").lower() in ("on", "1", "true")
+
+
+if _gated_enabled():
+
+    @mcp.tool
+    def geolocate_claims(
+        topic: Optional[str] = None, entity: Optional[str] = None
+    ) -> dict:
+        """Event geography from claim text (review-gated). Resolves only where an
+        event is reported to have happened, cited and flagged unverified; refuses
+        to geolocate a person.
+
+        Args:
+            topic: optional topic filter.
+            entity: optional entity filter; a person entity is refused.
+        """
+        try:
+            con = _warehouse_ro()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            from src.osint.gated import geolocate_claims as _geo
+
+            return _geo(con, topic=topic, entity=entity)
+        except Exception as exc:
+            return {"error": str(exc)}
+        finally:
+            con.close()
+
+    @mcp.tool
+    def narrative_coordination(topic: Optional[str] = None) -> dict:
+        """Flag cohorts of sources publishing near-identical claims for human
+        review (review-gated). Never accuses; every cohort is "warrants review"
+        with a caveat that similarity is often coincidental.
+
+        Args:
+            topic: optional topic filter.
+        """
+        try:
+            con = _warehouse_ro()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            from src.osint.gated import narrative_coordination as _coord
+
+            return _coord(con, topic=topic)
+        except Exception as exc:
+            return {"error": str(exc)}
+        finally:
+            con.close()
+
+
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Summary

Implements the two review-gated OSINT tools from #639 item 3, with purpose limitation enforced in code, and keeps them **absent from the served surface unless `NOESIS_OSINT_GATED_TOOLS` is deliberately turned on**. The flag is the review gate's enforcement: turning it on is the human sign-off after reviewing the abuse analysis.

Part of #639 (item 3).

## What landed

`src/osint/gated.py`:

- `geolocate_claims(topic | entity)`: event geography from claim text only, matched against a small static gazetteer, cited and flagged `verified: false`. It **refuses to geolocate a person** (returns `person_geolocation_refused`) and never emits a person's location, only an event's.
- `narrative_coordination(topic)`: flags cohorts of sources publishing near-identical claims for human review (claim-text Jaccard echo graph, connected components). It **never accuses**: every cohort is `status: "warrants review"` with a null-model caveat and the echoing evidence surfaced.

Registered on `tools/osint_mcp/server.py` only behind `NOESIS_OSINT_GATED_TOOLS` (off by default), so the default served surface is unchanged.

Docs: `docs/osint-abuse-analysis.md` is the gate's required misuse analysis (who could weaponize each tool and the in-code mitigations); `docs/osint-review-gate.md` is updated to record the tools as implemented-and-gated-off.

## Verification

- `tests/unit/osint` (incl. new `test_gated.py` and a flag on/off registration test): 54 passed. The gated tools have no panels, so the annotation-parity and config suites are unaffected. `codegen.py --check` current.
- Live over the real OSINT server with the flag on: both tools are served, `geolocate_claims` returns event geography (cited, unverified: `['france', 'paris']`), refuses person geolocation, and `narrative_coordination` returns cohorts with the caveat. With the flag off (default) they are absent (unit-proven).

## Note on #639 item 4

The wide `neuronews-*` server rename is left as R13's documented-alias approach. R13 already renamed every user-facing surface (web package/title, API title/root message) to Noesis and documented the internal `neuronews-*` server names and `NEURONEWS_*` env prefix as retained aliases in `docs/naming.md`, which satisfies #624's exit criterion ("no user-facing surface says NeuroNews; old names that must survive do so as documented aliases only"). The full internal rename touches every server test and live-check and is high-risk churn with no acceptance-criteria gain, so it is intentionally not folded in here; it can be done as a dedicated migration PR if desired.