### PR TITLE
M4.3: External-Postgres provisioning backend

### DIFF
--- a/src/provisioning/namespaces.py
+++ b/src/provisioning/namespaces.py
@@ -62,7 +62,18 @@ def require_valid_name(name: str) -> str:
 # database entirely.
 BACKEND_TABLE_PREFIX = "table-prefix"
 BACKEND_ATTACHED = "attached"
+# M4.3: an external Postgres database attached under the KG's alias via DuckDB's
+# postgres extension, so the namespace lives in Postgres rather than a DuckDB
+# file. Reuses the attached-backend machinery (alias-qualified tables); the only
+# difference is the ATTACH target (a DSN) and TYPE.
+BACKEND_POSTGRES = "postgres"
 _ROLES = ("documents", "entities", "claims")
+
+
+def _attached_like(backend: str) -> bool:
+    """Backends whose namespace lives in a database attached under the KG alias
+    (its own DuckDB file, or an external Postgres), so tables are alias.role."""
+    return backend in (BACKEND_ATTACHED, BACKEND_POSTGRES)
 
 
 def namespace_prefix(name: str) -> str:
@@ -114,16 +125,64 @@ def ensure_attached(conn, name: str, db_path: Optional[str] = None) -> str:
 
 
 def detach(conn, name: str) -> None:
-    """Detach a KG's database if attached (the file is left on disk)."""
+    """Detach a KG's database if attached (the file / Postgres schema is left in
+    place)."""
     alias = attached_alias(name)
     if _is_attached(conn, alias):
         conn.execute(f"DETACH {alias}")
 
 
+def postgres_dsn(name: str, dsn: Optional[str] = None, tenant: Optional[str] = None) -> str:
+    """Resolve the Postgres DSN for a KG's attached database (M4.3). Explicit
+    ``dsn`` wins; otherwise a per-tenant ``NOESIS_PROV_PG_DSN_<TENANT>`` env var,
+    then the shared ``NOESIS_PROV_PG_DSN``. Raises when none is configured, so a
+    Postgres deploy fails clearly rather than silently falling back."""
+    require_valid_name(name)
+    if dsn:
+        return dsn
+    import os
+
+    if tenant and tenant != "default":
+        suffix = "_" + "".join(c if c.isalnum() else "_" for c in tenant).upper()
+        per_tenant = os.getenv("NOESIS_PROV_PG_DSN" + suffix)
+        if per_tenant:
+            return per_tenant
+    shared = os.getenv("NOESIS_PROV_PG_DSN")
+    if shared:
+        return shared
+    raise ValueError(
+        "no Postgres DSN configured; set NOESIS_PROV_PG_DSN (or a per-tenant "
+        "NOESIS_PROV_PG_DSN_<TENANT>) to use the postgres backend"
+    )
+
+
+def postgres_attach_sql(name: str, dsn: str) -> str:
+    """The ATTACH statement for a KG's Postgres database. The alias is derived
+    from a validated name; the DSN is quoted."""
+    alias = attached_alias(name)
+    return f"ATTACH '{dsn}' AS {alias} (TYPE POSTGRES)"
+
+
+def ensure_attached_postgres(conn, name: str, dsn: str) -> str:
+    """Attach a KG's external Postgres database under its alias if not already
+    attached in this connection (M4.3). Requires DuckDB's postgres extension."""
+    alias = attached_alias(name)
+    if _is_attached(conn, alias):
+        return alias
+    try:
+        conn.execute("INSTALL postgres")
+        conn.execute("LOAD postgres")
+    except Exception:
+        pass  # extension may be bundled or preloaded; ATTACH will error if not
+    conn.execute(postgres_attach_sql(name, dsn))
+    return alias
+
+
 def namespace_tables(name: str, backend: str = BACKEND_TABLE_PREFIX) -> Dict[str, str]:
