### PR TITLE
M9.2: Domain-pack registry (publish and discover)

### DIFF
--- a/src/domains/pack_registry.py
+++ b/src/domains/pack_registry.py
@@ -1,0 +1,176 @@
+"""
+Domain-pack registry: publish and discover (M9.2).
+
+A packaged pack (M9.1) is a single ``pack.json`` manifest. The registry is where
+those manifests are published so they can be discovered and installed (M9.3) by
+a fresh instance. It is a filesystem-backed store, laid out as
+
+    <root>/<name>/<version>/pack.json
+
+so the directory tree *is* the index: a pack's name is a directory, each of its
+published versions a sub-directory. Versions are immutable — publishing a version
+that already exists is refused unless ``force`` is set — so an installed pack can
+always be reproduced from its ``(name, version)``.
+
+The registry root defaults to ``NOESIS_PACK_REGISTRY`` / ``NEURONEWS_PACK_REGISTRY``
+(a shared, discoverable location), falling back to ``<repo>/data/pack_registry``.
+
+Stdlib-only; composes with :mod:`src.domains.pack_format`.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.domains.pack_format import (
+    MANIFEST_FILENAME,
+    PackFormatError,
+    PackManifest,
+    load_manifest,
+    package_pack,
+    validate_manifest,
+)
+
+
+def default_root() -> str:
+    """The registry root: ``NOESIS_PACK_REGISTRY`` / ``NEURONEWS_PACK_REGISTRY``,
+    else ``<repo>/data/pack_registry``."""
+    from src.config.env import resolve_env
+
+    configured = resolve_env("PACK_REGISTRY")
+    if configured:
+        return configured
+    return str(Path(__file__).resolve().parents[2] / "data" / "pack_registry")
+
+
+def _root(root: Optional[str]) -> Path:
+    return Path(root) if root is not None else Path(default_root())
+
+
+def _version_key(version: str) -> Tuple[int, ...]:
+    """Parse ``major.minor.patch`` into a comparable tuple; unparseable parts
+    sort low so a malformed dir never outranks a real version."""
+    parts = []
+    for chunk in str(version).split("."):
+        try:
+            parts.append(int(chunk))
+        except ValueError:
+            parts.append(-1)
+    return tuple(parts)
+
+
+class PackRegistryError(RuntimeError):
+    """A publish/lookup could not be completed (e.g. a duplicate version)."""
+
+
+def publish(manifest: PackManifest, root: Optional[str] = None, force: bool = False) -> Dict[str, Any]:
+    """Publish a manifest to the registry under ``<name>/<version>``. Validates
+    first, so only contract-valid packs land. Refuses to overwrite an existing
+    version unless ``force`` (versions are immutable). Returns the published
+    coordinates."""
+    errors = validate_manifest(manifest.to_dict())
+    if errors:
+        raise PackFormatError(f"manifest is invalid: {'; '.join(errors[:3])}")
+    dest = _root(root) / manifest.name / manifest.version
+    if (dest / MANIFEST_FILENAME).exists() and not force:
+        raise PackRegistryError(
+            f"{manifest.name} {manifest.version} is already published "
+            f"(versions are immutable; pass force to overwrite)"
+        )
+    path = package_pack(manifest, str(dest))
+    return {"name": manifest.name, "version": manifest.version, "path": path}
+
+
+def publish_path(pack_path: str, root: Optional[str] = None, force: bool = False) -> Dict[str, Any]:
+    """Publish a packaged pack from disk (a ``pack.json`` file or its directory)."""
+    return publish(load_manifest(pack_path), root=root, force=force)
+
+
+def list_packs(root: Optional[str] = None) -> List[str]:
+    """The names of all published packs, sorted."""
+    base = _root(root)
+    if not base.is_dir():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_dir() and versions(p.name, root))
+
+
+def versions(name: str, root: Optional[str] = None) -> List[str]:
+    """Published versions of a pack, newest (highest semver) first."""
+    pack_dir = _root(root) / name
+    if not pack_dir.is_dir():
+        return []
+    vs = [
+        v.name for v in pack_dir.iterdir()
+        if v.is_dir() and (v / MANIFEST_FILENAME).exists()
+    ]
+    return sorted(vs, key=_version_key, reverse=True)
+
+
+def latest_version(name: str, root: Optional[str] = None) -> Optional[str]:
+    """The highest published version of a pack, or None if unpublished."""
+    vs = versions(name, root)
+    return vs[0] if vs else None
+
+
+def get(name: str, version: Optional[str] = None, root: Optional[str] = None) -> Optional[PackManifest]:
+    """Load a published pack manifest. With no ``version``, resolves the latest.
+    Returns None if the pack (or the requested version) is not published."""
+    resolved = version or latest_version(name, root)
+    if resolved is None:
+        return None
+    path = _root(root) / name / resolved / MANIFEST_FILENAME
+    if not path.exists():
+        return None
+    try:
+        return load_manifest(str(path))
+    except PackFormatError:
+        return None
+
+
+def discover(root: Optional[str] = None) -> List[Dict[str, Any]]:
+    """A catalogue of published packs for discovery: each name with its latest
+    version, all versions, and the latest description."""
+    out = []
+    for name in list_packs(root):
+        vs = versions(name, root)
+        latest = get(name, vs[0], root) if vs else None
+        out.append(
+            {
+                "name": name,
+                "latest_version": vs[0] if vs else None,
+                "versions": vs,
+                "description": latest.description if latest else "",
+                "source_types": latest.source_types if latest else [],
+            }
+        )
+    return out
+
+
+def unpublish(name: str, version: Optional[str] = None, root: Optional[str] = None) -> bool:
+    """Remove a published version (or the whole pack when ``version`` is None).
+    Returns True if anything was removed. For registry maintenance/tests."""
+    base = _root(root) / name
+    target = base / version if version else base
+    if not target.is_dir():
+        return False
+    shutil.rmtree(target)
+    # Clean up an emptied pack directory.
+    if base.is_dir() and not any(base.iterdir()):
+        base.rmdir()
+    return True
+
+
+__all__ = [
+    "default_root",
+    "PackRegistryError",
+    "publish",
+    "publish_path",
+    "list_packs",
+    "versions",
+    "latest_version",
+    "get",
+    "discover",
+    "unpublish",
+]

--- a/tests/unit/domains/test_pack_registry.py
+++ b/tests/unit/domains/test_pack_registry.py
@@ -1,0 +1,105 @@
+"""M9.2: the domain-pack registry. A packaged pack publishes to the registry and
+is discoverable and versioned there; versions are immutable and the latest
+resolves."""
+
+from pathlib import Path
+
+import pytest
+
+from src.domains import pack_registry
+from src.domains.pack_format import PackFormatError, PackManifest
+from src.domains.pack_registry import PackRegistryError
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _manifest(version="1.0.0", desc="Energy pack"):
+    return PackManifest(
+        name="energy",
+        version=version,
+        description=desc,
+        source_types=["news"],
+        ui_flags={"energy": True},
+        planner_keywords={"trend": ["grid", "outage"]},
+    )
+
+
+@pytest.fixture
+def root(tmp_path):
+    return str(tmp_path / "registry")
+
+
+def test_publish_then_discover_and_get(root):
+    pub = pack_registry.publish(_manifest(), root=root)
+    assert pub["name"] == "energy" and pub["version"] == "1.0.0"
+
+    # Discoverable.
+    found = pack_registry.discover(root)
+    assert len(found) == 1
+    assert found[0]["name"] == "energy"
+    assert found[0]["latest_version"] == "1.0.0"
+
+    # Retrievable, with contents intact.
+    got = pack_registry.get("energy", root=root)
+    assert got is not None
+    assert got.planner_keywords == {"trend": ["grid", "outage"]}
+
+
+def test_versioning_keeps_all_versions_and_resolves_latest(root):
+    pack_registry.publish(_manifest("1.0.0"), root=root)
+    pack_registry.publish(_manifest("1.2.0"), root=root)
+    pack_registry.publish(_manifest("1.10.0"), root=root)  # semver: 10 > 2
+
+    assert pack_registry.versions("energy", root=root) == ["1.10.0", "1.2.0", "1.0.0"]
+    assert pack_registry.latest_version("energy", root=root) == "1.10.0"
+    # get with no version resolves the latest; a pinned version resolves exactly.
+    assert pack_registry.get("energy", root=root).version == "1.10.0"
+    assert pack_registry.get("energy", "1.0.0", root=root).version == "1.0.0"
+
+
+def test_versions_are_immutable(root):
+    pack_registry.publish(_manifest("1.0.0", desc="first"), root=root)
+    with pytest.raises(PackRegistryError):
+        pack_registry.publish(_manifest("1.0.0", desc="second"), root=root)
+    # The original is untouched.
+    assert pack_registry.get("energy", "1.0.0", root=root).description == "first"
+    # force overwrites.
+    pack_registry.publish(_manifest("1.0.0", desc="second"), root=root, force=True)
+    assert pack_registry.get("energy", "1.0.0", root=root).description == "second"
+
+
+def test_publish_refuses_invalid_manifest(root):
+    bad = _manifest()
+    bad.version = "nope"
+    with pytest.raises(PackFormatError):
+        pack_registry.publish(bad, root=root)
+
+
+def test_publish_from_a_packaged_path(root, tmp_path):
+    # The shipped example pack publishes straight from disk.
+    src = REPO / "packs" / "energy" / "pack.json"
+    pub = pack_registry.publish_path(str(src), root=root)
+    assert pub["name"] == "energy"
+    assert pack_registry.get("energy", root=root).name == "energy"
+
+
+def test_missing_pack_reads_back_as_none(root):
+    assert pack_registry.get("ghost", root=root) is None
+    assert pack_registry.versions("ghost", root=root) == []
+    assert pack_registry.list_packs(root) == []
+
+
+def test_unpublish(root):
+    pack_registry.publish(_manifest("1.0.0"), root=root)
+    pack_registry.publish(_manifest("2.0.0"), root=root)
+    assert pack_registry.unpublish("energy", "1.0.0", root=root) is True
+    assert pack_registry.versions("energy", root=root) == ["2.0.0"]
+    assert pack_registry.unpublish("energy", root=root) is True  # whole pack
+    assert pack_registry.list_packs(root) == []
+
+
+def test_default_root_honours_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("NOESIS_PACK_REGISTRY", str(tmp_path / "envreg"))
+    assert pack_registry.default_root() == str(tmp_path / "envreg")
+    pack_registry.publish(_manifest(), root=None)
+    assert "energy" in pack_registry.list_packs(None)


### PR DESCRIPTION
Closes #688.

## Summary

A packaged pack (M9.1) is a single `pack.json` manifest. This adds the registry a pack **publishes to and is discovered from, with versioning** — the M9.2 done-when.

## What changed

- **`src/domains/pack_registry.py`** (new): a filesystem-backed registry laid out as `<root>/<name>/<version>/pack.json`, so the directory tree *is* the index.
  - `publish(manifest, force=?)` — validates, then writes under `(name, version)`. Versions are **immutable**: republishing an existing version is refused unless `force`, so an installed pack is always reproducible from its `(name, version)`.
  - `publish_path(pack.json)` — publish straight from a packaged pack on disk.
  - `discover()` — catalogue of published packs (name, latest version, all versions, description, source_types).
  - `versions` / `latest_version` — resolve by semver (so `1.10.0 > 1.2.0`, not string order).
  - `get(name, version=None)` — load a pinned version, or the latest.
  - `unpublish` — registry maintenance.

  The root defaults to `NOESIS_PACK_REGISTRY` / `NEURONEWS_PACK_REGISTRY`, else `<repo>/data/pack_registry`.

## Testing

- `tests/unit/domains/test_pack_registry.py` — publish → discover → get; multi-version coexistence with semver latest resolution; version immutability + `force`; refusal of an invalid manifest; publishing the shipped `packs/energy/pack.json` from disk; missing-pack reads as None; unpublish; env-driven default root.
- `pytest tests/unit/domains/test_pack_registry.py` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_