### PR TITLE
Pack authoring &amp; publish from the UI (M9)

### DIFF
--- a/apps/web/src/genui/PackPublish.tsx
+++ b/apps/web/src/genui/PackPublish.tsx
@@ -1,0 +1,91 @@
+// Author and publish a domain pack (M9): paste a noesis-pack-v1 manifest and
+// publish it to the registry via POST /api/v1/packs/publish. Client-side JSON
+// parsing gives immediate feedback; the backend validates the contract and
+// returns the published coordinates. Disabled unless pack admin is enabled.
+
+import { useState } from "react";
+import { Check, ChevronDown, ChevronRight, Loader2, Upload } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { usePublishPack } from "./usePacks";
+
+const TEMPLATE = `{
+  "pack_format": "noesis-pack-v1",
+  "name": "energy",
+  "version": "1.0.1",
+  "description": "Energy-sector pack",
+  "source_types": ["news"],
+  "ui_flags": { "energy": true },
+  "planner_keywords": { "trend": ["grid", "outage"] }
+}`;
+
+export default function PackPublish({ admin }: { admin: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState(TEMPLATE);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [published, setPublished] = useState<string | null>(null);
+  const publish = usePublishPack();
+
+  const submit = () => {
+    setPublished(null);
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(text);
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : "invalid JSON");
+      return;
+    }
+    setParseError(null);
+    publish.mutate(
+      { manifest, force: false },
+      { onSuccess: (p) => setPublished(`${p.name} v${p.version}`) },
+    );
+  };
+
+  return (
+    <div className="mt-5 border-t pt-4">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 font-mono text-[9.5px] tracking-[0.16em] text-muted-foreground/60 hover:text-foreground"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        AUTHOR &amp; PUBLISH A PACK
+      </button>
+      {open ? (
+        <div className="mt-2.5 flex flex-col gap-2">
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            spellCheck={false}
+            rows={10}
+            className="w-full rounded-md border border-input bg-secondary/40 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground outline-none focus:border-primary/50"
+            placeholder="paste a noesis-pack-v1 manifest…"
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              className="h-7 rounded-md px-3 font-mono text-[10px]"
+              disabled={!admin || publish.isPending}
+              onClick={submit}
+              title={admin ? "Publish this manifest to the registry" : "Enable NOESIS_PACKS_ADMIN to publish"}
+            >
+              {publish.isPending ? <Loader2 className="!size-3 animate-spin" /> : <Upload className="!size-3" />}
+              PUBLISH
+            </Button>
+            {published ? (
+              <span className="flex items-center gap-1 font-mono text-[10px] text-emerald-400">
+                <Check className="size-3" /> published {published}
+              </span>
+            ) : null}
+            {parseError ? <span className="font-mono text-[10px] text-red-400">JSON: {parseError}</span> : null}
+            {publish.isError && !parseError ? (
+              <span className="font-mono text-[10px] text-red-400">
+                rejected — invalid manifest or version already published
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/genui/PacksButton.tsx
+++ b/apps/web/src/genui/PacksButton.tsx
@@ -14,6 +14,7 @@ import {
   usePackTemplates,
   useUninstallPack,
 } from "./usePacks";
+import PackPublish from "./PackPublish";
 
 function PacksModal({ onClose }: { onClose: () => void }) {
   const discovery = usePackDiscovery();
@@ -139,6 +140,9 @@ function PacksModal({ onClose }: { onClose: () => void }) {
               </div>
             </div>
           ) : null}
+
+          {/* Author and publish a new pack to the registry (M9). */}
+          <PackPublish admin={admin} />
         </div>
       </div>
     </div>

--- a/apps/web/src/genui/usePacks.ts
+++ b/apps/web/src/genui/usePacks.ts
@@ -47,3 +47,12 @@ export function useDeployTemplate() {
     mutationFn: (name: string) => packsApi.deployTemplate(name),
   });
 }
+
+export function usePublishPack() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { manifest: Record<string, unknown>; force?: boolean }) =>
+      packsApi.publish(vars.manifest, vars.force),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["packs"] }),
+  });
+}

--- a/apps/web/src/lib/packsApi.ts
+++ b/apps/web/src/lib/packsApi.ts
@@ -94,4 +94,10 @@ export const packsApi = {
       `/api/v1/packs/templates/${encodeURIComponent(name)}/deploy`,
       { method: "POST" },
     ).then((r) => r.deployed),
+
+  publish: (manifest: Record<string, unknown>, force = false) =>
+    call<{ published: { name: string; version: string; path: string } }>("/api/v1/packs/publish", {
+      method: "POST",
+      body: { manifest, force },
+    }).then((r) => r.published),
 };


### PR DESCRIPTION
Closes #744.

## Summary

Let an operator author a domain pack and publish it to the registry from the canvas app, using the publish route added with the pack ecosystem API.

## What changed (apps/web)

- **`lib/packsApi.ts`**: `publish(manifest, force)` over `POST /api/v1/packs/publish`.
- **`genui/usePacks.ts`**: `usePublishPack` mutation (invalidates the pack list on success).
- **`genui/PackPublish.tsx`**: an "author & publish" section in the packs modal with a manifest editor (seeded with a `noesis-pack-v1` template), client-side JSON parse feedback, and a Publish button that reports the published name/version or a rejection. Disabled unless the backend reports `admin_enabled` (`NOESIS_PACKS_ADMIN`); the server validates the manifest contract and enforces version immutability.

## Testing

- `tsc` + `vite build` clean.
- Integration-verified with the other follow-up branches: zero conflicts, all green together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_