### PR TITLE
M9.4: End-to-end pack lifecycle acceptance

### DIFF
--- a/docs/domains-m9-acceptance.md
+++ b/docs/domains-m9-acceptance.md
@@ -1,0 +1,53 @@
+# M9 acceptance: the domain-pack lifecycle, package to live
+
+Milestone M9 (issues #687-#690) turns a domain pack from a code module into a
+distributable, installable unit. This is the acceptance record; its executable
+form is `scripts/domains/m9_acceptance.py`, run in CI by
+`tests/unit/domains/test_m9_acceptance.py`.
+
+## What it proves
+
+The harness runs the full lifecycle on the shipped example pack
+(`packs/energy/pack.json`) and confirms its capabilities are live in a fresh
+instance.
+
+1. **Package (M9.1).** The manifest is packaged into `noesis-pack-v1` and
+   validates against the contract (`src/domains/pack_format.py`). A pack is one
+   `pack.json` bundling panels, planner keywords, enrichers, provisioning
+   templates and UI flags — all declarative, no Python.
+2. **Publish (M9.2).** It publishes to a registry
+   (`src/domains/pack_registry.py`) and is discoverable and versioned there
+   (`<root>/<name>/<version>/pack.json`, immutable versions, semver latest).
+3. **Install (M9.3).** A fresh instance installs it from the registry
+   (`src/domains/pack_install.py`) with no code changes: panels register into the
+   catalog, keywords into the planner, enrichers compile to pure functions, and
+   provisioning templates become deployable.
+4. **Live.** Every capability is exercised:
+   - the pack panel `energy_outages` resolves in the catalog and validates in a
+     ui-spec;
+   - the `energy_tag` enricher runs and tags a matching document;
+   - the `energy` ui_flag is active in `merged_ui_flags`;
+   - the pack's keywords steer the planner (`grid megawatt capacity` scores the
+     trend facet);
+   - the `energy_kg` provisioning template deploys through the Provisioner.
+
+The harness cleans up every runtime registration at the end, so it leaves no
+global state behind.
+
+## Result
+
+```
+1. package: energy 1.0.0 validates: True
+2. publish: discoverable=True, versions=['1.0.0']
+3. install: energy 1.0.0 panels=['energy_outages'] enrichers=['energy_tag'] templates=['energy_kg']
+4. live: panel=True, enricher=True, ui_flag=True, planner=True, template_deployed=True
+
+RESULT: OK - packaged, published, installed, and every capability is live
+```
+
+## Why this matters
+
+Before M9, adding a domain meant editing the catalog, the planner keyword map,
+the enricher registry, and wiring a `DomainPack` in code. After M9, a domain is
+data: authored once as a manifest, published to a registry, and installed into
+any instance — the ecosystem story for third-party and per-tenant domains.

