### PR TITLE
M4.1: Per-tenant namespace isolation

### DIFF
--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -57,8 +57,12 @@ class Provisioner:
         ensure: bool = True,
         pipeline_runner: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         contract_validator: Optional[Callable[[str, Dict[str, Any]], Dict[str, Any]]] = None,
+        tenant: str = store.DEFAULT_TENANT,
     ):
         self._conn = conn
+        # M4.1: the owning tenant. Every read/list/act is scoped to it, so one
+        # tenant can never see or touch another tenant's namespaces.
+        self._tenant = tenant or store.DEFAULT_TENANT
         self._lock = lock if lock is not None else _NullLock()
         self._quotas = quotas if quotas is not None else Quotas.from_env()
         self._clock = clock
@@ -97,7 +101,16 @@ class Provisioner:
         if backend not in (namespaces.BACKEND_TABLE_PREFIX, namespaces.BACKEND_ATTACHED):
             return {"error": f"unknown backend {backend!r}", "code": "bad_backend"}
 
-        existing = store.get_kg(self._conn, name)
+        # Namespace names are globally unique (shared tables); a name owned by
+        # another tenant is refused rather than silently co-opted.
+        global_existing = store.get_kg(self._conn, name)
+        if (
+            global_existing is not None
+            and global_existing.get("tenant", store.DEFAULT_TENANT) != self._tenant
+        ):
+            return {"error": f"KG name {name!r} is owned by another tenant",
+                    "code": "name_taken"}
+        existing = store.get_kg(self._conn, name, tenant=self._tenant)
         is_new = existing is None or existing.get("status") != store.STATUS_DEPLOYED
         # A converging re-deploy keeps the original backend.
         if existing is not None and existing.get("backend"):
@@ -110,7 +123,7 @@ class Provisioner:
 
         if not approve:
             try:
-                self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+                self._quotas.check_deploy_quota(store.count_deployed(self._conn, tenant=self._tenant), is_new)
                 if is_attached:
                     self._quotas.check_database_quota(self._count_databases(), is_new)
             except GuardrailError as exc:
@@ -127,14 +140,14 @@ class Provisioner:
 
         try:
             with self._lock:
