### PR TITLE
Frontend: domain-pack manager + generic pack-panel rendering (M9)

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@
 import { Bookmark, Plus, Share2, Sparkles, X } from "lucide-react";
 import { HOME, type CanvasDef } from "../genui/canvases";
 import { useSavedCanvases } from "../genui/useSavedCanvases";
+import PacksButton from "../genui/PacksButton";
 import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 
@@ -103,6 +104,8 @@ export default function Sidebar({ canvases, activeId, onSelect, onOpenSaved, onR
 
       {/* Footer */}
       <div className="flex flex-col gap-2 border-t px-4 py-3.5">
+        {/* Domain-pack manager (M9). */}
+        <PacksButton />
         <div className="flex items-center gap-2">
           <span className="h-[7px] w-[7px] rounded-full bg-emerald-400" style={{ animation: "blink 2s infinite" }} />
           <span className="font-mono text-[10.5px] text-muted-foreground">PIPELINE LIVE</span>

--- a/apps/web/src/genui/PacksButton.tsx
+++ b/apps/web/src/genui/PacksButton.tsx
@@ -1,0 +1,164 @@
+// Domain-pack manager (M9): a sidebar entry point that opens a modal to
+// discover published packs, install / uninstall them, and deploy their
+// provisioning templates. Mutations are disabled unless the backend has
+// NOESIS_PACKS_ADMIN enabled.
+
+import { useState } from "react";
+import { Boxes, Check, Download, Loader2, Trash2, X } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
+import {
+  useDeployTemplate,
+  useInstallPack,
+  usePackDiscovery,
+  usePackTemplates,
+  useUninstallPack,
+} from "./usePacks";
+
+function PacksModal({ onClose }: { onClose: () => void }) {
+  const discovery = usePackDiscovery();
+  const templates = usePackTemplates();
+  const install = useInstallPack();
+  const uninstall = useUninstallPack();
+  const deploy = useDeployTemplate();
+  const [deployed, setDeployed] = useState<Record<string, boolean>>({});
+
+  const admin = discovery.data?.admin_enabled ?? false;
+  const packs = discovery.data?.packs ?? [];
+  const busy = install.isPending || uninstall.isPending;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border bg-[#070d13] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2.5 border-b px-5 py-3.5">
+          <Boxes className="size-4 text-primary" />
+          <span className="font-grotesk text-sm font-semibold">Domain packs</span>
+          {!admin ? (
+            <Badge variant="outline" className="border-amber-400/30 bg-amber-400/10 text-amber-400" title="Set NOESIS_PACKS_ADMIN=on to install">
+              READ-ONLY
+            </Badge>
+          ) : null}
+          <span className="flex-1" />
+          <button onClick={onClose} className="rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground">
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          {discovery.isLoading ? (
+            <div className="py-8 text-center font-mono text-[11px] text-muted-foreground">loading packs…</div>
+          ) : discovery.isError ? (
+            <div className="py-8 text-center font-mono text-[11px] text-muted-foreground">
+              the pack API is unavailable
+            </div>
+          ) : packs.length === 0 ? (
+            <div className="py-8 text-center font-mono text-[11px] text-muted-foreground">
+              no packs published to the registry
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2.5">
+              {packs.map((p) => {
+                const installed = !!p.installed_version;
+                return (
+                  <div key={p.name} className="rounded-lg border bg-secondary/30 px-3.5 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="font-grotesk text-[13px] font-semibold">{p.name}</span>
+                      <span className="font-mono text-[10px] text-muted-foreground/60">
+                        v{p.latest_version ?? "?"}
+                      </span>
+                      {installed ? (
+                        <Badge variant="live" title={`Installed v${p.installed_version}`}>INSTALLED</Badge>
+                      ) : null}
+                      <span className="flex-1" />
+                      {installed ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-6 rounded-md px-2 font-mono text-[10px]"
+                          disabled={!admin || busy}
+                          onClick={() => uninstall.mutate(p.name)}
+                          title={admin ? "Uninstall this pack" : "Enable NOESIS_PACKS_ADMIN to uninstall"}
+                        >
+                          <Trash2 className="!size-3" /> REMOVE
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-6 rounded-md px-2 font-mono text-[10px]"
+                          disabled={!admin || busy}
+                          onClick={() => install.mutate({ name: p.name })}
+                          title={admin ? "Install this pack" : "Enable NOESIS_PACKS_ADMIN to install"}
+                        >
+                          {install.isPending ? <Loader2 className="!size-3 animate-spin" /> : <Download className="!size-3" />}
+                          INSTALL
+                        </Button>
+                      )}
+                    </div>
+                    {p.description ? (
+                      <p className="mt-1.5 text-[11.5px] leading-snug text-muted-foreground">{p.description}</p>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Provisioning templates enabled by installed packs. */}
+          {templates.data && templates.data.length > 0 ? (
+            <div className="mt-5">
+              <div className="mb-2 font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60">
+                PROVISIONING TEMPLATES
+              </div>
+              <div className="flex flex-col gap-2">
+                {templates.data.map((t) => (
+                  <div key={t.name} className="flex items-center gap-2 rounded-lg border bg-secondary/30 px-3.5 py-2.5">
+                    <span className="font-mono text-[12px]">{t.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{t.description}</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 rounded-md px-2 font-mono text-[10px]"
+                      disabled={!admin || deploy.isPending}
+                      onClick={() =>
+                        deploy.mutate(t.name, { onSuccess: () => setDeployed((d) => ({ ...d, [t.name]: true })) })
+                      }
+                      title={admin ? "Deploy this template's knowledge graph" : "Enable NOESIS_PACKS_ADMIN to deploy"}
+                    >
+                      {deployed[t.name] ? <Check className="!size-3 text-emerald-400" /> : null}
+                      {deployed[t.name] ? "DEPLOYED" : "DEPLOY KG"}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PacksButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 w-full justify-start gap-2 rounded-md px-2.5 font-mono text-[10.5px] text-muted-foreground"
+        onClick={() => setOpen(true)}
+        title="Discover and install domain packs"
+      >
+        <Boxes className="!size-3.5" /> PACKS
+      </Button>
+      {open ? <PacksModal onClose={() => setOpen(false)} /> : null}
+    </>
+  );
+}

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1446,10 +1446,43 @@ function ProvenanceTracePanel(props: PanelProps) {
   );
 }
 
+// Generic renderer for a panel type with no dedicated component — notably a
+// panel contributed by an installed domain pack (M9). It renders what the spec
+// carries (rationale, body, params) so a pack panel is meaningful even without
+// a bespoke visualization.
 function UnknownPanel(props: PanelProps) {
+  const { panel } = props;
+  const params = Object.entries(panel.params ?? {}).filter(
+    ([, v]) => v != null && v !== "",
+  );
+  const hasContent = !!panel.rationale || !!panel.body || params.length > 0;
+  if (!hasContent) {
+    return (
+      <GenPanel {...props}>
+        <Empty text={`Renderer for '${panel.type}' not installed`} />
+      </GenPanel>
+    );
+  }
   return (
     <GenPanel {...props}>
-      <Empty text={`Renderer for '${props.panel.type}' not installed`} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {panel.rationale ? (
+          <div style={{ fontSize: 12, lineHeight: 1.45, color: "#c7d3d9" }}>{panel.rationale}</div>
+        ) : null}
+        {panel.body ? (
+          <div style={{ fontSize: 12, lineHeight: 1.45, color: "#c7d3d9" }}>{panel.body}</div>
+        ) : null}
+        {params.length ? (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {params.map(([k, v]) => (
+              <span key={k} style={chip("#5f7580")}>
+                {k}: {String(v)}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <div style={mono}>generic view · panel type “{panel.type}” from an installed pack</div>
+      </div>
     </GenPanel>
   );
 }

--- a/apps/web/src/genui/usePacks.ts
+++ b/apps/web/src/genui/usePacks.ts
@@ -1,0 +1,49 @@
+// React-query hooks over the domain-pack ecosystem API (M9): discover packs and
+// the install / uninstall / deploy-template mutations that keep the list fresh.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { packsApi, type PackDiscovery, type PackTemplate } from "../lib/packsApi";
+
+const DISCOVER_KEY = ["packs", "discover"];
+
+export function usePackDiscovery() {
+  return useQuery<PackDiscovery>({
+    queryKey: DISCOVER_KEY,
+    queryFn: packsApi.discover,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+export function usePackTemplates() {
+  return useQuery<PackTemplate[]>({
+    queryKey: ["packs", "templates"],
+    queryFn: () => packsApi.templates().then((r) => r.templates),
+    staleTime: 30_000,
+    retry: false,
+    placeholderData: [],
+  });
+}
+
+export function useInstallPack() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { name: string; version?: string }) =>
+      packsApi.install(vars.name, vars.version),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["packs"] }),
+  });
+}
+
+export function useUninstallPack() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => packsApi.uninstall(name),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["packs"] }),
+  });
+}
+
+export function useDeployTemplate() {
+  return useMutation({
+    mutationFn: (name: string) => packsApi.deployTemplate(name),
+  });
+}

--- a/apps/web/src/lib/packsApi.ts
+++ b/apps/web/src/lib/packsApi.ts
@@ -1,0 +1,97 @@
+// Typed client for the domain-pack ecosystem API (M9): discover published
+// packs, install / uninstall them, and deploy their provisioning templates.
+//
+// Reads are always available; the mutating calls only succeed when the backend
+// has NOESIS_PACKS_ADMIN enabled (the discover payload reports admin_enabled).
+
+const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+const TIMEOUT_MS = 8000;
+
+export class PacksApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "PacksApiError";
+  }
+}
+
+async function call<T>(path: string, opts: { method?: string; body?: unknown } = {}): Promise<T> {
+  const url = new URL(BASE_URL + path, BASE_URL || window.location.origin);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  try {
+    const res = await fetch(url.toString(), {
+      method: opts.method ?? "GET",
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new PacksApiError(`Request failed: ${path}`, res.status);
+    return (await res.json()) as T;
+  } catch (err) {
+    if (err instanceof PacksApiError) throw err;
+    throw new PacksApiError(err instanceof Error ? err.message : `Request error: ${path}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface PackEntry {
+  name: string;
+  latest_version: string | null;
+  versions: string[];
+  description: string;
+  source_types: string[];
+  installed_version: string | null;
+}
+
+export interface PackDiscovery {
+  admin_enabled: boolean;
+  packs: PackEntry[];
+  installed: Record<string, string>;
+  count: number;
+}
+
+export interface PackInstallReport {
+  name: string;
+  version: string;
+  panels: string[];
+  enrichers: string[];
+  ui_flags: Record<string, boolean>;
+  planner_facets: string[];
+  templates: string[];
+}
+
+export interface PackTemplate {
+  name: string;
+  description?: string;
+  sources?: string[];
+  backend?: string;
+  pack?: string;
+}
+
+export const packsApi = {
+  discover: () => call<PackDiscovery>("/api/v1/packs"),
+
+  templates: () =>
+    call<{ templates: PackTemplate[]; count: number }>("/api/v1/packs/templates"),
+
+  install: (name: string, version?: string) =>
+    call<{ installed: PackInstallReport }>("/api/v1/packs/install", {
+      method: "POST",
+      body: { name, version },
+    }).then((r) => r.installed),
+
+  uninstall: (name: string) =>
+    call<{ uninstalled: string }>(`/api/v1/packs/${encodeURIComponent(name)}`, { method: "DELETE" }),
+
+  deployTemplate: (name: string) =>
+    call<{ deployed: Record<string, unknown> }>(
+      `/api/v1/packs/templates/${encodeURIComponent(name)}/deploy`,
+      { method: "POST" },
+    ).then((r) => r.deployed),
+};


### PR DESCRIPTION
## Summary

Follow-up to M9 (and the pack ecosystem API): wire pack discovery/installation into the canvas app, and make installed-pack panels render meaningfully.

## What changed (apps/web)

- **`lib/packsApi.ts`** — typed client for the pack routes (discover / install / uninstall / deploy-template).
- **`genui/usePacks.ts`** — react-query hooks (discovery, templates, and the install / uninstall / deploy mutations that keep the list fresh).
- **`genui/PacksButton.tsx`** — a **PACKS** entry point in the sidebar footer that opens a modal to browse published packs, install / uninstall them, and deploy their provisioning templates. Mutations are disabled with a **READ-ONLY** badge unless the backend reports `admin_enabled` (`NOESIS_PACKS_ADMIN`).
- **`registry.tsx`** — the fallback renderer for an unregistered panel type (e.g. one contributed by an installed pack) now renders what the spec carries — rationale, body, params — as a **generic pack panel**, instead of a bare "renderer not installed" message.

## Verification

- `tsc --noEmit` clean.
- `vite build` succeeds (1873 modules transformed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_