### PR TITLE
M3.1: Live pipeline runner for kg_ingest

### DIFF
--- a/src/provisioning/pipeline_runner.py
+++ b/src/provisioning/pipeline_runner.py
@@ -1,0 +1,163 @@
+"""Live pipeline runner for provisioned KGs (M3.1).
+
+Track P2 wired ``Provisioner.ingest`` to run bound pipelines through an injected
+``pipeline_runner`` callable, but left that callable unbound in the serving path
+so ``kg_ingest`` degraded to routing already-ingested documents. This module is
+the real runner: it runs a bound connector through the ingestion connector
+registry (the same connectors ``pipeline_mcp`` exposes), and persists the
+harvested documents into the shared ``news_articles`` corpus so ingest routing
+copies them into the KG namespace. No simulation branch.
+
+Persistence is idempotent by document id, so re-ingesting a connector converges
+rather than duplicating. The harvester is injectable so tests can exercise the
+real persist-and-route path without a live network fetch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+# Max records to harvest per connector run (a sample-sized live pull, matching
+# the pipeline_mcp connector sample cap).
+DEFAULT_LIMIT = 25
+
+_ARTICLE_COLUMNS = (
+    "id",
+    "title",
+    "url",
+    "content",
+    "publish_date",
+    "source",
+    "category",
+)
+
+
+def _ensure_articles(conn) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS news_articles ("
+        "id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+
+
+def _existing_ids(conn) -> set:
+    try:
+        return {r[0] for r in conn.execute("SELECT id FROM news_articles").fetchall()}
+    except Exception:
+        return set()
+
+
+def persist_records(conn, source: str, records: List[Dict[str, Any]]) -> int:
+    """Write harvested records into ``news_articles`` keyed by ``source``,
+    skipping ids already present (idempotent). Returns the number written."""
+    if not records:
+        return 0
+    _ensure_articles(conn)
+    seen = _existing_ids(conn)
+    rows = []
+    for rec in records:
+        rid = rec.get("id")
+        if not rid or rid in seen:
+            continue
+        seen.add(rid)
+        rows.append(
+            (
+                rid,
+                rec.get("title") or "",
+                rec.get("url") or "",
+                rec.get("content") or "",
+                rec.get("publish_date"),
+                rec.get("source") or source,
+                rec.get("category"),
+            )
+        )
+    if not rows:
+        return 0
+    conn.executemany(
+        "INSERT INTO news_articles (id, title, url, content, publish_date, source, category) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    return len(rows)
+
+
+def _doc_to_record(doc: Any, connector_type: str) -> Dict[str, Any]:
+    """Normalize a connector ``Document`` (or article) to a news_articles row."""
+    meta = getattr(doc, "metadata", None) or {}
+    published = (
+        getattr(doc, "published_at", None)
+        or getattr(doc, "publish_date", None)
+        or meta.get("published_at")
+    )
+    return {
+        "id": getattr(doc, "document_id", None) or getattr(doc, "id", None) or meta.get("id"),
+        "title": getattr(doc, "title", None) or "",
+        "url": getattr(doc, "url", None) or meta.get("url") or "",
+        "content": getattr(doc, "content", None) or "",
+        "publish_date": published.isoformat() if hasattr(published, "isoformat") else published,
+        "category": connector_type,
+    }
+
+
+def default_harvester(connector_type: str, config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Run a real connector from the ingestion registry and return normalized
+    records. Best-effort: an unknown connector type or a fetch error yields an
+    empty list (ingest then degrades to routing), never a raise."""
+    query = config.get("query") if isinstance(config, dict) else None
+    try:
+        import src.ingestion.connectors  # noqa: F401 - trigger registrations
+        from src.ingestion.connectors.registry import get_connector, is_registered
+    except Exception:
+        return []
+    if not is_registered(connector_type):
+        return []
+    try:
+        connector = get_connector(connector_type)
+    except Exception:
+        return []
+    records: List[Dict[str, Any]] = []
+    try:
+        refs = list(connector.discover(query))[:DEFAULT_LIMIT]
+    except Exception:
+        return []
+    for ref in refs:
+        try:
+            for doc in connector.parse(connector.fetch(ref)):
+                rec = _doc_to_record(doc, connector_type)
+                if rec.get("id"):
+                    records.append(rec)
+        except Exception:
+            continue
+        if len(records) >= DEFAULT_LIMIT:
+            break
+    return records[:DEFAULT_LIMIT]
+
+
+def build_pipeline_runner(
+    conn,
+    harvester: Optional[Callable[[str, Dict[str, Any]], List[Dict[str, Any]]]] = None,
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Return the ``pipeline_runner`` callable ``Provisioner`` invokes per bound
+    pipeline: run the connector for real and persist its documents into the
+    corpus so ingest routing picks them up. The harvester defaults to the live
+    connector registry and is injectable for tests."""
+    harvest = harvester or default_harvester
+
+    def runner(spec: Dict[str, Any]) -> Dict[str, Any]:
+        connector = spec.get("connector")
+        connector_type = spec.get("connector_type") or ""
+        config = spec.get("config") or {}
+        source = config.get("source") or connector
+        records = harvest(connector_type, config)
+        for rec in records:
+            rec.setdefault("source", source)
+        written = persist_records(conn, source, records)
+        return {
+            "connector": connector,
+            "source": source,
+            "fetched": len(records),
+            "written": written,
+        }
+
+    return runner

--- a/tests/unit/provisioning/test_live_pipeline_runner.py
+++ b/tests/unit/provisioning/test_live_pipeline_runner.py
@@ -1,0 +1,87 @@
+"""M3.1: the live pipeline runner. kg_ingest runs bound connectors for real (the
+runner harvests documents into the corpus) and then routes them into the KG
+namespace, with no simulation branch. The harvester is injected so the real
+persist-and-route path is exercised without a network fetch."""
+
+from datetime import datetime, timezone
+
+from src.provisioning import store
+from src.provisioning.pipeline_runner import (
+    build_pipeline_runner,
+    default_harvester,
+    persist_records,
+)
+from src.provisioning.provisioner import Provisioner
+
+
+def _clock():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _records(n, source="TestFeed"):
+    return [
+        {
+            "id": f"doc-{i}",
+            "title": f"Grid resilience report {i}",
+            "url": f"http://feed/{i}",
+            "content": "content",
+            "publish_date": "2026-05-20",
+            "source": source,
+        }
+        for i in range(n)
+    ]
+
+
+def test_ingest_runs_connector_and_routes_into_namespace(conn):
+    store.ensure_schema(conn)
+    harvested = _records(3)
+    runner = build_pipeline_runner(conn, harvester=lambda ctype, cfg: list(harvested))
+    prov = Provisioner(conn, clock=_clock, pipeline_runner=runner)
+
+    assert prov.deploy("energy", "Energy grid", approve=True).get("deployed")
+    attached = prov.attach_pipeline(
+        "energy",
+        connector="grid-feed",
+        connector_type="rss",
+        config={"url": "http://feed", "source": "TestFeed"},
+        approve=True,
+    )
+    assert attached.get("attached"), attached
+    prov.attach_sources("energy", sources=["TestFeed"])
+
+    out = prov.ingest("energy")
+    assert out.get("ingested") is True, out
+    run = out["pipeline_runs"][0]
+    assert run["ok"] is True and run["result"]["written"] == 3
+
+    # The connector really persisted into the shared corpus...
+    corpus = conn.execute(
+        "SELECT COUNT(*) FROM news_articles WHERE source = 'TestFeed'"
+    ).fetchone()[0]
+    assert corpus == 3
+    # ...and ingest routed those documents into the KG namespace.
+    assert out["totals"]["documents"] == 3
+
+
+def test_persist_records_is_idempotent_by_id(conn):
+    assert persist_records(conn, "S", _records(2)) == 2
+    # Re-persisting the same ids writes nothing new.
+    assert persist_records(conn, "S", _records(2)) == 0
+    assert conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 2
+
+
+def test_ingest_without_runner_degrades_to_routing(conn, seed):
+    # No pipeline_runner: pre-existing corpus docs are still routed (R8 path).
+    seed.articles([("a1", "t", "http://a/1", None, "2026-05-01", "Alpha Wire", "news")])
+    prov = Provisioner(conn, clock=_clock)
+    prov.deploy("legacy", "legacy corpus", approve=True)
+    prov.attach_sources("legacy", sources=["Alpha Wire"])
+    out = prov.ingest("legacy")
+    assert out["ingested"] is True
+    assert out["pipeline_runs"] == []
+    assert out["totals"]["documents"] == 1
+
+
+def test_default_harvester_unknown_connector_is_empty():
+    # Best-effort: an unregistered connector type yields nothing, never raises.
+    assert default_harvester("not-a-real-connector-type", {"query": None}) == []

--- a/tools/provisioning_mcp/server.py
+++ b/tools/provisioning_mcp/server.py
@@ -217,13 +217,18 @@ def kg_ingest(kg: str, backfill_days: Optional[int] = None) -> dict:
         backfill_days: optional lookback window for the routed corpus.
     """
     from src.provisioning import Provisioner
+    from src.provisioning.pipeline_runner import build_pipeline_runner
 
     try:
         con = _warehouse_rw()
     except Exception as exc:
         return {"error": str(exc)}
     try:
-        prov = Provisioner(con, lock=_WRITE_LOCK)
+        # M3.1: run bound connectors for real (the live pipeline runner harvests
+        # documents into the corpus) before routing them into the namespace.
+        prov = Provisioner(
+            con, lock=_WRITE_LOCK, pipeline_runner=build_pipeline_runner(con)
+        )
         return prov.ingest(kg, backfill_days=backfill_days)
     except Exception as exc:
         return {"error": str(exc)}


### PR DESCRIPTION
Part of M3 (#651), roadmap epic #659. Closes #667.

## What

Track P2 wired `Provisioner.ingest` to run bound pipelines through an injected `pipeline_runner`, but left that callable unbound in the serving path, so `kg_ingest` degraded to routing already-ingested documents. This adds the real runner:

- `src/provisioning/pipeline_runner.py`: runs a bound connector through the ingestion connector registry (the same connectors `pipeline_mcp` exposes) and persists harvested documents into the shared `news_articles` corpus, so ingest routing copies them into the KG namespace. No simulation branch. Persistence is idempotent by document id.
- `tools/provisioning_mcp/server.py`: `kg_ingest` now injects `build_pipeline_runner(con)`.

The harvester is injectable, so the real persist-and-route path is testable without a live network fetch.

## Tests

New `tests/unit/provisioning/test_live_pipeline_runner.py`:

- ingest runs the connector and routes the harvested docs into the namespace (corpus gets 3 rows, namespace documents == 3).
- `persist_records` is idempotent by id.
- with no runner, ingest still degrades to routing (R8 path).
- `default_harvester` on an unknown connector type is empty, never raises.

Full provisioning suite passes (36 tests).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_