### PR TITLE
Live entry point: domain-pack ecosystem API routes

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -32,6 +32,7 @@ SECURITY_ROUTES_AVAILABLE = False
 GENUI_ROUTES_AVAILABLE = False
 GENUI_DATA_ROUTES_AVAILABLE = False
 CANVAS_ROUTES_AVAILABLE = False
+PACK_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -406,6 +407,19 @@ def try_import_canvas_routes():
         return False
 
 
+def try_import_pack_routes():
+    """Try to import the domain-pack ecosystem routes (M9: discover/install)."""
+    global PACK_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import pack_routes
+        _imported_modules['pack_routes'] = pack_routes
+        PACK_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        PACK_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -466,6 +480,7 @@ def check_all_imports():
     try_import_genui_routes()
     try_import_genui_data_routes()
     try_import_canvas_routes()
+    try_import_pack_routes()
     _load_domain_packs()
 
 
@@ -810,6 +825,13 @@ def include_optional_routers(app):
             app.include_router(canvas_routes.router)
             routers_included += 1
 
+    # Include the domain-pack ecosystem routes (M9: discover/install).
+    if PACK_ROUTES_AVAILABLE:
+        pack_routes = _imported_modules.get('pack_routes')
+        if pack_routes:
+            app.include_router(pack_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -930,6 +952,7 @@ async def root():
             "generative_ui": GENUI_ROUTES_AVAILABLE,
             "generative_ui_data": GENUI_DATA_ROUTES_AVAILABLE,
             "generative_ui_canvas": CANVAS_ROUTES_AVAILABLE,
+            "domain_packs": PACK_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/pack_routes.py
+++ b/src/api/routes/pack_routes.py
@@ -1,0 +1,149 @@
+"""Domain-pack ecosystem routes (M9, live entry point).
+
+Expose the M9 registry and installer over HTTP so an operator can discover,
+install, and manage domain packs at runtime instead of only from Python:
+
+    GET    /api/v1/packs                      discover published packs + status
+    GET    /api/v1/packs/installed            the currently-installed packs
+    GET    /api/v1/packs/templates            provisioning templates from packs
+    POST   /api/v1/packs/install              install a pack (name, version?)
+    DELETE /api/v1/packs/{name}               uninstall a pack
+    POST   /api/v1/packs/publish              publish a manifest to the registry
+    POST   /api/v1/packs/templates/{name}/deploy   deploy a pack's KG template
+
+Reads are always available. The mutating operations (install, uninstall,
+publish, deploy) change the running instance, so they are gated behind
+``NOESIS_PACKS_ADMIN`` (off by default); ``GET /api/v1/packs`` reports whether
+they are enabled so the frontend can adapt.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from src.domains import pack_install, pack_registry
+from src.domains.pack_format import PackFormatError, PackManifest, validate_manifest
+
+router = APIRouter(prefix="/api/v1/packs", tags=["domain_packs"])
+
+
+def admin_enabled() -> bool:
+    """Whether pack-mutating operations are enabled (``NOESIS_PACKS_ADMIN``)."""
+    return os.getenv("NOESIS_PACKS_ADMIN", "off").lower() in ("on", "1", "true")
+
+
+def _require_admin() -> None:
+    if not admin_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail="pack administration is disabled (set NOESIS_PACKS_ADMIN=on)",
+        )
+
+
+def _conn():
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    return get_shared_connection(), _LOCK
+
+
+class InstallRequest(BaseModel):
+    name: str = Field(..., max_length=64)
+    version: Optional[str] = Field(default=None, max_length=32)
+
+
+class PublishRequest(BaseModel):
+    manifest: Dict[str, Any] = Field(..., description="A noesis-pack-v1 manifest")
+    force: bool = Field(default=False)
+
+
+@router.get("")
+def list_packs() -> Dict[str, Any]:
+    """Discover published packs with their installed state and admin status."""
+    try:
+        installed = pack_install.installed_packs()
+        packs = pack_registry.discover()
+        for entry in packs:
+            entry["installed_version"] = installed.get(entry["name"])
+        return {
+            "admin_enabled": admin_enabled(),
+            "packs": packs,
+            "installed": installed,
+            "count": len(packs),
+        }
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"pack discovery failed: {err}")
+
+
+@router.get("/installed")
+def installed() -> Dict[str, Any]:
+    """The currently-installed packs and their versions."""
+    packs = pack_install.installed_packs()
+    return {"installed": packs, "count": len(packs)}
+
+
+@router.get("/templates")
+def templates() -> Dict[str, Any]:
+    """The provisioning templates enabled by installed packs."""
+    names = pack_install.list_templates()
+    return {"templates": [pack_install.get_template(n) for n in names], "count": len(names)}
+
+
+@router.post("/install")
+def install(request: InstallRequest) -> Dict[str, Any]:
+    """Install a published pack into the running instance."""
+    _require_admin()
+    try:
+        report = pack_install.install(request.name, version=request.version)
+    except pack_install.PackInstallError as err:
+        raise HTTPException(status_code=404, detail=str(err))
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"pack install failed: {err}")
+    return {"installed": report}
+
+
+@router.delete("/{name}")
+def uninstall(name: str) -> Dict[str, Any]:
+    """Uninstall a pack, withdrawing its panels, keywords, enrichers and
+    templates."""
+    _require_admin()
+    removed = pack_install.uninstall(name)
+    if not removed:
+        raise HTTPException(status_code=404, detail=f"pack {name!r} is not installed")
+    return {"uninstalled": name}
+
+
+@router.post("/publish")
+def publish(request: PublishRequest) -> Dict[str, Any]:
+    """Publish a manifest to the registry (validated first; versions immutable)."""
+    _require_admin()
+    errors = validate_manifest(request.manifest)
+    if errors:
+        raise HTTPException(status_code=400, detail=f"invalid manifest: {'; '.join(errors[:3])}")
+    try:
+        published = pack_registry.publish(
+            PackManifest.from_dict(request.manifest), force=request.force
+        )
+    except pack_registry.PackRegistryError as err:
+        raise HTTPException(status_code=409, detail=str(err))
+    except PackFormatError as err:
+        raise HTTPException(status_code=400, detail=str(err))
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"pack publish failed: {err}")
+    return {"published": published}
+
+
+@router.post("/templates/{name}/deploy")
+def deploy_template(name: str) -> Dict[str, Any]:
+    """Deploy a pack's provisioning template (its KG) through the Provisioner."""
+    _require_admin()
+    conn, lock = _conn()
+    try:
+        with lock:
+            result = pack_install.deploy_template(conn, name)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"template deploy failed: {err}")
+    if result.get("code") == "template_not_found":
+        raise HTTPException(status_code=404, detail=result.get("error"))
+    return {"deployed": result}

