### PR TITLE
M6.3: Refinement intents to spec diffs

### DIFF
--- a/src/genui/refine.py
+++ b/src/genui/refine.py
@@ -1,0 +1,104 @@
+"""
+Refinement intents to spec diffs (M6.3).
+
+A heuristic that turns a natural refinement instruction ("add a contradiction
+ledger", "drop the forecast", "focus on energy") into a spec diff (M6.1) against
+the current canvas. It is the default refiner for :class:`CanvasSession` when no
+LLM is configured, and a signature-compatible ``(spec, instruction, context) ->
+diff`` refiner.
+
+Matching is keyword-based over the panel catalog (type tokens plus title), so a
+phrase like "contradiction ledger" resolves to ``contradiction_ledger``.
+Multi-clause instructions ("add X and drop Y") are split on "and". Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+from src.genui.catalog import PANEL_TYPES, get_panel_def
+from src.genui.spec import UISpec
+
+_ADD = re.compile(r"\b(?:add|show|include|bring up|put)\b\s+(?:an?|the|a\s+new)?\s*(.+)")
+_REMOVE = re.compile(r"\b(?:remove|drop|hide|delete|get rid of|take out|lose)\b\s+(?:the|that)?\s*(.+)")
+_FOCUS = re.compile(r"\b(?:focus on|zoom in on|narrow to|only|filter to|about|for)\b\s+(.+)")
+
+_STOP = {"panel", "panels", "chart", "the", "a", "an", "view", "please"}
+
+
+@lru_cache(maxsize=1)
+def _lookup() -> Dict[str, str]:
+    """phrase -> panel type, over the catalog (type tokens + title)."""
+    out: Dict[str, str] = {}
+    for ptype in PANEL_TYPES:
+        out[ptype] = ptype
+        out[ptype.replace("_", " ")] = ptype
+        pdef = get_panel_def(ptype)
+        if pdef and pdef.title:
+            out[pdef.title.lower()] = ptype
+    return out
+
+
+def match_panel(text: str) -> Optional[str]:
+    """Resolve a phrase to a panel type by exact match, then best token overlap."""
+    text = text.lower().strip().strip(".!?")
+    lookup = _lookup()
+    if text in lookup:
+        return lookup[text]
+    tokens = {t for t in re.findall(r"[a-z]+", text) if t not in _STOP}
+    if not tokens:
+        return None
+    best, best_score = None, 0
+    for phrase, ptype in lookup.items():
+        ptoks = set(phrase.split())
+        score = len(tokens & ptoks)
+        if phrase in text:
+            score += 2
+        if score > best_score:
+            best, best_score = ptype, score
+    return best if best_score > 0 else None
+
+
+def _data_panel_types(spec: UISpec) -> List[str]:
+    seen: List[str] = []
+    for p in spec.panels:
+        if p.type != "note" and p.type not in seen:
+            seen.append(p.type)
+    return seen
+
+
+def refine_to_diff(
+    spec: UISpec, instruction: str, context: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
+    """Turn a refinement instruction into a spec diff against ``spec``. Returns
+    an empty list when nothing was recognized (a no-op refinement)."""
+    diff: List[Dict[str, Any]] = []
+    for clause in re.split(r"\s+and\s+|,\s*", (instruction or "").lower()):
+        clause = clause.strip()
+        if not clause:
+            continue
+        m = _REMOVE.search(clause)
+        if m:
+            panel = match_panel(m.group(1))
+            if panel:
+                diff.append({"op": "remove", "type": panel})
+                continue
+        m = _ADD.search(clause)
+        if m:
+            panel = match_panel(m.group(1))
+            if panel:
+                diff.append({"op": "add", "panel": {"type": panel}})
+                continue
+        m = _FOCUS.search(clause)
+        if m:
+            topic = m.group(1).strip().strip(".!?")
+            # If the focus target is itself a panel name, treat it as an add.
+            panel = match_panel(topic)
+            if panel and topic in _lookup():
+                diff.append({"op": "add", "panel": {"type": panel}})
+            elif topic:
+                for ptype in _data_panel_types(spec):
+                    diff.append({"op": "retarget", "type": ptype, "params": {"topic": topic}})
+    return diff

--- a/tests/unit/genui/test_refine.py
+++ b/tests/unit/genui/test_refine.py
@@ -1,0 +1,61 @@
+"""M6.3: refinement intents to spec diffs. A natural instruction turns into a
+spec diff against the current canvas, and applying it through a session produces
+the expected canvas."""
+
+from src.genui.canvas_session import start_session
+from src.genui.planner import plan
+from src.genui.refine import match_panel, refine_to_diff
+
+
+def _types(spec):
+    return [p.type for p in spec.panels if p.type != "note"]
+
+
+def _canvas():
+    return plan("who are the key actors")
+
+
+def test_match_panel_resolves_phrases():
+    assert match_panel("contradiction ledger") == "contradiction_ledger"
+    assert match_panel("the forecast panel") == "forecast"
+    assert match_panel("reliability card") == "reliability_card"
+    assert match_panel("nonsense words here") is None
+
+
+def test_add_instruction_becomes_add_op():
+    diff = refine_to_diff(_canvas(), "add a contradiction ledger")
+    assert diff == [{"op": "add", "panel": {"type": "contradiction_ledger"}}]
+
+
+def test_drop_instruction_becomes_remove_op():
+    diff = refine_to_diff(_canvas(), "drop the forecast")
+    assert diff == [{"op": "remove", "type": "forecast"}]
+
+
+def test_focus_instruction_retargets_all_data_panels():
+    spec = _canvas()
+    diff = refine_to_diff(spec, "focus on energy")
+    assert diff and all(op["op"] == "retarget" for op in diff)
+    assert all(op["params"] == {"topic": "energy"} for op in diff)
+    assert {op["type"] for op in diff} == set(_types(spec))
+
+
+def test_multi_clause_instruction():
+    diff = refine_to_diff(_canvas(), "add corroboration and remove actors")
+    assert {"op": "add", "panel": {"type": "corroboration"}} in diff
+    assert {"op": "remove", "type": "actors"} in diff
+
+
+def test_unrecognized_instruction_is_a_noop_diff():
+    assert refine_to_diff(_canvas(), "make it pretty please") == []
+
+
+def test_diff_applies_cleanly_through_a_session():
+    session = start_session("who are the key actors")
+    spec, errors = session.refine_with("add a contradiction ledger", refine_to_diff)
+    assert errors == [] and "contradiction_ledger" in _types(spec)
+
+    spec, errors = session.refine_with("focus on nuclear", refine_to_diff)
+    assert errors == []
+    topics = {(p.params or {}).get("topic") for p in spec.panels if p.type != "note"}
+    assert topics == {"nuclear"}


### PR DESCRIPTION
Part of M6 (#654), roadmap epic #659. Closes #679.

## What

`src/genui/refine.py`: `refine_to_diff(spec, instruction, context)` turns a natural refinement instruction into a spec diff (M6.1) against the current canvas:

- `"add a contradiction ledger"` → `add contradiction_ledger`
- `"drop the forecast"` → `remove forecast`
- `"focus on energy"` → `retarget` every data panel's `topic`
- multi-clause (`"add X and remove Y"`) splits on `and`

Panel phrases resolve via keyword match over the catalog (type tokens + title). It is a signature-compatible `CanvasSession` refiner and the default when no LLM is configured; an unrecognized instruction yields an empty (no-op) diff.

## Tests

`tests/unit/genui/test_refine.py` (7): phrase matching, add/drop/focus/multi-clause parsing, no-op on unrecognized input, and end-to-end through a session (`refine_with(instruction, refine_to_diff)`).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_