### PR TITLE
M8.2: Shareable read-only canvas links

### DIFF
--- a/src/api/routes/canvas_routes.py
+++ b/src/api/routes/canvas_routes.py
@@ -17,7 +17,7 @@ never stored.
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from src.genui import canvas_store
@@ -151,3 +151,71 @@ def delete_canvas(
     if not removed:
         raise HTTPException(status_code=404, detail="canvas not found")
     return {"deleted": canvas_id}
+
+
+# --------------------------------------------------------------------------- #
+# Read-only sharing (M8.2)
+# --------------------------------------------------------------------------- #
+
+def _share_url(request: Request, token: str) -> str:
+    """The read-only link a viewer opens, resolved against the request host."""
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/api/v1/ui/canvas/shared/{token}"
+
+
+@router.post("/canvas/{canvas_id}/share")
+def share_canvas(
+    canvas_id: str,
+    request: Request,
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """Mint (or return the existing) read-only share link for one of the owner's
+    canvases. Idempotent, so the link stays stable across calls."""
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            token = canvas_store.share_canvas(conn, canvas_id, owner)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas share failed: {err}")
+    if token is None:
+        raise HTTPException(status_code=404, detail="canvas not found")
+    return {"canvas_id": canvas_id, "share_token": token, "url": _share_url(request, token)}
+
+
+@router.delete("/canvas/{canvas_id}/share")
+def unshare_canvas(
+    canvas_id: str,
+    x_canvas_owner: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    """Revoke a canvas's read-only link (owner only)."""
+    owner = _owner(x_canvas_owner)
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            ok = canvas_store.unshare_canvas(conn, canvas_id, owner)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"canvas unshare failed: {err}")
+    if not ok:
+        raise HTTPException(status_code=404, detail="canvas not found")
+    return {"canvas_id": canvas_id, "revoked": True}
+
+
+@router.get("/canvas/shared/{share_token}")
+def get_shared_canvas(share_token: str) -> Dict[str, Any]:
+    """Render a canvas from a read-only share link, for a viewer who is not the
+    owner. No owner header is required; the response is marked read-only and the
+    owner's identity is never exposed. There is no write path through a token, so
+    a viewer can view but not edit."""
+    conn, lock = _conn()
+    try:
+        with lock:
+            canvas_store.ensure_schema(conn)
+            canvas = canvas_store.get_shared_canvas(conn, share_token)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"shared canvas read failed: {err}")
+    if canvas is None:
+        raise HTTPException(status_code=404, detail="shared canvas not found or link revoked")
+    return {"canvas": canvas}

--- a/src/genui/canvas_store.py
+++ b/src/genui/canvas_store.py
@@ -92,6 +92,12 @@ def new_id() -> str:
     return secrets.token_urlsafe(9)
 
 
+def new_share_token() -> str:
+    """An unguessable, URL-safe share token (longer than a canvas id, since it
+    is the only credential a read-only link carries)."""
+    return secrets.token_urlsafe(24)
+
+
 def save_canvas(
     conn,
     owner: str,
@@ -190,3 +196,61 @@ def delete_canvas(conn, canvas_id: str, owner: str) -> bool:
         return False
     conn.execute("DELETE FROM saved_canvases WHERE id = ?", [canvas_id])
     return True
+
+
+# --------------------------------------------------------------------------- #
+# Read-only sharing (M8.2)
+# --------------------------------------------------------------------------- #
+
+def share_canvas(conn, canvas_id: str, owner: str) -> Optional[str]:
+    """Mint (or return the existing) read-only share token for a canvas the
+    owner owns. Idempotent: sharing an already-shared canvas returns the same
+    token, so a shared link stays stable. Returns None if the owner does not own
+    the canvas."""
+    canvas = get_canvas(conn, canvas_id, owner=owner)
+    if canvas is None:
+        return None
+    if canvas["share_token"]:
+        return canvas["share_token"]
+    token = new_share_token()
+    conn.execute(
+        "UPDATE saved_canvases SET share_token = ? WHERE id = ?", [token, canvas_id]
+    )
+    return token
+
+
+def unshare_canvas(conn, canvas_id: str, owner: str) -> bool:
+    """Revoke a canvas's share token so its read-only link stops resolving.
+    Returns True if the owner owns the canvas (whether or not it was shared)."""
+    canvas = get_canvas(conn, canvas_id, owner=owner)
+    if canvas is None:
+        return False
+    conn.execute(
+        "UPDATE saved_canvases SET share_token = NULL WHERE id = ?", [canvas_id]
+    )
+    return True
+
+
+def get_shared_canvas(conn, share_token: str) -> Optional[Dict[str, Any]]:
+    """Resolve a canvas by its read-only share token, for a viewer who is not the
+    owner. Returns the record with ``read_only`` set and the owner elided, or
+    None when the token is unknown or revoked. This path never mutates and never
+    exposes the owner's identity."""
+    if not schema_ready(conn) or not share_token:
+        return None
+    row = conn.execute(
+        f"SELECT {_COLUMNS} FROM saved_canvases WHERE share_token = ?",
+        [share_token],
+    ).fetchone()
+    if not row:
+        return None
+    canvas = _row_to_canvas(row)
+    return {
+        "id": canvas["id"],
+        "title": canvas["title"],
+        "spec": canvas["spec"],
+        "data_bindings": canvas["data_bindings"],
+        "read_only": True,
+        "created_at": canvas["created_at"],
+        "updated_at": canvas["updated_at"],
+    }

--- a/tests/unit/api/routes/test_canvas_routes.py
+++ b/tests/unit/api/routes/test_canvas_routes.py
@@ -137,3 +137,69 @@ def test_update_in_place_with_id(client):
     assert listed["count"] == 1  # updated, not duplicated
     canvas = client.get(f"/api/v1/ui/canvas/{cid}", headers={"X-Canvas-Owner": "alice"}).json()["canvas"]
     assert canvas["spec"]["topic"] == "energy transition"
+
+
+# --- M8.2: read-only sharing through the routes --------------------------------
+
+
+def _own(cid_owner):
+    return {"X-Canvas-Owner": cid_owner}
+
+
+def test_share_link_renders_for_a_second_user_read_only(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec(), "data_bindings": _bindings()},
+        headers=_own("alice"),
+    ).json()["canvas"]["id"]
+
+    share = client.post(f"/api/v1/ui/canvas/{cid}/share", headers=_own("alice"))
+    assert share.status_code == 200
+    token = share.json()["share_token"]
+    assert token and share.json()["url"].endswith(f"/canvas/shared/{token}")
+
+    # A second user (different owner) opens the link and gets the canvas read-only,
+    # with its live data bindings, and no owner identity leaked.
+    viewed = client.get(f"/api/v1/ui/canvas/shared/{token}", headers=_own("bob"))
+    assert viewed.status_code == 200
+    canvas = viewed.json()["canvas"]
+    assert canvas["read_only"] is True
+    assert canvas["spec"] == _valid_spec()
+    assert canvas["data_bindings"] == _bindings()
+    assert "owner" not in canvas
+
+
+def test_second_user_cannot_edit_the_shared_canvas(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec("original")}, headers=_own("alice")
+    ).json()["canvas"]["id"]
+    client.post(f"/api/v1/ui/canvas/{cid}/share", headers=_own("alice"))
+
+    # Bob cannot reopen it by id (owner-scoped) ...
+    assert client.get(f"/api/v1/ui/canvas/{cid}", headers=_own("bob")).status_code == 404
+    # ... and POSTing with Alice's id under Bob's owner makes Bob a *copy*, never
+    # mutating Alice's canvas.
+    bob_id = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec("hijacked"), "id": cid}, headers=_own("bob")
+    ).json()["canvas"]["id"]
+    assert bob_id != cid
+    alice_view = client.get(f"/api/v1/ui/canvas/{cid}", headers=_own("alice")).json()["canvas"]
+    assert alice_view["spec"]["topic"] == "original"  # untouched
+
+
+def test_revoked_link_stops_resolving(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec()}, headers=_own("alice")
+    ).json()["canvas"]["id"]
+    token = client.post(f"/api/v1/ui/canvas/{cid}/share", headers=_own("alice")).json()["share_token"]
+    assert client.get(f"/api/v1/ui/canvas/shared/{token}").status_code == 200
+
+    revoke = client.delete(f"/api/v1/ui/canvas/{cid}/share", headers=_own("alice"))
+    assert revoke.status_code == 200
+    assert client.get(f"/api/v1/ui/canvas/shared/{token}").status_code == 404
+
+
+def test_non_owner_cannot_mint_a_share_link(client):
+    cid = client.post(
+        "/api/v1/ui/canvas", json={"spec": _valid_spec()}, headers=_own("alice")
+    ).json()["canvas"]["id"]
+    assert client.post(f"/api/v1/ui/canvas/{cid}/share", headers=_own("bob")).status_code == 404

