### PR TITLE
In-canvas refinement (M6) end to end

### DIFF
--- a/apps/web/src/genui/Canvas.tsx
+++ b/apps/web/src/genui/Canvas.tsx
@@ -3,10 +3,13 @@
 // the pipeline (entity constellation, movers, ingest stats) and points at
 // the ⌘K command bar. With an intent, the planned layout fills the surface.
 
+import { useEffect, useState } from "react";
 import { RotateCcw } from "lucide-react";
 import SpecRenderer from "./SpecRenderer";
 import SavedCanvasView from "./SavedCanvasView";
 import CanvasActions from "./CanvasActions";
+import RefineBar from "./RefineBar";
+import type { UISpec } from "./spec";
 import EntityGraph from "../components/charts/EntityGraph";
 import { useArticles, useClusters, useEntityGraph, useUiTelemetry } from "../lib/queries";
 import { useUiSpec } from "./useUiSpec";
@@ -149,7 +152,13 @@ export default function Canvas({ canvas, onIntent }: Props) {
   const hasIntent = canvas.intent.trim().length > 0;
   const { spec, source, isLoading } = useUiSpec(canvas.intent, adaptive.signals, hasIntent && !isSaved);
 
-  const planner = PLANNER_BADGE[spec.generated_by] ?? PLANNER_BADGE.heuristic;
+  // M6 in-canvas refinement: an applied refinement overlays the generated spec
+  // until the base plan changes (new intent / regenerate), when it is dropped.
+  const [refined, setRefined] = useState<UISpec | null>(null);
+  useEffect(() => setRefined(null), [spec]);
+  const view = refined ?? spec;
+
+  const planner = PLANNER_BADGE[view.generated_by] ?? PLANNER_BADGE.heuristic;
 
   // A server-persisted canvas renders from its stored spec, not a fresh plan.
   if (isSaved && canvas.savedId) {
@@ -178,9 +187,14 @@ export default function Canvas({ canvas, onIntent }: Props) {
         <Badge variant={isLoading ? "sync" : source === "live" ? "live" : "demo"}>
           {isLoading ? "SYNC" : source === "live" ? "LIVE" : "DEMO"}
         </Badge>
-        <span className="font-grotesk text-sm font-semibold">{spec.title}</span>
-        {spec.subtitle ? (
-          <span className="font-mono text-[10.5px] text-muted-foreground">{spec.subtitle}</span>
+        <span className="font-grotesk text-sm font-semibold">{view.title}</span>
+        {view.subtitle ? (
+          <span className="font-mono text-[10.5px] text-muted-foreground">{view.subtitle}</span>
+        ) : null}
+        {refined ? (
+          <Badge variant="outline" className="border-violet-400/30 bg-violet-400/10 text-violet-400" title="This canvas has been refined in place">
+            REFINED
+          </Badge>
         ) : null}
         <span className="flex-1" />
         {adaptive.signals.dismissed.length > 0 ? (
@@ -210,10 +224,15 @@ export default function Canvas({ canvas, onIntent }: Props) {
           </Button>
         ) : null}
         {/* Persist / share this canvas server-side (M8). */}
-        <CanvasActions spec={spec} />
+        <CanvasActions spec={view} />
       </div>
 
-      <SpecRenderer spec={spec} adaptive={adaptive} />
+      {/* In-canvas refinement (M6): mutate this layout with a follow-up. */}
+      <div className="mb-4">
+        <RefineBar spec={view} onRefined={setRefined} />
+      </div>
+
+      <SpecRenderer spec={view} adaptive={adaptive} />
     </div>
   );
 }

--- a/apps/web/src/genui/RefineBar.tsx
+++ b/apps/web/src/genui/RefineBar.tsx
@@ -1,0 +1,68 @@
+// In-canvas refinement input (M6): a follow-up instruction that mutates the
+// current canvas in place (add/remove/focus a panel) instead of regenerating
+// from a new intent. Applies the diff returned by POST /api/v1/ui/refine.
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2, Wand2 } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { refineUi } from "../lib/refineApi";
+import type { UISpec } from "./spec";
+
+export default function RefineBar({
+  spec,
+  onRefined,
+}: {
+  spec: UISpec;
+  onRefined: (spec: UISpec) => void;
+}) {
+  const [instruction, setInstruction] = useState("");
+  const [note, setNote] = useState<string | null>(null);
+  const refine = useMutation({
+    mutationFn: (text: string) => refineUi({ spec, instruction: text }),
+    onSuccess: (res) => {
+      if (res.changed) {
+        onRefined(res.spec);
+        setInstruction("");
+        setNote(null);
+      } else {
+        setNote("no change — try add / remove / focus on <topic>");
+      }
+    },
+    onError: () => setNote("refinement unavailable"),
+  });
+
+  const submit = () => {
+    const text = instruction.trim();
+    if (text) refine.mutate(text);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative flex-1">
+        <Wand2 className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/50" />
+        <Input
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !refine.isPending) submit();
+          }}
+          placeholder="refine: add sentiment, remove claims, focus on the delta…"
+          className="h-7 pl-8 font-mono text-[11px]"
+        />
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 rounded-md px-3 font-mono text-[10px]"
+        disabled={refine.isPending || !instruction.trim()}
+        onClick={submit}
+        title="Apply this refinement to the current canvas"
+      >
+        {refine.isPending ? <Loader2 className="!size-3 animate-spin" /> : null} REFINE
+      </Button>
+      {note ? <span className="font-mono text-[10px] text-muted-foreground/70">{note}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/refineApi.ts
+++ b/apps/web/src/lib/refineApi.ts
@@ -1,0 +1,45 @@
+// Client for in-canvas refinement (M6): POST /api/v1/ui/refine turns an
+// instruction into a spec diff and applies it to the current canvas in place.
+
+import type { UISpec } from "../genui/spec";
+
+const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+const TIMEOUT_MS = 8000;
+
+export class RefineApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "RefineApiError";
+  }
+}
+
+export interface RefineResponse {
+  spec: UISpec;
+  diff: Array<Record<string, unknown>>;
+  errors: string[];
+  changed: boolean;
+}
+
+export async function refineUi(body: { spec: UISpec; instruction: string }): Promise<RefineResponse> {
+  const url = new URL(BASE_URL + "/api/v1/ui/refine", BASE_URL || window.location.origin);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new RefineApiError("refine failed", res.status);
+    return (await res.json()) as RefineResponse;
+  } catch (err) {
+    if (err instanceof RefineApiError) throw err;
+    throw new RefineApiError(err instanceof Error ? err.message : "refine error");
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/api/routes/genui_routes.py
+++ b/src/api/routes/genui_routes.py
@@ -16,7 +16,9 @@ from src.genui.adaptivity import resolve_availability, resolve_ui_flags
 from src.genui.discovery import merged_catalog_dict
 from src.genui.llm import llm_config, plan_with_llm
 from src.genui.planner import plan
-from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, validate_spec
+from src.genui.refine import refine_to_diff
+from src.genui.spec import MAX_INTENT_LENGTH, SOURCE_TYPES, spec_from_dict, validate_spec
+from src.genui.spec_diff import apply_diff
 from src.genui.telemetry import pack_telemetry
 from src.mcp_host import host_status
 
@@ -165,3 +167,48 @@ async def ui_panels() -> Dict[str, Any]:
         return {"panels": panels, "count": len(panels)}
     except Exception as err:
         raise HTTPException(status_code=500, detail=f"UI panel catalog failed: {err}")
+
+
+class RefineUiRequest(BaseModel):
+    """Body for POST /api/v1/ui/refine (M6 in-canvas refinement)."""
+
+    spec: Dict[str, Any] = Field(..., description="The current ui-spec-v1 layout")
+    instruction: str = Field("", max_length=MAX_INTENT_LENGTH, description="Refinement instruction")
+
+
+@router.post("/refine")
+def refine_ui(request: RefineUiRequest) -> Dict[str, Any]:
+    """Apply a natural-language refinement to an existing canvas (M6): turn the
+    instruction into a spec diff and apply it in place, so a follow-up mutates
+    the current layout instead of regenerating it.
+
+    Returns the refined spec, the diff that was applied, and any per-op errors.
+    An unrecognized instruction is a no-op (``changed`` is false, spec unchanged).
+    """
+    errors = validate_spec(request.spec)
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail=f"spec failed validation: {'; '.join(errors[:3])}",
+        )
+    try:
+        spec = spec_from_dict(request.spec)
+        diff = refine_to_diff(spec, request.instruction)
+        # An unrecognized instruction changes nothing: return the input untouched.
+        if not diff:
+            return {"spec": request.spec, "diff": [], "errors": [], "changed": False}
+        new_spec, apply_errors = apply_diff(spec, diff)
+        new_dict = new_spec.to_dict()
+        # The diff engine already caps/validates, but double-check the contract;
+        # on any violation fall back to the original spec rather than emit an
+        # invalid layout.
+        if validate_spec(new_dict):
+            return {"spec": request.spec, "diff": [], "errors": apply_errors, "changed": False}
+        return {
+            "spec": new_dict,
+            "diff": diff,
+            "errors": apply_errors,
+            "changed": True,
+        }
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"UI refinement failed: {err}")

