### PR TITLE
Live entry point: agent host API routes

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -33,6 +33,7 @@ GENUI_ROUTES_AVAILABLE = False
 GENUI_DATA_ROUTES_AVAILABLE = False
 CANVAS_ROUTES_AVAILABLE = False
 PACK_ROUTES_AVAILABLE = False
+AGENT_ROUTES_AVAILABLE = False
 
 # Store imported modules globally
 _imported_modules = {}
@@ -420,6 +421,19 @@ def try_import_pack_routes():
         return False
 
 
+def try_import_agent_routes():
+    """Try to import the agent host routes (M10: analyst/investigator/replay)."""
+    global AGENT_ROUTES_AVAILABLE
+    try:
+        from src.api.routes import agent_routes
+        _imported_modules['agent_routes'] = agent_routes
+        AGENT_ROUTES_AVAILABLE = True
+        return True
+    except ImportError:
+        AGENT_ROUTES_AVAILABLE = False
+        return False
+
+
 def try_import_report_routes():
     """Try to import report generation routes (issues #51, #52)."""
     global REPORT_ROUTES_AVAILABLE
@@ -481,6 +495,7 @@ def check_all_imports():
     try_import_genui_data_routes()
     try_import_canvas_routes()
     try_import_pack_routes()
+    try_import_agent_routes()
     _load_domain_packs()
 
 
@@ -832,6 +847,13 @@ def include_optional_routers(app):
             app.include_router(pack_routes.router)
             routers_included += 1
 
+    # Include the agent host routes (M10: analyst/investigator/replay).
+    if AGENT_ROUTES_AVAILABLE:
+        agent_routes = _imported_modules.get('agent_routes')
+        if agent_routes:
+            app.include_router(agent_routes.router)
+            routers_included += 1
+
     return routers_included
 
 
@@ -953,6 +975,7 @@ async def root():
             "generative_ui_data": GENUI_DATA_ROUTES_AVAILABLE,
             "generative_ui_canvas": CANVAS_ROUTES_AVAILABLE,
             "domain_packs": PACK_ROUTES_AVAILABLE,
+            "agent": AGENT_ROUTES_AVAILABLE,
         },
     }
 

