### PR TITLE
M8.3: Canvas access model and acceptance

### DIFF
--- a/docs/genui-m8-acceptance.md
+++ b/docs/genui-m8-acceptance.md
@@ -1,0 +1,63 @@
+# M8 acceptance: persisted canvases, saved, reopened, shared
+
+Milestone M8 (issues #684-#686) takes a canvas from an ephemeral, per-session
+layout to a **persisted, shareable** object. This is the acceptance record; its
+executable form is `scripts/genui/m8_acceptance.py`, run in CI by
+`tests/unit/genui/test_canvas_access.py`.
+
+## The access model
+
+A persisted canvas has one **owner** (the identity that saved it) and, once
+shared, a read-only **share token**. `src/genui/canvas_access.py` is the single,
+declarative authority for the resulting permissions:
+
+| role | read | write | share | delete |
+|---|---|---|---|---|
+| **owner** | yes | yes | yes | yes |
+| **viewer** (holds a valid share link) | yes | no | no | no |
+| **none** (everyone else) | no | no | no | no |
+
+`authorize(canvas, requester, action, via_share_token=?)` is the one enforcement
+decision. The store consults it for every owner-scoped read, so ownership checks
+are never re-derived ad hoc; the shared-link read path grants the viewer role and
+never more.
+
+## What it proves
+
+One warehouse, two identities: `alice` (the owner) and `bob` (a second user).
+
+1. **Save and reopen (M8.1).** Alice saves a canvas; it reopens with its
+   `ui-spec` and its live data bindings (which data-mode tool feeds each panel,
+   plus the client's snapshot) intact.
+2. **Share, stable (M8.2).** Alice mints a read-only share link; minting again
+   returns the same token, so the link is stable.
+3. **Viewer is read-only (M8.2).** Bob opens the link and sees the canvas marked
+   `read_only`, with its bindings, and no owner identity leaked.
+4. **Model enforced (M8.3).** Bob cannot reopen the canvas by id, cannot delete
+   or share it, and editing it under his own identity produces a *copy* rather
+   than mutating Alice's original (owner-keyed update-in-place). The permission
+   matrix matches the table above.
+5. **Revocable (M8.2).** Revoking the link stops it resolving.
+
+## Result
+
+```
+1. alice saved canvas 'hA0n5BqIueUI'
+2. reopened with spec + live bindings intact: True
+3. alice minted a stable share link: True
+4. bob renders the link read-only, no owner leaked: True
+5. bob cannot reopen/delete/share; his edit is a copy: True
+6. permission matrix matches the model: True
+7. revoked link no longer resolves: True
+
+RESULT: OK - canvas saved, reopened, shared read-only, access model enforced
+```
+
+## How read-only is enforced, not just labelled
+
+A share token carries no write path: the only mutation endpoints are owner-scoped
+(`POST /api/v1/ui/canvas` with the owner's identity). A viewer POSTing with the
+owner's canvas id under their own identity is routed to a new canvas of their own
+by the M8.1 update-in-place rule, so the original is structurally unreachable for
+writes. Read-only is a property of the model, not a flag the client is trusted to
+honour.

--- a/scripts/genui/m8_acceptance.py
+++ b/scripts/genui/m8_acceptance.py
@@ -1,0 +1,153 @@
+"""
+M8 acceptance: the full persisted-canvas lifecycle, save -> reopen -> share.
+
+One warehouse, two identities (alice the owner, bob a second user). The harness
+drives the whole M8 flow through the canvas store and asserts the access model
+is enforced end to end:
+
+  * alice saves a canvas; it reopens with its spec and live data bindings intact
+    (M8.1);
+  * alice mints a read-only share link; bob opens it and sees the canvas
+    read-only, with no owner identity leaked (M8.2);
+  * the model is enforced (M8.3): bob cannot reopen it by id, cannot delete or
+    share it, and editing it under his own identity makes a copy rather than
+    mutating alice's; revoking the link stops it resolving.
+
+Run:  python scripts/genui/m8_acceptance.py
+
+The executable form of docs/genui-m8-acceptance.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _now():
+    return datetime(2026, 7, 3, tzinfo=timezone.utc)
+
+
+def _spec(topic="climate policy"):
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "track the climate policy debate",
+        "title": "Climate policy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["claims"],
+        "topic": topic,
+        "source_type": None,
+        "panels": [
+            {"id": "p1", "type": "claims", "title": "Key claims", "span": 6,
+             "priority": 0.8, "rationale": "", "endpoint": None,
+             "params": {"topic": topic}, "body": ""}
+        ],
+    }
+
+
+def _bindings():
+    return {"p1": {"server": "neuronews-arguments", "tool": "list_claims",
+                   "arguments": {"topic": "climate policy"},
+                   "snapshot": {"claims": [{"claim_id": "k1"}]}}}
+
+
+def main() -> dict:
+    import duckdb
+
+    from src.genui import canvas_access, canvas_store
+
+    conn = duckdb.connect(":memory:")
+    canvas_store.ensure_schema(conn)
+
+    print("M8 acceptance: save -> reopen -> share, access model enforced\n")
+
+    # 1) Alice saves a canvas (M8.1).
+    saved = canvas_store.save_canvas(
+        conn, owner="alice", spec=_spec(), now=_now(), data_bindings=_bindings()
+    )
+    cid = saved["id"]
+    print(f"1. alice saved canvas {cid!r}")
+
+    # 2) It reopens with spec and live data bindings intact.
+    reopened = canvas_store.get_canvas(conn, cid, owner="alice")
+    save_reopen_ok = (
+        reopened is not None
+        and reopened["spec"] == _spec()
+        and reopened["data_bindings"] == _bindings()
+    )
+    print(f"2. reopened with spec + live bindings intact: {save_reopen_ok}")
+
+    # 3) Alice mints a read-only share link (M8.2), stable across calls.
+    token = canvas_store.share_canvas(conn, cid, owner="alice")
+    stable = token == canvas_store.share_canvas(conn, cid, owner="alice")
+    print(f"3. alice minted a stable share link: {bool(token) and stable}")
+
+    # 4) Bob opens the link: read-only, bindings present, no owner leaked (M8.2).
+    shared = canvas_store.get_shared_canvas(conn, token)
+    viewer_ok = (
+        shared is not None
+        and shared["read_only"] is True
+        and shared["spec"] == _spec()
+        and "owner" not in shared
+    )
+    print(f"4. bob renders the link read-only, no owner leaked: {viewer_ok}")
+
+    # 5) The access model is enforced (M8.3).
+    bob_cannot_reopen = canvas_store.get_canvas(conn, cid, owner="bob") is None
+    bob_cannot_delete = canvas_store.delete_canvas(conn, cid, owner="bob") is False
+    bob_cannot_share = canvas_store.share_canvas(conn, cid, owner="bob") is None
+    bob_copy = canvas_store.save_canvas(
+        conn, owner="bob", spec=_spec("hijacked"), now=_now(), canvas_id=cid
+    )
+    original_untouched = canvas_store.get_canvas(conn, cid, owner="alice")["spec"]["topic"] == "climate policy"
+    made_a_copy = bob_copy["id"] != cid
+    enforced = (
+        bob_cannot_reopen and bob_cannot_delete and bob_cannot_share
+        and original_untouched and made_a_copy
+    )
+    print(f"5. bob cannot reopen/delete/share; his edit is a copy: {enforced}")
+
+    # 6) The permission matrix matches the stated model.
+    alice_canvas = canvas_store.get_canvas(conn, cid)
+    matrix_ok = (
+        canvas_access.role_for(alice_canvas, "alice") == canvas_access.ROLE_OWNER
+        and canvas_access.role_for(alice_canvas, "bob") == canvas_access.ROLE_NONE
+        and canvas_access.role_for(alice_canvas, "bob", via_share_token=True) == canvas_access.ROLE_VIEWER
+        and canvas_access.can(canvas_access.ROLE_OWNER, canvas_access.DELETE)
+        and canvas_access.can(canvas_access.ROLE_VIEWER, canvas_access.READ)
+        and not canvas_access.can(canvas_access.ROLE_VIEWER, canvas_access.WRITE)
+        and not canvas_access.can(canvas_access.ROLE_NONE, canvas_access.READ)
+    )
+    print(f"6. permission matrix matches the model: {matrix_ok}")
+
+    # 7) Revoking the link stops it resolving (M8.2).
+    canvas_store.unshare_canvas(conn, cid, owner="alice")
+    revoked_ok = canvas_store.get_shared_canvas(conn, token) is None
+    print(f"7. revoked link no longer resolves: {revoked_ok}")
+
+    conn.close()
+    ok = all([save_reopen_ok, bool(token), stable, viewer_ok, enforced, matrix_ok, revoked_ok])
+    print("\nRESULT: " + (
+        "OK - canvas saved, reopened, shared read-only, access model enforced"
+        if ok else "FAIL"
+    ))
+    return {
+        "canvas_id": cid,
+        "save_reopen_ok": save_reopen_ok,
+        "share_stable": bool(token) and stable,
+        "viewer_read_only_ok": viewer_ok,
+        "access_enforced": enforced,
+        "matrix_ok": matrix_ok,
+        "revoked_ok": revoked_ok,
+        "ok": bool(ok),
+    }
+
+
+if __name__ == "__main__":
+    result = main()
+    sys.exit(0 if result["ok"] else 1)

--- a/src/genui/canvas_access.py
+++ b/src/genui/canvas_access.py
@@ -1,0 +1,84 @@
+"""
+Canvas access model (M8.3).
+
+The single, declarative authority for who may do what to a persisted canvas.
+M8.1 gave canvases an owner and M8.2 gave them read-only share links; this module
+states the resulting permission model in one place so it is enforced uniformly
+rather than re-derived at each call site.
+
+Three roles, one permission matrix:
+
+* **owner** - the identity that saved the canvas: may read, write, share, delete.
+* **viewer** - anyone holding a valid read-only share link: may read only.
+* **none** - everyone else: no access at all.
+
+:func:`authorize` is the one enforcement entry point; the store consults it for
+every owner-scoped read, and the shared-link read path grants the viewer role.
+Stdlib-only, no I/O: it decides on an already-loaded canvas record.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+ROLE_OWNER = "owner"
+ROLE_VIEWER = "viewer"  # holds a valid read-only share link
+ROLE_NONE = "none"
+
+READ = "read"
+WRITE = "write"
+SHARE = "share"
+DELETE = "delete"
+ACTIONS = (READ, WRITE, SHARE, DELETE)
+
+# The permission matrix. Owners do everything; viewers read only; nobody else
+# touches the canvas.
+_PERMISSIONS = {
+    ROLE_OWNER: frozenset({READ, WRITE, SHARE, DELETE}),
+    ROLE_VIEWER: frozenset({READ}),
+    ROLE_NONE: frozenset(),
+}
+
+
+def role_for(
+    canvas: Dict[str, Any], requester: Optional[str], via_share_token: bool = False
+) -> str:
+    """The role ``requester`` holds on ``canvas``. Ownership wins: the saving
+    identity is the owner. A requester who arrived via a valid share link (and is
+    not the owner) is a viewer. Everyone else is ``none``."""
+    if requester is not None and canvas.get("owner") == requester:
+        return ROLE_OWNER
+    if via_share_token:
+        return ROLE_VIEWER
+    return ROLE_NONE
+
+
+def can(role: str, action: str) -> bool:
+    """Whether ``role`` may perform ``action`` (one of :data:`ACTIONS`)."""
+    return action in _PERMISSIONS.get(role, frozenset())
+
+
+def authorize(
+    canvas: Dict[str, Any],
+    requester: Optional[str],
+    action: str,
+    via_share_token: bool = False,
+) -> bool:
+    """The one enforcement decision: may ``requester`` perform ``action`` on
+    ``canvas``? Resolves the role, then checks the matrix."""
+    return can(role_for(canvas, requester, via_share_token=via_share_token), action)
+
+
+__all__ = [
+    "ROLE_OWNER",
+    "ROLE_VIEWER",
+    "ROLE_NONE",
+    "READ",
+    "WRITE",
+    "SHARE",
+    "DELETE",
+    "ACTIONS",
+    "role_for",
+    "can",
+    "authorize",
+]

--- a/src/genui/canvas_store.py
+++ b/src/genui/canvas_store.py
@@ -25,6 +25,8 @@ import json
 import secrets
 from typing import Any, Dict, List, Optional
 
+from src.genui import canvas_access
+
 # Size ceiling for a persisted canvas payload (spec + bindings, serialized), so a
 # runaway spec cannot bloat the warehouse. Enforced by :func:`save_canvas`.
 MAX_CANVAS_BYTES = 256 * 1024
@@ -156,7 +158,9 @@ def get_canvas(
     if not row:
         return None
     canvas = _row_to_canvas(row)
-    if owner is not None and canvas["owner"] != owner:
+    # Owner-scoped read: the access model is the single authority. Only the owner
+    # role can read, so a non-owner requester reads back as None (isolation).
+    if owner is not None and not canvas_access.authorize(canvas, owner, canvas_access.READ):
         return None
     return canvas
 

--- a/tests/unit/genui/test_canvas_access.py
+++ b/tests/unit/genui/test_canvas_access.py
@@ -1,0 +1,139 @@
+"""M8.3: the canvas access model and the full save/reopen/share acceptance.
+
+Asserts the permission matrix, that the store enforces it, and that the M8
+acceptance harness reports the whole save -> reopen -> share flow green."""
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.genui import canvas_access, canvas_store
+
+duckdb = pytest.importorskip("duckdb")
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _load_harness():
+    path = REPO / "scripts/genui/m8_acceptance.py"
+    spec = importlib.util.spec_from_file_location("m8_acceptance_mod", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _now():
+    return datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _spec(topic="climate policy"):
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "track the debate",
+        "title": "Climate policy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["claims"],
+        "topic": topic,
+        "source_type": None,
+        "panels": [
+            {"id": "p1", "type": "claims", "title": "Key claims", "span": 6,
+             "priority": 0.8, "rationale": "", "endpoint": None,
+             "params": {"topic": topic}, "body": ""}
+        ],
+    }
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    canvas_store.ensure_schema(c)
+    yield c
+    c.close()
+
+
+# --- the declarative model -----------------------------------------------------
+
+
+def test_permission_matrix_matches_the_stated_model():
+    A = canvas_access
+    # Owner: everything. Viewer: read only. None: nothing.
+    assert all(A.can(A.ROLE_OWNER, act) for act in A.ACTIONS)
+    assert A.can(A.ROLE_VIEWER, A.READ)
+    assert not any(A.can(A.ROLE_VIEWER, act) for act in (A.WRITE, A.SHARE, A.DELETE))
+    assert not any(A.can(A.ROLE_NONE, act) for act in A.ACTIONS)
+
+
+def test_role_resolution():
+    A = canvas_access
+    canvas = {"owner": "alice"}
+    assert A.role_for(canvas, "alice") == A.ROLE_OWNER
+    assert A.role_for(canvas, "bob") == A.ROLE_NONE
+    # A share link grants a non-owner the viewer role, never more.
+    assert A.role_for(canvas, "bob", via_share_token=True) == A.ROLE_VIEWER
+    # Ownership always wins over the share flag.
+    assert A.role_for(canvas, "alice", via_share_token=True) == A.ROLE_OWNER
+
+
+def test_authorize_is_the_single_decision():
+    A = canvas_access
+    canvas = {"owner": "alice"}
+    assert A.authorize(canvas, "alice", A.WRITE) is True
+    assert A.authorize(canvas, "bob", A.READ) is False
+    assert A.authorize(canvas, "bob", A.READ, via_share_token=True) is True
+    assert A.authorize(canvas, "bob", A.WRITE, via_share_token=True) is False
+
+
+# --- the model enforced through the store -------------------------------------
+
+
+def test_store_enforces_owner_only_writes_and_deletes(conn):
+    saved = canvas_store.save_canvas(conn, owner="alice", spec=_spec(), now=_now())
+    cid = saved["id"]
+    # None-role (bob) can neither read, delete, nor share.
+    assert canvas_store.get_canvas(conn, cid, owner="bob") is None
+    assert canvas_store.delete_canvas(conn, cid, owner="bob") is False
+    assert canvas_store.share_canvas(conn, cid, owner="bob") is None
+    # Owner can do all three.
+    assert canvas_store.get_canvas(conn, cid, owner="alice") is not None
+    assert canvas_store.share_canvas(conn, cid, owner="alice")
+    assert canvas_store.delete_canvas(conn, cid, owner="alice") is True
+
+
+# --- the full acceptance flow --------------------------------------------------
+
+
+def test_full_save_reopen_share_acceptance_flow(conn):
+    # 1) save with live bindings; 2) reopen intact
+    bindings = {"p1": {"tool": "list_claims"}}
+    saved = canvas_store.save_canvas(
+        conn, owner="alice", spec=_spec(), now=_now(), data_bindings=bindings
+    )
+    cid = saved["id"]
+    reopened = canvas_store.get_canvas(conn, cid, owner="alice")
+    assert reopened["spec"] == _spec() and reopened["data_bindings"] == bindings
+
+    # 3) share; 4) viewer sees read-only, no owner leaked
+    token = canvas_store.share_canvas(conn, cid, owner="alice")
+    shared = canvas_store.get_shared_canvas(conn, token)
+    assert shared["read_only"] is True and "owner" not in shared
+
+    # 5) second user cannot edit the original -- his write is a copy
+    bob_copy = canvas_store.save_canvas(
+        conn, owner="bob", spec=_spec("hijacked"), now=_now(), canvas_id=cid
+    )
+    assert bob_copy["id"] != cid
+    assert canvas_store.get_canvas(conn, cid)["spec"]["topic"] == "climate policy"
+
+    # 6) revoke stops the link resolving
+    canvas_store.unshare_canvas(conn, cid, owner="alice")
+    assert canvas_store.get_shared_canvas(conn, token) is None
+
+
+def test_m8_acceptance_harness_reports_green():
+    result = _load_harness().main()
+    assert result["ok"] is True
+    assert result["save_reopen_ok"] and result["viewer_read_only_ok"]
+    assert result["access_enforced"] and result["matrix_ok"] and result["revoked_ok"]


### PR DESCRIPTION
Closes #686.

## Summary

Formalize the persisted-canvas access model in one declarative place and prove the full **save → reopen → share** flow end to end. This is the M8.3 done-when: the access model is enforced and an acceptance test covers the full save/reopen/share flow.

## What changed

- **`src/genui/canvas_access.py`** (new): the single, declarative authority for canvas permissions. Three roles and one matrix:

  | role | read | write | share | delete |
  |---|---|---|---|---|
  | **owner** | yes | yes | yes | yes |
  | **viewer** (holds a valid share link) | yes | no | no | no |
  | **none** (everyone else) | no | no | no | no |

  `role_for` / `can` / `authorize` decide on an already-loaded canvas record — stdlib-only, no I/O.
- **`src/genui/canvas_store.py`**: the owner-scoped read now routes through `canvas_access.authorize`, so ownership is enforced uniformly rather than re-derived ad hoc. Behaviour is unchanged (all M8.1/M8.2 tests stay green) — the change makes the model the single source of truth.
- **`scripts/genui/m8_acceptance.py`** (new): the executable acceptance harness. One warehouse, two identities (`alice` the owner, `bob` a second user); drives save → reopen (spec + live bindings intact) → share → read-only viewer → model enforced (bob cannot reopen/delete/share; his edit becomes a copy) → revoke.
- **`docs/genui-m8-acceptance.md`** (new): the acceptance record with the permission table and the harness output.

## How read-only is enforced, not just labelled

A share token carries no write path: the only mutation endpoints are owner-scoped. A viewer POSTing with the owner's canvas id under their own identity is routed to a *new* canvas of their own by the M8.1 update-in-place rule, so the original is structurally unreachable for writes. A test asserts the original is untouched after exactly that attempt.

## Testing

- `tests/unit/genui/test_canvas_access.py` — the permission matrix, role resolution, `authorize` as the single decision, the store enforcing owner-only writes/deletes/shares, the full save/reopen/share flow, and the acceptance harness reporting green.
- `pytest tests/unit/genui/ tests/unit/api/routes/test_canvas_routes.py` — 389 passed.
- `python scripts/genui/m8_acceptance.py` — exits 0 (OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_