### PR TITLE
M8.1: Server-persisted canvas store

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -31,6 +31,7 @@ PRIVACY_ROUTES_AVAILABLE = False
 SECURITY_ROUTES_AVAILABLE = False
 GENUI_ROUTES_AVAILABLE = False
 GENUI_DATA_ROUTES_AVAILABLE = False
+CANVAS_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -392,6 +393,19 @@ def try_import_genui_data_routes():
         return False
 
 
+def try_import_canvas_routes():
+    """Try to import the persisted-canvas routes (M8: save/reopen/share)."""
+    global CANVAS_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import canvas_routes
+        _imported_modules['canvas_routes'] = canvas_routes
+        CANVAS_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        CANVAS_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -451,6 +465,7 @@ def check_all_imports():
     try_import_security_routes()
     try_import_genui_routes()
     try_import_genui_data_routes()
+    try_import_canvas_routes()
     _load_domain_packs()
 
 
@@ -788,6 +803,13 @@ def include_optional_routers(app):
             app.include_router(genui_data_routes.router)
             routers_included += 1
 
+    # Include the persisted-canvas routes (M8: save/reopen/share).
+    if CANVAS_ROUTES_AVAILABLE:
+        canvas_routes = _imported_modules.get('canvas_routes')
+        if canvas_routes:
+            app.include_router(canvas_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -907,6 +929,7 @@ async def root():
             "local_storage_security": SECURITY_ROUTES_AVAILABLE,
             "generative_ui": GENUI_ROUTES_AVAILABLE,
             "generative_ui_data": GENUI_DATA_ROUTES_AVAILABLE,
+            "generative_ui_canvas": CANVAS_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/canvas_routes.py
+++ b/src/api/routes/canvas_routes.py
@@ -1,0 +1,153 @@
+"""Persisted-canvas routes (M8).
+
+A generated canvas is ephemeral by default. These routes let a canvas be saved
+server-side and reopened later with its live data bindings intact (M8.1):
+
+    POST   /api/v1/ui/canvas          save a canvas (create or update)
+    GET    /api/v1/ui/canvas          list the owner's saved canvases
+    GET    /api/v1/ui/canvas/{id}     reopen one canvas (owner-scoped)
+    DELETE /api/v1/ui/canvas/{id}     delete one canvas (owner-scoped)
+
+Owner identity for this prototype comes from the ``X-Canvas-Owner`` header
+(default ``local``); the access model M8.3 formalises it. The persisted spec is
+validated against the ``ui-spec-v1`` contract on save, so a malformed layout is
+never stored.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from src.genui import canvas_store
+from src.genui.spec import validate_spec
+
+router = APIRouter(prefix="/api/v1/ui", tags=["generative_ui_canvas"])
+
+DEFAULT_OWNER = "local"
+
+
+def _owner(header_value: Optional[str]) -> str:
+    """The owner for a request, from the ``X-Canvas-Owner`` header."""
+    value = (header_value or "").strip()
+    return value[:128] if value else DEFAULT_OWNER
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _conn():
+    """The shared, writable warehouse connection with its serialising lock."""
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    return get_shared_connection(), _LOCK
+
+
+class SaveCanvasRequest(BaseModel):
+    """Body for POST /api/v1/ui/canvas."""
+
+    spec: Dict[str, Any] = Field(..., description="The ui-spec-v1 layout to persist")
+    data_bindings: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Per-panel live data bindings (server/tool/arguments/snapshot)",
+    )
+    title: Optional[str] = Field(default=None, max_length=200)
+    id: Optional[str] = Field(
+        default=None, max_length=64, description="Existing canvas id to update in place"
+    )
+
+
+@router.post("/canvas")
+def save_canvas(
+    request: SaveCanvasRequest,
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """Save a canvas (its spec plus live data bindings) and return the stored
+    record. Creates a new canvas, or updates one the owner already owns when
+    ``id`` is given. Sync on purpose: the warehouse write runs in the
+    threadpool.
+    """
+    errors = validate_spec(request.spec)
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail=f"spec failed validation: {'; '.join(errors[:3])}",
+        )
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            saved = canvas_store.save_canvas(
+                conn,
+                owner=owner,
+                spec=request.spec,
+                now=_now(),
+                data_bindings=request.data_bindings,
+                title=request.title,
+                canvas_id=request.id,
+            )
+    except canvas_store.CanvasStoreError as err:
+        raise HTTPException(status_code=413, detail=str(err))
+    except HTTPException:
+        raise
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas save failed: {err}")
+    return {"canvas": saved}
+
+
+@router.get("/canvas")
+def list_canvases(
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """List the owner's saved canvases (lightweight summaries)."""
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            canvases = canvas_store.list_canvases(conn, owner)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas list failed: {err}")
+    return {"canvases": canvases, "count": len(canvases)}
+
+
+@router.get("/canvas/{canvas_id}")
+def get_canvas(
+    canvas_id: str,
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """Reopen a saved canvas by id, with its spec and live data bindings intact.
+    Scoped to the owner: another owner's canvas reads back as 404."""
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            canvas = canvas_store.get_canvas(conn, canvas_id, owner=owner)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas read failed: {err}")
+    if canvas is None:
+        raise HTTPException(status_code=404, detail="canvas not found")
+    return {"canvas": canvas}
+
+
+@router.delete("/canvas/{canvas_id}")
+def delete_canvas(
+    canvas_id: str,
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """Delete one of the owner's canvases."""
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            removed = canvas_store.delete_canvas(conn, canvas_id, owner)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas delete failed: {err}")
+    if not removed:
+        raise HTTPException(status_code=404, detail="canvas not found")
+    return {"deleted": canvas_id}

--- a/src/genui/canvas_store.py
+++ b/src/genui/canvas_store.py
@@ -1,0 +1,192 @@
+"""
+Server-persisted canvas store (M8.1).
+
+A generated canvas is normally ephemeral: it lives in the browser for one
+session and is gone on reload. This store persists a canvas server-side so it
+can be saved and reopened later, surviving the session. Two things are kept:
+
+* the **ui-spec** (the ``ui-spec-v1`` layout document), and
+* its **live data bindings** — the descriptors that tell each panel which
+  data-mode tool feeds it (server / tool / arguments), plus any snapshot the
+  client captured — so reopening rebinds to live data instead of a blank grid.
+
+One warehouse-side table, ``saved_canvases``, outside the shared corpus. Every
+canvas has an ``owner`` and an unguessable ``id``; reads can be scoped to an
+owner so one owner never sees another's canvas (the access model M8.3 builds
+on). Writes are keyed by id, so re-saving an existing canvas updates it in place
+rather than duplicating.
+
+Stdlib-only (``json`` + ``secrets``); the connection is injected.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any, Dict, List, Optional
+
+# Size ceiling for a persisted canvas payload (spec + bindings, serialized), so a
+# runaway spec cannot bloat the warehouse. Enforced by :func:`save_canvas`.
+MAX_CANVAS_BYTES = 256 * 1024
+
+
+class CanvasStoreError(ValueError):
+    """A canvas could not be saved (e.g. it exceeds the size ceiling)."""
+
+
+def ensure_schema(conn) -> None:
+    """Create the ``saved_canvases`` table if absent (idempotent)."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS saved_canvases ("
+        "id VARCHAR PRIMARY KEY, owner VARCHAR, title VARCHAR, "
+        "spec VARCHAR, data_bindings VARCHAR, share_token VARCHAR, "
+        "created_at TIMESTAMP, updated_at TIMESTAMP)"
+    )
+    # Migrate a store that predates the share column (M8.2 adds sharing).
+    try:
+        conn.execute("ALTER TABLE saved_canvases ADD COLUMN IF NOT EXISTS share_token VARCHAR")
+    except Exception:
+        pass
+
+
+def schema_ready(conn) -> bool:
+    """True once the ``saved_canvases`` table exists (reads may run before any
+    canvas has been saved)."""
+    try:
+        rows = conn.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_name = 'saved_canvases'"
+        ).fetchall()
+        return bool(rows)
+    except Exception:
+        return False
+
+
+def _loads(value: Optional[str], fallback: Any) -> Any:
+    if not value:
+        return fallback
+    try:
+        return json.loads(value)
+    except Exception:
+        return fallback
+
+
+def _row_to_canvas(row) -> Dict[str, Any]:
+    return {
+        "id": row[0],
+        "owner": row[1],
+        "title": row[2],
+        "spec": _loads(row[3], {}),
+        "data_bindings": _loads(row[4], {}),
+        "share_token": row[5],
+        "created_at": str(row[6]) if row[6] is not None else None,
+        "updated_at": str(row[7]) if row[7] is not None else None,
+    }
+
+
+_COLUMNS = "id, owner, title, spec, data_bindings, share_token, created_at, updated_at"
+
+
+def new_id() -> str:
+    """An unguessable, URL-safe canvas id."""
+    return secrets.token_urlsafe(9)
+
+
+def save_canvas(
+    conn,
+    owner: str,
+    spec: Dict[str, Any],
+    now: Any,
+    data_bindings: Optional[Dict[str, Any]] = None,
+    title: Optional[str] = None,
+    canvas_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Persist a canvas (its spec plus live data bindings) and return the stored
+    record.
+
+    With no ``canvas_id`` a new canvas is created under ``owner``. With a
+    ``canvas_id`` that ``owner`` already owns, the canvas is updated in place
+    (spec, bindings, title refreshed; id, owner, ``created_at`` and any
+    ``share_token`` preserved). A ``canvas_id`` the owner does not own is treated
+    as a new canvas, so one owner can never overwrite another's.
+    """
+    bindings = data_bindings or {}
+    spec_json = json.dumps(spec, default=str)
+    bindings_json = json.dumps(bindings, default=str)
+    if len(spec_json) + len(bindings_json) > MAX_CANVAS_BYTES:
+        raise CanvasStoreError(
+            f"canvas exceeds the {MAX_CANVAS_BYTES}-byte ceiling"
+        )
+    resolved_title = title if title is not None else (spec.get("title") or "Untitled canvas")
+
+    existing = get_canvas(conn, canvas_id, owner=owner) if canvas_id else None
+    if existing is None:
+        cid = new_id()
+        conn.execute(
+            "INSERT INTO saved_canvases "
+            "(id, owner, title, spec, data_bindings, share_token, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, NULL, ?, ?)",
+            [cid, owner, resolved_title, spec_json, bindings_json, now, now],
+        )
+        return get_canvas(conn, cid)
+    conn.execute(
+        "UPDATE saved_canvases SET title = ?, spec = ?, data_bindings = ?, updated_at = ? "
+        "WHERE id = ?",
+        [resolved_title, spec_json, bindings_json, now, existing["id"]],
+    )
+    return get_canvas(conn, existing["id"])
+
+
+def get_canvas(
+    conn, canvas_id: str, owner: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """The canvas record for ``canvas_id``, or None. When ``owner`` is given, a
+    canvas owned by someone else reads back as None (owner isolation)."""
+    if not schema_ready(conn) or not canvas_id:
+        return None
+    row = conn.execute(
+        f"SELECT {_COLUMNS} FROM saved_canvases WHERE id = ?", [canvas_id]
+    ).fetchone()
+    if not row:
+        return None
+    canvas = _row_to_canvas(row)
+    if owner is not None and canvas["owner"] != owner:
+        return None
+    return canvas
+
+
+def list_canvases(conn, owner: str) -> List[Dict[str, Any]]:
+    """An owner's saved canvases, newest first. Spec and bindings are elided to a
+    lightweight summary so a listing is cheap; reopen one by id for the full
+    record."""
+    if not schema_ready(conn):
+        return []
+    rows = conn.execute(
+        f"SELECT {_COLUMNS} FROM saved_canvases WHERE owner = ? "
+        "ORDER BY updated_at DESC NULLS LAST, id",
+        [owner],
+    ).fetchall()
+    out = []
+    for r in rows:
+        c = _row_to_canvas(r)
+        spec = c["spec"] if isinstance(c["spec"], dict) else {}
+        out.append(
+            {
+                "id": c["id"],
+                "title": c["title"],
+                "topic": spec.get("topic"),
+                "panel_count": len(spec.get("panels") or []),
+                "shared": c["share_token"] is not None,
+                "created_at": c["created_at"],
+                "updated_at": c["updated_at"],
+            }
+        )
+    return out
+
+
+def delete_canvas(conn, canvas_id: str, owner: str) -> bool:
+    """Delete a canvas the owner owns. Returns True if a row was removed."""
+    if get_canvas(conn, canvas_id, owner=owner) is None:
+        return False
+    conn.execute("DELETE FROM saved_canvases WHERE id = ?", [canvas_id])
+    return True

--- a/tests/unit/api/routes/test_canvas_routes.py
+++ b/tests/unit/api/routes/test_canvas_routes.py
@@ -1,0 +1,139 @@
+"""Route tests for src/api/routes/canvas_routes.py (M8.1 persisted canvas).
+
+Loads the route module BY PATH (never via src.api.routes, whose __init__
+eagerly imports heavy ML modules), mounts only that router, and points its
+warehouse connection at an in-memory DuckDB so no real warehouse is touched.
+Covers the save -> reopen round-trip (spec + live data bindings intact), owner
+scoping, spec validation, and list/delete.
+"""
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("fastapi")
+duckdb = pytest.importorskip("duckdb")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "canvas_routes_under_test", REPO / "src/api/routes/canvas_routes.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _valid_spec(topic="climate policy"):
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "track the climate policy debate",
+        "title": "Climate policy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["claims"],
+        "topic": topic,
+        "source_type": None,
+        "panels": [
+            {
+                "id": "p1",
+                "type": "claims",
+                "title": "Key claims",
+                "span": 6,
+                "priority": 0.8,
+                "rationale": "",
+                "endpoint": None,
+                "params": {"topic": topic},
+                "body": "",
+            }
+        ],
+    }
+
+
+def _bindings():
+    return {
+        "p1": {
+            "server": "neuronews-arguments",
+            "tool": "list_claims",
+            "arguments": {"topic": "climate policy"},
+            "snapshot": {"claims": [{"claim_id": "k1"}]},
+        }
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    conn = duckdb.connect(":memory:")
+    lock = threading.Lock()
+    monkeypatch.setattr(mod, "_conn", lambda: (conn, lock))
+    app = FastAPI()
+    app.include_router(mod.router)
+    yield TestClient(app)
+    conn.close()
+
+
+def test_save_then_reopen_round_trips_spec_and_bindings(client):
+    save = client.post(
+        "/api/v1/ui/canvas",
+        json={"spec": _valid_spec(), "data_bindings": _bindings()},
+        headers={"X-Canvas-Owner": "alice"},
+    )
+    assert save.status_code == 200
+    cid = save.json()["canvas"]["id"]
+    assert cid
+
+    reopen = client.get(f"/api/v1/ui/canvas/{cid}", headers={"X-Canvas-Owner": "alice"})
+    assert reopen.status_code == 200
+    canvas = reopen.json()["canvas"]
+    assert canvas["spec"] == _valid_spec()
+    assert canvas["data_bindings"] == _bindings()  # live bindings survive
+
+
+def test_reopen_is_owner_scoped(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec()}, headers={"X-Canvas-Owner": "alice"}
+    ).json()["canvas"]["id"]
+    # A different owner gets a 404, not another user's canvas.
+    assert client.get(f"/api/v1/ui/canvas/{cid}", headers={"X-Canvas-Owner": "bob"}).status_code == 404
+
+
+def test_invalid_spec_is_rejected(client):
+    bad = _valid_spec()
+    bad["panels"] = []  # a spec with no panels is invalid
+    resp = client.post("/api/v1/ui/canvas", json={"spec": bad}, headers={"X-Canvas-Owner": "alice"})
+    assert resp.status_code == 400
+
+
+def test_list_and_delete(client):
+    for topic in ("a", "b"):
+        client.post(
+            "/api/v1/ui/canvas", json={"spec": _valid_spec(topic)}, headers={"X-Canvas-Owner": "alice"}
+        )
+    listed = client.get("/api/v1/ui/canvas", headers={"X-Canvas-Owner": "alice"}).json()
+    assert listed["count"] == 2
+
+    cid = listed["canvases"][0]["id"]
+    assert client.delete(f"/api/v1/ui/canvas/{cid}", headers={"X-Canvas-Owner": "alice"}).status_code == 200
+    assert client.get("/api/v1/ui/canvas", headers={"X-Canvas-Owner": "alice"}).json()["count"] == 1
+
+
+def test_update_in_place_with_id(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec("energy")}, headers={"X-Canvas-Owner": "alice"}
+    ).json()["canvas"]["id"]
+    client.post(
+        "/api/v1/ui/canvas",
+        json={"spec": _valid_spec("energy transition"), "id": cid},
+        headers={"X-Canvas-Owner": "alice"},
+    )
+    listed = client.get("/api/v1/ui/canvas", headers={"X-Canvas-Owner": "alice"}).json()
+    assert listed["count"] == 1  # updated, not duplicated
+    canvas = client.get(f"/api/v1/ui/canvas/{cid}", headers={"X-Canvas-Owner": "alice"}).json()["canvas"]
+    assert canvas["spec"]["topic"] == "energy transition"

--- a/tests/unit/genui/test_canvas_store.py
+++ b/tests/unit/genui/test_canvas_store.py
@@ -1,0 +1,138 @@
+"""M8.1: the server-persisted canvas store. A canvas saves and reopens with its
+spec and live data bindings intact, is scoped to its owner, and updates in place
+when re-saved."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.genui import canvas_store
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _now():
+    return datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _spec(topic="climate policy"):
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "track the climate policy debate",
+        "title": "Climate policy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["claims"],
+        "topic": topic,
+        "source_type": None,
+        "panels": [
+            {
+                "id": "p1",
+                "type": "claims",
+                "title": "Key claims",
+                "span": 6,
+                "priority": 0.8,
+                "rationale": "",
+                "endpoint": None,
+                "params": {"topic": topic},
+                "body": "",
+            }
+        ],
+    }
+
+
+def _bindings():
+    # Per-panel live data bindings: which data-mode tool feeds each panel, plus a
+    # snapshot the client captured, so reopening rebinds to live data.
+    return {
+        "p1": {
+            "server": "neuronews-arguments",
+            "tool": "list_claims",
+            "arguments": {"topic": "climate policy"},
+            "snapshot": {"claims": [{"claim_id": "k1", "text": "a claim"}]},
+        }
+    }
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    canvas_store.ensure_schema(c)
+    yield c
+    c.close()
+
+
+def test_save_then_reopen_preserves_spec_and_data_bindings(conn):
+    saved = canvas_store.save_canvas(
+        conn, owner="alice", spec=_spec(), now=_now(), data_bindings=_bindings()
+    )
+    assert saved["id"]
+    assert saved["owner"] == "alice"
+
+    reopened = canvas_store.get_canvas(conn, saved["id"])
+    assert reopened is not None
+    # The spec round-trips byte-for-byte (structurally).
+    assert reopened["spec"] == _spec()
+    # The live data bindings survive intact -- the whole point of M8.1.
+    assert reopened["data_bindings"] == _bindings()
+    assert reopened["data_bindings"]["p1"]["tool"] == "list_claims"
+
+
+def test_reopen_is_scoped_to_owner(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    # Bob cannot reopen Alice's canvas by id.
+    assert canvas_store.get_canvas(conn, saved["id"], owner="bob") is None
+    # Alice can.
+    assert canvas_store.get_canvas(conn, saved["id"], owner="alice") is not None
+
+
+def test_resave_with_id_updates_in_place(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec("energy"), now=_now())
+    updated = canvas_store.save_canvas(
+        conn,
+        owner="alice",
+        spec=_spec("energy transition"),
+        now=datetime(2026, 7, 3, 13, 0, 0, tzinfo=timezone.utc),
+        canvas_id=saved["id"],
+    )
+    assert updated["id"] == saved["id"]  # same canvas, not a duplicate
+    assert updated["spec"]["topic"] == "energy transition"
+    assert len(canvas_store.list_canvases(conn, "alice")) == 1
+    # created_at is preserved across the update.
+    assert updated["created_at"] == saved["created_at"]
+
+
+def test_resave_with_foreign_id_creates_new_canvas(conn):
+    alice = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    # Bob supplying Alice's id must not overwrite it -- he gets a new canvas.
+    bob = canvas_store.save_canvas(
+        conn, owner="bob", spec=_spec("markets"), now=_now(), canvas_id=alice["id"]
+    )
+    assert bob["id"] != alice["id"]
+    assert canvas_store.get_canvas(conn, alice["id"])["owner"] == "alice"
+
+
+def test_list_is_owner_scoped_and_summarised(conn):
+    canvas_store.save_canvas(conn, owner="alice", spec=_spec("a"), now=_now())
+    canvas_store.save_canvas(conn, owner="alice", spec=_spec("b"), now=_now())
+    canvas_store.save_canvas(conn, owner="bob", spec=_spec("c"), now=_now())
+
+    alice_list = canvas_store.list_canvases(conn, "alice")
+    assert len(alice_list) == 2
+    assert all("spec" not in entry for entry in alice_list)  # summaries only
+    assert all(entry["panel_count"] == 1 for entry in alice_list)
+    assert len(canvas_store.list_canvases(conn, "bob")) == 1
+
+
+def test_delete_is_owner_scoped(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    assert canvas_store.delete_canvas(conn, saved["id"], "bob") is False  # not bob's
+    assert canvas_store.delete_canvas(conn, saved["id"], "alice") is True
+    assert canvas_store.get_canvas(conn, saved["id"]) is None
+
+
+def test_oversize_canvas_is_refused(conn):
+    big = _spec()
+    big["panels"][0]["body"] = "x" * (canvas_store.MAX_CANVAS_BYTES + 1)
+    with pytest.raises(canvas_store.CanvasStoreError):
+        canvas_store.save_canvas(conn, owner="alice", spec=big, now=_now())


### PR DESCRIPTION
Closes #684.

## Summary

A generated canvas is ephemeral by default: it lives in the browser for one session and is gone on reload. This adds a server-side store so a canvas can be **saved and reopened later with its live data bindings intact**, which is the M8.1 done-when.

## What changed

- **`src/genui/canvas_store.py`** (new): a `saved_canvases` warehouse table (outside the shared corpus), keyed by an unguessable id. Each canvas persists:
  - the **ui-spec** (the `ui-spec-v1` layout document), and
  - its **live data bindings** — a per-panel map of which data-mode tool feeds each panel (server / tool / arguments) plus any snapshot the client captured — so reopening rebinds to live data rather than a blank grid.

  Reads are **owner-scoped** (a canvas owned by someone else reads back as None), re-saving with an id the owner owns **updates in place** (preserving `created_at` and any share token), and a `MAX_CANVAS_BYTES` ceiling refuses runaway payloads.
- **`src/api/routes/canvas_routes.py`** (new):
  - `POST /api/v1/ui/canvas` — save or update a canvas (spec validated against `ui-spec-v1` first)
  - `GET /api/v1/ui/canvas` — list the owner's canvases (lightweight summaries)
  - `GET /api/v1/ui/canvas/{id}` — reopen one canvas, owner-scoped
  - `DELETE /api/v1/ui/canvas/{id}` — delete one canvas

  Owner identity comes from the `X-Canvas-Owner` header (default `local`); the access model M8.3 formalises it.
- **`src/api/app.py`**: the canvas router is wired behind the same try-import pattern as the other genui routers, and reported in the router-availability status.

## Testing

- `tests/unit/genui/test_canvas_store.py` — store round-trip (spec + bindings preserved), owner isolation, update-in-place, foreign-id-creates-new, owner-scoped list/delete, size ceiling.
- `tests/unit/api/routes/test_canvas_routes.py` — the same behaviours through the HTTP routes against an in-memory warehouse: save/reopen round-trip, owner scoping (404 for another owner), invalid-spec rejection, list/delete, update-in-place.
- `pytest tests/unit/genui/ tests/unit/api/routes/test_canvas_routes.py` — 374 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_