### PR TITLE
M10.2: Analyst agent (goal to provisioned KG to OSINT to canvas)

### DIFF
--- a/src/agent/analyst.py
+++ b/src/agent/analyst.py
@@ -1,0 +1,123 @@
+"""
+Analyst agent (M10.2).
+
+Given a goal, the analyst drives the full Noesis loop end to end, entirely
+through the agent runtime (M10.1) and thus over the MCP surface:
+
+1. **KG** - select an existing provisioned KG for the goal, or provision one
+   (deploy, attach sources, ingest) on the **provisioning** plane;
+2. **OSINT** - run a composition sweep on the **osint** plane (contradiction
+   scan, plus corroboration / dossier / reliability when the goal names a claim,
+   entity or source);
+3. **Canvas** - assemble a ``ui-spec-v1`` layout for the goal on the **genui**
+   plane.
+
+The agent only ever calls ``runtime.call(plane, tool, args)``, so every step is
+allowlisted, budgeted and audited by the runtime, and the agent is identical
+whether it runs over live MCP or the in-process backend. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from src.agent.runtime import (
+    AgentRuntime,
+    PLANE_GENUI,
+    PLANE_OSINT,
+    PLANE_PROVISIONING,
+)
+
+
+def kg_name_for(goal: str) -> str:
+    """A valid KG name derived from a goal ([a-z][a-z0-9_]{1,30})."""
+    slug = re.sub(r"[^a-z0-9]+", "_", goal.lower()).strip("_")
+    if not slug or not slug[0].isalpha():
+        slug = "kg_" + slug
+    slug = slug[:30].rstrip("_")
+    return slug or "kg_default"
+
+
+@dataclass
+class AnalystResult:
+    """The end-to-end outcome of an analyst run."""
+
+    goal: str
+    kg: Dict[str, Any]
+    osint: List[Dict[str, Any]] = field(default_factory=list)
+    canvas: Optional[Dict[str, Any]] = None
+    steps: int = 0
+
+    @property
+    def findings(self) -> int:
+        """How many OSINT tools returned a usable (non-error) result."""
+        return sum(1 for f in self.osint if f.get("ok"))
+
+
+class AnalystAgent:
+    """Drives goal -> KG -> OSINT -> canvas over the runtime."""
+
+    def __init__(self, runtime: AgentRuntime):
+        self._rt = runtime
+
+    def run(
+        self,
+        goal: str,
+        *,
+        kg_name: Optional[str] = None,
+        sources: Optional[List[str]] = None,
+        topic: Optional[str] = None,
+        entity: Optional[str] = None,
+        claim_id: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> AnalystResult:
+        # 1) Select or provision a KG.
+        name = kg_name or kg_name_for(goal)
+        listing = self._rt.call(PLANE_PROVISIONING, "kg_list", {})
+        existing = {k.get("name") for k in (listing.get("kgs") or [])}
+        provisioned = False
+        if name not in existing:
+            self._rt.call(
+                PLANE_PROVISIONING, "kg_deploy",
+                {"name": name, "description": goal, "approve": True},
+            )
+            if sources:
+                self._rt.call(
+                    PLANE_PROVISIONING, "kg_attach_sources",
+                    {"name": name, "sources": sources},
+                )
+            self._rt.call(PLANE_PROVISIONING, "kg_ingest", {"name": name})
+            provisioned = True
+        status = self._rt.call(PLANE_PROVISIONING, "kg_status", {"name": name})
+
+        # 2) OSINT composition sweep. contradiction_scan always; the targeted
+        #    tools when the goal supplies a subject.
+        osint: List[Dict[str, Any]] = []
+        osint.append(self._osint("contradiction_scan", {"topic": topic or goal}))
+        if claim_id:
+            osint.append(self._osint("corroborate", {"claim_id": claim_id}))
+        if entity:
+            osint.append(self._osint("entity_dossier", {"entity": entity}))
+        if source:
+            osint.append(self._osint("source_reliability", {"source": source}))
+
+        # 3) Assemble the canvas.
+        canvas = self._rt.call(PLANE_GENUI, "noesis_generate_view", {"intent": goal})
+
+        return AnalystResult(
+            goal=goal,
+            kg={"name": name, "provisioned": provisioned, "status": status},
+            osint=osint,
+            canvas=canvas,
+            steps=self._rt.steps_used,
+        )
+
+    def _osint(self, tool: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        result = self._rt.call(PLANE_OSINT, tool, args)
+        ok = not (isinstance(result, dict) and result.get("error"))
+        return {"tool": tool, "ok": ok, "result": result}
+
+
+__all__ = ["AnalystAgent", "AnalystResult", "kg_name_for"]

--- a/src/agent/local_backend.py
+++ b/src/agent/local_backend.py
@@ -1,0 +1,109 @@
+"""
+In-process backend for the agent runtime (M10.2+).
+
+:func:`build_local_caller` returns a tool caller for :class:`AgentRuntime` that
+dispatches the three planes to their real Python backends against an injected
+DuckDB connection, instead of over live MCP transports:
+
+* **provisioning** -> :class:`src.provisioning.provisioner.Provisioner`,
+* **osint** -> the ``src.osint`` composition functions,
+* **genui** -> :func:`src.genui.planner.plan`.
+
+The tool names and argument shapes match the MCP tool surface, so an agent
+written against the runtime is identical whether it runs over live MCP
+(``runtime.live_caller``) or in-process here. This is what lets the agents run
+end to end deterministically in tests and offline acceptance harnesses.
+
+Stdlib + duckdb (via the injected connection).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+
+def build_local_caller(conn, clock: Optional[Callable[[], Any]] = None):
+    """A ``(server, tool, arguments) -> result`` caller backed by the real
+    provisioning / OSINT / genui code against ``conn``."""
+    from src.provisioning.provisioner import Provisioner
+
+    prov = Provisioner(conn, clock=clock) if clock else Provisioner(conn)
+
+    def _provisioning(tool: str, a: Dict[str, Any]) -> Any:
+        if tool == "kg_deploy":
+            return prov.deploy(
+                a["name"], a.get("description", ""), ontology=a.get("ontology"),
+                approve=a.get("approve", True), backend=a.get("backend", "table-prefix"),
+            )
+        if tool == "kg_attach_sources":
+            return prov.attach_sources(a["name"], sources=a.get("sources"), criteria=a.get("criteria"))
+        if tool == "kg_attach_pipeline":
+            return prov.attach_pipeline(
+                a["name"], connector=a["connector"], connector_type=a.get("connector_type", "rss"),
+                config=a.get("config"), approve=a.get("approve", True),
+            )
+        if tool == "kg_ingest":
+            return prov.ingest(a["name"], backfill_days=a.get("backfill_days"))
+        if tool == "kg_status":
+            return prov.status(a["name"])
+        if tool == "kg_list":
+            return prov.list_kgs(include_archived=a.get("include_archived", False))
+        if tool == "kg_view":
+            return prov.view(a.get("name"))
+        if tool == "kg_lineage":
+            return prov.lineage(a.get("name"), limit=a.get("limit", 50))
+        if tool == "kg_teardown":
+            return prov.teardown(a["name"], confirm=a.get("confirm", False))
+        raise RuntimeError(f"no local backend for provisioning tool {tool!r}")
+
+    def _osint(tool: str, a: Dict[str, Any]) -> Any:
+        from src.osint import (
+            contradiction_scan, corroborate, entity_dossier, investigation_audit,
+            relationship_path, source_reliability, timeline_reconstruct, trace_artifact,
+        )
+
+        if tool == "corroborate":
+            return corroborate(conn, a["claim_id"])
+        if tool == "source_reliability":
+            return source_reliability(conn, a["source"])
+        if tool == "contradiction_scan":
+            return contradiction_scan(conn, topic=a.get("topic"), entity=a.get("entity"))
+        if tool == "entity_dossier":
+            return entity_dossier(conn, a["entity"], entity_type=a.get("entity_type"))
+        if tool == "relationship_path":
+            return relationship_path(conn, a["a"], a["b"])
+        if tool == "timeline_reconstruct":
+            return timeline_reconstruct(conn, topic=a.get("topic"), entity=a.get("entity"))
+        if tool == "trace_artifact":
+            return trace_artifact(conn, claim_id=a.get("claim_id"), document_id=a.get("document_id"))
+        if tool == "investigation_audit":
+            return investigation_audit(conn, a["name"])
+        if tool in ("geolocate_claims", "narrative_coordination"):
+            from src.osint import gated
+            fn = getattr(gated, tool)
+            return fn(conn, **{k: v for k, v in a.items()})
+        raise RuntimeError(f"no local backend for osint tool {tool!r}")
+
+    def _genui(tool: str, a: Dict[str, Any]) -> Any:
+        if tool == "noesis_generate_view":
+            from src.genui.planner import plan
+            return plan(a.get("intent", ""), source_type=a.get("source_type")).to_dict()
+        if tool == "noesis_panels":
+            from src.genui.discovery import merged_catalog_dict
+            return {"panels": merged_catalog_dict()}
+        raise RuntimeError(f"no local backend for genui tool {tool!r}")
+
+    def caller(server: str, tool: str, arguments: Dict[str, Any]) -> Any:
+        args = arguments or {}
+        if server == "neuronews-provisioning":
+            return _provisioning(tool, args)
+        if server == "neuronews-osint":
+            return _osint(tool, args)
+        if server == "noesis":
+            return _genui(tool, args)
+        raise RuntimeError(f"no local backend for server {server!r}")
+
+    return caller
+
+
+__all__ = ["build_local_caller"]

