### PR TITLE
M3.2: Record each connector run in provisioning lineage

### DIFF
--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -408,6 +408,27 @@ class Provisioner:
                 # Stage 1: run the bound pipelines (connector -> contract ->
                 # enrich), collecting per-pipeline progress.
                 pipeline_runs = self._run_pipelines(pipelines)
+                # M3.2: record each connector run as its own lineage entry so the
+                # audit trail names the real run (connector, source, run id, and
+                # the fetched/written document counts), not just a nested blob.
+                for run in pipeline_runs:
+                    result = run.get("result", {}) if isinstance(run, dict) else {}
+                    connector = run.get("connector")
+                    store.record_event(
+                        self._conn,
+                        name,
+                        "pipeline_run",
+                        {
+                            "run_id": f"{name}:{connector}:{now.isoformat()}",
+                            "connector": connector,
+                            "source": result.get("source"),
+                            "fetched": result.get("fetched"),
+                            "written": result.get("written"),
+                            "ok": run.get("ok"),
+                            "error": run.get("error"),
+                        },
+                        now,
+                    )
                 # Stage 2: route the matching documents into the namespace.
                 routed = namespaces.route_documents(
                     self._conn, name, bound, now, backfill_days, backend, db_path

--- a/tests/unit/provisioning/test_connector_lineage.py
+++ b/tests/unit/provisioning/test_connector_lineage.py
@@ -1,0 +1,60 @@
+"""M3.2: a live ingest records each connector run as its own lineage entry
+(connector, source, run id, fetched/written counts), and the investigation
+audit trail replays it, so a live investigation is fully reconstructable."""
+
+from datetime import datetime, timezone
+
+from src.osint import investigation_audit
+from src.provisioning import store
+from src.provisioning.pipeline_runner import build_pipeline_runner
+from src.provisioning.provisioner import Provisioner
+
+
+def _clock():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _records(n):
+    return [
+        {"id": f"d{i}", "title": f"t{i}", "url": f"http://f/{i}", "content": "c",
+         "publish_date": "2026-05-20", "source": "TestFeed"}
+        for i in range(n)
+    ]
+
+
+def _ingest(conn):
+    store.ensure_schema(conn)
+    runner = build_pipeline_runner(conn, harvester=lambda ctype, cfg: _records(3))
+    prov = Provisioner(conn, clock=_clock, pipeline_runner=runner)
+    prov.deploy("op_daybreak", "an investigation", approve=True)
+    prov.attach_pipeline(
+        "op_daybreak", connector="grid-feed", connector_type="rss",
+        config={"url": "http://feed", "source": "TestFeed"}, approve=True,
+    )
+    prov.attach_sources("op_daybreak", sources=["TestFeed"])
+    return prov.ingest("op_daybreak")
+
+
+def test_pipeline_run_is_recorded_in_lineage(conn):
+    _ingest(conn)
+    events = store.list_events(conn, "op_daybreak")
+    runs = [e for e in events if e["event"] == "pipeline_run"]
+    assert len(runs) == 1
+    detail = runs[0]["detail"]
+    assert detail["connector"] == "grid-feed"
+    assert detail["source"] == "TestFeed"
+    assert detail["fetched"] == 3 and detail["written"] == 3
+    assert detail["ok"] is True
+    assert detail["run_id"].startswith("op_daybreak:grid-feed:")
+
+
+def test_investigation_audit_replays_the_connector_run(conn):
+    _ingest(conn)
+    audit = investigation_audit(conn, "op_daybreak")
+    assert audit["reconstructable"] is True
+    trail = [e["event"] for e in audit["audit_trail"]]
+    # The connector run is on the trail, ahead of the ingest routing event.
+    assert "pipeline_run" in trail
+    assert trail.index("pipeline_run") < trail.index("ingest")
+    run = next(e for e in audit["audit_trail"] if e["event"] == "pipeline_run")
+    assert run["detail"]["written"] == 3


### PR DESCRIPTION
Part of M3 (#651), roadmap epic #659. Closes #668.

## What

A live ingest now records a distinct `pipeline_run` lineage entry per bound connector, naming the run id, connector, source, and fetched/written document counts, ahead of the ingest routing event. `investigation_audit` replays these, so a live investigation is reconstructable down to which connector wrote what.

With no runner (the R8 path), no `pipeline_run` events are recorded, so existing audit trails are unchanged.

## Tests

New `tests/unit/provisioning/test_connector_lineage.py`: the lineage records the connector run with its counts and run id; the investigation audit trail replays it ahead of the ingest event. R11 investigations and provisioner suites still pass (15 tests).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_