### PR TITLE
M2.2: Warm connection pool signal for the data proxy

### DIFF
--- a/src/genui/dataplane.py
+++ b/src/genui/dataplane.py
@@ -152,6 +152,47 @@ def _data_tool_for_panel(panel_type: str) -> Optional[Tuple[str, str]]:
     return None
 
 
+def warm_data_plane() -> Dict[str, Any]:
+    """Warmth summary for the data-plane servers (M2.2): which MCP servers that
+    back a data-mode panel currently hold a live (warm) session the proxy can
+    reuse. A ``/ui/data`` request against a warm server skips the connect cost;
+    a request against a cold server pays it (or falls back). ``ready`` is True
+    only when every data-plane server is warm."""
+    servers = sorted({server for (server, _tool) in data_mode_tools()})
+    try:
+        from src.mcp_host import get_host
+
+        host = get_host()
+    except Exception:  # pragma: no cover - defensive import guard
+        host = None
+    warm: Dict[str, bool] = {}
+    for server in servers:
+        warm[server] = bool(
+            host is not None
+            and hasattr(host, "is_connected")
+            and host.is_connected(server)
+        )
+    return {
+        "ready": bool(servers) and all(warm.values()),
+        "servers": warm,
+        "count": len(servers),
+        "warm_count": sum(1 for v in warm.values() if v),
+    }
+
+
+def wait_warm(timeout: float = 2.0, interval: float = 0.05) -> Dict[str, Any]:
+    """Poll :func:`warm_data_plane` until every data-plane server is warm or the
+    timeout elapses. Returns the final warmth summary. Used to gate the cold
+    path: the first fetch (or the generate pre-warm) can wait briefly for the
+    supervised sessions to come up instead of racing startup and missing."""
+    deadline = time.time() + max(0.0, timeout)
+    summary = warm_data_plane()
+    while not summary["ready"] and time.time() < deadline:
+        time.sleep(max(0.001, interval))
+        summary = warm_data_plane()
+    return summary
+
+
 def prewarm_from_spec(spec: Dict[str, Any], background: bool = True) -> int:
     """Warm the shared tool cache for every panel in a spec that a data-mode
     tool can serve, so the browser's first ``/ui/data`` fetch is a cache hit
@@ -190,6 +231,11 @@ def prewarm_from_spec(spec: Dict[str, Any], background: bool = True) -> int:
             host = None
         if host is None:
             return
+        # M2.2: wait briefly for the supervised sessions to be warm before
+        # warming the cache, so a startup race does not make the pre-warm miss
+        # (a cold session would drop the warming call and the browser's first
+        # fetch would still pay the connect cost).
+        wait_warm(timeout=2.0)
         for server, tool in targets:
             try:
                 # Same empty-args call the browser makes, so the cache key matches.

--- a/src/mcp_host/host.py
+++ b/src/mcp_host/host.py
@@ -381,6 +381,13 @@ class MCPHost:
             self._call_cache[key] = (result, now + (ttl if ttl is not None else self.stats_ttl))
         return result
 
+    def is_connected(self, server: str) -> bool:
+        """True when ``server`` holds a live supervised session — a warm
+        connection the data proxy can reuse without paying connect cost (M2.2).
+        Thread-safe: reads the session map under the lock."""
+        with self._lock:
+            return self._sessions.get(server) is not None
+
     def invalidate_cached_calls(self, server: Optional[str] = None) -> None:
         """Drop cached tool results, for one server or all of them."""
         with self._lock:

--- a/tests/unit/genui/test_dataplane_warm.py
+++ b/tests/unit/genui/test_dataplane_warm.py
@@ -1,0 +1,69 @@
+"""M2.2: the data-plane warm-session pool. The proxy reuses R1's supervised
+sessions; these cover the warmth signal (is_connected / warm_data_plane) and the
+wait-for-warm gate that stops the generate pre-warm racing startup."""
+
+import src.genui.dataplane as dp
+from src.mcp_host.host import MCPHost
+
+
+def test_host_is_connected_reflects_live_session():
+    host = MCPHost(specs=[])
+    assert host.is_connected("pipeline_mcp") is False
+    host._sessions["pipeline_mcp"] = object()  # a live supervised session
+    assert host.is_connected("pipeline_mcp") is True
+    host._sessions.pop("pipeline_mcp")
+    assert host.is_connected("pipeline_mcp") is False
+
+
+class _StubHost:
+    def __init__(self, connected):
+        self._connected = set(connected)
+
+    def is_connected(self, server):
+        return server in self._connected
+
+
+def _patch(monkeypatch, allowlist, connected):
+    monkeypatch.setattr(dp, "data_mode_tools", lambda: allowlist)
+    import src.mcp_host as mh
+
+    monkeypatch.setattr(mh, "get_host", lambda: _StubHost(connected))
+
+
+ALLOWLIST = {
+    ("pipeline_mcp", "articles_data"): {"panel": "articles"},
+    ("osint_mcp", "corroborate"): {"panel": "corroboration"},
+}
+
+
+def test_warm_data_plane_reports_per_server_warmth(monkeypatch):
+    _patch(monkeypatch, ALLOWLIST, {"pipeline_mcp"})
+    out = dp.warm_data_plane()
+    assert out["count"] == 2
+    assert out["servers"] == {"pipeline_mcp": True, "osint_mcp": False}
+    assert out["warm_count"] == 1
+    assert out["ready"] is False
+
+
+def test_warm_data_plane_ready_when_all_warm(monkeypatch):
+    _patch(monkeypatch, ALLOWLIST, {"pipeline_mcp", "osint_mcp"})
+    out = dp.warm_data_plane()
+    assert out["ready"] is True and out["warm_count"] == 2
+
+
+def test_wait_warm_returns_immediately_when_ready(monkeypatch):
+    _patch(monkeypatch, ALLOWLIST, {"pipeline_mcp", "osint_mcp"})
+    out = dp.wait_warm(timeout=1.0)
+    assert out["ready"] is True
+
+
+def test_wait_warm_times_out_when_cold(monkeypatch):
+    _patch(monkeypatch, ALLOWLIST, set())
+    out = dp.wait_warm(timeout=0.1, interval=0.02)
+    assert out["ready"] is False
+
+
+def test_warm_data_plane_empty_when_no_data_tools(monkeypatch):
+    _patch(monkeypatch, {}, set())
+    out = dp.warm_data_plane()
+    assert out["count"] == 0 and out["ready"] is False


### PR DESCRIPTION
Part of M2 (#650), roadmap epic #659. Closes #665.

## What

The data proxy already reuses R1's supervised sessions on every `call_tool` (connect cost is paid once by the supervisor, not per request). This PR adds the warmth guarantees around that pool:

- `MCPHost.is_connected(server)`: whether a server holds a live (warm) session.
- `dataplane.warm_data_plane()`: per-server warmth summary for the data-mode servers, with a `ready` flag when all are warm.
- `dataplane.wait_warm(timeout)`: polls until every data-plane server is warm or the timeout elapses.
- The generate pre-warm (#646) now calls `wait_warm` before warming the cache, so a startup race no longer makes the pre-warm miss and leave the browser's first fetch paying the connect cost.

## Tests

New `tests/unit/genui/test_dataplane_warm.py`: `is_connected` reflects live sessions; `warm_data_plane` reports per-server warmth and readiness; `wait_warm` returns immediately when ready and times out when cold; empty allowlist is not ready. Data-plane suite still passes (23 total).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_