### PR TITLE
M4.2: Per-tenant quotas and read-write authority

### DIFF
--- a/src/provisioning/guardrails.py
+++ b/src/provisioning/guardrails.py
@@ -65,6 +65,28 @@ class Quotas:
             max_pipelines_per_kg=_env_int("NOESIS_PROV_MAX_PIPELINES", 8),
         )
 
+    @classmethod
+    def for_tenant(cls, tenant: str) -> "Quotas":
+        """Per-tenant quotas (M4.2): each limit can be overridden for one tenant
+        via ``NOESIS_PROV_MAX_KGS_<TENANT>`` (etc.), else the global default. The
+        quotas are counted per tenant (``store.count_deployed`` is tenant-scoped),
+        so one tenant hitting its budget never blocks another."""
+        base = cls.from_env()
+        if not tenant or tenant == "default":
+            return base
+        suffix = "_" + "".join(c if c.isalnum() else "_" for c in tenant).upper()
+        return cls(
+            max_kgs=_env_int("NOESIS_PROV_MAX_KGS" + suffix, base.max_kgs),
+            max_sources_per_kg=_env_int("NOESIS_PROV_MAX_SOURCES" + suffix, base.max_sources_per_kg),
+            ingest_min_interval_s=_env_int(
+                "NOESIS_PROV_INGEST_MIN_INTERVAL_S" + suffix, base.ingest_min_interval_s
+            ),
+            max_databases=_env_int("NOESIS_PROV_MAX_DATABASES" + suffix, base.max_databases),
+            max_pipelines_per_kg=_env_int(
+                "NOESIS_PROV_MAX_PIPELINES" + suffix, base.max_pipelines_per_kg
+            ),
+        )
+
     def check_database_quota(self, deployed_db_count: int, is_new_db: bool) -> None:
         """Refuse a *new* attached-database deploy past the max-databases quota."""
         if is_new_db and deployed_db_count >= self.max_databases:

--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -64,7 +64,9 @@ class Provisioner:
         # tenant can never see or touch another tenant's namespaces.
         self._tenant = tenant or store.DEFAULT_TENANT
         self._lock = lock if lock is not None else _NullLock()
-        self._quotas = quotas if quotas is not None else Quotas.from_env()
+        # M4.2: quotas resolve per tenant (env overrides per tenant, counted
+        # per tenant) unless an explicit Quotas is injected.
+        self._quotas = quotas if quotas is not None else Quotas.for_tenant(self._tenant)
         self._clock = clock
         # P2: how a bound pipeline actually runs (injected so the server wires
         # it to the MCP pipeline server and tests inject a fake); and how a

--- a/tests/unit/provisioning/test_tenant_quotas.py
+++ b/tests/unit/provisioning/test_tenant_quotas.py
@@ -1,0 +1,66 @@
+"""M4.2: per-tenant quotas and read-write authority. Quotas are counted and
+enforced per tenant (one tenant's budget never blocks another, and a tenant can
+carry its own override), and a cross-tenant write is refused."""
+
+from datetime import datetime, timezone
+
+from src.provisioning import store
+from src.provisioning.guardrails import Quotas
+from src.provisioning.provisioner import Provisioner
+
+
+def _clock():
+    return datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def test_for_tenant_reads_per_tenant_override(monkeypatch):
+    monkeypatch.setenv("NOESIS_PROV_MAX_KGS", "1")
+    monkeypatch.setenv("NOESIS_PROV_MAX_KGS_GLOBEX", "3")
+    assert Quotas.for_tenant("acme").max_kgs == 1  # falls back to global
+    assert Quotas.for_tenant("globex").max_kgs == 3  # tenant override
+    assert Quotas.for_tenant("default").max_kgs == 1
+
+
+def test_deploy_quota_is_counted_per_tenant(conn, monkeypatch):
+    monkeypatch.setenv("NOESIS_PROV_MAX_KGS", "1")
+    store.ensure_schema(conn)
+    acme = Provisioner(conn, clock=_clock, tenant="acme")
+    globex = Provisioner(conn, clock=_clock, tenant="globex")
+
+    assert acme.deploy("acme_one", approve=True).get("deployed")
+    # acme is at its 1-KG budget; a second acme deploy is refused...
+    blocked = acme.deploy("acme_two", approve=True)
+    assert blocked.get("code", "").startswith("quota")
+    # ...but globex's budget is independent, so it can still deploy its own KG.
+    assert globex.deploy("globex_one", approve=True).get("deployed")
+
+
+def test_per_tenant_override_raises_one_tenants_budget(conn, monkeypatch):
+    monkeypatch.setenv("NOESIS_PROV_MAX_KGS", "1")
+    monkeypatch.setenv("NOESIS_PROV_MAX_KGS_GLOBEX", "3")
+    store.ensure_schema(conn)
+    globex = Provisioner(conn, clock=_clock, tenant="globex")
+    assert globex.deploy("g1", approve=True).get("deployed")
+    assert globex.deploy("g2", approve=True).get("deployed")
+    assert globex.deploy("g3", approve=True).get("deployed")
+
+
+def test_cross_tenant_writes_are_refused(conn):
+    store.ensure_schema(conn)
+    acme = Provisioner(conn, clock=_clock, tenant="acme")
+    globex = Provisioner(conn, clock=_clock, tenant="globex")
+    acme.deploy("energy", approve=True)
+
+    # globex cannot attach, ingest, pipeline-bind or tear down acme's KG: the KG
+    # is invisible to it, so every write is refused (never a success).
+    refused = {"not_found", "not_deployed"}
+    assert globex.attach_sources("energy", sources=["X"]).get("code") in refused
+    assert globex.ingest("energy").get("code") in refused
+    assert globex.attach_pipeline(
+        "energy", connector="c", connector_type="rss",
+        config={"url": "http://x"}, approve=True,
+    ).get("code") in refused
+    assert globex.teardown("energy", confirm=True).get("code") in refused
+
+    # acme's KG is intact and still owned by acme.
+    assert acme.status("energy")["kg"]["tenant"] == "acme"


### PR DESCRIPTION
Part of M4 (#652), roadmap epic #659. Closes #671.

## What

- `Quotas.for_tenant(tenant)`: each provisioning limit can be overridden per tenant via `NOESIS_PROV_MAX_KGS_<TENANT>` (and the other limits), else the global default.
- The `Provisioner` resolves quotas per its tenant by default. Combined with M4.1's tenant-scoped `count_deployed`, quotas are counted per tenant, so one tenant hitting its budget never blocks another.
- Read-write authority is confined by M4.1's scoping: a cross-tenant attach / ingest / pipeline-bind / teardown is refused because the KG is invisible to the other tenant.

## Tests

New `tests/unit/provisioning/test_tenant_quotas.py`: `for_tenant` reads per-tenant overrides; the deploy quota is counted per tenant (acme at its limit, globex unaffected); a per-tenant override raises one tenant's budget; cross-tenant writes are all refused. Full provisioning suite passes (48 tests).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_