--- a/tests/unit/api/routes/test_pack_routes.py
+++ b/tests/unit/api/routes/test_pack_routes.py
@@ -1,0 +1,125 @@
+"""Route tests for src/api/routes/pack_routes.py (M9 ecosystem, live entry point).
+
+Loads the route module BY PATH (src.api.routes.__init__ eagerly imports heavy ML
+modules), points the registry at a temp dir and the warehouse at an in-memory
+DuckDB, and drives discover / install / uninstall / deploy through HTTP.
+"""
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("fastapi")
+duckdb = pytest.importorskip("duckdb")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.domains import pack_install, pack_registry  # noqa: E402
+from src.domains.pack_format import PackManifest  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "pack_routes_under_test", REPO / "src/api/routes/pack_routes.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _manifest(version="1.0.0"):
+    return PackManifest(
+        name="energy",
+        version=version,
+        description="Energy pack",
+        source_types=["news"],
+        ui_flags={"energy": True},
+        planner_keywords={"trend": ["grid", "outage"]},
+        provisioning_templates=[
+            {"name": "energy_kg", "description": "Energy KG", "sources": ["Energy Wire"],
+             "backend": "table-prefix"}
+        ],
+    )
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOESIS_PACK_REGISTRY", str(tmp_path / "registry"))
+    monkeypatch.setenv("NOESIS_PACKS_ADMIN", "on")
+    pack_registry.publish(_manifest(), root=None)  # honours the env root
+    conn = duckdb.connect(":memory:")
+    monkeypatch.setattr(mod, "_conn", lambda: (conn, threading.Lock()))
+    app = FastAPI()
+    app.include_router(mod.router)
+    yield TestClient(app)
+    # Undo any global install state a test left behind.
+    pack_install.uninstall("energy")
+    from src.domains import registry as domain_registry
+    domain_registry._REGISTRY.pop("energy", None)
+    domain_registry._ENABLED.discard("energy")
+    conn.close()
+
+
+def test_discover_lists_published_packs(client):
+    body = client.get("/api/v1/packs").json()
+    assert body["admin_enabled"] is True
+    assert any(p["name"] == "energy" for p in body["packs"])
+    energy = next(p for p in body["packs"] if p["name"] == "energy")
+    assert energy["latest_version"] == "1.0.0"
+    assert energy["installed_version"] is None
+
+
+def test_install_then_reflects_in_discovery_and_templates(client):
+    resp = client.post("/api/v1/packs/install", json={"name": "energy"})
+    assert resp.status_code == 200
+    assert resp.json()["installed"]["name"] == "energy"
+
+    body = client.get("/api/v1/packs").json()
+    assert body["installed"] == {"energy": "1.0.0"}
+    templates = client.get("/api/v1/packs/templates").json()
+    assert any(t["name"] == "energy_kg" for t in templates["templates"])
+
+
+def test_deploy_template_stands_up_a_kg(client):
+    client.post("/api/v1/packs/install", json={"name": "energy"})
+    resp = client.post("/api/v1/packs/templates/energy_kg/deploy")
+    assert resp.status_code == 200
+    assert not resp.json()["deployed"].get("error")
+
+
+def test_uninstall_removes_the_pack(client):
+    client.post("/api/v1/packs/install", json={"name": "energy"})
+    assert client.delete("/api/v1/packs/energy").status_code == 200
+    assert client.get("/api/v1/packs/installed").json()["installed"] == {}
+
+
+def test_publish_a_new_version(client):
+    resp = client.post(
+        "/api/v1/packs/publish",
+        json={"manifest": _manifest("2.0.0").to_dict()},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["published"]["version"] == "2.0.0"
+    assert "2.0.0" in pack_registry.versions("energy", root=None)
+
+
+def test_install_unknown_pack_is_404(client):
+    assert client.post("/api/v1/packs/install", json={"name": "ghost"}).status_code == 404
+
+
+def test_mutations_are_gated_when_admin_is_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOESIS_PACK_REGISTRY", str(tmp_path / "reg2"))
+    monkeypatch.setenv("NOESIS_PACKS_ADMIN", "off")
+    pack_registry.publish(_manifest(), root=None)
+    app = FastAPI()
+    app.include_router(mod.router)
+    c = TestClient(app)
+    # Reads still work; mutations are refused with 404 (disabled).
+    assert c.get("/api/v1/packs").json()["admin_enabled"] is False
+    assert c.post("/api/v1/packs/install", json={"name": "energy"}).status_code == 404
+    assert c.delete("/api/v1/packs/energy").status_code == 404


### PR DESCRIPTION
## Summary

Follow-up to the M9 milestone: the registry and installer existed only as Python libraries. This exposes them over HTTP so an operator (and the frontend) can discover, install, and manage domain packs at runtime — no code changes.

## What changed

- **`src/api/routes/pack_routes.py`** (new):
  - `GET /api/v1/packs` — discover published packs with their installed state and the admin-enabled flag,
  - `GET /api/v1/packs/installed`, `GET /api/v1/packs/templates`,
  - `POST /api/v1/packs/install` `{name, version?}`, `DELETE /api/v1/packs/{name}`,
  - `POST /api/v1/packs/publish` `{manifest}`, `POST /api/v1/packs/templates/{name}/deploy`.

  Reads are always available. The mutating operations change the running instance, so they are gated behind **`NOESIS_PACKS_ADMIN`** (off by default), and `GET /api/v1/packs` reports whether they are enabled so the frontend can adapt — the same gated-flag discipline the data proxy uses.
- **`src/api/app.py`**: wired behind the same try-import pattern as the other genui routers, reported in the router-availability status.

## Testing

- `tests/unit/api/routes/test_pack_routes.py` — discover → install → deploy-template → uninstall and publish through HTTP against a temp registry and an in-memory warehouse; unknown-pack 404; and mutations refused (404) when admin is off. 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_