### PR TITLE
Chart type: sentiment trajectory (line + confidence band)

### DIFF
--- a/apps/web/src/components/charts/LineBand.tsx
+++ b/apps/web/src/components/charts/LineBand.tsx
@@ -1,0 +1,183 @@
+// LineBand — a single time series drawn as a 2px line over a shaded
+// confidence band (lo..hi). One series, so no legend: the panel title names
+// it. Polarity is never color-alone — a neutral-gray zero baseline anchors the
+// sign and the latest value is direct-labeled and tinted by sign. The band is
+// always shown, so the series is never a bare point estimate.
+//
+// Marks are drawn in a 0..100 SVG box with preserveAspectRatio="none" so the
+// plot fills the panel width; the line uses a non-scaling stroke and the dots,
+// value label and date ticks are HTML overlays so text and markers stay crisp
+// and round regardless of the horizontal stretch.
+
+import { ACCENT, palette, fonts } from "../../theme";
+
+export interface LinePoint {
+  label: string; // x-axis label (e.g. a date)
+  value: number;
+  lo?: number;
+  hi?: number;
+}
+
+interface Props {
+  points: LinePoint[];
+  height?: number;
+  unit?: string;
+}
+
+const INSET_X = 2; // % horizontal padding so end dots are not clipped
+const PAD_Y = 8; // % vertical padding around the value range
+
+export default function LineBand({ points, height = 118, unit = "" }: Props) {
+  if (points.length < 2) {
+    return (
+      <div
+        style={{
+          height,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: palette.faint,
+          fontFamily: fonts.mono,
+          fontSize: 11.5,
+        }}
+      >
+        not enough points to plot a trajectory
+      </div>
+    );
+  }
+
+  const values = points.map((p) => p.value);
+  const los = points.map((p) => (p.lo ?? p.value));
+  const his = points.map((p) => (p.hi ?? p.value));
+  // Domain always includes zero so the baseline is meaningful for polarity.
+  const lo = Math.min(0, ...los, ...values);
+  const hi = Math.max(0, ...his, ...values);
+  const span = hi - lo || 1;
+
+  const x = (i: number) => INSET_X + (i / (points.length - 1)) * (100 - 2 * INSET_X);
+  const y = (v: number) => PAD_Y + (1 - (v - lo) / span) * (100 - 2 * PAD_Y);
+
+  const linePts = points.map((p, i) => `${x(i)},${y(p.value)}`).join(" ");
+  // Band polygon: hi across, then lo back.
+  const bandPts =
+    points.map((p, i) => `${x(i)},${y(p.hi ?? p.value)}`).join(" ") +
+    " " +
+    points
+      .slice()
+      .reverse()
+      .map((p, ri) => {
+        const i = points.length - 1 - ri;
+        return `${x(i)},${y(p.lo ?? p.value)}`;
+      })
+      .join(" ");
+
+  const zeroY = y(0);
+  const last = points[points.length - 1];
+  const lastSign = last.value >= 0 ? palette.pos : palette.neg;
+  const hasBand = points.some((p) => p.lo != null && p.hi != null);
+
+  // Which x labels to show: first, last, and a couple in between.
+  const tickEvery = Math.max(1, Math.round((points.length - 1) / 3));
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ position: "relative", width: "100%", height }}>
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          width="100%"
+          height={height}
+          style={{ display: "block", overflow: "visible" }}
+        >
+          {hasBand ? <polygon points={bandPts} fill={`${ACCENT}22`} stroke="none" /> : null}
+          {/* zero baseline — neutral, recessive */}
+          <line
+            x1="0"
+            x2="100"
+            y1={zeroY}
+            y2={zeroY}
+            stroke={palette.neu}
+            strokeWidth={1}
+            strokeDasharray="3 3"
+            vectorEffect="non-scaling-stroke"
+            opacity={0.5}
+          />
+          <polyline
+            points={linePts}
+            fill="none"
+            stroke={ACCENT}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+
+        {/* dot overlay — round + crisp, native hover tooltip per point */}
+        {points.map((p, i) => (
+          <div
+            key={i}
+            title={`${p.label} · ${p.value >= 0 ? "+" : ""}${p.value.toFixed(2)}${unit}${
+              p.lo != null && p.hi != null ? ` [${p.lo.toFixed(2)}, ${p.hi.toFixed(2)}]` : ""
+            }`}
+            style={{
+              position: "absolute",
+              left: `${x(i)}%`,
+              top: `${y(p.value)}%`,
+              width: i === points.length - 1 ? 8 : 5,
+              height: i === points.length - 1 ? 8 : 5,
+              marginLeft: i === points.length - 1 ? -4 : -2.5,
+              marginTop: i === points.length - 1 ? -4 : -2.5,
+              borderRadius: "50%",
+              background: i === points.length - 1 ? lastSign : ACCENT,
+              boxShadow: `0 0 0 2px ${"#0B151E"}`,
+              cursor: "default",
+            }}
+          />
+        ))}
+
+        {/* latest value, direct-labeled and tinted by sign */}
+        <div
+          style={{
+            position: "absolute",
+            right: 0,
+            top: `${Math.min(84, Math.max(0, y(last.value) - 16))}%`,
+            fontFamily: fonts.mono,
+            fontSize: 11,
+            fontWeight: 600,
+            color: lastSign,
+            background: "#0B151Ecc",
+            padding: "0 3px",
+            borderRadius: 3,
+          }}
+        >
+          {last.value >= 0 ? "+" : ""}
+          {last.value.toFixed(2)}
+          {unit}
+        </div>
+      </div>
+
+      {/* x-axis ticks */}
+      <div style={{ position: "relative", height: 12 }}>
+        {points.map((p, i) =>
+          i % tickEvery === 0 || i === points.length - 1 ? (
+            <div
+              key={i}
+              style={{
+                position: "absolute",
+                left: `${x(i)}%`,
+                transform: "translateX(-50%)",
+                fontFamily: fonts.mono,
+                fontSize: 9,
+                color: palette.faint,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {p.label}
+            </div>
+          ) : null,
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -17,6 +17,7 @@ export type PanelType =
   | "timeline"
   | "sentiment_heatmap"
   | "topic_sentiment"
+  | "sentiment_trend"
   | "entity_graph"
   | "claims"
   | "stance"
@@ -83,6 +84,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "timeline", title: "Story timeline", facets: ["events"], defaultSpan: 6, topicParam: true },
   { type: "sentiment_heatmap", title: "Sentiment heatmap", facets: ["sentiment", "trend"], defaultSpan: 6, daysParam: true, maxDays: 60 },
   { type: "topic_sentiment", title: "Sentiment by topic", facets: ["sentiment"], defaultSpan: 6, daysParam: true, maxDays: 90 },
+  { type: "sentiment_trend", title: "Sentiment trajectory", facets: ["sentiment", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "entity_graph", title: "Entity graph", facets: ["entities", "actors", "overview"], defaultSpan: 6, daysParam: true, maxDays: 30 },
   { type: "claims", title: "Extracted claims", facets: ["claims", "conflict"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "stance", title: "Stance breakdown", facets: ["stance", "conflict", "sentiment"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -31,6 +31,8 @@ import { mockStories, mockTimeline, mockWatchlist } from "../data/mock";
 import Heatmap from "../components/charts/Heatmap";
 import EntityGraph from "../components/charts/EntityGraph";
 import Sparkline from "../components/charts/Sparkline";
+import LineBand from "../components/charts/LineBand";
+import type { LinePoint } from "../components/charts/LineBand";
 import GenPanel from "./GenPanel";
 import type { OutletScore } from "../types";
 import type { PanelSpec, PanelType } from "./spec";
@@ -404,6 +406,40 @@ function TopicSentimentPanel(props: PanelProps) {
           })}
         </div>
       )}
+    </GenPanel>
+  );
+}
+
+const DEMO_SENTIMENT_TREND: { method: string; n: number; unit: string; points: LinePoint[] } = {
+  method: "7-day rolling mean sentiment with a bootstrap 90% band",
+  n: 64,
+  unit: "",
+  points: [
+    { label: "Jun 21", value: -0.14, lo: -0.26, hi: -0.02 },
+    { label: "Jun 23", value: -0.18, lo: -0.29, hi: -0.07 },
+    { label: "Jun 25", value: -0.09, lo: -0.2, hi: 0.02 },
+    { label: "Jun 27", value: 0.02, lo: -0.09, hi: 0.13 },
+    { label: "Jun 29", value: -0.03, lo: -0.15, hi: 0.09 },
+    { label: "Jul 01", value: 0.11, lo: 0.0, hi: 0.22 },
+    { label: "Jul 03", value: 0.19, lo: 0.07, hi: 0.31 },
+    { label: "Jul 05", value: 0.24, lo: 0.1, hi: 0.38 },
+  ],
+};
+
+function SentimentTrendPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "sentiment_trend",
+    DEMO_SENTIMENT_TREND,
+    (r) =>
+      Array.isArray(r.points) && r.points.length > 1
+        ? (r as unknown as typeof DEMO_SENTIMENT_TREND)
+        : null,
+    { topic: props.panel.params?.topic, days: daysParam(props.panel) },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <LineBand points={d.points} unit={d.unit} />
+      <AnalyticCaption method={d.method} n={d.n} />
     </GenPanel>
   );
 }
