### PR TITLE
M2.1: Lighter data-proxy response encoding

### DIFF
--- a/src/api/routes/genui_data_routes.py
+++ b/src/api/routes/genui_data_routes.py
@@ -12,7 +12,7 @@ panels can be served through the proxy.
 
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
 from src.genui.dataplane import (
@@ -21,6 +21,7 @@ from src.genui.dataplane import (
     check_request_size,
     data_mode_tools,
     data_proxy_enabled,
+    encode_payload,
     invoke_data_tool,
 )
 
@@ -57,13 +58,17 @@ def data_tools() -> Dict[str, Any]:
 
 
 @router.post("/data")
-def ui_data(request: DataRequest, http_request: Request) -> Dict[str, Any]:
+def ui_data(request: DataRequest, http_request: Request) -> Response:
     """Invoke an allowlisted data-mode MCP tool and return its payload.
 
     Refuses when the flag is off (404), when the tool is not allowlisted (403),
     when the client is over its rate limit (429), or when a size cap is
     exceeded (413). Sync on purpose: the blocking MCP call runs in the
     threadpool.
+
+    The response uses the lighter data-plane encoding (M2.1): compact JSON,
+    gzip-compressed when the client accepts it and the payload is large enough
+    to benefit, which shrinks the cold-path transfer.
     """
     if not data_proxy_enabled():
         raise HTTPException(
@@ -76,8 +81,12 @@ def ui_data(request: DataRequest, http_request: Request) -> Dict[str, Any]:
         payload = invoke_data_tool(request.server, request.tool, request.arguments)
     except DataPlaneError as err:
         raise HTTPException(status_code=err.status, detail=err.message)
-    return {
-        "server": request.server,
-        "tool": request.tool,
-        "data": payload,
-    }
+    body = {"server": request.server, "tool": request.tool, "data": payload}
+    data_bytes, encoding = encode_payload(
+        body, http_request.headers.get("accept-encoding", "")
+    )
+    headers = {"Content-Length": str(len(data_bytes))}
+    if encoding:
+        headers["Content-Encoding"] = encoding
+        headers["Vary"] = "Accept-Encoding"
+    return Response(content=data_bytes, media_type="application/json", headers=headers)

--- a/src/genui/dataplane.py
+++ b/src/genui/dataplane.py
@@ -206,6 +206,29 @@ def prewarm_from_spec(spec: Dict[str, Any], background: bool = True) -> int:
     return len(targets)
 
 
+# Lighter-encoding threshold (M2.1): payloads at or above this size are worth
+# gzip-compressing; smaller ones ship raw so tiny responses pay no CPU cost.
+COMPRESS_MIN_BYTES = 2 * 1024
+
+
+def encode_payload(body: Any, accept_encoding: str = "") -> Tuple[bytes, Optional[str]]:
+    """Serialize a data-plane response body to compact JSON bytes, gzip-compressing
+    it when the client accepts gzip and the payload is large enough to benefit.
+
+    Returns ``(data_bytes, content_encoding)`` where ``content_encoding`` is
+    ``"gzip"`` or ``None``. Pure (stdlib only) so the route stays thin and this
+    is unit-testable without FastAPI. The compact separators drop inter-token
+    whitespace even on the uncompressed path.
+    """
+    import gzip
+    import json
+
+    raw = json.dumps(body, separators=(",", ":"), default=str).encode("utf-8")
+    if len(raw) >= COMPRESS_MIN_BYTES and "gzip" in (accept_encoding or "").lower():
+        return gzip.compress(raw, compresslevel=6), "gzip"
+    return raw, None
+
+
 def invoke_data_tool(
     server: str, tool: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:

--- a/tests/unit/genui/test_dataplane_encoding.py
+++ b/tests/unit/genui/test_dataplane_encoding.py
@@ -1,0 +1,45 @@
+"""M2.1: the lighter data-plane response encoding. encode_payload emits compact
+JSON and gzip-compresses large payloads when the client accepts gzip, shrinking
+the cold-path transfer while round-tripping exactly."""
+
+import gzip
+import json
+
+from src.genui.dataplane import COMPRESS_MIN_BYTES, encode_payload
+
+
+def _big_body():
+    # A payload comfortably over the compression threshold.
+    rows = [{"id": f"row-{i}", "text": "grid resilience under peak load " * 4} for i in range(200)]
+    return {"server": "pipeline_mcp", "tool": "articles_data", "data": {"count": len(rows), "rows": rows}}
+
+
+def test_small_payload_ships_raw_even_when_gzip_accepted():
+    body = {"server": "s", "tool": "t", "data": {"ok": True}}
+    data, encoding = encode_payload(body, "gzip, deflate")
+    assert encoding is None
+    assert json.loads(data.decode("utf-8")) == body
+
+
+def test_compact_separators_drop_whitespace():
+    data, _ = encode_payload({"a": 1, "b": [1, 2]}, "")
+    text = data.decode("utf-8")
+    assert ", " not in text and '": ' not in text  # no inter-token spaces
+
+
+def test_large_payload_gzips_when_accepted_and_round_trips():
+    body = _big_body()
+    data, encoding = encode_payload(body, "gzip")
+    assert encoding == "gzip"
+    # Smaller than the raw compact JSON, and decompresses back to the body.
+    raw = json.dumps(body, separators=(",", ":"), default=str).encode("utf-8")
+    assert len(data) < len(raw)
+    assert json.loads(gzip.decompress(data).decode("utf-8")) == body
+
+
+def test_large_payload_stays_raw_without_gzip_accept():
+    body = _big_body()
+    data, encoding = encode_payload(body, "identity")
+    assert encoding is None
+    assert len(data) >= COMPRESS_MIN_BYTES
+    assert json.loads(data.decode("utf-8")) == body


### PR DESCRIPTION
Part of M2 (#650), roadmap epic #659. Closes #664.

## What

Add `encode_payload` (stdlib-only, in `src/genui/dataplane.py`): serializes a data-plane response to compact JSON and gzip-compresses it when the client accepts gzip and the payload is at or above a 2KB threshold. The `POST /api/v1/ui/data` route returns a `Response` carrying `Content-Encoding: gzip` and `Vary: Accept-Encoding` when compression applies; small payloads and non-gzip clients ship raw.

This shrinks the cold-path transfer for the large analytics/OSINT payloads the M1 wiring now fetches.

## Tests

New `tests/unit/genui/test_dataplane_encoding.py`: compact separators, small-payload passthrough, large-payload gzip round-trip and size reduction, no-gzip passthrough. Existing data-plane tests still pass (21 total).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_