### PR TITLE
M5.2: Planner eval scorer

### DIFF
--- a/src/genui/planner_eval.py
+++ b/src/genui/planner_eval.py
@@ -1,0 +1,111 @@
+"""
+Planner evaluation scorer (M5.2).
+
+Runs the golden intents (``tests/data/planner_golden.json``, M5.1) through a
+planner and scores its panel/facet selection: facet precision and recall against
+the labeled facets, and panel recall against the labeled ``must_panels``. Works
+for both the heuristic planner and the LLM planner; the LLM planner scores as
+unavailable (``None``) when no LLM is configured, so the harness runs everywhere.
+
+Run:  python -m src.genui.planner_eval
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# The regression threshold CI (M5.3) gates on: the combined score must not drop
+# below this for the heuristic planner.
+SCORE_THRESHOLD = 0.9
+
+_GOLDEN = Path(__file__).resolve().parents[2] / "tests" / "data" / "planner_golden.json"
+
+# A planner returns (facets, panel_types) for an intent, or None if unavailable.
+PlannerFn = Callable[[str], Optional[Tuple[List[str], List[str]]]]
+
+
+def load_golden(path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    return json.loads((path or _GOLDEN).read_text())["cases"]
+
+
+def _metrics_for_case(facets: List[str], panels: List[str], case: Dict[str, Any]) -> Dict[str, float]:
+    exp, top = set(case["facets"]), set(facets)
+    must, act = set(case["must_panels"]), set(panels)
+    inter_f = exp & top
+    return {
+        "facet_precision": (len(inter_f) / len(top)) if top else 0.0,
+        "facet_recall": (len(inter_f) / len(exp)) if exp else 1.0,
+        "panel_recall": (len(must & act) / len(must)) if must else 1.0,
+    }
+
+
+def score_planner(cases: List[Dict[str, Any]], planner_fn: PlannerFn) -> Optional[Dict[str, Any]]:
+    """Aggregate metrics over the golden cases, or None if the planner is
+    unavailable (the first call returns None)."""
+    per: List[Dict[str, Any]] = []
+    for case in cases:
+        result = planner_fn(case["intent"])
+        if result is None:
+            return None
+        facets, panels = result
+        per.append({"intent": case["intent"], **_metrics_for_case(facets, panels, case)})
+    n = len(per)
+    agg = {
+        key: sum(p[key] for p in per) / n
+        for key in ("facet_precision", "facet_recall", "panel_recall")
+    }
+    agg["score"] = 0.5 * agg["facet_recall"] + 0.5 * agg["panel_recall"]
+    return {"n": n, **agg, "per_case": per}
+
+
+def heuristic_planner(intent: str) -> Tuple[List[str], List[str]]:
+    from src.genui.planner import plan
+
+    spec = plan(intent)
+    return list(spec.facets), [p.type for p in spec.panels if p.type != "note"]
+
+
+def llm_planner(intent: str) -> Optional[Tuple[List[str], List[str]]]:
+    from src.genui.llm import plan_with_llm
+
+    spec = plan_with_llm(intent)
+    if spec is None:
+        return None
+    return list(spec.facets), [p.type for p in spec.panels if p.type != "note"]
+
+
+def evaluate(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Score the heuristic and LLM planners on the golden set. The LLM entry is
+    None when no LLM is configured."""
+    cases = load_golden(path)
+    return {
+        "heuristic": score_planner(cases, heuristic_planner),
+        "llm": score_planner(cases, llm_planner),
+    }
+
+
+def _fmt(result: Optional[Dict[str, Any]]) -> str:
+    if result is None:
+        return "unavailable"
+    return (
+        f"score={result['score']:.3f}  facet_p={result['facet_precision']:.3f}  "
+        f"facet_r={result['facet_recall']:.3f}  panel_r={result['panel_recall']:.3f}  "
+        f"(n={result['n']})"
+    )
+
+
+def main() -> None:
+    out = evaluate()
+    print("Planner eval (golden set)\n")
+    for name in ("heuristic", "llm"):
+        print(f"  {name:<10} {_fmt(out[name])}")
+    heur = out["heuristic"]
+    if heur is not None:
+        gate = "PASS" if heur["score"] >= SCORE_THRESHOLD else "FAIL"
+        print(f"\nthreshold {SCORE_THRESHOLD}: heuristic {gate}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/genui/test_planner_eval.py
+++ b/tests/unit/genui/test_planner_eval.py
@@ -1,0 +1,48 @@
+"""M5.2: the planner eval scorer. Scores facet precision/recall and panel recall
+over the golden set for the heuristic (and LLM, when configured) planner."""
+
+from src.genui.planner_eval import (
+    SCORE_THRESHOLD,
+    _metrics_for_case,
+    evaluate,
+    heuristic_planner,
+    load_golden,
+    score_planner,
+)
+
+
+def test_metrics_for_a_perfect_case():
+    case = {"facets": ["claims"], "must_panels": ["corroboration", "claims"]}
+    m = _metrics_for_case(["claims"], ["corroboration", "claims", "frames"], case)
+    assert m["facet_precision"] == 1.0
+    assert m["facet_recall"] == 1.0
+    assert m["panel_recall"] == 1.0
+
+
+def test_metrics_penalize_missing_panels_and_extra_facets():
+    case = {"facets": ["claims"], "must_panels": ["corroboration", "claims"]}
+    # Extra facet lowers precision; a missing must-panel lowers panel recall.
+    m = _metrics_for_case(["claims", "sources"], ["claims"], case)
+    assert m["facet_precision"] == 0.5
+    assert m["facet_recall"] == 1.0
+    assert m["panel_recall"] == 0.5
+
+
+def test_heuristic_planner_meets_the_threshold():
+    cases = load_golden()
+    result = score_planner(cases, heuristic_planner)
+    assert result is not None
+    assert result["n"] == len(cases)
+    for key in ("facet_precision", "facet_recall", "panel_recall", "score"):
+        assert 0.0 <= result[key] <= 1.0
+    assert result["score"] >= SCORE_THRESHOLD, result["score"]
+
+
+def test_unavailable_planner_scores_none():
+    assert score_planner(load_golden(), lambda intent: None) is None
+
+
+def test_evaluate_returns_both_planner_slots():
+    out = evaluate()
+    assert out["heuristic"] is not None
+    assert "llm" in out  # None here (no LLM configured), present as a slot


### PR DESCRIPTION
Part of M5 (#653), roadmap epic #659. Closes #675.

## What

`src/genui/planner_eval.py`: runs the golden intents (M5.1) through a planner and scores facet precision/recall against the labeled facets and panel recall against `must_panels`, aggregated into a combined `score`. Scores both the heuristic and LLM planners; the LLM slot is `None` when no LLM is configured, so the harness runs everywhere. A CLI (`python -m src.genui.planner_eval`) prints the per-planner table and the threshold gate.

Current heuristic: `score=1.000 facet_p=0.875 facet_r=1.000 panel_r=1.000 (n=12)`.

## Tests

`tests/unit/genui/test_planner_eval.py`: per-case metric math (perfect and penalized), the heuristic meets `SCORE_THRESHOLD`, an unavailable planner scores `None`, and `evaluate()` returns both planner slots.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_