--- a/scripts/domains/m9_acceptance.py
+++ b/scripts/domains/m9_acceptance.py
@@ -1,0 +1,140 @@
+"""
+M9 acceptance: the full domain-pack lifecycle, package -> publish -> install -> live.
+
+Runs the whole ecosystem end to end on the shipped example pack
+(``packs/energy/pack.json``) and confirms the pack's capabilities are live in a
+fresh instance:
+
+  1. **package** (M9.1): the manifest is packaged into noesis-pack-v1 and validates;
+  2. **publish** (M9.2): it publishes to a temporary registry and is discoverable
+     and versioned there;
+  3. **install** (M9.3): a fresh instance installs it from the registry with no
+     code changes;
+  4. **live** capabilities: its panel resolves and validates in a spec, its
+     enricher runs, its ui_flag is active, its keywords steer the planner, and
+     its provisioning template deploys through the Provisioner.
+
+Run:  python scripts/domains/m9_acceptance.py
+
+The executable form of docs/domains-m9-acceptance.md. Cleans up all runtime
+registrations at the end, so it leaves no global state behind.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _energy_spec():
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "grid outages",
+        "title": "Energy",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": ["trend", "events"],
+        "topic": "grid",
+        "source_type": None,
+        "panels": [
+            {"id": "p1", "type": "energy_outages", "title": "Grid outages", "span": 6,
+             "priority": 0.7, "rationale": "", "endpoint": None,
+             "params": {"topic": "grid"}, "body": ""}
+        ],
+    }
+
+
+def main() -> dict:
+    import duckdb
+
+    from src.domains import pack_install, pack_registry
+    from src.domains import registry as domain_registry
+    from src.domains.pack_format import load_manifest, validate_manifest
+    from src.genui import catalog, planner
+    from src.genui.adaptivity import merged_ui_flags
+    from src.genui.spec import validate_spec
+    from src.provisioning import store
+
+    print("M9 acceptance: package -> publish -> install -> live\n")
+
+    shipped = REPO_ROOT / "packs" / "energy" / "pack.json"
+    tmp = tempfile.mkdtemp()
+    registry_root = str(Path(tmp) / "registry")
+
+    try:
+        # 1) package (M9.1): the shipped manifest loads and validates.
+        manifest = load_manifest(str(shipped))
+        package_ok = validate_manifest(manifest.to_dict()) == []
+        print(f"1. package: {manifest.name} {manifest.version} validates: {package_ok}")
+
+        # 2) publish (M9.2): publish and confirm discoverable + versioned.
+        pack_registry.publish(manifest, root=registry_root)
+        discovered = pack_registry.discover(registry_root)
+        publish_ok = (
+            any(d["name"] == "energy" for d in discovered)
+            and pack_registry.latest_version("energy", registry_root) == manifest.version
+        )
+        print(f"2. publish: discoverable={publish_ok}, versions="
+              f"{pack_registry.versions('energy', registry_root)}")
+
+        # 3) install (M9.3): a fresh instance installs from the registry.
+        report = pack_install.install("energy", root=registry_root)
+        install_ok = pack_install.installed_packs().get("energy") == manifest.version
+        print(f"3. install: {report['name']} {report['version']} "
+              f"panels={report['panels']} enrichers={report['enrichers']} "
+              f"templates={report['templates']}")
+
+        # 4) live capabilities.
+        panel_ok = (
+            catalog.get_panel_def("energy_outages") is not None
+            and validate_spec(_energy_spec()) == []
+        )
+        pack = domain_registry.get_pack("energy")
+        enricher_ok = (
+            pack is not None
+            and pack.enrichers
+            and pack.enrichers[0].run({"content": "The grid suffered an outage."}) == {"tag": "energy"}
+        )
+        flag_ok = merged_ui_flags().get("energy") is True
+        planner_ok = planner.score_facets("grid megawatt capacity").get("trend", 0) >= 2
+
+        conn = duckdb.connect(":memory:")
+        deploy = pack_install.deploy_template(conn, "energy_kg")
+        kg = store.get_kg(conn, "energy_kg")
+        template_ok = not deploy.get("error") and kg is not None and kg["status"] == "deployed"
+        conn.close()
+
+        print(f"4. live: panel={panel_ok}, enricher={enricher_ok}, ui_flag={flag_ok}, "
+              f"planner={planner_ok}, template_deployed={template_ok}")
+
+        ok = all([package_ok, publish_ok, install_ok, panel_ok, enricher_ok,
+                  flag_ok, planner_ok, template_ok])
+        print("\nRESULT: " + (
+            "OK - packaged, published, installed, and every capability is live"
+            if ok else "FAIL"
+        ))
+        return {
+            "package_ok": package_ok,
+            "publish_ok": publish_ok,
+            "install_ok": install_ok,
+            "panel_ok": panel_ok,
+            "enricher_ok": enricher_ok,
+            "flag_ok": flag_ok,
+            "planner_ok": planner_ok,
+            "template_ok": template_ok,
+            "ok": bool(ok),
+        }
+    finally:
+        # Leave no global state behind.
+        pack_install.uninstall("energy")
+        domain_registry._REGISTRY.pop("energy", None)
+        domain_registry._ENABLED.discard("energy")
+
+
+if __name__ == "__main__":
+    result = main()
+    sys.exit(0 if result["ok"] else 1)

--- a/tests/unit/domains/test_m9_acceptance.py
+++ b/tests/unit/domains/test_m9_acceptance.py
@@ -1,0 +1,39 @@
+"""M9.4: the end-to-end pack-lifecycle acceptance. The harness runs
+package -> publish -> install -> live on the shipped example pack and reports
+every stage green."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("duckdb")
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _load_harness():
+    path = REPO / "scripts/domains/m9_acceptance.py"
+    spec = importlib.util.spec_from_file_location("m9_acceptance_mod", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_m9_lifecycle_acceptance_reports_green():
+    result = _load_harness().main()
+    assert result["ok"] is True
+    # Every stage of the lifecycle passed.
+    for stage in ("package_ok", "publish_ok", "install_ok", "panel_ok",
+                  "enricher_ok", "flag_ok", "planner_ok", "template_ok"):
+        assert result[stage] is True, stage
+
+
+def test_harness_leaves_no_global_state():
+    from src.domains import pack_install
+    from src.genui import catalog
+
+    _load_harness().main()
+    # The harness cleaned up after itself: nothing installed, no pack panel left.
+    assert "energy" not in pack_install.installed_packs()
+    assert catalog.get_panel_def("energy_outages") is None


### PR DESCRIPTION
Closes #690.

## Summary

An acceptance harness that runs the full domain-pack lifecycle — **package → publish → install → live-capability** — on the shipped example pack, with a report. The M9.4 done-when.

## What changed

- **`scripts/domains/m9_acceptance.py`** (new): the executable lifecycle harness. On `packs/energy/pack.json`:
  1. **package (M9.1)** — the manifest packages into `noesis-pack-v1` and validates;
  2. **publish (M9.2)** — it publishes to a temporary registry and is discoverable and versioned;
  3. **install (M9.3)** — a fresh instance installs it from the registry with no code changes;
  4. **live** — the pack panel resolves and validates in a ui-spec, the enricher runs, the `energy` ui_flag is active, the keywords steer the planner, and the `energy_kg` provisioning template deploys through the Provisioner.

  Cleans up every runtime registration at the end, so it leaves no global state behind.
- **`docs/domains-m9-acceptance.md`** (new): the acceptance record with the harness output and the before/after ecosystem story.

## Result

```
1. package: energy 1.0.0 validates: True
2. publish: discoverable=True, versions=['1.0.0']
3. install: energy 1.0.0 panels=['energy_outages'] enrichers=['energy_tag'] templates=['energy_kg']
4. live: panel=True, enricher=True, ui_flag=True, planner=True, template_deployed=True

RESULT: OK - packaged, published, installed, and every capability is live
```

## Testing

- `tests/unit/domains/test_m9_acceptance.py` — runs the harness and asserts every lifecycle stage reports green, and that it leaves no global state behind.
- `pytest tests/unit/domains/` — 49 passed.
- `python scripts/domains/m9_acceptance.py` — exits 0 (OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_