-    """The three namespaced table references for a KG, keyed by role. For the
-    ``attached`` backend these are qualified by the KG's database alias."""
-    if backend == BACKEND_ATTACHED:
+    """The three namespaced table references for a KG, keyed by role. For an
+    attached backend (own DuckDB file or external Postgres) these are qualified
+    by the KG's database alias."""
+    if _attached_like(backend):
         alias = attached_alias(name)
         return {role: f"{alias}.{role}" for role in _ROLES}
     prefix = namespace_prefix(name)
@@ -131,10 +190,12 @@ def namespace_tables(name: str, backend: str = BACKEND_TABLE_PREFIX) -> Dict[str
 
 
 def _prepare(conn, name: str, backend: str, db_path: Optional[str]) -> Dict[str, str]:
-    """Ensure the backend is ready (attach the DB for ``attached``) and return
-    the table refs."""
+    """Ensure the backend is ready (attach the DB for an attached backend) and
+    return the table refs. For ``postgres`` ``db_path`` carries the DSN."""
     if backend == BACKEND_ATTACHED:
         ensure_attached(conn, name, db_path)
+    elif backend == BACKEND_POSTGRES:
+        ensure_attached_postgres(conn, name, postgres_dsn(name, db_path))
     return namespace_tables(name, backend)
 
 
@@ -194,12 +255,16 @@ def archive_namespace(
     """Archive a KG's namespace without deleting it (the teardown guarantee).
 
     For ``table-prefix`` the tables are renamed aside under ``zz_archived__``;
-    for ``attached`` the database is detached and its file left on disk."""
+    for an attached backend the database is detached and its file / Postgres
+    schema left in place (never dropped)."""
     require_valid_name(name)
-    if backend == BACKEND_ATTACHED:
-        path = db_path or attached_db_path(name)
+    if _attached_like(backend):
+        if backend == BACKEND_POSTGRES:
+            target = db_path or "postgres"
+        else:
+            target = db_path or attached_db_path(name)
         detach(conn, name)
-        return {"detached_db": path}
+        return {"detached_db": target}
     archived: Dict[str, str] = {}
     for role, table in namespace_tables(name).items():
         target = f"zz_archived__{table}"
@@ -346,9 +411,7 @@ def namespace_sample(
     documents, the top derived entities, and a sample of scoped claims. This
     is what a per-namespace ``documents`` / ``entity_graph`` / ``claims`` view
     reads (the R9 scoped family)."""
-    if backend == BACKEND_ATTACHED:
-        ensure_attached(conn, name, db_path)
-    tables = namespace_tables(name, backend)
+    tables = _prepare(conn, name, backend, db_path)
     out: Dict[str, Any] = {"documents": [], "entities": [], "claims": []}
     if _table_exists(conn, tables["documents"]):
         rows = conn.execute(
@@ -391,9 +454,7 @@ def namespace_counts(
     conn, name: str, backend: str = BACKEND_TABLE_PREFIX, db_path: Optional[str] = None
 ) -> Dict[str, int]:
     """Live row counts for a KG's three namespace tables (0 when absent)."""
-    if backend == BACKEND_ATTACHED:
-        ensure_attached(conn, name, db_path)
-    tables = namespace_tables(name, backend)
+    tables = _prepare(conn, name, backend, db_path)
     out: Dict[str, int] = {}
     for role, table in tables.items():
         if _table_exists(conn, table):

--- a/src/provisioning/provisioner.py
+++ b/src/provisioning/provisioner.py
@@ -100,7 +100,11 @@ class Provisioner:
             namespaces.require_valid_name(name)
         except ValueError as exc:
             return {"error": str(exc), "code": "invalid_name"}
-        if backend not in (namespaces.BACKEND_TABLE_PREFIX, namespaces.BACKEND_ATTACHED):
+        if backend not in (
+            namespaces.BACKEND_TABLE_PREFIX,
+            namespaces.BACKEND_ATTACHED,
+            namespaces.BACKEND_POSTGRES,
+        ):
             return {"error": f"unknown backend {backend!r}", "code": "bad_backend"}
 
         # Namespace names are globally unique (shared tables); a name owned by
@@ -117,11 +121,21 @@ class Provisioner:
         # A converging re-deploy keeps the original backend.
         if existing is not None and existing.get("backend"):
             backend = existing["backend"]
-        is_attached = backend == namespaces.BACKEND_ATTACHED
-        db_path = (
-            (existing or {}).get("db_path")
-            or (namespaces.attached_db_path(name) if is_attached else None)
-        )
+        # Both the own-DuckDB and external-Postgres backends give a KG its own
+        # database, so both count toward the database quota. For Postgres,
+        # db_path carries the resolved DSN.
+        is_own_db = namespaces._attached_like(backend)
+        prior_db = (existing or {}).get("db_path")
+        if backend == namespaces.BACKEND_ATTACHED:
+            db_path = prior_db or namespaces.attached_db_path(name)
+        elif backend == namespaces.BACKEND_POSTGRES:
+            try:
+                db_path = prior_db or namespaces.postgres_dsn(name, tenant=self._tenant)
+            except ValueError as exc:
+                return {"error": str(exc), "code": "no_pg_dsn"}
+        else:
+            db_path = None
+        is_attached = is_own_db
 
         if not approve:
             try:
@@ -167,7 +181,7 @@ class Provisioner:
         return sum(
             1
             for kg in store.list_kgs(self._conn, include_archived=False, tenant=self._tenant)
-            if kg.get("backend") == namespaces.BACKEND_ATTACHED
+            if namespaces._attached_like(kg.get("backend"))
         )
 
     # ----------------------------------------------------------------- attach

--- a/tests/unit/provisioning/test_postgres_backend.py
+++ b/tests/unit/provisioning/test_postgres_backend.py
@@ -1,0 +1,105 @@
+"""M4.3: the external-Postgres provisioning backend. Brings Postgres to parity
+with the attached-DuckDB backend by attaching an external Postgres database under
+the KG alias (DuckDB postgres extension). Covers the DSN resolution, the ATTACH
+plumbing, alias-qualified table naming, teardown-by-detach, and deploy wiring; a
+live end-to-end path runs only when NOESIS_PROV_PG_DSN is configured."""
+
+import os
+
+import pytest
+
+from src.provisioning import namespaces as ns
+from src.provisioning import store
+from src.provisioning.provisioner import Provisioner
+
+
+def test_postgres_is_attached_like_with_alias_qualified_tables():
+    assert ns._attached_like("postgres") is True
+    tables = ns.namespace_tables("climate", "postgres")
+    assert tables == {
+        "documents": "kg_climate.documents",
+        "entities": "kg_climate.entities",
+        "claims": "kg_climate.claims",
+    }
+
+
+def test_postgres_dsn_resolution(monkeypatch):
+    monkeypatch.delenv("NOESIS_PROV_PG_DSN", raising=False)
+    # Explicit DSN wins.
+    assert ns.postgres_dsn("climate", dsn="host=a dbname=b") == "host=a dbname=b"
+    # Per-tenant override, then shared.
+    monkeypatch.setenv("NOESIS_PROV_PG_DSN", "host=shared")
+    monkeypatch.setenv("NOESIS_PROV_PG_DSN_ACME", "host=acme")
+    assert ns.postgres_dsn("climate", tenant="acme") == "host=acme"
+    assert ns.postgres_dsn("climate", tenant="globex") == "host=shared"
+    # None configured -> a clear error, no silent fallback.
+    monkeypatch.delenv("NOESIS_PROV_PG_DSN", raising=False)
+    monkeypatch.delenv("NOESIS_PROV_PG_DSN_ACME", raising=False)
+    with pytest.raises(ValueError):
+        ns.postgres_dsn("climate", tenant="globex")
+
+
+def test_postgres_attach_sql_is_typed():
+    assert ns.postgres_attach_sql("climate", "host=a dbname=b") == (
+        "ATTACH 'host=a dbname=b' AS kg_climate (TYPE POSTGRES)"
+    )
+
+
+class _FakeConn:
+    """Records SQL; reports whether the KG alias is already attached (drives the
+    ATTACH-if-absent and DETACH-if-present branches)."""
+
+    def __init__(self, attached=False):
+        self.sql = []
+        self._attached = attached
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        attached = self._attached and "duckdb_databases" in sql
+
+        class _R:
+            def fetchall(self_inner):
+                return [[1]] if attached else []
+
+            def fetchone(self_inner):
+                return [0]
+
+        return _R()
+
+
+def test_ensure_attached_postgres_issues_typed_attach():
+    fake = _FakeConn(attached=False)  # not yet attached -> ATTACH is issued
+    alias = ns.ensure_attached_postgres(fake, "climate", "host=a dbname=b")
+    assert alias == "kg_climate"
+    assert "ATTACH 'host=a dbname=b' AS kg_climate (TYPE POSTGRES)" in fake.sql
+
+
+def test_archive_postgres_detaches_without_dropping():
+    fake = _FakeConn(attached=True)  # attached -> DETACH is issued
+    out = ns.archive_namespace(fake, "climate", "postgres", db_path="host=a")
+    # Detach is issued (schema left in place), never a DROP.
+    assert any(s.startswith("DETACH") for s in fake.sql)
+    assert not any("DROP" in s for s in fake.sql)
+    assert out["detached_db"] == "host=a"
+
+
+def test_deploy_postgres_without_dsn_is_a_clean_error(conn, monkeypatch):
+    monkeypatch.delenv("NOESIS_PROV_PG_DSN", raising=False)
+    store.ensure_schema(conn)
+    prov = Provisioner(conn, tenant="acme")
+    out = prov.deploy("climate", backend="postgres", approve=True)
+    assert out.get("code") == "no_pg_dsn"
+
+
+@pytest.mark.skipif(
+    not os.getenv("NOESIS_PROV_PG_DSN"),
+    reason="live Postgres backend requires NOESIS_PROV_PG_DSN and the duckdb postgres extension",
+)
+def test_deploy_and_ingest_on_live_postgres(conn):
+    store.ensure_schema(conn)
+    prov = Provisioner(conn)
+    dep = prov.deploy("climate", backend="postgres", approve=True)
+    assert dep.get("deployed") and dep["backend"] == "postgres"
+    prov.attach_sources("climate", sources=["X"])
+    ing = prov.ingest("climate")
+    assert ing.get("ingested")


### PR DESCRIPTION
Part of M4 (#652), roadmap epic #659. Closes #672.

## What

Add a `postgres` backend to the namespace machinery, bringing it to parity with the attached-DuckDB backend. A KG's namespace lives in an external Postgres database attached under the KG alias via DuckDB's postgres extension (`ATTACH ... (TYPE POSTGRES)`), so tables are alias-qualified exactly like the attached backend and the same routing / counts / view code path applies.

- `namespaces`: `BACKEND_POSTGRES`, `_attached_like`, `postgres_dsn` (explicit / per-tenant `NOESIS_PROV_PG_DSN_<TENANT>` / shared, raising when unset), `postgres_attach_sql`, `ensure_attached_postgres`. `namespace_tables`, `_prepare` and `archive_namespace` handle both attached backends; teardown detaches and never drops the Postgres schema.
- `Provisioner.deploy` accepts `backend=postgres` (db_path carries the DSN, a clean `no_pg_dsn` error when unconfigured) and counts it toward the database quota.

## Tests

`tests/unit/provisioning/test_postgres_backend.py`: DSN resolution (explicit / per-tenant / shared / raises), the typed ATTACH plumbing, alias-qualified naming, detach-on-teardown, and the deploy wiring. A live end-to-end deploy+ingest runs only when `NOESIS_PROV_PG_DSN` is set (skipped otherwise). Full provisioning suite passes (54 tests, 1 skipped).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_