### PR TITLE
M10.3: Investigator agent variant

### DIFF
--- a/src/agent/investigator.py
+++ b/src/agent/investigator.py
@@ -1,0 +1,124 @@
+"""
+Investigator agent (M10.3).
+
+A variant of the analyst tuned for investigations. It opens an investigation - a
+provisioned KG namespace (R11) - and drives the R11 investigation surface over
+the runtime:
+
+* **entity_dossier** - a cited brief per entity,
+* **relationship_path** - how two entities are connected, edge by cited edge,
+* **timeline_reconstruct** - a dated, corroboration-weighted event sequence,
+* **trace_artifact** - the provenance chain behind a claim,
+
+then surfaces the findings on a canvas. Because it runs entirely through the
+runtime, it inherits the review gate: it only ever calls the ungated R11 tools,
+and the runtime would refuse a gated tool (``geolocate_claims`` /
+``narrative_coordination``) while the gate is closed. The run is auditable via
+``investigation_audit`` on the same namespace. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.agent.analyst import kg_name_for
+from src.agent.runtime import (
+    AgentRuntime,
+    PLANE_GENUI,
+    PLANE_OSINT,
+    PLANE_PROVISIONING,
+)
+
+# The gated OSINT tools an investigator must never invoke while the gate is off.
+GATED_TOOLS = frozenset({"geolocate_claims", "narrative_coordination"})
+
+
+@dataclass
+class InvestigationResult:
+    """The outcome of an investigator run."""
+
+    title: str
+    kg: Dict[str, Any]
+    surface: List[Dict[str, Any]] = field(default_factory=list)
+    audit: Optional[Dict[str, Any]] = None
+    canvas: Optional[Dict[str, Any]] = None
+    steps: int = 0
+    gated_calls: int = 0
+
+    @property
+    def findings(self) -> int:
+        return sum(1 for f in self.surface if f.get("ok"))
+
+
+class InvestigatorAgent:
+    """Drives open-investigation -> R11 surface -> canvas over the runtime,
+    respecting the review gate."""
+
+    def __init__(self, runtime: AgentRuntime):
+        self._rt = runtime
+
+    def run(
+        self,
+        title: str,
+        *,
+        entities: Optional[List[str]] = None,
+        related_pair: Optional[Tuple[str, str]] = None,
+        topic: Optional[str] = None,
+        claim_id: Optional[str] = None,
+        sources: Optional[List[str]] = None,
+    ) -> InvestigationResult:
+        # 1) Open the investigation (its KG namespace): select or provision.
+        name = kg_name_for(title)
+        listing = self._rt.call(PLANE_PROVISIONING, "kg_list", {})
+        existing = {k.get("name") for k in (listing.get("kgs") or [])}
+        provisioned = False
+        if name not in existing:
+            self._rt.call(
+                PLANE_PROVISIONING, "kg_deploy",
+                {"name": name, "description": f"investigation: {title}", "approve": True},
+            )
+            if sources:
+                self._rt.call(PLANE_PROVISIONING, "kg_attach_sources", {"name": name, "sources": sources})
+            self._rt.call(PLANE_PROVISIONING, "kg_ingest", {"name": name})
+            provisioned = True
+
+        # 2) Drive the R11 investigation surface (all ungated).
+        surface: List[Dict[str, Any]] = []
+        for entity in entities or []:
+            surface.append(self._surface("entity_dossier", {"entity": entity}))
+        if related_pair:
+            a, b = related_pair
+            surface.append(self._surface("relationship_path", {"a": a, "b": b}))
+        if topic:
+            surface.append(self._surface("timeline_reconstruct", {"topic": topic}))
+        if claim_id:
+            surface.append(self._surface("trace_artifact", {"claim_id": claim_id}))
+
+        # 3) The investigation is auditable from its namespace.
+        audit = self._rt.call(PLANE_PROVISIONING, "kg_lineage", {"name": name})
+
+        # 4) Surface the findings on a canvas.
+        canvas = self._rt.call(
+            PLANE_GENUI, "noesis_generate_view",
+            {"intent": f"investigation dossier connections and timeline for {title}"},
+        )
+
+        gated_calls = sum(1 for c in self._rt.transcript() if c.tool in GATED_TOOLS)
+        return InvestigationResult(
+            title=title,
+            kg={"name": name, "provisioned": provisioned},
+            surface=surface,
+            audit=audit,
+            canvas=canvas,
+            steps=self._rt.steps_used,
+            gated_calls=gated_calls,
+        )
+
+    def _surface(self, tool: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        result = self._rt.call(PLANE_OSINT, tool, args)
+        ok = not (isinstance(result, dict) and result.get("error"))
+        return {"tool": tool, "ok": ok, "result": result}
+
+
+__all__ = ["InvestigatorAgent", "InvestigationResult", "GATED_TOOLS"]

--- a/tests/unit/agent/test_investigator_agent.py
+++ b/tests/unit/agent/test_investigator_agent.py
@@ -1,0 +1,110 @@
+"""M10.3: the investigator agent runs an investigation end to end over the MCP
+surface (dossier, relationship path, timeline, trace) and never invokes a gated
+tool while the review gate is off."""
+
+import pytest
+
+from src.agent.analyst import kg_name_for
+from src.agent.investigator import GATED_TOOLS, InvestigatorAgent
+from src.agent.local_backend import build_local_caller
+from src.agent.runtime import AgentRuntime, NotAllowed, PLANE_GENUI, PLANE_OSINT, PLANE_PROVISIONING
+from src.genui.spec import validate_spec
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _seed(conn):
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO news_articles (id, title, url, source, publish_date) VALUES (?,?,?,?,?)",
+        [
+            ("d1", "Delta summit", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Delta follow-up", "http://b/1", "Beta Journal", "2026-06-05"),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE argument_claims (claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO argument_claims VALUES (?,?,?,?,?,?)",
+        [
+            ("k1", "Severe flooding struck the delta in June.", "d1", "news", 0.9, None),
+            ("k2", "Recovery in the delta continued.", "d2", "news", 0.8, None),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE document_actors (document_id VARCHAR, source_type VARCHAR, actor_name VARCHAR, "
+        "entity_id VARCHAR, role VARCHAR, confidence DOUBLE, extracted_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO document_actors (document_id, actor_name, entity_id, role) VALUES (?,?,?,?)",
+        [
+            ("d1", "Jordan Rivera", "person:jr", "speaker"),
+            ("d1", "Casey Morgan", "person:cm", "subject"),
+            ("d2", "Jordan Rivera", "person:jr", "speaker"),
+        ],
+    )
+
+
+@pytest.fixture
+def runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "off")  # gate closed
+    conn = duckdb.connect(str(tmp_path / "wh.duckdb"))
+    _seed(conn)
+    rt = AgentRuntime(build_local_caller(conn))
+    yield rt
+    conn.close()
+
+
+TITLE = "delta flooding response"
+
+
+def test_investigator_runs_end_to_end_over_the_r11_surface(runtime):
+    result = InvestigatorAgent(runtime).run(
+        TITLE,
+        entities=["Jordan Rivera"],
+        related_pair=("Jordan Rivera", "Casey Morgan"),
+        topic="delta",
+        claim_id="k1",
+        sources=["Alpha Wire", "Beta Journal"],
+    )
+
+    # An investigation namespace was opened (provisioned) for the case.
+    assert result.kg["name"] == kg_name_for(TITLE)
+    assert result.kg["provisioned"] is True
+
+    # The R11 surface was driven and returned usable findings.
+    tools_run = {f["tool"] for f in result.surface}
+    assert {"entity_dossier", "relationship_path", "timeline_reconstruct", "trace_artifact"} <= tools_run
+    assert result.findings >= 3
+
+    # It is auditable, and it surfaced a valid canvas.
+    assert result.audit is not None
+    assert validate_spec(result.canvas) == []
+
+
+def test_investigator_never_invokes_a_gated_tool_while_the_gate_is_off(runtime):
+    result = InvestigatorAgent(runtime).run(
+        TITLE, entities=["Jordan Rivera"], topic="delta", claim_id="k1",
+    )
+    # No gated tool appears anywhere in the run transcript.
+    assert result.gated_calls == 0
+    assert not any(c.tool in GATED_TOOLS for c in runtime.transcript())
+
+
+def test_runtime_refuses_a_gated_tool_while_the_gate_is_off(runtime):
+    # Even an explicit attempt is refused by the runtime (defence in depth).
+    with pytest.raises(NotAllowed):
+        runtime.call(PLANE_OSINT, "geolocate_claims", {"entity": "Jordan Rivera"})
+    with pytest.raises(NotAllowed):
+        runtime.call(PLANE_OSINT, "narrative_coordination", {"topic": "delta"})
+
+
+def test_investigator_crosses_provisioning_osint_and_genui(runtime):
+    InvestigatorAgent(runtime).run(TITLE, entities=["Jordan Rivera"], topic="delta")
+    planes = {c.plane for c in runtime.transcript()}
+    assert planes == {PLANE_PROVISIONING, PLANE_OSINT, PLANE_GENUI}


### PR DESCRIPTION
Closes #693.

## Summary

A variant of the analyst tuned for investigations. It opens an investigation — a provisioned KG namespace (R11) — drives the R11 investigation surface over the runtime, and surfaces findings on a canvas, **respecting the review gate**: it runs end to end over MCP and never invokes a gated tool while the gate is off — the M10.3 done-when.

## What changed

- **`src/agent/investigator.py`** (new): `InvestigatorAgent.run(title)`:
  1. selects or provisions the investigation's KG namespace on the **provisioning** plane;
  2. drives the R11 surface — `entity_dossier`, `relationship_path`, `timeline_reconstruct`, `trace_artifact` — on the **osint** plane;
  3. reads the namespace lineage for auditability;
  4. assembles an investigation-focused canvas on the **genui** plane.

  It only ever calls the ungated R11 tools. Because it runs through the runtime, a gated tool (`geolocate_claims`, `narrative_coordination`) would be refused while the review gate is closed — defence in depth. The result's `gated_calls` reports `0`.

## Testing

- `tests/unit/agent/test_investigator_agent.py` — end to end over a seeded warehouse (dossier for a person entity, a co-mention relationship path, a dated timeline, a provenance trace); a valid canvas and an audit trail; and the review gate proof: `gated_calls == 0`, no gated tool in the transcript, and the runtime refuses an explicit gated-tool attempt while the gate is off. Also asserts the run crosses all three planes.
- `pytest tests/unit/agent/` — 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_