--- a/tests/unit/api/routes/test_genui_refine_route.py
+++ b/tests/unit/api/routes/test_genui_refine_route.py
@@ -1,0 +1,92 @@
+"""Route test for POST /api/v1/ui/refine (M6 in-canvas refinement).
+
+Loads the genui route module BY PATH and drives the refine endpoint, which turns
+a natural-language instruction into a spec diff and applies it in place.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "genui_routes_under_test", REPO / "src/api/routes/genui_routes.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app)
+
+
+def _spec_dict():
+    return {
+        "spec_version": "ui-spec-v1",
+        "intent": "overview of the debate",
+        "title": "Overview",
+        "subtitle": "",
+        "generated_by": "heuristic",
+        "facets": [],
+        "topic": None,
+        "source_type": None,
+        "panels": [
+            {"id": "n", "type": "note", "title": "Plan", "span": 12, "priority": 1.0,
+             "rationale": "", "endpoint": None, "params": {}, "body": "how it was built"},
+            {"id": "p1", "type": "claims", "title": "Extracted claims", "span": 6,
+             "priority": 0.8, "rationale": "", "endpoint": None, "params": {"topic": "x"}, "body": ""},
+            {"id": "p2", "type": "articles", "title": "Latest documents", "span": 6,
+             "priority": 0.7, "rationale": "", "endpoint": None, "params": {}, "body": ""},
+        ],
+    }
+
+
+def test_refine_removes_a_panel(client):
+    resp = client.post("/api/v1/ui/refine", json={"spec": _spec_dict(), "instruction": "remove claims"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["changed"] is True
+    types = {p["type"] for p in body["spec"]["panels"]}
+    assert "claims" not in types
+    assert any(op["op"] == "remove" for op in body["diff"])
+
+
+def test_refine_focus_retargets_data_panels(client):
+    resp = client.post(
+        "/api/v1/ui/refine",
+        json={"spec": _spec_dict(), "instruction": "focus on climate policy"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["changed"] is True
+    claims = next(p for p in body["spec"]["panels"] if p["type"] == "claims")
+    assert claims["params"]["topic"] == "climate policy"
+
+
+def test_unrecognized_instruction_is_a_noop(client):
+    resp = client.post("/api/v1/ui/refine", json={"spec": _spec_dict(), "instruction": "make it nicer"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["changed"] is False
+    assert body["diff"] == []
+    assert body["spec"] == _spec_dict()  # unchanged
+
+
+def test_invalid_spec_is_rejected(client):
+    bad = _spec_dict()
+    bad["panels"] = []
+    resp = client.post("/api/v1/ui/refine", json={"spec": bad, "instruction": "remove claims"})
+    assert resp.status_code == 400


### PR DESCRIPTION
Closes #742.

## Summary

Expose the M6 refinement engine and wire it into the canvas so a follow-up instruction mutates the current layout in place instead of regenerating it.

## What changed

- **`src/api/routes/genui_routes.py`**: `POST /api/v1/ui/refine` — validate the incoming spec, turn the instruction into a spec diff (`refine_to_diff`), apply it (`apply_diff`), and return the refined spec plus the diff. An unrecognized instruction is a no-op (`changed=false`, spec returned untouched); an invalid spec is refused (400).
- **`apps/web`**: `lib/refineApi.ts` + `genui/RefineBar.tsx` — a refine input on a generated canvas ("add sentiment", "remove claims", "focus on the delta") that applies the diff and overlays the result; a **REFINED** badge marks a refined canvas, and the overlay is dropped when the base plan changes. Save/Share and the renderer all follow the refined view.

Data-binding rehydration on reopen needs no new code: a saved canvas renders through the same `SpecRenderer` whose panels self-fetch live data via the data proxy, so reopened panels already rehydrate when the proxy is on.

## Testing

- `tests/unit/api/routes/test_genui_refine_route.py` — remove / focus / no-op / invalid-spec. `tsc` + `vite build` clean.
- Integration-verified with the other follow-up branches: zero conflicts, all green together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_