@@ -1498,6 +1534,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   timeline: TimelinePanel,
   sentiment_heatmap: SentimentHeatmapPanel,
   topic_sentiment: TopicSentimentPanel,
+  sentiment_trend: SentimentTrendPanel,
   entity_graph: EntityGraphPanel,
   claims: ClaimsPanel,
   stance: StancePanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -170,6 +170,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         max_days=90,
     ),
     PanelDef(
+        type="sentiment_trend",
+        title="Sentiment trajectory",
+        description="How sentiment on a topic moves over time, as a smoothed line with a confidence band; never a bare point estimate.",
+        endpoint=None,
+        facets=("sentiment", "trend"),
+        tables=("news_articles",),
+        default_span=6,
+        topic_param="topic",
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="entity_graph",
         title="Entity graph",
         description="Co-mention network of entities in recent coverage.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -196,3 +196,10 @@ class TestPlan:
         assert "climate policy" in body
         assert "blog" in body
         assert "14" in body
+
+    def test_sentiment_trajectory_selected_for_over_time_intent(self):
+        spec = plan("how sentiment shifted over time on climate policy")
+        types = [p.type for p in spec.panels]
+        assert "sentiment_trend" in types
+        trend = next(p for p in spec.panels if p.type == "sentiment_trend")
+        assert trend.params["topic"] == "climate policy"


### PR DESCRIPTION
## Summary

Adds the `sentiment_trend` panel and a reusable `LineBand` chart primitive: a 2px line over a shaded lo..hi confidence band. It shows how sentiment on a topic moves over time, the first true line-over-time view in the catalog (existing sentiment panels are a topic-by-time grid and a per-topic average bar).

## What changed

- New `apps/web/src/components/charts/LineBand.tsx`. One series, so no legend (the title names it). The band is always shown, so the series is never a bare point estimate. Polarity is never color-alone: a neutral-gray zero baseline anchors the sign and the latest value is direct-labeled and tinted by sign. Marks fill the panel width via a non-scaling stroke; dots, labels and date ticks are HTML overlays so text stays crisp and dots stay round.
- `src/genui/catalog.py`: `sentiment_trend` PanelDef (facets sentiment and trend, topic and days params).
- Regenerated `apps/web/src/genui/catalog.gen.ts` and the `ui-spec-v1.json` contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer with a demo fixture and a defensive live-adapter, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `sentiment_trend` for a sentiment-over-time intent and carries the topic param.

## Verification

- `pytest tests/unit/genui` (planner, codegen, smoke): 66 passed.
- `python scripts/genui/codegen.py --check`: generated artifacts current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the real component in a browser (both a rising series ending positive and a falling series ending negative): line, band, dashed zero baseline, per-point dots, sign-tinted latest value, and dated ticks all render with no overflow or label collision.
- Diverging sentiment color pair validated with the dataviz palette validator (CVD separation well above threshold); polarity carries secondary encoding (zero baseline, sign, position).

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_