### PR TITLE
M5.3: CI regression gate for the planner eval

### DIFF
--- a/.github/workflows/planner-eval.yml
+++ b/.github/workflows/planner-eval.yml
@@ -1,0 +1,41 @@
+name: Planner Eval
+
+# M5.3: score the generative-UI planner against the golden intent set on every
+# change to the planner, its keywords, the catalog, or the golden fixtures, and
+# fail the build when the score regresses below the threshold.
+on:
+  pull_request:
+    paths:
+      - 'src/genui/planner.py'
+      - 'src/genui/planner_eval.py'
+      - 'src/genui/catalog.py'
+      - 'src/genui/llm.py'
+      - 'tests/data/planner_golden.json'
+      - '.github/workflows/planner-eval.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/genui/planner.py'
+      - 'src/genui/catalog.py'
+      - 'tests/data/planner_golden.json'
+
+jobs:
+  planner-eval:
+    name: Planner eval (golden set)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Run the planner eval gate
+        run: |
+          echo "Scoring the planner against the golden intent set..."
+          python -m src.genui.planner_eval

--- a/src/genui/planner_eval.py
+++ b/src/genui/planner_eval.py
@@ -96,16 +96,25 @@ def _fmt(result: Optional[Dict[str, Any]]) -> str:
     )
 
 
-def main() -> None:
+def gate_passes(out: Dict[str, Any]) -> bool:
+    """The CI gate (M5.3): the heuristic planner's score must not regress below
+    the threshold. The LLM planner is reported but never gates (it is optional
+    and may be unavailable in CI)."""
+    heur = out.get("heuristic")
+    return heur is not None and heur["score"] >= SCORE_THRESHOLD
+
+
+def main() -> int:
     out = evaluate()
     print("Planner eval (golden set)\n")
     for name in ("heuristic", "llm"):
         print(f"  {name:<10} {_fmt(out[name])}")
-    heur = out["heuristic"]
-    if heur is not None:
-        gate = "PASS" if heur["score"] >= SCORE_THRESHOLD else "FAIL"
-        print(f"\nthreshold {SCORE_THRESHOLD}: heuristic {gate}")
+    passed = gate_passes(out)
+    print(f"\nthreshold {SCORE_THRESHOLD}: heuristic {'PASS' if passed else 'FAIL'}")
+    return 0 if passed else 1
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    sys.exit(main())

--- a/tests/unit/genui/test_planner_eval_gate.py
+++ b/tests/unit/genui/test_planner_eval_gate.py
@@ -1,0 +1,21 @@
+"""M5.3: the CI regression gate. The planner-eval gate passes on the current
+baseline and fails when the heuristic score regresses below the threshold."""
+
+from src.genui.planner_eval import SCORE_THRESHOLD, evaluate, gate_passes, main
+
+
+def test_gate_passes_on_the_current_baseline():
+    assert gate_passes(evaluate()) is True
+
+
+def test_gate_fails_on_a_regression_below_threshold():
+    regressed = {"heuristic": {"score": SCORE_THRESHOLD - 0.01}, "llm": None}
+    assert gate_passes(regressed) is False
+
+
+def test_gate_fails_when_heuristic_is_unavailable():
+    assert gate_passes({"heuristic": None, "llm": None}) is False
+
+
+def test_main_exits_zero_on_the_baseline():
+    assert main() == 0


### PR DESCRIPTION
Part of M5 (#653), roadmap epic #659. Closes #676. Completes milestone M5.

## What

- `.github/workflows/planner-eval.yml`: runs the planner eval on every change to `planner.py`, the catalog, the LLM planner, `planner_eval.py`, or the golden fixtures, and fails the build when the heuristic score regresses below the threshold.
- The eval CLI now returns a non-zero exit code on a below-threshold score (`gate_passes` / `main`).

## Tests

`tests/unit/genui/test_planner_eval_gate.py`: the gate passes on the current baseline, fails on a simulated regression below threshold, and fails when the heuristic planner is unavailable; `main()` exits 0 on the baseline.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_