### PR TITLE
M10.4: Full audit-trail coverage and end-to-end acceptance

### DIFF
--- a/docs/agent-m10-acceptance.md
+++ b/docs/agent-m10-acceptance.md
@@ -1,0 +1,54 @@
+# M10 acceptance: agent runs, accountable by replay
+
+Milestone M10 (issues #691-#694) puts an agent on top of Noesis: a runtime over
+the MCP surface, an analyst agent, an investigator agent, and full audit-trail
+coverage. This is the acceptance record for the accountability guarantee; its
+executable form is `scripts/agent/m10_acceptance.py`, run in CI by
+`tests/unit/agent/test_agent_audit.py`.
+
+## The agent stack
+
+- **M10.1** `src/agent/runtime.py` - the runtime: a budgeted, allowlisted, audited
+  gate between an agent and the provisioning / OSINT / genui planes. It refuses
+  un-allowlisted tools, refuses gated OSINT tools while the review gate is closed,
+  and records every call.
+- **M10.2** `src/agent/analyst.py` - the analyst: goal -> provisioned KG -> OSINT
+  -> canvas.
+- **M10.3** `src/agent/investigator.py` - the investigator: opens an investigation
+  KG, drives the R11 surface (dossier, path, timeline, trace), never touches a
+  gated tool while the gate is off.
+- **M10.4** `src/agent/audit.py` - the audit trail: every agent call is written to
+  the same `provisioning_events` log that records KG lineage, and `replay_run`
+  reconstructs a run from it.
+
+## What the acceptance proves
+
+The harness runs the analyst end to end with the provisioning audit sink attached
+to the runtime, then reconstructs the run from the audit trail alone:
+
+1. **Full coverage.** Every tool call the agent made is written to the
+   provisioning audit trail (one `agent_call` event per call, grouped under a
+   `run_id`).
+2. **Reconstructable.** Replaying the trail yields the same ordered sequence of
+   `(plane, server, tool, arguments, ok)` as the live run - call for call.
+
+Failed calls are recorded too (with `ok=false`), so the record never hides what
+happened.
+
+## Result
+
+```
+1. analyst run: steps=9, findings=3, kg='flooding_in_the_coastal_delta' provisioned=True
+2. audit trail: 9 events recorded for 9 calls; complete=True
+3. replay: sequence_matches=True, arguments_match=True
+
+RESULT: OK - the run is fully reconstructable from the audit trail
+```
+
+## Why this matters
+
+An agent that provisions KGs, runs OSINT, and builds canvases is only trustworthy
+if every action it took is on the record. By writing agent calls to the same
+audit trail that already makes provisioning replayable, an agent run inherits the
+same accountability: nothing the agent did is invisible, and the whole run can be
+replayed from the log.

--- a/scripts/agent/m10_acceptance.py
+++ b/scripts/agent/m10_acceptance.py
@@ -1,0 +1,127 @@
+"""
+M10 acceptance: an agent run is fully reconstructable from the audit trail.
+
+Runs the analyst agent (M10.2) end to end with the provisioning audit sink
+(M10.4) attached to the runtime, then reconstructs the run from the audit trail
+alone and confirms it matches the live transcript call for call:
+
+  * every tool call the agent made is written to the provisioning audit trail;
+  * replaying the trail yields the same ordered sequence of (plane, server, tool,
+    arguments, ok) - the run is reproducible from the record.
+
+Run:  python scripts/agent/m10_acceptance.py
+
+The executable form of docs/agent-m10-acceptance.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+RUN_ID = "analyst-run-delta"
+GOAL = "flooding in the coastal delta"
+
+
+def _seed(conn):
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO news_articles (id, title, url, source, publish_date) VALUES (?,?,?,?,?)",
+        [
+            ("d1", "Delta flooding", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Delta support", "http://b/1", "Beta Journal", "2026-06-02"),
+            ("d3", "Delta support two", "http://c/1", "Gamma Review", "2026-06-03"),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE argument_claims (claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO argument_claims VALUES ('k1', 'Severe flooding struck the delta.', 'd1', 'news', 0.9, NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE claim_evidence (evidence_id VARCHAR, claim_id VARCHAR, evidence_text VARCHAR, "
+        "evidence_document_id VARCHAR, evidence_source_type VARCHAR, relation VARCHAR, "
+        "similarity_score DOUBLE, found_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO claim_evidence (evidence_id, claim_id, evidence_document_id, "
+        "evidence_source_type, relation, similarity_score) VALUES (?,?,?,?,?,?)",
+        [("e1", "k1", "d2", "news", "supports", 0.88), ("e2", "k1", "d3", "news", "supports", 0.82)],
+    )
+    conn.execute(
+        "CREATE TABLE outlet_scores (source VARCHAR, source_type VARCHAR, score_date VARCHAR, "
+        "frame_diversity DOUBLE, attribution_rate DOUBLE, stance_neutrality DOUBLE, "
+        "composite_score DOUBLE, doc_count INTEGER, claim_count INTEGER, computed_at VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO outlet_scores (source, source_type, score_date, composite_score) "
+        "VALUES ('Alpha Wire', 'outlet', '2026-06-01', 0.62)"
+    )
+
+
+def _key(call):
+    return (call.get("step"), call.get("plane"), call.get("server"), call.get("tool"), call.get("ok"))
+
+
+def main() -> dict:
+    import duckdb
+
+    from src.agent.analyst import AnalystAgent
+    from src.agent.audit import provisioning_audit_sink, replay_run
+    from src.agent.local_backend import build_local_caller
+    from src.agent.runtime import AgentRuntime
+
+    print("M10 acceptance: an agent run is reconstructable from the audit trail\n")
+
+    conn = duckdb.connect(":memory:")
+    _seed(conn)
+
+    sink = provisioning_audit_sink(conn, RUN_ID)
+    runtime = AgentRuntime(build_local_caller(conn), audit_sink=sink)
+    result = AnalystAgent(runtime).run(
+        GOAL, sources=["Alpha Wire", "Beta Journal", "Gamma Review"],
+        claim_id="k1", source="Alpha Wire",
+    )
+    print(f"1. analyst run: steps={result.steps}, findings={result.findings}, "
+          f"kg={result.kg['name']!r} provisioned={result.kg['provisioned']}")
+
+    live = [c.summary() for c in runtime.transcript()]
+    replayed = replay_run(conn, RUN_ID)
+    conn.close()
+
+    # Every call was recorded, and the replay matches the live run call for call.
+    all_recorded = len(replayed) == len(live) and len(live) > 0
+    same_sequence = [_key(c) for c in replayed] == [_key(c) for c in live]
+    same_arguments = all(r.get("arguments") == l.get("arguments") for r, l in zip(replayed, live))
+
+    print(f"2. audit trail: {len(replayed)} events recorded for {len(live)} calls; "
+          f"complete={all_recorded}")
+    print(f"3. replay: sequence_matches={same_sequence}, arguments_match={same_arguments}")
+
+    ok = all([all_recorded, same_sequence, same_arguments, result.findings >= 2])
+    print("\nRESULT: " + (
+        "OK - the run is fully reconstructable from the audit trail"
+        if ok else "FAIL"
+    ))
+    return {
+        "steps": result.steps,
+        "calls": len(live),
+        "events": len(replayed),
+        "all_recorded": all_recorded,
+        "same_sequence": same_sequence,
+        "same_arguments": same_arguments,
+        "ok": bool(ok),
+    }
+
+
+if __name__ == "__main__":
+    result = main()
+    sys.exit(0 if result["ok"] else 1)

--- a/src/agent/audit.py
+++ b/src/agent/audit.py
@@ -1,0 +1,77 @@
+"""
+Agent audit trail and replay (M10.4).
+
+Every action an agent takes through the runtime (M10.1) is written to the
+**provisioning audit trail** - the same append-only ``provisioning_events`` log
+that records deploy/attach/ingest/teardown - so an agent run lives alongside the
+provisioning lineage it drives and is reconstructable the same way.
+
+:func:`provisioning_audit_sink` returns an :class:`AgentRuntime` audit sink that
+appends one event per tool call, grouped under a ``run_id``. :func:`replay_run`
+reads those events back in order and reconstructs the exact call sequence, so a
+run can be replayed from the trail alone - the M10.4 accountability guarantee.
+
+Stdlib-only; the connection is injected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from src.agent.runtime import ToolCall
+
+# The event name under which an agent tool call is logged.
+AGENT_EVENT = "agent_call"
+
+
+def provisioning_audit_sink(
+    conn,
+    run_id: str,
+    lock: Any = None,
+    clock: Optional[Callable[[], Any]] = None,
+) -> Callable[[ToolCall], None]:
+    """An audit sink that writes each agent call to the provisioning audit trail,
+    grouped under ``run_id``. Attach it to an :class:`AgentRuntime` as
+    ``audit_sink`` and every call the agent makes is recorded."""
+    from datetime import datetime, timezone
+
+    from src.provisioning import store
+
+    def _now():
+        if clock is not None:
+            return clock()
+        return datetime.now(timezone.utc)
+
+    if lock is not None:
+        with lock:
+            store.ensure_schema(conn)
+    else:
+        store.ensure_schema(conn)
+
+    def sink(call: ToolCall) -> None:
+        detail = dict(call.summary())
+        detail["run_id"] = run_id
+        now = _now()
+        if lock is not None:
+            with lock:
+                store.record_event(conn, run_id, AGENT_EVENT, detail, now)
+        else:
+            store.record_event(conn, run_id, AGENT_EVENT, detail, now)
+
+    return sink
+
+
+def replay_run(conn, run_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
+    """Reconstruct an agent run's ordered call sequence from the audit trail.
+    Returns the per-call records (plane, server, tool, arguments, ok, step) in
+    execution order."""
+    from src.provisioning import store
+
+    events = store.list_events(conn, name=run_id, limit=limit)
+    calls = [e["detail"] for e in events if e.get("event") == AGENT_EVENT]
+    # list_events is newest-first; order by the recorded step for exact replay.
+    calls.sort(key=lambda d: d.get("step", 0))
+    return calls
+
+
+__all__ = ["AGENT_EVENT", "provisioning_audit_sink", "replay_run"]

--- a/tests/unit/agent/test_agent_audit.py
+++ b/tests/unit/agent/test_agent_audit.py
@@ -1,0 +1,96 @@
+"""M10.4: full audit-trail coverage and replay. Every agent call is written to
+the provisioning audit trail, and an agent run is fully reconstructable from that
+trail alone -- proven at the unit level and by the end-to-end acceptance
+harness."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from src.agent.audit import AGENT_EVENT, provisioning_audit_sink, replay_run
+from src.agent.runtime import AgentRuntime, PLANE_GENUI, PLANE_OSINT, PLANE_PROVISIONING
+
+duckdb = pytest.importorskip("duckdb")
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _fake_caller(server, tool, arguments):
+    return {"server": server, "tool": tool, "echo": arguments}
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    yield c
+    c.close()
+
+
+def test_every_agent_call_is_written_to_the_provisioning_audit_trail(conn):
+    rt = AgentRuntime(_fake_caller, audit_sink=provisioning_audit_sink(conn, "run-1"))
+    rt.call(PLANE_PROVISIONING, "kg_deploy", {"name": "energy_kg"})
+    rt.call(PLANE_OSINT, "corroborate", {"claim_id": "k1"})
+    rt.call(PLANE_GENUI, "noesis_generate_view", {"intent": "energy"})
+
+    from src.provisioning import store
+    events = store.list_events(conn, name="run-1", limit=100)
+    assert len(events) == 3
+    assert all(e["event"] == AGENT_EVENT for e in events)
+    # The trail lives in the same provisioning_events log used for KG lineage.
+    assert {e["detail"]["tool"] for e in events} == {"kg_deploy", "corroborate", "noesis_generate_view"}
+
+
+def test_run_is_reconstructable_from_the_trail(conn):
+    rt = AgentRuntime(_fake_caller, audit_sink=provisioning_audit_sink(conn, "run-2"))
+    rt.call(PLANE_PROVISIONING, "kg_list", {})
+    rt.call(PLANE_PROVISIONING, "kg_deploy", {"name": "kg2", "approve": True})
+    rt.call(PLANE_OSINT, "entity_dossier", {"entity": "Rivera"})
+
+    live = [c.summary() for c in rt.transcript()]
+    replayed = replay_run(conn, "run-2")
+    # Same length, same order, same (plane, tool, arguments) per call.
+    assert len(replayed) == len(live)
+    for r, l in zip(replayed, live):
+        assert r["step"] == l["step"]
+        assert (r["plane"], r["tool"]) == (l["plane"], l["tool"])
+        assert r["arguments"] == l["arguments"]
+        assert r["ok"] == l["ok"]
+
+
+def test_replay_is_scoped_to_its_run(conn):
+    sink_a = provisioning_audit_sink(conn, "run-a")
+    sink_b = provisioning_audit_sink(conn, "run-b")
+    AgentRuntime(_fake_caller, audit_sink=sink_a).call(PLANE_OSINT, "corroborate", {"claim_id": "k1"})
+    rt_b = AgentRuntime(_fake_caller, audit_sink=sink_b)
+    rt_b.call(PLANE_GENUI, "noesis_generate_view", {"intent": "x"})
+    rt_b.call(PLANE_OSINT, "source_reliability", {"source": "Alpha"})
+
+    assert len(replay_run(conn, "run-a")) == 1
+    assert len(replay_run(conn, "run-b")) == 2  # runs do not bleed into each other
+
+
+def test_failed_calls_are_also_recorded(conn):
+    def boom(server, tool, arguments):
+        raise RuntimeError("nope")
+
+    rt = AgentRuntime(boom, audit_sink=provisioning_audit_sink(conn, "run-fail"))
+    rt.call(PLANE_OSINT, "corroborate", {"claim_id": "k1"})
+    replayed = replay_run(conn, "run-fail")
+    assert len(replayed) == 1
+    assert replayed[0]["ok"] is False  # the failure is in the record, not hidden
+
+
+def _load_harness():
+    path = REPO / "scripts/agent/m10_acceptance.py"
+    spec = importlib.util.spec_from_file_location("m10_acceptance_mod", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_m10_acceptance_harness_reports_green():
+    result = _load_harness().main()
+    assert result["ok"] is True
+    assert result["all_recorded"] and result["same_sequence"] and result["same_arguments"]
+    assert result["events"] == result["calls"]


### PR DESCRIPTION
Closes #694.

## Summary

Every action an agent takes is written to the provisioning audit trail, and an agent run is **fully reconstructable from that trail** — proven by an end-to-end acceptance test. The M10.4 done-when.

## What changed

- **`src/agent/audit.py`** (new):
  - `provisioning_audit_sink(conn, run_id)` — an `AgentRuntime` audit sink that appends one `agent_call` event per tool call to the same `provisioning_events` log that records KG lineage, grouped under a `run_id`. Failed calls are recorded too (`ok=false`), never hidden.
  - `replay_run(conn, run_id)` — reads the events back in execution order and reconstructs the exact call sequence, so a run replays from the trail alone.
- **`scripts/agent/m10_acceptance.py`** (new): runs the analyst end to end with the audit sink attached, then reconstructs the run from the audit trail and confirms it matches the live transcript **call for call** (same count, order, and arguments).
- **`docs/agent-m10-acceptance.md`** (new): the acceptance record plus the M10 agent-stack overview.

## Result

```
1. analyst run: steps=9, findings=3, kg='flooding_in_the_coastal_delta' provisioned=True
2. audit trail: 9 events recorded for 9 calls; complete=True
3. replay: sequence_matches=True, arguments_match=True

RESULT: OK - the run is fully reconstructable from the audit trail
```

## Testing

- `tests/unit/agent/test_agent_audit.py` — full call coverage into the provisioning trail; exact replay (step / plane / tool / arguments / ok); per-run scoping so runs do not bleed together; failed-call recording; and the acceptance harness reporting green.
- `pytest tests/unit/agent/` — 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_