### PR TITLE
Frontend: canvas save / reopen / share (M8)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,34 @@ import Sidebar from "./components/Sidebar";
 import TopBar from "./components/TopBar";
 import BreakingTicker from "./components/BreakingTicker";
 import Canvas from "./genui/Canvas";
+import SavedCanvasView from "./genui/SavedCanvasView";
+
+// A read-only shared canvas is opened via ?shared=<token> (M8): the whole app
+// becomes the shared view — no composer, no sidebar — so a recipient sees only
+// the canvas and cannot edit it.
+function sharedToken(): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get("shared");
+  } catch {
+    return null;
+  }
+}
+
+function SharedApp({ token }: { token: string }) {
+  return (
+    <div className="flex h-screen w-full flex-col overflow-hidden bg-background text-foreground">
+      <div className="flex items-center gap-3 border-b px-5 py-3">
+        <div className="glow-text font-grotesk text-base font-bold tracking-tight">Noesis</div>
+        <span className="font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60">
+          SHARED CANVAS
+        </span>
+      </div>
+      <main className="min-h-0 flex-1">
+        <SavedCanvasView sharedToken={token} />
+      </main>
+    </div>
+  );
+}
 
 // The app is a single generative surface: nothing is rendered until an
 // intent is submitted through the composer (or a sidebar suggestion) — the
