### PR TITLE
M6.1: Spec-diff apply path for canvas refinement

### DIFF
--- a/src/genui/spec_diff.py
+++ b/src/genui/spec_diff.py
@@ -1,0 +1,127 @@
+"""
+Spec-diff apply path (M6.1): refine a canvas by applying a small diff instead of
+regenerating the whole ui-spec.
+
+A diff is a list of operations, each a dict:
+
+  {"op": "add", "panel": {"type": "contradiction_ledger", "title"?, "span"?, "params"?}}
+  {"op": "remove", "type": "forecast"}          # or {"id": "p3"}
+  {"op": "retarget", "type": "articles", "params": {"topic": "energy"}, "span"?: 8}
+
+:func:`apply_diff` applies the ops in order onto an existing :class:`UISpec` and
+returns ``(new_spec, errors)``. Invalid ops are skipped and reported; the note
+panel is preserved and panels are re-numbered. The returned spec is validated
+against the ui-spec contract, so a caller can reject a diff that would produce an
+invalid canvas. Stdlib-only; untrusted (LLM-produced) input never raises.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Tuple
+
+from src.genui.catalog import PANEL_TYPES, get_panel_def
+from src.genui.spec import MAX_PANELS, PanelSpec, UISpec, validate_spec
+
+_MAX_DATA_PANELS = MAX_PANELS - 1  # one slot is the plan note
+
+
+def _data_panels(panels: List[PanelSpec]) -> List[PanelSpec]:
+    return [p for p in panels if p.type != "note"]
+
+
+def apply_diff(spec: UISpec, diff: List[Dict[str, Any]]) -> Tuple[UISpec, List[str]]:
+    """Apply a spec diff to ``spec``. Returns ``(new_spec, errors)``; ``errors``
+    is empty when every op applied and the result validates."""
+    errors: List[str] = []
+    panels: List[PanelSpec] = [deepcopy(p) for p in spec.panels]
+
+    if not isinstance(diff, list):
+        return spec, ["diff must be a list of operations"]
+
+    for i, op in enumerate(diff):
+        where = f"diff[{i}]"
+        if not isinstance(op, dict):
+            errors.append(f"{where}: not an object")
+            continue
+        kind = op.get("op")
+        if kind == "add":
+            errors += _apply_add(op, panels, where)
+        elif kind == "remove":
+            errors += _apply_remove(op, panels, where)
+        elif kind == "retarget":
+            errors += _apply_retarget(op, panels, where)
+        else:
+            errors.append(f"{where}: unknown op {kind!r}")
+
+    # Keep the note first, cap data panels, re-number ids.
+    note = [p for p in panels if p.type == "note"][:1]
+    rest = _data_panels(panels)[:_MAX_DATA_PANELS]
+    ordered = note + rest
+    for j, panel in enumerate(ordered):
+        panel.id = f"p{j + 1}"
+
+    new_spec = UISpec(
+        intent=spec.intent,
+        title=spec.title,
+        subtitle=spec.subtitle,
+        generated_by=spec.generated_by,
+        facets=list(spec.facets),
+        topic=spec.topic,
+        source_type=spec.source_type,
+        panels=ordered,
+    )
+    return new_spec, errors + validate_spec(new_spec.to_dict())
+
+
+def _apply_add(op: Dict[str, Any], panels: List[PanelSpec], where: str) -> List[str]:
+    panel = op.get("panel")
+    if not isinstance(panel, dict) or not panel.get("type"):
+        return [f"{where}: add requires a panel with a type"]
+    ptype = str(panel["type"])
+    if ptype not in PANEL_TYPES:
+        return [f"{where}: unknown panel type {ptype!r}"]
+    if len(_data_panels(panels)) >= _MAX_DATA_PANELS:
+        return [f"{where}: canvas is full ({_MAX_DATA_PANELS} panels)"]
+    pdef = get_panel_def(ptype)
+    panels.append(
+        PanelSpec(
+            id="tmp",
+            type=ptype,
+            title=str(panel.get("title") or (pdef.title if pdef else ptype)),
+            span=int(panel.get("span") or (pdef.default_span if pdef else 6)),
+            priority=float(panel.get("priority") or 0.6),
+            rationale=str(panel.get("rationale") or "added by refinement"),
+            params=panel.get("params") if isinstance(panel.get("params"), dict) else {},
+        )
+    )
+    return []
+
+
+def _apply_remove(op: Dict[str, Any], panels: List[PanelSpec], where: str) -> List[str]:
+    target_type, target_id = op.get("type"), op.get("id")
+    if not target_type and not target_id:
+        return [f"{where}: remove requires a type or id"]
+    before = len(panels)
+    panels[:] = [
+        p
+        for p in panels
+        if p.type == "note"
+        or not ((target_type and p.type == target_type) or (target_id and p.id == target_id))
+    ]
+    return [] if len(panels) < before else [f"{where}: no panel matched remove"]
+
+
+def _apply_retarget(op: Dict[str, Any], panels: List[PanelSpec], where: str) -> List[str]:
+    target_type = op.get("type")
+    if not target_type:
+        return [f"{where}: retarget requires a type"]
+    new_params = op.get("params") if isinstance(op.get("params"), dict) else {}
+    matched = False
+    for p in panels:
+        if p.type == target_type and p.type != "note":
+            p.params = {**p.params, **new_params}
+            if "span" in op:
+                p.span = int(op["span"])
+            matched = True
+    return [] if matched else [f"{where}: no panel matched retarget {target_type!r}"]

--- a/tests/unit/genui/test_spec_diff.py
+++ b/tests/unit/genui/test_spec_diff.py
@@ -1,0 +1,90 @@
+"""M6.1: the spec-diff apply path. Applies add/remove/retarget diffs onto a
+canvas and returns a validated ui-spec, so a refinement is a diff, not a
+full regeneration."""
+
+from src.genui.planner import plan
+from src.genui.spec_diff import apply_diff
+
+
+def _canvas():
+    # A focused canvas (the actors facet yields 5 panels), leaving room to add.
+    return plan("who are the key actors")
+
+
+def _types(spec):
+    return [p.type for p in spec.panels if p.type != "note"]
+
+
+def test_add_panel_appends_and_validates():
+    spec = _canvas()
+    out, errors = apply_diff(spec, [{"op": "add", "panel": {"type": "contradiction_ledger"}}])
+    assert errors == []
+    assert "contradiction_ledger" in _types(out)
+    # Ids are re-numbered and the note stays first.
+    assert out.panels[0].type == "note"
+    assert [p.id for p in out.panels] == [f"p{i + 1}" for i in range(len(out.panels))]
+
+
+def test_remove_panel_by_type():
+    spec = _canvas()
+    assert "actors" in _types(spec)
+    out, errors = apply_diff(spec, [{"op": "remove", "type": "actors"}])
+    assert errors == []
+    assert "actors" not in _types(out)
+
+
+def test_retarget_merges_params():
+    spec = _canvas()
+    target = _types(spec)[0]
+    out, errors = apply_diff(spec, [{"op": "retarget", "type": target, "params": {"topic": "nuclear"}}])
+    assert errors == []
+    panel = next(p for p in out.panels if p.type == target)
+    assert panel.params.get("topic") == "nuclear"
+
+
+def test_unknown_panel_type_is_reported_not_applied():
+    spec = _canvas()
+    out, errors = apply_diff(spec, [{"op": "add", "panel": {"type": "not_a_panel"}}])
+    assert any("unknown panel type" in e for e in errors)
+    assert "not_a_panel" not in _types(out)
+
+
+def test_unknown_op_and_bad_shapes_are_reported():
+    spec = _canvas()
+    _, errors = apply_diff(spec, [{"op": "frobnicate"}, "nope", {"op": "remove"}])
+    assert any("unknown op" in e for e in errors)
+    assert any("not an object" in e for e in errors)
+    assert any("requires a type or id" in e for e in errors)
+
+
+def test_note_is_never_removed():
+    spec = _canvas()
+    out, _ = apply_diff(spec, [{"op": "remove", "type": "note"}])
+    assert out.panels[0].type == "note"
+
+
+def test_full_canvas_rejects_further_adds():
+    spec = _canvas()
+    # Fill to capacity, then one more add is rejected.
+    # 5 base + 6 fillers = 11 (the data-panel cap).
+    fillers = ["clusters", "timeline", "watchlists", "documents", "frames", "controversy"]
+    diff = [{"op": "add", "panel": {"type": t}} for t in fillers]
+    out, _ = apply_diff(spec, diff)
+    assert len(_types(out)) == 11
+    over, errors = apply_diff(out, [{"op": "add", "panel": {"type": "provenance_trace"}}])
+    assert len(_types(over)) == 11
+    assert any("canvas is full" in e for e in errors)
+
+
+def test_multi_op_diff_applies_in_order_and_validates():
+    spec = _canvas()
+    out, errors = apply_diff(
+        spec,
+        [
+            {"op": "add", "panel": {"type": "corroboration"}},
+            {"op": "remove", "type": "positions"},
+        ],
+    )
+    assert errors == []
+    types = _types(out)
+    assert "corroboration" in types and "positions" not in types


### PR DESCRIPTION
Part of M6 (#654), roadmap epic #659. Closes #677.

## What

`src/genui/spec_diff.py`: `apply_diff(spec, diff)` applies a small diff onto an existing canvas and returns a validated ui-spec, so a refinement is a diff rather than a full regeneration.

Ops:
- `{"op": "add", "panel": {"type", "title"?, "span"?, "params"?}}`
- `{"op": "remove", "type"|"id"}`
- `{"op": "retarget", "type", "params"?, "span"?}`

The note panel is preserved, panels are re-numbered, the data-panel cap is enforced, and invalid ops (unknown panel type, unknown op, malformed shapes, full canvas) are skipped and reported. Untrusted (LLM-produced) input never raises; the result is validated against the ui-spec contract.

## Tests

`tests/unit/genui/test_spec_diff.py` (8): add/remove/retarget apply and validate, unknown types/ops/shapes are reported not applied, the note is never removed, a full canvas rejects further adds, and a multi-op diff applies in order.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_