--- a/src/api/routes/agent_routes.py
+++ b/src/api/routes/agent_routes.py
@@ -1,0 +1,163 @@
+"""Agent host routes (M10, live entry point).
+
+Expose the M10 analyst and investigator agents over HTTP so an operator (and the
+frontend) can launch an agent on a goal at runtime and replay its audit trail:
+
+    GET  /api/v1/agent                    whether the agent API is enabled
+    POST /api/v1/agent/analyst            run the analyst on a goal
+    POST /api/v1/agent/investigator       run an investigation
+    GET  /api/v1/agent/runs/{run_id}      replay a run from the audit trail
+
+An agent provisions KGs and drives the whole surface, so the run endpoints are
+gated behind ``NOESIS_AGENT_API`` (off by default). Each run is driven over the
+in-process backend against the shared warehouse, with the provisioning audit
+sink attached so every call is recorded and replayable (M10.4).
+"""
+
+import os
+import secrets
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from src.agent.analyst import AnalystAgent
+from src.agent.audit import provisioning_audit_sink, replay_run
+from src.agent.investigator import InvestigatorAgent
+from src.agent.local_backend import build_local_caller
+from src.agent.runtime import AgentRuntime, Budget
+
+router = APIRouter(prefix="/api/v1/agent", tags=["agent"])
+
+
+def agent_enabled() -> bool:
+    """Whether the agent run endpoints are enabled (``NOESIS_AGENT_API``)."""
+    return os.getenv("NOESIS_AGENT_API", "off").lower() in ("on", "1", "true")
+
+
+def _require_enabled() -> None:
+    if not agent_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail="agent API is disabled (set NOESIS_AGENT_API=on)",
+        )
+
+
+def _conn():
+    from src.database.local_analytics_connector import _LOCK, get_shared_connection
+
+    return get_shared_connection(), _LOCK
+
+
+class AnalystRequest(BaseModel):
+    goal: str = Field(..., max_length=500)
+    kg_name: Optional[str] = Field(default=None, max_length=64)
+    sources: Optional[List[str]] = None
+    topic: Optional[str] = None
+    entity: Optional[str] = None
+    claim_id: Optional[str] = None
+    source: Optional[str] = None
+    max_steps: int = Field(default=24, ge=1, le=100)
+
+
+class InvestigatorRequest(BaseModel):
+    title: str = Field(..., max_length=200)
+    entities: Optional[List[str]] = None
+    related_pair: Optional[Tuple[str, str]] = None
+    topic: Optional[str] = None
+    claim_id: Optional[str] = None
+    sources: Optional[List[str]] = None
+    max_steps: int = Field(default=24, ge=1, le=100)
+
+
+@router.get("")
+def status() -> Dict[str, Any]:
+    """Whether the agent run endpoints are enabled."""
+    return {"enabled": agent_enabled()}
+
+
+@router.post("/analyst")
+def run_analyst(request: AnalystRequest) -> Dict[str, Any]:
+    """Run the analyst agent on a goal (goal -> KG -> OSINT -> canvas), recording
+    every call to the audit trail under a fresh run id."""
+    _require_enabled()
+    conn, lock = _conn()
+    run_id = "analyst-" + secrets.token_urlsafe(6)
+    try:
+        with lock:
+            runtime = AgentRuntime(
+                build_local_caller(conn),
+                budget=Budget(max_steps=request.max_steps),
+                audit_sink=provisioning_audit_sink(conn, run_id),
+            )
+            result = AnalystAgent(runtime).run(
+                request.goal,
+                kg_name=request.kg_name,
+                sources=request.sources,
+                topic=request.topic,
+                entity=request.entity,
+                claim_id=request.claim_id,
+                source=request.source,
+            )
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"analyst run failed: {err}")
+    return {
+        "run_id": run_id,
+        "goal": result.goal,
+        "kg": result.kg,
+        "osint": result.osint,
+        "canvas": result.canvas,
+        "steps": result.steps,
+        "findings": result.findings,
+    }
+
+
+@router.post("/investigator")
+def run_investigator(request: InvestigatorRequest) -> Dict[str, Any]:
+    """Run an investigation (open KG -> R11 surface -> canvas), respecting the
+    review gate and recording every call to the audit trail."""
+    _require_enabled()
+    conn, lock = _conn()
+    run_id = "investigation-" + secrets.token_urlsafe(6)
+    try:
+        with lock:
+            runtime = AgentRuntime(
+                build_local_caller(conn),
+                budget=Budget(max_steps=request.max_steps),
+                audit_sink=provisioning_audit_sink(conn, run_id),
+            )
+            result = InvestigatorAgent(runtime).run(
+                request.title,
+                entities=request.entities,
+                related_pair=request.related_pair,
+                topic=request.topic,
+                claim_id=request.claim_id,
+                sources=request.sources,
+            )
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"investigation run failed: {err}")
+    return {
+        "run_id": run_id,
+        "title": result.title,
+        "kg": result.kg,
+        "surface": result.surface,
+        "audit": result.audit,
+        "canvas": result.canvas,
+        "steps": result.steps,
+        "gated_calls": result.gated_calls,
+        "findings": result.findings,
+    }
+
+
+@router.get("/runs/{run_id}")
+def run_audit(run_id: str) -> Dict[str, Any]:
+    """Replay a run from the audit trail: its ordered tool calls."""
+    conn, lock = _conn()
+    try:
+        with lock:
+            calls = replay_run(conn, run_id)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"run replay failed: {err}")
+    if not calls:
+        raise HTTPException(status_code=404, detail=f"no audit trail for run {run_id!r}")
+    return {"run_id": run_id, "calls": calls, "count": len(calls)}

