### PR TITLE
Agents over live MCP + run transcript viewer

### DIFF
--- a/apps/web/src/genui/AgentButton.tsx
+++ b/apps/web/src/genui/AgentButton.tsx
@@ -4,18 +4,61 @@
 // canvas onto the board. Disabled unless the backend has NOESIS_AGENT_API on.
 
 import { useState } from "react";
-import { Bot, Check, Loader2, Play, Search, X } from "lucide-react";
+import { Bot, Check, ListTree, Loader2, Play, Radio, Search, X } from "lucide-react";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Input } from "../components/ui/input";
 import { canvasApi } from "../lib/canvasStore";
 import type { AnalystResult, InvestigatorResult } from "../lib/agentApi";
-import { useAgentStatus, useRunAnalyst, useRunInvestigator } from "./useAgents";
+import { useAgentStatus, useRunAnalyst, useRunInvestigator, useRunReplay } from "./useAgents";
 
 type Mode = "analyst" | "investigator";
 
 function isInvestigation(r: AnalystResult | InvestigatorResult): r is InvestigatorResult {
   return "gated_calls" in r;
+}
+
+const PLANE_COLOR: Record<string, string> = {
+  provisioning: "text-violet-400",
+  osint: "text-teal-400",
+  genui: "text-amber-400",
+};
+
+// The audit trail of a run, replayed from GET /agent/runs/{id} on demand.
+function RunTrail({ runId }: { runId: string }) {
+  const [open, setOpen] = useState(false);
+  const trail = useRunReplay(runId, open);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+      >
+        <ListTree className="size-3" /> {open ? "hide trail" : "view trail"}
+      </button>
+      {open ? (
+        <div className="mt-2 flex flex-col gap-0.5">
+          {trail.isLoading ? (
+            <span className="font-mono text-[10px] text-muted-foreground">loading trail…</span>
+          ) : trail.data && trail.data.calls.length ? (
+            trail.data.calls.map((c) => (
+              <div key={c.step} className="flex items-center gap-2 font-mono text-[10px]">
+                <span className="w-5 text-right text-muted-foreground/50">{c.step}</span>
+                <span className={"w-20 shrink-0 " + (PLANE_COLOR[c.plane] ?? "text-muted-foreground")}>
+                  {c.plane}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-foreground/80">{c.tool}</span>
+                <span className={c.ok ? "text-emerald-400" : "text-red-400"}>{c.ok ? "ok" : "err"}</span>
+              </div>
+            ))
+          ) : (
+            <span className="font-mono text-[10px] text-muted-foreground">no trail recorded</span>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function ResultCard({
@@ -85,6 +128,9 @@ function ResultCard({
         {opened ? <Check className="!size-3" /> : opening ? <Loader2 className="!size-3 animate-spin" /> : null}
         {opened ? "OPENED" : "OPEN CANVAS"}
       </Button>
+
+      {/* The full audit trail of this run (M10.4), replayed on demand. */}
+      <RunTrail runId={result.run_id} />
     </div>
   );
 }
@@ -104,11 +150,13 @@ function AgentModal({
   const [claimId, setClaimId] = useState("");
   const [entity, setEntity] = useState("");
   const [topic, setTopic] = useState("");
+  const [live, setLive] = useState(false);
 
   const enabled = status.data?.enabled ?? false;
   const running = analyst.isPending || investigator.isPending;
   const result = mode === "analyst" ? analyst.data : investigator.data;
   const error = mode === "analyst" ? analyst.error : investigator.error;
+  const transport = live ? "live" : "local";
 
   const run = () => {
     if (!goal.trim()) return;
@@ -118,12 +166,14 @@ function AgentModal({
         claim_id: claimId.trim() || undefined,
         entity: entity.trim() || undefined,
         topic: topic.trim() || undefined,
+        transport,
       });
     } else {
       investigator.mutate({
         title: goal.trim(),
         entities: entity.trim() ? [entity.trim()] : undefined,
         topic: topic.trim() || undefined,
+        transport,
         claim_id: claimId.trim() || undefined,
       });
     }
@@ -158,7 +208,7 @@ function AgentModal({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
-          <div className="mb-3 flex gap-1.5">
+          <div className="mb-3 flex items-center gap-1.5">
             {(["analyst", "investigator"] as Mode[]).map((m) => (
               <Button
                 key={m}
@@ -171,6 +221,17 @@ function AgentModal({
                 {m.toUpperCase()}
               </Button>
             ))}
+            <span className="flex-1" />
+            {/* Transport: in-process backend (default) vs the live MCP surface. */}
+            <Button
+              variant={live ? "default" : "outline"}
+              size="sm"
+              className="h-7 rounded-md px-3 font-mono text-[10.5px]"
+              onClick={() => setLive((v) => !v)}
+              title="Drive the run over the live MCP servers instead of the in-process backend"
+            >
+              <Radio className="!size-3" /> {live ? "LIVE MCP" : "IN-PROCESS"}
+            </Button>
           </div>
 
           <label className="mb-1 block font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60">

--- a/apps/web/src/genui/useAgents.ts
+++ b/apps/web/src/genui/useAgents.ts
@@ -2,13 +2,22 @@
 // the analyst / investigator run mutations.
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { agentApi, type AnalystInput, type InvestigatorInput } from "../lib/agentApi";
+import { agentApi, type AnalystInput, type InvestigatorInput, type RunCall } from "../lib/agentApi";
 
 export function useAgentStatus() {
   return useQuery<{ enabled: boolean }>({
     queryKey: ["agent", "status"],
     queryFn: agentApi.status,
     staleTime: 60_000,
+    retry: false,
+  });
+}
+
+export function useRunReplay(runId: string | null, enabled: boolean) {
+  return useQuery<{ run_id: string; calls: RunCall[]; count: number }>({
+    enabled: enabled && !!runId,
+    queryKey: ["agent", "run", runId],
+    queryFn: () => agentApi.run(runId as string),
     retry: false,
   });
 }

--- a/apps/web/src/lib/agentApi.ts
+++ b/apps/web/src/lib/agentApi.ts
@@ -54,6 +54,7 @@ export interface AgentFinding {
 
 export interface AnalystResult {
   run_id: string;
+  transport?: string;
   goal: string;
   kg: AgentKg;
   osint: AgentFinding[];
@@ -64,6 +65,7 @@ export interface AnalystResult {
 
 export interface InvestigatorResult {
   run_id: string;
+  transport?: string;
   title: string;
   kg: AgentKg;
   surface: AgentFinding[];
@@ -90,6 +92,7 @@ export interface AnalystInput {
   entity?: string;
   claim_id?: string;
   source?: string;
+  transport?: "local" | "live";
 }
 
 export interface InvestigatorInput {
@@ -99,6 +102,7 @@ export interface InvestigatorInput {
   topic?: string;
   claim_id?: string;
   sources?: string[];
+  transport?: "local" | "live";
 }
 
 export const agentApi = {

--- a/src/api/routes/agent_routes.py
+++ b/src/api/routes/agent_routes.py
@@ -25,14 +25,36 @@ from src.agent.analyst import AnalystAgent
 from src.agent.audit import provisioning_audit_sink, replay_run
 from src.agent.investigator import InvestigatorAgent
 from src.agent.local_backend import build_local_caller
-from src.agent.runtime import AgentRuntime, Budget
+from src.agent.runtime import AgentRuntime, Budget, live_caller
 
 router = APIRouter(prefix="/api/v1/agent", tags=["agent"])
+
+# Transports an agent run can drive:
+#   "local" - the in-process backend against the shared warehouse (default),
+#   "live"  - the real MCP servers via the supervised host (runtime.live_caller).
+TRANSPORTS = ("local", "live")
 
 
 def agent_enabled() -> bool:
     """Whether the agent run endpoints are enabled (``NOESIS_AGENT_API``)."""
     return os.getenv("NOESIS_AGENT_API", "off").lower() in ("on", "1", "true")
+
+
+def default_transport() -> str:
+    """The default run transport (``NOESIS_AGENT_TRANSPORT``); ``local`` unless
+    explicitly set to ``live``."""
+    value = os.getenv("NOESIS_AGENT_TRANSPORT", "local").lower()
+    return value if value in TRANSPORTS else "local"
+
+
+def _build_caller(conn, transport: Optional[str]):
+    """Resolve the tool caller for a run. ``live`` drives the real MCP surface
+    (and fails loudly if the host is down); anything else is the in-process
+    backend against ``conn``."""
+    chosen = (transport or default_transport()).lower()
+    if chosen == "live":
+        return live_caller(), "live"
+    return build_local_caller(conn), "local"
 
 
 def _require_enabled() -> None:
@@ -58,6 +80,7 @@ class AnalystRequest(BaseModel):
     claim_id: Optional[str] = None
     source: Optional[str] = None
     max_steps: int = Field(default=24, ge=1, le=100)
+    transport: Optional[str] = Field(default=None, description="local | live")
 
 
 class InvestigatorRequest(BaseModel):
@@ -68,6 +91,7 @@ class InvestigatorRequest(BaseModel):
     claim_id: Optional[str] = None
     sources: Optional[List[str]] = None
     max_steps: int = Field(default=24, ge=1, le=100)
+    transport: Optional[str] = Field(default=None, description="local | live")
 
 
 @router.get("")
@@ -83,10 +107,11 @@ def run_analyst(request: AnalystRequest) -> Dict[str, Any]:
     _require_enabled()
     conn, lock = _conn()
     run_id = "analyst-" + secrets.token_urlsafe(6)
+    caller, transport = _build_caller(conn, request.transport)
     try:
         with lock:
             runtime = AgentRuntime(
-                build_local_caller(conn),
+                caller,
                 budget=Budget(max_steps=request.max_steps),
                 audit_sink=provisioning_audit_sink(conn, run_id),
             )
@@ -103,6 +128,7 @@ def run_analyst(request: AnalystRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail=f"analyst run failed: {err}")
     return {
         "run_id": run_id,
+        "transport": transport,
         "goal": result.goal,
         "kg": result.kg,
         "osint": result.osint,
@@ -119,10 +145,11 @@ def run_investigator(request: InvestigatorRequest) -> Dict[str, Any]:
     _require_enabled()
     conn, lock = _conn()
     run_id = "investigation-" + secrets.token_urlsafe(6)
+    caller, transport = _build_caller(conn, request.transport)
     try:
         with lock:
             runtime = AgentRuntime(
-                build_local_caller(conn),
+                caller,
                 budget=Budget(max_steps=request.max_steps),
                 audit_sink=provisioning_audit_sink(conn, run_id),
             )
@@ -138,6 +165,7 @@ def run_investigator(request: InvestigatorRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail=f"investigation run failed: {err}")
     return {
         "run_id": run_id,
+        "transport": transport,
         "title": result.title,
         "kg": result.kg,
         "surface": result.surface,

--- a/tests/unit/api/routes/test_agent_routes.py
+++ b/tests/unit/api/routes/test_agent_routes.py
@@ -124,3 +124,52 @@ def test_status_and_gating(monkeypatch):
 
 def test_replay_unknown_run_is_404(client):
     assert client.get("/api/v1/agent/runs/does-not-exist").status_code == 404
+
+
+# --- transport switch (live MCP vs in-process) --------------------------------
+
+
+def test_default_transport_is_local(client):
+    body = client.post("/api/v1/agent/analyst", json={"goal": "delta flooding", "claim_id": "k1"}).json()
+    assert body["transport"] == "local"
+
+
+def test_live_transport_uses_the_live_caller(client, monkeypatch):
+    from src.agent.local_backend import build_local_caller
+
+    conn = mod._conn()[0]
+    used = {"live": False}
+
+    def fake_live_caller():
+        used["live"] = True
+        return build_local_caller(conn)  # drive the seeded warehouse, but via the live path
+
+    monkeypatch.setattr(mod, "live_caller", fake_live_caller)
+    resp = client.post(
+        "/api/v1/agent/analyst",
+        json={"goal": "delta flooding", "claim_id": "k1", "transport": "live"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["transport"] == "live"
+    assert used["live"] is True
+
+
+def test_live_transport_degrades_when_the_caller_errors(client, monkeypatch):
+    # The runtime absorbs per-call tool errors (records ok=False), so a live run
+    # whose caller fails still returns a well-formed response with no findings
+    # rather than a 500 -- the run is auditable either way.
+    def failing_caller():
+        def _call(server, tool, arguments):
+            raise RuntimeError("MCP host is not running")
+        return _call
+
+    monkeypatch.setattr(mod, "live_caller", failing_caller)
+    resp = client.post(
+        "/api/v1/agent/analyst",
+        json={"goal": "delta flooding", "claim_id": "k1", "transport": "live"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["transport"] == "live"
+    assert body["findings"] == 0
+    assert body["kg"]["provisioned"] is True  # deploy call was attempted (and recorded)


### PR DESCRIPTION
Closes #740.

## Summary

Let an agent run drive the real MCP surface instead of only the in-process backend, and surface the run's audit trail in the UI.

## What changed

- **`src/api/routes/agent_routes.py`**: a transport switch — `local` (in-process backend against the shared warehouse, the default) or `live` (the real MCP servers via `runtime.live_caller`). Selected per request (`transport` field) or by `NOESIS_AGENT_TRANSPORT`; the run response reports which transport was used. A live run whose caller errors is absorbed by the runtime (calls recorded `ok=false`) and still returns a well-formed, auditable result rather than a 500.
- **`apps/web`**: `AgentButton` gains an **IN-PROCESS / LIVE MCP** toggle passed as `transport`, and a **view-trail** control that replays the run from `GET /agent/runs/{id}`, listing each call (step, plane, tool, ok) colour-coded by plane.

## Testing

- `tests/unit/api/routes/test_agent_routes.py` — default-local, live selecting the live caller, and graceful degradation when the live caller errors. `tsc` + `vite build` clean.
- Integration-verified with the other two follow-up branches: merges with zero conflicts, 88 backend tests pass together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_