-                self._quotas.check_deploy_quota(store.count_deployed(self._conn), is_new)
+                self._quotas.check_deploy_quota(store.count_deployed(self._conn, tenant=self._tenant), is_new)
                 if is_attached:
                     self._quotas.check_database_quota(self._count_databases(), is_new)
                 now = self._clock()
                 namespaces.create_namespace(self._conn, name, backend, db_path)
                 kg = store.upsert_kg(
                     self._conn, name, description, ontology, now,
-                    backend=backend, db_path=db_path,
+                    backend=backend, db_path=db_path, tenant=self._tenant,
                 )
                 store.record_event(
                     self._conn,
@@ -151,7 +164,7 @@ class Provisioner:
         """How many deployed KGs use the attached-database backend."""
         return sum(
             1
-            for kg in store.list_kgs(self._conn, include_archived=False)
+            for kg in store.list_kgs(self._conn, include_archived=False, tenant=self._tenant)
             if kg.get("backend") == namespaces.BACKEND_ATTACHED
         )
 
@@ -166,7 +179,7 @@ class Provisioner:
         """Bind sources to a KG, explicitly or by a quality criterion resolved
         against the outlet transparency scores. Idempotent by ``(kg, source)``.
         """
-        kg = store.get_kg(self._conn, name)
+        kg = store.get_kg(self._conn, name, tenant=self._tenant)
         if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
             return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
 
@@ -292,7 +305,7 @@ class Provisioner:
         """Bind a pipeline (a connector or feed) to a KG, contract-validated at
         attach. Approval-gated (it binds a connector that will run on ingest);
         idempotent by ``(kg, connector)``."""
-        kg = store.get_kg(self._conn, name)
+        kg = store.get_kg(self._conn, name, tenant=self._tenant)
         if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
             return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
         if not connector or not connector_type:
@@ -387,7 +400,7 @@ class Provisioner:
         copies the matching documents into the namespace. With no pipeline or
         runner, it degrades to routing already-ingested documents (R8 behaviour).
         """
-        kg = store.get_kg(self._conn, name)
+        kg = store.get_kg(self._conn, name, tenant=self._tenant)
         if kg is None or kg.get("status") != store.STATUS_DEPLOYED:
             return {"error": f"KG {name!r} is not deployed", "code": "not_deployed"}
         bound = [r["source"] for r in store.list_sources(self._conn, name)]
@@ -490,7 +503,7 @@ class Provisioner:
     def status(self, name: str) -> Dict[str, Any]:
         """Entity/document/claim counts, bound-source health and ingest lag for
         a KG. Read-only and free (no approval needed)."""
-        kg = store.get_kg(self._conn, name)
+        kg = store.get_kg(self._conn, name, tenant=self._tenant)
         if kg is None:
             return {"error": f"KG {name!r} not found", "code": "not_found"}
         sources = store.list_sources(self._conn, name)
@@ -533,7 +546,7 @@ class Provisioner:
 
     def list_kgs(self, include_archived: bool = False) -> Dict[str, Any]:
         """List KGs with their namespace counts."""
-        kgs = store.list_kgs(self._conn, include_archived=include_archived)
+        kgs = store.list_kgs(self._conn, include_archived=include_archived, tenant=self._tenant)
         out = []
         for kg in kgs:
             backend = kg.get("backend") or namespaces.BACKEND_TABLE_PREFIX
@@ -554,7 +567,7 @@ class Provisioner:
         counts, bound sources (and why), and a sample of its routed documents,
         top entities and scoped claims. With ``name``, scopes to one KG. This
         is what the discovered ``provisioned_kg`` panel renders."""
-        kgs = store.list_kgs(self._conn, include_archived=False)
+        kgs = store.list_kgs(self._conn, include_archived=False, tenant=self._tenant)
         if name is not None:
             kgs = [k for k in kgs if k["name"] == name]
         out = []
@@ -588,7 +601,7 @@ class Provisioner:
         ``attached`` detach its database (the file is left on disk); detach its
         sources and pipelines; mark it archived. Confirm-gated; never touches
         the shared corpus."""
-        kg = store.get_kg(self._conn, name)
+        kg = store.get_kg(self._conn, name, tenant=self._tenant)
         if kg is None:
             return {"error": f"KG {name!r} not found", "code": "not_found"}
         if kg.get("status") == store.STATUS_ARCHIVED:

--- a/src/provisioning/store.py
+++ b/src/provisioning/store.py
@@ -32,10 +32,12 @@ def ensure_schema(conn) -> None:
         "CREATE TABLE IF NOT EXISTS provisioned_kgs ("
         "name VARCHAR PRIMARY KEY, description VARCHAR, ontology VARCHAR, "
         "status VARCHAR, created_at TIMESTAMP, updated_at TIMESTAMP, "
-        "last_ingest_at TIMESTAMP, backend VARCHAR, db_path VARCHAR)"
+        "last_ingest_at TIMESTAMP, backend VARCHAR, db_path VARCHAR, "
+        "tenant VARCHAR)"
     )
-    # Migrate an R8/R9 registry that predates the backend columns (P2 / #640).
-    for col, decl in (("backend", "VARCHAR"), ("db_path", "VARCHAR")):
+    # Migrate an R8/R9 registry that predates the backend columns (P2 / #640) and
+    # the tenant column (M4.1). Older rows get tenant NULL, read back as DEFAULT.
+    for col, decl in (("backend", "VARCHAR"), ("db_path", "VARCHAR"), ("tenant", "VARCHAR")):
         try:
             conn.execute(f"ALTER TABLE provisioned_kgs ADD COLUMN IF NOT EXISTS {col} {decl}")
         except Exception:
@@ -89,49 +91,69 @@ def _row_to_kg(row) -> Dict[str, Any]:
         "last_ingest_at": str(row[6]) if row[6] is not None else None,
         "backend": (row[7] if len(row) > 7 and row[7] else "table-prefix"),
         "db_path": (row[8] if len(row) > 8 else None),
+        "tenant": (row[9] if len(row) > 9 and row[9] else DEFAULT_TENANT),
     }
 
 
+# The tenant an unscoped caller (and pre-M4.1 rows) belong to.
+DEFAULT_TENANT = "default"
+
 _KG_COLUMNS = (
     "name, description, ontology, status, created_at, updated_at, "
-    "last_ingest_at, backend, db_path"
+    "last_ingest_at, backend, db_path, tenant"
 )
 
 
-def get_kg(conn, name: str) -> Optional[Dict[str, Any]]:
-    """Return the KG record for ``name``, or None."""
+def get_kg(conn, name: str, tenant: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Return the KG record for ``name``, or None. When ``tenant`` is given, a KG
+    owned by a different tenant reads back as None (isolation), so one tenant can
+    never see or act on another's namespace."""
     if not schema_ready(conn):
         return None
     row = conn.execute(
         f"SELECT {_KG_COLUMNS} FROM provisioned_kgs WHERE name = ?",
         [name],
     ).fetchone()
-    return _row_to_kg(row) if row else None
+    if not row:
+        return None
+    kg = _row_to_kg(row)
+    if tenant is not None and kg.get("tenant", DEFAULT_TENANT) != tenant:
+        return None
+    return kg
 
 
-def list_kgs(conn, include_archived: bool = False) -> List[Dict[str, Any]]:
-    """List KGs, deployed-only by default."""
+def list_kgs(
+    conn, include_archived: bool = False, tenant: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """List KGs, deployed-only by default. Scoped to ``tenant`` when given."""
     if not schema_ready(conn):
         return []
     sql = f"SELECT {_KG_COLUMNS} FROM provisioned_kgs"
+    where: List[str] = []
     params: List[Any] = []
     if not include_archived:
-        sql += " WHERE status = ?"
+        where.append("status = ?")
         params.append(STATUS_DEPLOYED)
+    if tenant is not None:
+        where.append("COALESCE(tenant, ?) = ?")
+        params.extend([DEFAULT_TENANT, tenant])
+    if where:
+        sql += " WHERE " + " AND ".join(where)
     sql += " ORDER BY created_at NULLS LAST, name"
     return [_row_to_kg(r) for r in conn.execute(sql, params).fetchall()]
 
 
-def count_deployed(conn) -> int:
-    """How many KGs are currently deployed (for the max-KGs quota)."""
+def count_deployed(conn, tenant: Optional[str] = None) -> int:
+    """How many KGs are currently deployed (for the max-KGs quota), scoped to
+    ``tenant`` when given so each tenant's quota is counted independently."""
     if not schema_ready(conn):
         return 0
-    return int(
-        conn.execute(
-            "SELECT COUNT(*) FROM provisioned_kgs WHERE status = ?",
-            [STATUS_DEPLOYED],
-        ).fetchone()[0]
-    )
+    sql = "SELECT COUNT(*) FROM provisioned_kgs WHERE status = ?"
+    params: List[Any] = [STATUS_DEPLOYED]
+    if tenant is not None:
+        sql += " AND COALESCE(tenant, ?) = ?"
+        params.extend([DEFAULT_TENANT, tenant])
+    return int(conn.execute(sql, params).fetchone()[0])
 
 
 def upsert_kg(
@@ -143,19 +165,20 @@ def upsert_kg(
     status: str = STATUS_DEPLOYED,
     backend: str = "table-prefix",
     db_path: Optional[str] = None,
+    tenant: str = DEFAULT_TENANT,
 ) -> Dict[str, Any]:
     """Insert or update a KG keyed by name (idempotent). Preserves the original
-    ``created_at`` and the ``backend``/``db_path`` on re-deploy so a converging
-    re-run does not reset them."""
+    ``created_at`` and the ``backend``/``db_path``/``tenant`` on re-deploy so a
+    converging re-run does not reset them."""
     ontology_json = json.dumps(ontology) if ontology is not None else None
     existing = get_kg(conn, name)
     if existing is None:
         conn.execute(
             "INSERT INTO provisioned_kgs "
             "(name, description, ontology, status, created_at, updated_at, "
-            "last_ingest_at, backend, db_path) "
-            "VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)",
-            [name, description, ontology_json, status, now, now, backend, db_path],
+            "last_ingest_at, backend, db_path, tenant) "
+            "VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+            [name, description, ontology_json, status, now, now, backend, db_path, tenant],
         )
     else:
         conn.execute(

--- a/tests/unit/provisioning/test_tenant_isolation.py
+++ b/tests/unit/provisioning/test_tenant_isolation.py
@@ -1,0 +1,59 @@
+"""M4.1: per-tenant namespace isolation. Two tenants on the same warehouse see
+and act on only their own namespaces; a name owned by one tenant cannot be
+co-opted or torn down by another."""
+
+from datetime import datetime, timezone
+
+from src.provisioning import store
+from src.provisioning.provisioner import Provisioner
+
+
+def _clock():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _provs(conn):
+    store.ensure_schema(conn)
+    acme = Provisioner(conn, clock=_clock, tenant="acme")
+    globex = Provisioner(conn, clock=_clock, tenant="globex")
+    acme.deploy("energy", "acme energy", approve=True)
+    globex.deploy("markets", "globex markets", approve=True)
+    return acme, globex
+
+
+def test_each_tenant_lists_only_its_own_namespaces(conn):
+    acme, globex = _provs(conn)
+    assert [k["name"] for k in acme.list_kgs()["kgs"]] == ["energy"]
+    assert [k["name"] for k in globex.list_kgs()["kgs"]] == ["markets"]
+
+
+def test_a_tenant_cannot_see_anothers_namespace(conn):
+    acme, globex = _provs(conn)
+    # acme cannot status or view globex's KG.
+    assert acme.status("markets")["code"] == "not_found"
+    # globex cannot status acme's KG.
+    assert globex.status("energy")["code"] == "not_found"
+
+
+def test_a_tenant_cannot_tear_down_anothers_namespace(conn):
+    acme, globex = _provs(conn)
+    out = acme.teardown("markets", confirm=True)
+    assert out.get("code") == "not_found"
+    # globex's KG is untouched.
+    assert globex.status("markets").get("kg", {}).get("name") == "markets"
+
+
+def test_a_name_owned_by_another_tenant_is_refused(conn):
+    acme, globex = _provs(conn)
+    out = globex.deploy("energy", "globex tries energy", approve=True)
+    assert out.get("code") == "name_taken"
+    # Still owned by acme.
+    assert acme.status("energy")["kg"]["tenant"] == "acme"
+
+
+def test_default_tenant_is_isolated_from_named_tenants(conn):
+    acme, _ = _provs(conn)
+    default = Provisioner(conn, clock=_clock)  # tenant defaults to "default"
+    default.deploy("policy", "default policy", approve=True)
+    assert [k["name"] for k in default.list_kgs()["kgs"]] == ["policy"]
+    assert default.status("energy")["code"] == "not_found"


### PR DESCRIPTION
Part of M4 (#652), roadmap epic #659. Closes #670.

## What

- `provisioned_kgs` gains a `tenant` column (migrated in with `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`; pre-M4.1 rows read back as the default tenant).
- `store.get_kg` / `list_kgs` / `count_deployed` take an optional `tenant`; a KG owned by another tenant reads back as None (isolation), and quota counting is per-tenant.
- `Provisioner` takes a `tenant` (default `"default"`) and threads it through deploy, status, view, ingest, teardown, and list, so one tenant only ever sees or acts on its own namespaces.
- Names stay globally unique (shared tables): a name owned by another tenant is refused with `code: "name_taken"` rather than silently co-opted.

## Tests

New `tests/unit/provisioning/test_tenant_isolation.py`: each tenant lists only its own KGs; a tenant cannot status/view/teardown another's; a name owned by another tenant is refused; the default tenant is isolated too. Full provisioning suite passes (44 tests), backward compatible (existing callers use the default tenant).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_