--- a/tests/unit/genui/test_canvas_share.py
+++ b/tests/unit/genui/test_canvas_share.py
@@ -1,0 +1,94 @@
+"""M8.2: read-only canvas sharing at the store layer. An owner mints a stable
+share token; a viewer resolves the canvas read-only by that token without the
+owner's identity; revoking the token stops it resolving."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.genui import canvas_store
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _now():
+    return datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _spec(topic="climate policy"):
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "track the debate",
+        "title": "Climate policy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["claims"],
+        "topic": topic,
+        "source_type": None,
+        "panels": [
+            {"id": "p1", "type": "claims", "title": "Key claims", "span": 6,
+             "priority": 0.8, "rationale": "", "endpoint": None,
+             "params": {"topic": topic}, "body": ""}
+        ],
+    }
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    canvas_store.ensure_schema(c)
+    yield c
+    c.close()
+
+
+def test_share_mints_a_stable_token_owner_only(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    token = canvas_store.share_canvas(conn, saved["id"], owner="alice")
+    assert token
+    # Idempotent: sharing again returns the same token, so the link stays stable.
+    assert canvas_store.share_canvas(conn, saved["id"], owner="alice") == token
+    # A non-owner cannot mint a share token.
+    assert canvas_store.share_canvas(conn, saved["id"], owner="bob") is None
+
+
+def test_viewer_resolves_shared_canvas_read_only(conn):
+    saved = canvas_store.save_canvas(
+        conn, owner="alice", spec=_spec(),
+        now=_now(), data_bindings={"p1": {"tool": "list_claims"}},
+    )
+    token = canvas_store.share_canvas(conn, saved["id"], owner="alice")
+
+    shared = canvas_store.get_shared_canvas(conn, token)
+    assert shared is not None
+    assert shared["read_only"] is True
+    assert shared["spec"] == _spec()
+    assert shared["data_bindings"] == {"p1": {"tool": "list_claims"}}
+    # The owner's identity is never exposed through the share view.
+    assert "owner" not in shared
+
+
+def test_unknown_token_does_not_resolve(conn):
+    assert canvas_store.get_shared_canvas(conn, "nope") is None
+
+
+def test_revoking_a_share_stops_it_resolving(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    token = canvas_store.share_canvas(conn, saved["id"], owner="alice")
+    assert canvas_store.get_shared_canvas(conn, token) is not None
+
+    assert canvas_store.unshare_canvas(conn, saved["id"], owner="alice") is True
+    assert canvas_store.get_shared_canvas(conn, token) is None
+    # A non-owner cannot revoke.
+    assert canvas_store.unshare_canvas(conn, saved["id"], owner="bob") is False
+
+
+def test_update_in_place_preserves_the_share_token(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec("a"), now=_now())
+    token = canvas_store.share_canvas(conn, saved["id"], owner="alice")
+    canvas_store.save_canvas(
+        conn, owner="alice", spec=_spec("b"), now=_now(), canvas_id=saved["id"]
+    )
+    # Editing the canvas does not break its existing share link.
+    shared = canvas_store.get_shared_canvas(conn, token)
+    assert shared is not None
+    assert shared["spec"]["topic"] == "b"


### PR DESCRIPTION
Closes #685.

## Summary

Read-only sharing built on the persisted canvas store (M8.1). An owner mints a stable, unguessable share token for a saved canvas; a **second user opens the link and renders the canvas read-only, with no edit path** — the M8.2 done-when.

## What changed

- **`src/genui/canvas_store.py`**:
  - `share_canvas(conn, id, owner)` — mint (or return the existing) share token, owner only, idempotent so the link stays stable.
  - `unshare_canvas(conn, id, owner)` — revoke, owner only.
  - `get_shared_canvas(conn, token)` — resolve a canvas by token for a viewer; returns it marked `read_only: true` with the owner's identity elided, or None when the token is unknown or revoked. Never mutates.
  - Editing a canvas in place (M8.1 update path) preserves its existing share token, so a live link does not break on edit.
- **`src/api/routes/canvas_routes.py`**:
  - `POST /api/v1/ui/canvas/{id}/share` — mint the link (returns the token and a host-resolved URL).
  - `DELETE /api/v1/ui/canvas/{id}/share` — revoke it.
  - `GET /api/v1/ui/canvas/shared/{token}` — render the canvas read-only; no owner header required. The shared path sits at a distinct route depth, so it never collides with the owner-scoped `/canvas/{id}` reopen route.

## How read-only is enforced

Structurally, not by a flag alone: a share token carries **no write path**, and a viewer POSTing with the owner's canvas id under their own identity gets a *copy* rather than mutating the original (owner-keyed update-in-place from M8.1). A test asserts the original is untouched after a second user tries exactly that.

## Testing

- `tests/unit/genui/test_canvas_share.py` — mint/stability/owner-only, viewer read-only resolution (bindings intact, no owner leak), unknown/revoked tokens, token preserved across edits.
- `tests/unit/api/routes/test_canvas_routes.py` (extended) — full route flow: a second user renders the link read-only, cannot reopen by id, cannot mutate the original; revoked link 404s; non-owner cannot mint.
- `pytest tests/unit/genui/test_canvas_share.py tests/unit/genui/test_canvas_store.py tests/unit/api/routes/test_canvas_routes.py` — 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_