### PR TITLE
M9.3: Install a pack into a fresh instance without code changes

### DIFF
--- a/src/domains/pack_install.py
+++ b/src/domains/pack_install.py
@@ -1,0 +1,219 @@
+"""
+Install a domain pack into a running instance (M9.3).
+
+Given a published pack (M9.2), install compiles its declarative manifest (M9.1)
+into live registrations, so a fresh instance gains the pack's capabilities with
+**no code changes**:
+
+* **panels** -> registered into the catalog runtime, so they validate in a spec
+  and surface on ``GET /api/v1/ui/panels``;
+* **planner_keywords** -> merged into the planner's facet routing, so the pack's
+  vocabulary steers layout;
+* **enrichers** -> the declarative descriptors compile to pure functions and,
+  with the pack's ``ui_flags``, register + enable a :class:`DomainPack`;
+* **provisioning_templates** -> registered as named, deployable templates
+  (enabled: :func:`deploy_template` stands one up through the Provisioner).
+
+Install is reversible (:func:`uninstall`) and idempotent per pack name. It holds
+no database handle: the warehouse connection is only needed to *deploy* a
+template, and is injected there.
+
+Stdlib-only; the provisioning import is lazy.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.domains import pack_registry
+from src.domains import registry as domain_registry
+from src.domains.base import DomainPack, Enricher
+from src.domains.pack_format import PackManifest
+from src.genui import catalog, planner
+from src.genui.catalog import PanelDef
+
+# Installed packs and the runtime registrations to undo on uninstall.
+_INSTALLED: Dict[str, Dict[str, Any]] = {}
+# Named provisioning templates contributed by installed packs.
+_TEMPLATES: Dict[str, Dict[str, Any]] = {}
+
+
+class PackInstallError(RuntimeError):
+    """A pack could not be installed (e.g. not found, or an unknown enricher)."""
+
+
+def _doc_field(document: Any, field: str) -> Optional[str]:
+    if isinstance(document, dict):
+        value = document.get(field)
+    else:
+        value = getattr(document, field, None)
+    return value if isinstance(value, str) else None
+
+
+def _compile_enricher(desc: Dict[str, Any]) -> Enricher:
+    """Compile a declarative enricher descriptor into a runtime Enricher. Only
+    the vetted, code-free kinds are accepted (no arbitrary code executes)."""
+    kind = desc.get("kind")
+    params = desc.get("params", {}) or {}
+    if kind == "keyword_tag":
+        field = params["field"]
+        label = params["label"]
+        keywords = [str(k).lower() for k in params["keywords"]]
+
+        def fn(document, _field=field, _label=label, _kws=tuple(keywords)):
+            text = _doc_field(document, _field)
+            if text and any(kw in text.lower() for kw in _kws):
+                return {"tag": _label}
+            return None
+
+        return Enricher(
+            name=desc["name"],
+            fn=fn,
+            source_types=list(desc.get("source_types", []) or []),
+            description=desc.get("description", ""),
+        )
+    raise PackInstallError(f"unknown enricher kind {kind!r}")
+
+
+def _panel_def(d: Dict[str, Any]) -> PanelDef:
+    return PanelDef(
+        type=d["type"],
+        title=d["title"],
+        description=d.get("description", ""),
+        endpoint=d.get("endpoint"),
+        facets=tuple(d.get("facets", ())),
+        tables=tuple(d.get("tables", ())),
+        ui_flag=d.get("ui_flag"),
+        default_span=int(d.get("default_span", 6)),
+        topic_param=d.get("topic_param"),
+        source_type_param=d.get("source_type_param"),
+    )
+
+
+def install_manifest(manifest: PackManifest) -> Dict[str, Any]:
+    """Install an in-memory manifest's capabilities into the running instance.
+    Reinstalling the same pack replaces its prior registration."""
+    if manifest.name in _INSTALLED:
+        uninstall(manifest.name)
+
+    # Panels -> catalog runtime.
+    for panel in manifest.panels:
+        catalog.register_panel(_panel_def(panel))
+
+    # Planner keywords -> facet routing.
+    for facet, words in manifest.planner_keywords.items():
+        planner.register_keywords(facet, words)
+
+    # Enrichers -> a synthesized, enabled DomainPack (also carries the ui_flags).
+    enrichers = [_compile_enricher(e) for e in manifest.enrichers]
+    pack = DomainPack(
+        name=manifest.name,
+        description=manifest.description,
+        source_types=list(manifest.source_types),
+        enrichers=enrichers,
+        ui_flags=dict(manifest.ui_flags),
+    )
+    domain_registry.register_pack(pack)
+    domain_registry.enable_pack(manifest.name)
+
+    # Provisioning templates -> the deployable-template registry.
+    template_names: List[str] = []
+    for template in manifest.provisioning_templates:
+        _TEMPLATES[template["name"]] = {**template, "pack": manifest.name}
+        template_names.append(template["name"])
+
+    _INSTALLED[manifest.name] = {
+        "version": manifest.version,
+        "panels": [p["type"] for p in manifest.panels],
+        "keywords": {f: list(w) for f, w in manifest.planner_keywords.items()},
+        "templates": template_names,
+    }
+    return {
+        "name": manifest.name,
+        "version": manifest.version,
+        "panels": [p["type"] for p in manifest.panels],
+        "enrichers": [e.name for e in enrichers],
+        "ui_flags": dict(manifest.ui_flags),
+        "planner_facets": sorted(manifest.planner_keywords.keys()),
+        "templates": template_names,
+    }
+
+
+def install(name: str, version: Optional[str] = None, root: Optional[str] = None) -> Dict[str, Any]:
+    """Pull a pack from the registry (latest, or a pinned version) and install
+    it. Raises :class:`PackInstallError` if it is not published."""
+    manifest = pack_registry.get(name, version, root)
+    if manifest is None:
+        raise PackInstallError(f"pack {name!r} (version {version or 'latest'}) not found in registry")
+    return install_manifest(manifest)
+
+
+def installed_packs() -> Dict[str, str]:
+    """Installed pack names mapped to their installed versions."""
+    return {name: info["version"] for name, info in _INSTALLED.items()}
+
+
+def is_installed(name: str) -> bool:
+    return name in _INSTALLED
+
+
+# --- provisioning templates ---------------------------------------------------
+
+def list_templates() -> List[str]:
+    """Names of all provisioning templates enabled by installed packs."""
+    return sorted(_TEMPLATES.keys())
+
+
+def get_template(name: str) -> Optional[Dict[str, Any]]:
+    return _TEMPLATES.get(name)
+
+
+def deploy_template(conn, name: str, provisioner: Any = None, approve: bool = True) -> Dict[str, Any]:
+    """Stand up an installed provisioning template through the Provisioner:
+    deploy the KG (with the template's ontology and backend) and attach its
+    sources. Returns the deploy result, or a ``template_not_found`` error."""
+    template = _TEMPLATES.get(name)
+    if template is None:
+        return {"error": f"template {name!r} is not installed", "code": "template_not_found"}
+    from src.provisioning.provisioner import Provisioner
+
+    prov = provisioner or Provisioner(conn)
+    result = prov.deploy(
+        template["name"],
+        template.get("description", ""),
+        ontology=template.get("ontology"),
+        approve=approve,
+        backend=template.get("backend", "table-prefix"),
+    )
+    if template.get("sources") and not result.get("error"):
+        prov.attach_sources(template["name"], sources=list(template["sources"]))
+    return result
+
+
+def uninstall(name: str) -> bool:
+    """Remove an installed pack's runtime registrations. Returns True if the pack
+    was installed."""
+    info = _INSTALLED.pop(name, None)
+    if info is None:
+        return False
+    for panel_type in info["panels"]:
+        catalog.unregister_panel(panel_type)
+    for facet, words in info["keywords"].items():
+        planner.unregister_keywords(facet, words)
+    for template_name in info["templates"]:
+        _TEMPLATES.pop(template_name, None)
+    domain_registry.disable_pack(name)
+    return True
+
+
+__all__ = [
+    "PackInstallError",
+    "install",
+    "install_manifest",
+    "installed_packs",
+    "is_installed",
+    "list_templates",
+    "get_template",
+    "deploy_template",
+    "uninstall",
+]

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -449,10 +449,38 @@ PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)
 
 _BY_TYPE: Dict[str, PanelDef] = {p.type: p for p in PANEL_CATALOG}
 
+# Runtime panel registry (M9.3): installed domain packs contribute panel defs
+# here at install time, so a pack surfaces its panels without editing the static
+# catalog. A static entry is authoritative and is never overridden by a pack.
+_RUNTIME_PANELS: Dict[str, PanelDef] = {}
+
+
+def register_panel(paneldef: PanelDef) -> None:
+    """Register a runtime panel def (e.g. from an installed domain pack). A panel
+    whose type is already in the static catalog is left untouched."""
+    if paneldef.type not in _BY_TYPE:
+        _RUNTIME_PANELS[paneldef.type] = paneldef
+
+
+def unregister_panel(panel_type: str) -> None:
+    """Remove a runtime panel def (pack uninstall)."""
+    _RUNTIME_PANELS.pop(panel_type, None)
+
+
+def runtime_panels() -> Tuple[PanelDef, ...]:
+    """The currently-registered runtime (pack) panel defs."""
+    return tuple(_RUNTIME_PANELS.values())
+
+
+def all_panel_types() -> Tuple[str, ...]:
+    """Every renderable panel type: static catalog plus installed-pack panels."""
+    return PANEL_TYPES + tuple(t for t in _RUNTIME_PANELS if t not in _BY_TYPE)
+
 
 def get_panel_def(panel_type: str) -> Optional[PanelDef]:
-    """Return the catalog entry for a panel type, or None."""
-    return _BY_TYPE.get(panel_type)
+    """Return the catalog entry for a panel type, or None. Consults the static
+    catalog first, then installed-pack panels."""
+    return _BY_TYPE.get(panel_type) or _RUNTIME_PANELS.get(panel_type)
 
 
 def panel_catalog_dict() -> List[Dict[str, Any]]:

--- a/src/genui/discovery.py
+++ b/src/genui/discovery.py
@@ -167,6 +167,14 @@ def merged_catalog() -> List[Tuple[PanelDef, Optional[str]]]:
             merged.append((panel, None))
     for panel_type in sorted(discovered):
         merged.append(discovered[panel_type])
+    # M9.3: installed domain packs contribute runtime panels; surface them so
+    # GET /api/v1/ui/panels exposes an installed pack's panels to the frontend.
+    from src.genui.catalog import runtime_panels
+
+    present = {p.type for p, _ in merged}
+    for panel in runtime_panels():
+        if panel.type not in present:
+            merged.append((panel, "pack"))
     return merged
 
 

--- a/src/genui/planner.py
+++ b/src/genui/planner.py
@@ -130,6 +130,43 @@ _DAYS_RE = re.compile(r"(\d+)\s*day")
 
 DEFAULT_FACETS = ("overview",)
 
+# Runtime keyword registry (M9.3): installed domain packs add facet keywords
+# here, so a pack's vocabulary steers the planner without editing FACET_KEYWORDS.
+# Facets are always existing catalog facets (the manifest validates that), so a
+# pack only enriches routing, never invents a facet.
+_RUNTIME_KEYWORDS: Dict[str, Tuple[str, ...]] = {}
+
+
+def register_keywords(facet: str, keywords: Iterable[str]) -> None:
+    """Add facet keywords contributed by an installed pack (deduplicated)."""
+    existing = set(_RUNTIME_KEYWORDS.get(facet, ()))
+    existing.update(k.lower() for k in keywords if k)
+    _RUNTIME_KEYWORDS[facet] = tuple(sorted(existing))
+
+
+def unregister_keywords(facet: str, keywords: Optional[Iterable[str]] = None) -> None:
+    """Remove pack-contributed keywords (pack uninstall). With ``keywords`` None,
+    drops all of a facet's runtime keywords."""
+    if keywords is None:
+        _RUNTIME_KEYWORDS.pop(facet, None)
+        return
+    remaining = set(_RUNTIME_KEYWORDS.get(facet, ())) - {k.lower() for k in keywords}
+    if remaining:
+        _RUNTIME_KEYWORDS[facet] = tuple(sorted(remaining))
+    else:
+        _RUNTIME_KEYWORDS.pop(facet, None)
+
+
+def effective_keywords() -> Dict[str, Tuple[str, ...]]:
+    """The planner's keyword map: the static ``FACET_KEYWORDS`` plus any
+    installed-pack keywords merged in per facet."""
+    if not _RUNTIME_KEYWORDS:
+        return FACET_KEYWORDS
+    merged = {facet: tuple(kws) for facet, kws in FACET_KEYWORDS.items()}
+    for facet, kws in _RUNTIME_KEYWORDS.items():
+        merged[facet] = tuple(merged.get(facet, ())) + tuple(kws)
+    return merged
+
 
 def _tokenize(text: str) -> List[str]:
     return _TOKEN_RE.findall(text.lower())
@@ -140,7 +177,7 @@ def score_facets(intent: str) -> Dict[str, int]:
     normalized = " ".join(_tokenize(intent))
     tokens = set(normalized.split())
     scores: Dict[str, int] = {}
-    for facet, keywords in FACET_KEYWORDS.items():
+    for facet, keywords in effective_keywords().items():
         hits = 0
         for kw in keywords:
             if " " in kw or "-" in kw:
@@ -176,7 +213,7 @@ def detect_days(intent: str) -> Optional[int]:
 def extract_topic(intent: str) -> Optional[str]:
     """Extract the topic phrase: what's left after facet/time/type words."""
     facet_words = set()
-    for keywords in FACET_KEYWORDS.values():
+    for keywords in effective_keywords().values():
         for kw in keywords:
             facet_words.update(kw.replace("-", " ").split())
     keep: List[str] = []

--- a/src/genui/spec.py
+++ b/src/genui/spec.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from src.genui.catalog import FACETS, PANEL_TYPES, get_panel_def
+from src.genui.catalog import FACETS, get_panel_def
 
 SPEC_VERSION = "ui-spec-v1"
 
@@ -201,7 +201,9 @@ def validate_spec(data: Dict[str, Any]) -> List[str]:
             seen_ids.add(pid)
 
         ptype = panel.get("type")
-        if ptype not in PANEL_TYPES:
+        # Accept static catalog panels and installed-pack panels (M9.3): a
+        # panel type is valid iff the catalog can resolve a def for it.
+        if not isinstance(ptype, str) or get_panel_def(ptype) is None:
             errors.append(f"{where}.type '{ptype}' is not in the panel catalog")
 
         if not isinstance(panel.get("title"), str) or not panel.get("title"):

--- a/tests/unit/domains/test_pack_install.py
+++ b/tests/unit/domains/test_pack_install.py
@@ -1,0 +1,165 @@
+"""M9.3: install a pack into a running instance without code changes. After
+install(name), the pack's panels validate and surface, its enrichers run, its
+planner keywords steer routing, its ui_flags are active, and its provisioning
+templates are deployable. Uninstall reverses all of it."""
+
+import pytest
+
+from src.domains import pack_install, pack_registry
+from src.domains import registry as domain_registry
+from src.domains.pack_format import PackManifest
+from src.genui import catalog, planner
+from src.genui.adaptivity import merged_ui_flags
+from src.genui.discovery import merged_catalog_dict
+from src.genui.spec import validate_spec
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _manifest():
+    return PackManifest(
+        name="energy",
+        version="1.0.0",
+        description="Energy-sector pack",
+        source_types=["news"],
+        ui_flags={"energy": True},
+        panels=[
+            {
+                "type": "energy_outages",
+                "title": "Grid outages",
+                "description": "Outages over time.",
+                "endpoint": None,
+                "facets": ["events", "trend"],
+                "tables": ["news_articles"],
+                "ui_flag": "energy",
+                "default_span": 6,
+                "topic_param": "topic",
+            }
+        ],
+        planner_keywords={"trend": ["grid", "megawatt", "blackout"]},
+        enrichers=[
+            {
+                "name": "energy_tag",
+                "kind": "keyword_tag",
+                "description": "Tag energy docs.",
+                "source_types": ["news"],
+                "params": {"field": "content", "label": "energy",
+                           "keywords": ["grid", "outage", "blackout"]},
+            }
+        ],
+        provisioning_templates=[
+            {
+                "name": "energy_kg",
+                "description": "Energy KG",
+                "ontology": {"entities": ["utility"]},
+                "sources": ["Energy Wire"],
+                "backend": "table-prefix",
+            }
+        ],
+    )
+
+
+@pytest.fixture
+def installed(tmp_path):
+    """A fresh registry with the energy pack published; install it, then tear
+    down every runtime registration so no global state leaks."""
+    root = str(tmp_path / "registry")
+    pack_registry.publish(_manifest(), root=root)
+    result = pack_install.install("energy", root=root)
+    try:
+        yield result
+    finally:
+        pack_install.uninstall("energy")
+        domain_registry._REGISTRY.pop("energy", None)
+        domain_registry._ENABLED.discard("energy")
+
+
+def test_install_pulls_from_registry_without_code_changes(installed):
+    assert installed["name"] == "energy" and installed["version"] == "1.0.0"
+    assert pack_install.installed_packs() == {"energy": "1.0.0"}
+
+
+def test_installed_pack_panel_surfaces_and_validates(installed):
+    # The pack panel resolves in the catalog ...
+    assert catalog.get_panel_def("energy_outages") is not None
+    assert "energy_outages" in catalog.all_panel_types()
+    # ... surfaces on the merged catalog (GET /api/v1/ui/panels) ...
+    types = {p["type"] for p in merged_catalog_dict()}
+    assert "energy_outages" in types
+    # ... and a spec that uses it validates.
+    spec = {
+        "spec_version": "ui-spec-v1",
+        "intent": "grid outages",
+        "title": "Energy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["trend", "events"],
+        "topic": "grid",
+        "source_type": None,
+        "panels": [
+            {"id": "p1", "type": "energy_outages", "title": "Grid outages", "span": 6,
+             "priority": 0.7, "rationale": "", "endpoint": None,
+             "params": {"topic": "grid"}, "body": ""}
+        ],
+    }
+    assert validate_spec(spec) == []
+
+
+def test_installed_pack_enricher_runs(installed):
+    pack = domain_registry.get_pack("energy")
+    assert pack is not None and len(pack.enrichers) == 1
+    enricher = pack.enrichers[0]
+    assert enricher.applies_to("news")
+    assert enricher.run({"content": "The grid suffered a major outage overnight."}) == {"tag": "energy"}
+    assert enricher.run({"content": "A story about the local sports team."}) is None
+
+
+def test_installed_pack_ui_flags_are_active(installed):
+    assert merged_ui_flags().get("energy") is True
+
+
+def test_installed_pack_keywords_steer_the_planner(installed):
+    scores = planner.score_facets("grid capacity and megawatt output")
+    assert scores.get("trend", 0) >= 2  # grid + megawatt both hit the trend facet
+
+
+def test_installed_pack_template_is_deployable(installed):
+    assert "energy_kg" in pack_install.list_templates()
+    conn = duckdb.connect(":memory:")
+    try:
+        result = pack_install.deploy_template(conn, "energy_kg")
+        assert not result.get("error"), result
+        # The template stood up a deployed KG through the Provisioner.
+        from src.provisioning import store
+        kg = store.get_kg(conn, "energy_kg")
+        assert kg is not None and kg["status"] == "deployed"
+    finally:
+        conn.close()
+
+
+def test_deploy_unknown_template_is_reported():
+    conn = duckdb.connect(":memory:")
+    try:
+        out = pack_install.deploy_template(conn, "no_such_template")
+        assert out.get("code") == "template_not_found"
+    finally:
+        conn.close()
+
+
+def test_uninstall_reverses_everything(tmp_path):
+    root = str(tmp_path / "registry")
+    pack_registry.publish(_manifest(), root=root)
+    pack_install.install("energy", root=root)
+    assert catalog.get_panel_def("energy_outages") is not None
+
+    assert pack_install.uninstall("energy") is True
+    domain_registry._REGISTRY.pop("energy", None)
+    domain_registry._ENABLED.discard("energy")
+
+    # Everything the pack contributed is gone.
+    assert catalog.get_panel_def("energy_outages") is None
+    assert "energy" not in pack_install.installed_packs()
+    assert "energy_kg" not in pack_install.list_templates()
+    assert merged_ui_flags().get("energy") is None
+    # The planner keywords are withdrawn (blackout was a pack-only keyword).
+    assert planner.score_facets("blackout").get("trend", 0) == 0


### PR DESCRIPTION
Closes #689.

## Summary

Compile a published pack's declarative manifest (M9.1) into live registrations, so a fresh instance gains the pack's panels, enrichers, and provisioning templates **with no code changes** — the M9.3 done-when.

## What changed

- **`src/domains/pack_install.py`** (new): `install(name, version?)` pulls a pack from the registry (M9.2) and registers everything:
  - **panels** → the catalog runtime (validate in a spec, surface on `/ui/panels`),
  - **planner_keywords** → the planner's facet routing,
  - **enrichers** → compiled to pure functions and, with the `ui_flags`, a synthesized enabled `DomainPack`,
  - **provisioning_templates** → a deployable-template registry; `deploy_template(conn, name)` stands one up through the `Provisioner` (deploy + attach sources).

  Install is reversible (`uninstall`) and idempotent per pack. Only the vetted `keyword_tag` enricher kind compiles — **no arbitrary code runs** from a pack.
- **Runtime extension points** so a pack needs no code edits:
  - `src/genui/catalog.py`: `register_panel` / `unregister_panel` / `runtime_panels` / `all_panel_types`; `get_panel_def` now consults installed-pack panels (static entries stay authoritative).
  - `src/genui/spec.py`: a panel type is valid iff `get_panel_def` resolves it (static **or** pack), so pack panels validate.
  - `src/genui/planner.py`: `register_keywords` / `effective_keywords`; `score_facets` and `extract_topic` use the merged (static + pack) keyword map. Packs only enrich existing facets, never invent one.
  - `src/genui/discovery.py`: `merged_catalog()` appends installed-pack panels so `GET /api/v1/ui/panels` exposes them.

`panel_catalog_dict()` (which feeds the codegen staleness gate) is unchanged, so generated `spec.ts` is unaffected.

## Testing

- `tests/unit/domains/test_pack_install.py` — a freshly installed pack: surfaces its panel (resolves in the catalog, appears in the merged catalog, validates in a spec), runs its enricher, activates its `ui_flags`, steers the planner with its keywords, and deploys its provisioning template through the Provisioner; and `uninstall` withdraws all of it.
- `pytest tests/unit/genui/ tests/unit/domains/` — 427 passed (no regressions across planner, spec, catalog, codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_