@@ -13,12 +41,16 @@ export default function App() {
   const { data: telemetry } = useUiTelemetry();
   const hasIntent = manager.active.intent.trim().length > 0;
 
+  const token = sharedToken();
+  if (token) return <SharedApp token={token} />;
+
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
       <Sidebar
         canvases={manager.canvases}
         activeId={manager.active.id}
         onSelect={manager.setActive}
+        onOpenSaved={manager.openSaved}
         onRemove={manager.remove}
         ingestRate="64"
       />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,8 +3,9 @@
 // else is generated — intents come from the composer, and suggestions live
 // on the empty canvas itself.
 
-import { Plus, Sparkles, X } from "lucide-react";
+import { Bookmark, Plus, Share2, Sparkles, X } from "lucide-react";
 import { HOME, type CanvasDef } from "../genui/canvases";
+import { useSavedCanvases } from "../genui/useSavedCanvases";
 import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 
@@ -12,11 +13,13 @@ interface Props {
   canvases: CanvasDef[];
   activeId: string;
   onSelect: (id: string) => void;
+  onOpenSaved: (savedId: string, label: string) => void;
   onRemove: (id: string) => void;
   ingestRate: string;
 }
 
-export default function Sidebar({ canvases, activeId, onSelect, onRemove, ingestRate }: Props) {
+export default function Sidebar({ canvases, activeId, onSelect, onOpenSaved, onRemove, ingestRate }: Props) {
+  const { data: saved } = useSavedCanvases();
   return (
     <aside className="flex w-60 shrink-0 flex-col border-r bg-[#070d13]">
       {/* Brand */}
@@ -69,6 +72,33 @@ export default function Sidebar({ canvases, activeId, onSelect, onRemove, ingest
             ) : null}
           </Button>
         ))}
+
+        {/* Server-persisted canvases (M8): saved and shareable, reopened by id. */}
+        {saved && saved.length > 0 ? (
+          <>
+            <div className="px-2.5 pb-1.5 pt-4 font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60">
+              SAVED
+            </div>
+            {saved.map((s) => (
+              <Button
+                key={s.id}
+                variant="ghost"
+                onClick={() => onOpenSaved(s.id, s.title)}
+                title={`Reopen saved canvas — ${s.panel_count} panel${s.panel_count === 1 ? "" : "s"}`}
+                className={cn(
+                  "h-auto w-full justify-start gap-2.5 px-2.5 py-2 text-[13px] font-medium text-muted-foreground",
+                  `s-${s.id}` === activeId && "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
+                )}
+              >
+                <span className="w-[18px] shrink-0 text-center">
+                  <Bookmark className="size-3.5" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-left">{s.title}</span>
+                {s.shared ? <Share2 className="size-3 shrink-0 text-sky-400/70" /> : null}
+              </Button>
+            ))}
+          </>
+        ) : null}
       </nav>
 
       {/* Footer */}

--- a/apps/web/src/genui/Canvas.tsx
+++ b/apps/web/src/genui/Canvas.tsx
@@ -5,6 +5,8 @@
 
 import { RotateCcw } from "lucide-react";
 import SpecRenderer from "./SpecRenderer";
+import SavedCanvasView from "./SavedCanvasView";
+import CanvasActions from "./CanvasActions";
 import EntityGraph from "../components/charts/EntityGraph";
 import { useArticles, useClusters, useEntityGraph, useUiTelemetry } from "../lib/queries";
 import { useUiSpec } from "./useUiSpec";
@@ -143,10 +145,20 @@ interface Props {
 
 export default function Canvas({ canvas, onIntent }: Props) {
   const adaptive = useAdaptiveSignals();
+  const isSaved = !!canvas.savedId;
   const hasIntent = canvas.intent.trim().length > 0;
-  const { spec, source, isLoading } = useUiSpec(canvas.intent, adaptive.signals, hasIntent);
+  const { spec, source, isLoading } = useUiSpec(canvas.intent, adaptive.signals, hasIntent && !isSaved);
 
   const planner = PLANNER_BADGE[spec.generated_by] ?? PLANNER_BADGE.heuristic;
+
+  // A server-persisted canvas renders from its stored spec, not a fresh plan.
+  if (isSaved && canvas.savedId) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <SavedCanvasView savedId={canvas.savedId} />
+      </div>
+    );
+  }
 
   if (!hasIntent) {
     return (
@@ -197,6 +209,8 @@ export default function Canvas({ canvas, onIntent }: Props) {
             <RotateCcw className="!size-3" /> RESET
           </Button>
         ) : null}
+        {/* Persist / share this canvas server-side (M8). */}
+        <CanvasActions spec={spec} />
       </div>
 
       <SpecRenderer spec={spec} adaptive={adaptive} />

--- a/apps/web/src/genui/CanvasActions.tsx
+++ b/apps/web/src/genui/CanvasActions.tsx
@@ -1,0 +1,93 @@
+// Save / share actions for a generated canvas (M8). "Save" persists the
+// current ui-spec server-side; "Share" mints a read-only link (saving first
+// if needed) and copies it to the clipboard.
+
+import { useState } from "react";
+import { Check, Copy, Save, Share2 } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { useSaveCanvas, useShareCanvas } from "./useSavedCanvases";
+import type { UISpec } from "./spec";
+
+export default function CanvasActions({ spec }: { spec: UISpec }) {
+  const save = useSaveCanvas();
+  const share = useShareCanvas();
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const ensureSaved = async (): Promise<string> => {
+    if (savedId) {
+      await save.mutateAsync({ spec, title: spec.title, id: savedId });
+      return savedId;
+    }
+    const canvas = await save.mutateAsync({ spec, title: spec.title });
+    setSavedId(canvas.id);
+    return canvas.id;
+  };
+
+  const onSave = () => {
+    ensureSaved().catch(() => undefined);
+  };
+
+  const onShare = () => {
+    (async () => {
+      const id = await ensureSaved();
+      const link = await share.mutateAsync(id);
+      setShareUrl(link.url);
+      try {
+        await navigator.clipboard.writeText(link.url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1600);
+      } catch {
+        // Clipboard unavailable; the link is still shown for manual copy.
+      }
+    })().catch(() => undefined);
+  };
+
+  const busy = save.isPending || share.isPending;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-6 rounded-md px-2 font-mono text-[10px]"
+        onClick={onSave}
+        disabled={busy}
+        title="Save this canvas to your account"
+      >
+        {savedId ? <Check className="!size-3" /> : <Save className="!size-3" />}
+        {savedId ? "SAVED" : "SAVE"}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-6 rounded-md px-2 font-mono text-[10px]"
+        onClick={onShare}
+        disabled={busy}
+        title="Create a read-only share link"
+      >
+        <Share2 className="!size-3" /> SHARE
+      </Button>
+      {shareUrl ? (
+        <button
+          type="button"
+          onClick={() => {
+            navigator.clipboard?.writeText(shareUrl).then(
+              () => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1600);
+              },
+              () => undefined,
+            );
+          }}
+          title={shareUrl}
+          className="flex items-center gap-1 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          {copied ? <Check className="size-3 text-emerald-400" /> : <Copy className="size-3" />}
+          {copied ? "link copied" : "copy link"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/genui/SavedCanvasView.tsx
+++ b/apps/web/src/genui/SavedCanvasView.tsx
@@ -1,0 +1,63 @@
+// Renders a server-persisted canvas (M8): a saved canvas fetched by id, or a
+// read-only shared canvas fetched by token. Both render the stored ui-spec
+// through the same SpecRenderer the generative canvas uses.
+
+import SpecRenderer from "./SpecRenderer";
+import { useAdaptiveSignals } from "./signals";
+import { useSavedCanvas, useSharedCanvas } from "./useSavedCanvases";
+import { Badge } from "../components/ui/badge";
+
+interface Props {
+  savedId?: string;
+  sharedToken?: string;
+}
+
+export default function SavedCanvasView({ savedId, sharedToken }: Props) {
+  const adaptive = useAdaptiveSignals();
+  const saved = useSavedCanvas(sharedToken ? null : savedId ?? null);
+  const shared = useSharedCanvas(sharedToken ?? null);
+  const readOnly = !!sharedToken;
+  const query = readOnly ? shared : saved;
+  const spec = query.data?.spec;
+
+  if (query.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center font-mono text-[11px] text-muted-foreground">
+        loading canvas…
+      </div>
+    );
+  }
+
+  if (query.isError || !spec) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-1 font-mono text-[11px] text-muted-foreground">
+        <span>{readOnly ? "shared canvas not found or link revoked" : "saved canvas unavailable"}</span>
+        <span className="text-muted-foreground/50">the persisted-canvas API may be disabled</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto px-6 pb-6 pt-5">
+      <div className="mb-4 flex flex-wrap items-center gap-2.5">
+        <Badge
+          variant="outline"
+          className={
+            readOnly
+              ? "border-sky-400/30 bg-sky-400/10 text-sky-400"
+              : "border-emerald-400/30 bg-emerald-400/10 text-emerald-400"
+          }
+          title={readOnly ? "A read-only shared canvas" : "A saved canvas"}
+        >
+          {readOnly ? "SHARED · READ-ONLY" : "SAVED"}
+        </Badge>
+        <span className="font-grotesk text-sm font-semibold">{spec.title}</span>
+        {spec.subtitle ? (
+          <span className="font-mono text-[10.5px] text-muted-foreground">{spec.subtitle}</span>
+        ) : null}
+      </div>
+
+      <SpecRenderer spec={spec} adaptive={adaptive} />
+    </div>
+  );
+}

--- a/apps/web/src/genui/canvases.ts
+++ b/apps/web/src/genui/canvases.ts
@@ -9,6 +9,9 @@ export interface CanvasDef {
   id: string;
   label: string;
   intent: string;
+  // Set when this canvas is a server-persisted one (M8): it renders from the
+  // saved spec (fetched by id) rather than from a freshly generated intent.
+  savedId?: string;
 }
 
 // The home canvas is intentionally empty: startup shows a bare surface
@@ -65,6 +68,7 @@ export interface CanvasManager {
   active: CanvasDef;
   setActive: (id: string) => void;
   open: (intent: string, label?: string) => void;
+  openSaved: (savedId: string, label: string) => void;
   remove: (id: string) => void;
 }
 
@@ -102,6 +106,17 @@ export function useCanvases(): CanvasManager {
     [update],
   );
 
+  const openSaved = useCallback(
+    (savedId: string, label: string) =>
+      update((s) => {
+        const existing = s.canvases.find((c) => c.savedId === savedId);
+        if (existing) return { ...s, activeId: existing.id };
+        const canvas: CanvasDef = { id: `s-${savedId}`, label, intent: "", savedId };
+        return { canvases: [...s.canvases, canvas], activeId: canvas.id };
+      }),
+    [update],
+  );
+
   const remove = useCallback(
     (id: string) =>
       update((s) => {
@@ -113,5 +128,5 @@ export function useCanvases(): CanvasManager {
   );
 
   const active = state.canvases.find((c) => c.id === state.activeId) ?? HOME;
-  return { canvases: state.canvases, active, setActive, open, remove };
+  return { canvases: state.canvases, active, setActive, open, openSaved, remove };
 }

--- a/apps/web/src/genui/useSavedCanvases.ts
+++ b/apps/web/src/genui/useSavedCanvases.ts
@@ -1,0 +1,63 @@
+// React-query hooks over the persisted-canvas API (M8): list saved canvases,
+// fetch one by id, resolve a shared link, and the save / share / delete
+// mutations that keep the list fresh.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { canvasApi, type SavedCanvas, type SavedCanvasSummary, type SharedCanvas } from "../lib/canvasStore";
+import type { UISpec } from "./spec";
+
+const LIST_KEY = ["savedCanvases"];
+
+export function useSavedCanvases() {
+  return useQuery<SavedCanvasSummary[]>({
+    queryKey: LIST_KEY,
+    queryFn: canvasApi.list,
+    staleTime: 30_000,
+    retry: false,
+    // The API may be unreachable (dev without backend); an empty list keeps
+    // the sidebar quiet rather than throwing.
+    placeholderData: [],
+  });
+}
+
+export function useSavedCanvas(id: string | null) {
+  return useQuery<SavedCanvas>({
+    enabled: !!id,
+    queryKey: ["savedCanvas", id],
+    queryFn: () => canvasApi.get(id as string),
+    retry: false,
+  });
+}
+
+export function useSharedCanvas(token: string | null) {
+  return useQuery<SharedCanvas>({
+    enabled: !!token,
+    queryKey: ["sharedCanvas", token],
+    queryFn: () => canvasApi.getShared(token as string),
+    retry: false,
+  });
+}
+
+export function useSaveCanvas() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { spec: UISpec; title?: string; id?: string }) => canvasApi.save(vars),
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}
+
+export function useShareCanvas() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => canvasApi.share(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}
+
+export function useDeleteCanvas() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => canvasApi.remove(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}

--- a/apps/web/src/lib/canvasStore.ts
+++ b/apps/web/src/lib/canvasStore.ts
@@ -1,0 +1,137 @@
+// Typed client for the persisted-canvas API (M8): save a canvas server-side,
+// list and reopen saved canvases, and mint / open read-only share links.
+//
+// A canvas is owned by a stable, per-browser identity sent as X-Canvas-Owner;
+// the backend scopes reads and writes to it. Shared links carry no owner and
+// resolve read-only for anyone.
+
+import type { UISpec } from "../genui/spec";
+
+const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+const TIMEOUT_MS = 8000;
+const OWNER_KEY = "noesis.canvas.owner";
+
+export class CanvasApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "CanvasApiError";
+  }
+}
+
+// A stable owner id for this browser, minted once and kept in localStorage.
+function ownerId(): string {
+  try {
+    let id = window.localStorage.getItem(OWNER_KEY);
+    if (!id) {
+      const rand =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2);
+      id = `web-${rand}`;
+      window.localStorage.setItem(OWNER_KEY, id);
+    }
+    return id;
+  } catch {
+    return "web-local";
+  }
+}
+
+async function call<T>(
+  path: string,
+  opts: { method?: string; body?: unknown; owner?: boolean } = {},
+): Promise<T> {
+  const url = new URL(BASE_URL + path, BASE_URL || window.location.origin);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  if (opts.owner !== false) headers["X-Canvas-Owner"] = ownerId();
+  try {
+    const res = await fetch(url.toString(), {
+      method: opts.method ?? "GET",
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new CanvasApiError(`Request failed: ${path}`, res.status);
+    return (await res.json()) as T;
+  } catch (err) {
+    if (err instanceof CanvasApiError) throw err;
+    throw new CanvasApiError(err instanceof Error ? err.message : `Request error: ${path}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------- response shapes ----------
+
+export interface SavedCanvas {
+  id: string;
+  owner: string;
+  title: string;
+  spec: UISpec;
+  data_bindings: Record<string, unknown>;
+  share_token: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface SavedCanvasSummary {
+  id: string;
+  title: string;
+  topic: string | null;
+  panel_count: number;
+  shared: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface SharedCanvas {
+  id: string;
+  title: string;
+  spec: UISpec;
+  data_bindings: Record<string, unknown>;
+  read_only: true;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface ShareLink {
+  canvas_id: string;
+  share_token: string;
+  url: string;
+}
+
+// ---------- endpoint calls ----------
+
+export const canvasApi = {
+  save: (body: { spec: UISpec; title?: string; id?: string; data_bindings?: Record<string, unknown> }) =>
+    call<{ canvas: SavedCanvas }>("/api/v1/ui/canvas", { method: "POST", body }).then((r) => r.canvas),
+
+  list: () =>
+    call<{ canvases: SavedCanvasSummary[]; count: number }>("/api/v1/ui/canvas").then((r) => r.canvases),
+
+  get: (id: string) =>
+    call<{ canvas: SavedCanvas }>(`/api/v1/ui/canvas/${encodeURIComponent(id)}`).then((r) => r.canvas),
+
+  remove: (id: string) =>
+    call<{ deleted: string }>(`/api/v1/ui/canvas/${encodeURIComponent(id)}`, { method: "DELETE" }),
+
+  share: (id: string) =>
+    call<ShareLink>(`/api/v1/ui/canvas/${encodeURIComponent(id)}/share`, { method: "POST" }),
+
+  unshare: (id: string) =>
+    call<{ canvas_id: string; revoked: boolean }>(
+      `/api/v1/ui/canvas/${encodeURIComponent(id)}/share`,
+      { method: "DELETE" },
+    ),
+
+  // The read-only viewer path: no owner header, resolves for anyone.
+  getShared: (token: string) =>
+    call<{ canvas: SharedCanvas }>(`/api/v1/ui/canvas/shared/${encodeURIComponent(token)}`, {
+      owner: false,
+    }).then((r) => r.canvas),
+};


### PR DESCRIPTION
## Summary

Follow-up to M8: the persisted-canvas + sharing API existed with no UI. This wires it into the generative canvas app so a user can save a canvas, reopen it, and share a read-only link.

## What changed (apps/web)

- **`lib/canvasStore.ts`** — typed client for the M8 routes with a stable per-browser `X-Canvas-Owner` identity (save / list / get / delete / share / getShared).
- **`genui/useSavedCanvases.ts`** — react-query hooks over the client (list, fetch-by-id, resolve-shared, and save / share / delete mutations that keep the list fresh).
- **`genui/CanvasActions.tsx`** — **Save** and **Share** buttons in the canvas provenance strip; Share mints a read-only link (saving first if needed) and copies it to the clipboard.
- **`genui/SavedCanvasView.tsx`** — renders a saved canvas (by id) or a read-only shared canvas (by token) through the same `SpecRenderer` the generative canvas uses.
- **Sidebar** gains a **SAVED** section listing server-persisted canvases (reopened by id, sharing marked); the canvas manager gains `openSaved`; **App** renders a full-screen read-only view when opened via `?shared=<token>` (no composer, no sidebar — a recipient sees only the canvas and cannot edit it).

## Verification

- `tsc --noEmit` clean.
- `vite build` succeeds (1870 modules transformed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_