--- a/tests/unit/agent/test_analyst_agent.py
+++ b/tests/unit/agent/test_analyst_agent.py
@@ -1,0 +1,123 @@
+"""M10.2: the analyst agent completes goal -> KG -> OSINT -> canvas on a sample
+goal, over the MCP surface (driven here by the in-process backend, which mirrors
+the live MCP tool surface)."""
+
+import pytest
+
+from src.agent.analyst import AnalystAgent, kg_name_for
+from src.agent.local_backend import build_local_caller
+from src.agent.runtime import AgentRuntime, PLANE_GENUI, PLANE_OSINT, PLANE_PROVISIONING
+from src.genui.spec import validate_spec
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _seed(conn):
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO news_articles (id, title, url, source, publish_date) VALUES (?,?,?,?,?)",
+        [
+            ("d1", "Delta flooding", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Delta support", "http://b/1", "Beta Journal", "2026-06-02"),
+            ("d3", "Delta support two", "http://c/1", "Gamma Review", "2026-06-03"),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE argument_claims (claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO argument_claims VALUES ('k1', 'Severe flooding struck the delta.', 'd1', 'news', 0.9, NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE claim_evidence (evidence_id VARCHAR, claim_id VARCHAR, evidence_text VARCHAR, "
+        "evidence_document_id VARCHAR, evidence_source_type VARCHAR, relation VARCHAR, "
+        "similarity_score DOUBLE, found_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO claim_evidence (evidence_id, claim_id, evidence_document_id, "
+        "evidence_source_type, relation, similarity_score) VALUES (?,?,?,?,?,?)",
+        [
+            ("e1", "k1", "d2", "news", "supports", 0.88),
+            ("e2", "k1", "d3", "news", "supports", 0.82),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE outlet_scores (source VARCHAR, source_type VARCHAR, score_date VARCHAR, "
+        "frame_diversity DOUBLE, attribution_rate DOUBLE, stance_neutrality DOUBLE, "
+        "composite_score DOUBLE, doc_count INTEGER, claim_count INTEGER, computed_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO outlet_scores (source, source_type, score_date, frame_diversity, "
+        "attribution_rate, stance_neutrality, composite_score) VALUES (?,?,?,?,?,?,?)",
+        [
+            ("Alpha Wire", "outlet", "2026-06-01", 0.6, 0.7, 0.5, 0.62),
+            ("Beta Journal", "outlet", "2026-06-01", 0.6, 0.8, 0.6, 0.8),
+            ("Gamma Review", "outlet", "2026-06-01", 0.5, 0.6, 0.5, 0.6),
+        ],
+    )
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    conn = duckdb.connect(str(tmp_path / "wh.duckdb"))
+    _seed(conn)
+    rt = AgentRuntime(build_local_caller(conn))
+    yield rt
+    conn.close()
+
+
+GOAL = "flooding in the coastal delta"
+
+
+def test_analyst_completes_goal_to_kg_to_osint_to_canvas(runtime):
+    agent = AnalystAgent(runtime)
+    result = agent.run(
+        GOAL,
+        sources=["Alpha Wire", "Beta Journal", "Gamma Review"],
+        claim_id="k1",
+        source="Alpha Wire",
+    )
+
+    # KG: a namespace was provisioned for the goal and is deployed.
+    assert result.kg["provisioned"] is True
+    assert result.kg["name"] == kg_name_for(GOAL)
+    assert result.kg["status"].get("error") is None
+
+    # OSINT: the sweep returned usable findings, including real corroboration.
+    assert result.findings >= 2
+    corroboration = next(f for f in result.osint if f["tool"] == "corroborate")
+    assert corroboration["result"]["independent_support_count"] == 2
+
+    # Canvas: a valid ui-spec-v1 layout for the goal.
+    assert validate_spec(result.canvas) == []
+    assert result.canvas["intent"] == GOAL
+
+    # The run genuinely crossed all three planes.
+    planes = {c.plane for c in runtime.transcript()}
+    assert planes == {PLANE_PROVISIONING, PLANE_OSINT, PLANE_GENUI}
+
+
+def test_analyst_selects_an_existing_kg_instead_of_reprovisioning(runtime):
+    name = kg_name_for(GOAL)
+    # Pre-provision the KG the goal would map to.
+    runtime.call(PLANE_PROVISIONING, "kg_deploy", {"name": name, "description": "seeded", "approve": True})
+
+    agent = AnalystAgent(runtime)
+    result = agent.run(GOAL, claim_id="k1")
+    # It reused the existing KG rather than deploying a second time.
+    assert result.kg["provisioned"] is False
+    assert result.kg["name"] == name
+
+
+def test_analyst_run_stays_within_budget(runtime):
+    from src.agent.runtime import Budget
+
+    # A generous but finite budget; the analyst run must fit inside it.
+    runtime._budget = Budget(max_steps=24)
+    result = AnalystAgent(runtime).run(GOAL, sources=["Alpha Wire"], claim_id="k1", source="Alpha Wire")
+    assert result.steps <= 24
+    assert runtime.steps_remaining() >= 0


### PR DESCRIPTION
Closes #692.

## Summary

An analyst agent that, given a goal, drives the full loop **goal → provisioned KG → OSINT → canvas** end to end through the agent runtime (M10.1), and thus over the MCP surface — the M10.2 done-when.

## What changed

- **`src/agent/analyst.py`** (new): `AnalystAgent.run(goal)`:
  1. selects an existing provisioned KG for the goal, or provisions one (deploy → attach sources → ingest) on the **provisioning** plane;
  2. runs an OSINT composition sweep (contradiction scan, plus corroboration / dossier / reliability when the goal names a claim, entity, or source) on the **osint** plane;
  3. assembles a `ui-spec-v1` canvas for the goal on the **genui** plane.

  It only ever calls `runtime.call(plane, tool, args)`, so every step is allowlisted, budgeted, and audited by the runtime.
- **`src/agent/local_backend.py`** (new): `build_local_caller(conn)` dispatches the three planes to their real Python backends (`Provisioner`, the `src.osint` composition functions, the planner) against an injected DuckDB connection, matching the MCP tool surface. This is what lets the agent run end to end deterministically offline; `runtime.live_caller` runs the identical agent over live MCP.

## Testing

- `tests/unit/agent/test_analyst_agent.py` — on a sample goal over a seeded warehouse, the analyst provisions a KG, returns real OSINT findings (2 independent corroborating sources), produces a valid ui-spec canvas, and genuinely crosses all three planes; it reuses an existing KG instead of reprovisioning; and it stays within budget.
- `pytest tests/unit/agent/` — 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_