### PR TITLE
M5.1: Golden intent fixture set for the planner eval

### DIFF
--- a/docs/planner-eval.md
+++ b/docs/planner-eval.md
@@ -1,0 +1,23 @@
+# Planner evaluation harness (M5)
+
+The generative-UI planner (`src/genui/planner.py`) maps a user intent to a set of
+facets and a canvas of panels. M5 makes that mapping measurable instead of
+asserted.
+
+## Golden fixture set (M5.1)
+
+`tests/data/planner_golden.json` is the labeled ground truth: a set of
+representative intents, each mapped to
+
+- `facets`: the facets the planner should select (the primary one must appear in
+  the planner's top facets), and
+- `must_panels`: the minimal set of panels that must appear in the generated
+  canvas (the recall target).
+
+Every facet in `FACET_KEYWORDS` is covered by at least one intent. The fixtures
+are validated by `tests/unit/genui/test_planner_golden.py`, which also asserts
+the shipped heuristic planner satisfies them (the baseline).
+
+The scorer (M5.2) measures panel-selection precision and recall against this set
+across the heuristic and LLM planners, and CI (M5.3) fails the build on a
+regression below threshold.

--- a/tests/data/planner_golden.json
+++ b/tests/data/planner_golden.json
@@ -1,0 +1,65 @@
+{
+  "description": "Golden intents for the planner eval harness (M5). Each item maps a representative user intent to the facets the planner should select and the panels that must appear in the generated canvas. Covers every facet in FACET_KEYWORDS with at least one labeled intent. must_panels is the minimal relevant set (recall target); the planner may add more (precision is scored against the union of all golden panels for a facet).",
+  "cases": [
+    {
+      "intent": "how has coverage of the energy transition trended over time",
+      "facets": ["trend"],
+      "must_panels": ["trending", "anomaly_timeline"]
+    },
+    {
+      "intent": "what is the sentiment and mood around nuclear power",
+      "facets": ["sentiment"],
+      "must_panels": ["topic_sentiment", "sentiment_heatmap"]
+    },
+    {
+      "intent": "fact-check the claims about the emissions rule",
+      "facets": ["claims"],
+      "must_panels": ["claims", "corroboration", "contradiction_ledger"]
+    },
+    {
+      "intent": "which actors support or oppose the carbon bill",
+      "facets": ["stance"],
+      "must_panels": ["stance", "positions"]
+    },
+    {
+      "intent": "who are the key people and speakers on this story",
+      "facets": ["actors"],
+      "must_panels": ["actors", "entity_dossier"]
+    },
+    {
+      "intent": "where does the public record contradict itself on storage costs",
+      "facets": ["conflict"],
+      "must_panels": ["controversy", "contradiction_ledger"]
+    },
+    {
+      "intent": "compare outlet reliability and framing bias",
+      "facets": ["sources"],
+      "must_panels": ["outlet_ranking", "reliability_card"]
+    },
+    {
+      "intent": "show the entity network and how they are connected",
+      "facets": ["entities"],
+      "must_panels": ["entity_graph", "relationship_path"]
+    },
+    {
+      "intent": "breaking events and the story timeline this week",
+      "facets": ["events"],
+      "must_panels": ["clusters", "timeline"]
+    },
+    {
+      "intent": "what do the papers and citations say about grid storage",
+      "facets": ["library"],
+      "must_panels": ["documents", "citation_graph", "literature_claims"]
+    },
+    {
+      "intent": "sentiment trend for the energy sector over time",
+      "facets": ["sentiment", "trend"],
+      "must_panels": ["topic_sentiment", "anomaly_timeline"]
+    },
+    {
+      "intent": "corroborate this claim and trace its provenance",
+      "facets": ["claims"],
+      "must_panels": ["corroboration", "provenance_trace"]
+    }
+  ]
+}

--- a/tests/unit/genui/test_planner_golden.py
+++ b/tests/unit/genui/test_planner_golden.py
@@ -1,0 +1,48 @@
+"""M5.1: the planner golden fixture set. Validates that the labeled intents are
+well-formed, cover every facet, name only real panel types, and that the current
+heuristic planner satisfies them (the baseline the M5.2 scorer measures against)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.genui.catalog import PANEL_TYPES
+from src.genui.planner import FACET_KEYWORDS, plan
+
+GOLDEN = Path(__file__).resolve().parents[2] / "data" / "planner_golden.json"
+
+
+@pytest.fixture(scope="module")
+def cases():
+    return json.loads(GOLDEN.read_text())["cases"]
+
+
+def test_fixtures_are_well_formed(cases):
+    assert len(cases) >= 10
+    for c in cases:
+        assert c["intent"] and isinstance(c["intent"], str)
+        assert c["facets"] and all(f in FACET_KEYWORDS for f in c["facets"])
+        assert c["must_panels"]
+        for panel in c["must_panels"]:
+            assert panel in PANEL_TYPES, f"unknown panel type {panel!r}"
+
+
+def test_every_facet_is_covered(cases):
+    covered = set()
+    for c in cases:
+        covered.update(c["facets"])
+    missing = set(FACET_KEYWORDS) - covered
+    assert not missing, f"facets with no golden intent: {sorted(missing)}"
+
+
+def test_current_planner_satisfies_the_golden(cases):
+    """The shipped heuristic planner selects each case's primary facet and
+    produces every must-panel: the baseline for the eval scorer."""
+    for c in cases:
+        spec = plan(c["intent"])
+        top = spec.facets
+        panels = {p.type for p in spec.panels if p.type != "note"}
+        assert c["facets"][0] in top, f"{c['intent']!r}: {c['facets'][0]} not in {top}"
+        missing = [p for p in c["must_panels"] if p not in panels]
+        assert not missing, f"{c['intent']!r}: missing panels {missing}"


### PR DESCRIPTION
Part of M5 (#653), roadmap epic #659. Closes #674.

## What

`tests/data/planner_golden.json`: representative intents each labeled with the facets the planner should select and the `must_panels` that must appear in the generated canvas. Covers every facet in `FACET_KEYWORDS` with at least one intent.

## Tests / docs

- `tests/unit/genui/test_planner_golden.py`: fixtures are well-formed, name only real panel types (`PANEL_TYPES`), cover every facet, and the shipped heuristic planner satisfies them (the baseline the M5.2 scorer measures against).
- `docs/planner-eval.md` documents the fixture set and the M5 harness.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_