--- a/tests/unit/api/routes/test_agent_routes.py
+++ b/tests/unit/api/routes/test_agent_routes.py
@@ -1,0 +1,126 @@
+"""Route tests for src/api/routes/agent_routes.py (M10 agents, live entry point).
+
+Loads the route module BY PATH, points the warehouse at a seeded in-memory
+DuckDB, and drives the analyst / investigator / replay endpoints through HTTP.
+"""
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("fastapi")
+duckdb = pytest.importorskip("duckdb")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "agent_routes_under_test", REPO / "src/api/routes/agent_routes.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _seed(conn):
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, content VARCHAR, "
+        "publish_date TIMESTAMP, source VARCHAR, category VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO news_articles (id, title, url, source, publish_date) VALUES (?,?,?,?,?)",
+        [
+            ("d1", "Delta flooding", "http://a/1", "Alpha Wire", "2026-06-01"),
+            ("d2", "Delta support", "http://b/1", "Beta Journal", "2026-06-02"),
+            ("d3", "Delta support two", "http://c/1", "Gamma Review", "2026-06-03"),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE argument_claims (claim_id VARCHAR, claim_text VARCHAR, document_id VARCHAR, "
+        "source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO argument_claims VALUES ('k1', 'Severe flooding struck the delta.', 'd1', 'news', 0.9, NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE claim_evidence (evidence_id VARCHAR, claim_id VARCHAR, evidence_text VARCHAR, "
+        "evidence_document_id VARCHAR, evidence_source_type VARCHAR, relation VARCHAR, "
+        "similarity_score DOUBLE, found_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO claim_evidence (evidence_id, claim_id, evidence_document_id, "
+        "evidence_source_type, relation, similarity_score) VALUES (?,?,?,?,?,?)",
+        [("e1", "k1", "d2", "news", "supports", 0.88), ("e2", "k1", "d3", "news", "supports", 0.82)],
+    )
+    conn.execute(
+        "CREATE TABLE document_actors (document_id VARCHAR, source_type VARCHAR, actor_name VARCHAR, "
+        "entity_id VARCHAR, role VARCHAR, confidence DOUBLE, extracted_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO document_actors (document_id, actor_name, entity_id, role) VALUES (?,?,?,?)",
+        [("d1", "Jordan Rivera", "person:jr", "speaker"), ("d1", "Casey Morgan", "person:cm", "subject")],
+    )
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("NOESIS_AGENT_API", "on")
+    monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "off")
+    conn = duckdb.connect(":memory:")
+    _seed(conn)
+    monkeypatch.setattr(mod, "_conn", lambda: (conn, threading.Lock()))
+    app = FastAPI()
+    app.include_router(mod.router)
+    yield TestClient(app)
+    conn.close()
+
+
+def test_analyst_run_then_replay(client):
+    resp = client.post(
+        "/api/v1/agent/analyst",
+        json={"goal": "flooding in the delta", "sources": ["Alpha Wire"],
+              "claim_id": "k1", "source": "Alpha Wire"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"].startswith("analyst-")
+    assert body["kg"]["provisioned"] is True
+    assert body["findings"] >= 2
+    assert body["canvas"]["spec_version"] == "ui-spec-v1"
+
+    # The run is replayable from its audit trail.
+    replay = client.get(f"/api/v1/agent/runs/{body['run_id']}")
+    assert replay.status_code == 200
+    assert replay.json()["count"] == body["steps"]
+
+
+def test_investigator_run_respects_the_gate(client):
+    resp = client.post(
+        "/api/v1/agent/investigator",
+        json={"title": "delta response", "entities": ["Jordan Rivera"],
+              "related_pair": ["Jordan Rivera", "Casey Morgan"], "topic": "delta", "claim_id": "k1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["gated_calls"] == 0  # never touches a gated tool while the gate is off
+    assert body["findings"] >= 2
+    assert body["canvas"]["spec_version"] == "ui-spec-v1"
+
+
+def test_status_and_gating(monkeypatch):
+    monkeypatch.setenv("NOESIS_AGENT_API", "off")
+    app = FastAPI()
+    app.include_router(mod.router)
+    c = TestClient(app)
+    assert c.get("/api/v1/agent").json()["enabled"] is False
+    assert c.post("/api/v1/agent/analyst", json={"goal": "x"}).status_code == 404
+
+
+def test_replay_unknown_run_is_404(client):
+    assert client.get("/api/v1/agent/runs/does-not-exist").status_code == 404


### PR DESCRIPTION
## Summary

Follow-up to the M10 milestone: the analyst/investigator agents and audit replay existed only as Python libraries. This exposes them over HTTP so an operator (and the frontend) can launch an agent on a goal at runtime and replay its audit trail.

## What changed

- **`src/api/routes/agent_routes.py`** (new):
  - `GET /api/v1/agent` — whether the agent API is enabled,
  - `POST /api/v1/agent/analyst` — run the analyst (goal → KG → OSINT → canvas),
  - `POST /api/v1/agent/investigator` — run an investigation (open KG → R11 surface → canvas), respecting the review gate,
  - `GET /api/v1/agent/runs/{run_id}` — replay a run from the audit trail.

  Each run is driven over the in-process backend against the shared warehouse, with the provisioning audit sink attached, so every call is recorded and replayable (M10.4). Because an agent provisions KGs and drives the whole surface, the run endpoints are gated behind **`NOESIS_AGENT_API`** (off by default).
- **`src/api/app.py`**: wired behind the same try-import pattern as the other routers, reported in router-availability status.

## Testing

- `tests/unit/api/routes/test_agent_routes.py` — an analyst run + replay (`count == steps`), an investigator run (`gated_calls == 0`, valid canvas), status/gating (404 when disabled), and unknown-run replay 404 — against a seeded in-memory warehouse. 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_