### PR TITLE
Chart type: event axis (dated horizontal timeline)

### DIFF
--- a/apps/web/src/components/charts/TimelineAxis.tsx
+++ b/apps/web/src/components/charts/TimelineAxis.tsx
@@ -1,0 +1,130 @@
+// TimelineAxis — events laid on a true dated horizontal axis. Each event sits
+// at its timestamp (uneven spacing is the point), its marker sized by coverage
+// volume and colored by sentiment. Sentiment is never color-alone: the stalk is
+// solid for positive and dashed for negative, and each label carries the signed
+// value. Labels alternate above/below the axis with a connecting stalk so they
+// do not collide.
+
+import { colors, palette, fonts } from "../../theme";
+
+export interface TimelineEvent {
+  t: number; // position on the axis (e.g. day offset); larger = later
+  date: string; // display label for the timestamp
+  label: string; // what happened
+  volume: number; // coverage volume -> marker radius
+  sentiment: number; // -1..1 -> marker color + stalk style
+}
+
+const INSET = 7; // % horizontal padding so end markers are not clipped
+
+function sentColor(v: number): string {
+  if (v > 0.05) return palette.pos;
+  if (v < -0.05) return palette.neg;
+  return palette.neu;
+}
+
+function signed(v: number): string {
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}`;
+}
+
+export default function TimelineAxis({
+  events,
+  height = 150,
+}: {
+  events: TimelineEvent[];
+  height?: number;
+}) {
+  if (!events.length) {
+    return (
+      <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: palette.faint, fontFamily: fonts.mono, fontSize: 11.5 }}>
+        no dated events in the window
+      </div>
+    );
+  }
+
+  const sorted = [...events].sort((a, b) => a.t - b.t);
+  const ts = sorted.map((e) => e.t);
+  const tMin = Math.min(...ts);
+  const tMax = Math.max(...ts);
+  const span = tMax - tMin || 1;
+  const x = (t: number) => INSET + ((t - tMin) / span) * (100 - 2 * INSET);
+  const vMax = Math.max(1, ...sorted.map((e) => e.volume));
+  const r = (v: number) => 4 + (v / vMax) * 6; // 4..10 px radius
+
+  const axisY = height / 2;
+  const labelTop = 6;
+  const labelBottom = height - 34;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ position: "relative", width: "100%", height }}>
+        {/* axis */}
+        <div style={{ position: "absolute", left: 0, right: 0, top: axisY, height: 1, background: colors.border3 }} />
+
+        {sorted.map((e, i) => {
+          const above = i % 2 === 0;
+          const cx = x(e.t);
+          const rad = r(e.volume);
+          const col = sentColor(e.sentiment);
+          const labelY = above ? labelTop : labelBottom;
+          const stalkTop = above ? labelTop + 24 : axisY;
+          const stalkH = above ? axisY - (labelTop + 24) : labelBottom - axisY;
+          return (
+            <div key={i}>
+              {/* stalk: solid = positive sentiment, dashed = negative */}
+              <div
+                style={{
+                  position: "absolute",
+                  left: `${cx}%`,
+                  top: stalkTop,
+                  height: Math.max(0, stalkH),
+                  width: 0,
+                  borderLeft: `1px ${e.sentiment < -0.05 ? "dashed" : "solid"} ${col}66`,
+                }}
+              />
+              {/* marker */}
+              <div
+                title={`${e.date} · ${e.label} · vol ${e.volume} · sentiment ${signed(e.sentiment)}`}
+                style={{
+                  position: "absolute",
+                  left: `${cx}%`,
+                  top: axisY,
+                  width: rad * 2,
+                  height: rad * 2,
+                  marginLeft: -rad,
+                  marginTop: -rad,
+                  borderRadius: "50%",
+                  background: col,
+                  boxShadow: `0 0 0 2px ${colors.card}`,
+                  cursor: "default",
+                }}
+              />
+              {/* label group */}
+              <div
+                style={{
+                  position: "absolute",
+                  left: `${cx}%`,
+                  top: labelY,
+                  transform: "translateX(-50%)",
+                  width: 96,
+                  textAlign: "center",
+                  pointerEvents: "none",
+                }}
+              >
+                <div style={{ fontSize: 11, fontWeight: 500, color: colors.text, lineHeight: 1.2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {e.label}
+                </div>
+                <div style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.faint }}>
+                  {e.date} · <span style={{ color: col }}>{signed(e.sentiment)}</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.faint }}>
+        marker size = coverage volume · color = sentiment (green up / red down) · dashed stalk = negative
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -13,6 +13,7 @@ export type PanelType =
   | "anomaly_timeline"
   | "trending"
   | "clusters"
+  | "event_axis"
   | "watchlists"
   | "timeline"
   | "sentiment_heatmap"
@@ -80,6 +81,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "anomaly_timeline", title: "Anomaly timeline", facets: ["trend", "overview"], defaultSpan: 6, topicParam: true },
   { type: "trending", title: "Trending topics", facets: ["overview", "trend", "events"], defaultSpan: 6, daysParam: true, maxDays: 30 },
   { type: "clusters", title: "Event clusters", facets: ["overview", "events"], defaultSpan: 6 },
+  { type: "event_axis", title: "Coverage timeline", facets: ["events", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "watchlists", title: "Watchlist", facets: ["events", "trend"], defaultSpan: 6 },
   { type: "timeline", title: "Story timeline", facets: ["events"], defaultSpan: 6, topicParam: true },
   { type: "sentiment_heatmap", title: "Sentiment heatmap", facets: ["sentiment", "trend"], defaultSpan: 6, daysParam: true, maxDays: 60 },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -33,6 +33,8 @@ import EntityGraph from "../components/charts/EntityGraph";
 import Sparkline from "../components/charts/Sparkline";
 import LineBand from "../components/charts/LineBand";
 import type { LinePoint } from "../components/charts/LineBand";
+import TimelineAxis from "../components/charts/TimelineAxis";
+import type { TimelineEvent } from "../components/charts/TimelineAxis";
 import GenPanel from "./GenPanel";
 import type { OutletScore } from "../types";
 import type { PanelSpec, PanelType } from "./spec";
@@ -367,6 +369,36 @@ function ClustersPanel(props: PanelProps) {
           })}
         </div>
       )}
+    </GenPanel>
+  );
+}
+
+const DEMO_EVENT_AXIS: { method: string; n: number; events: TimelineEvent[] } = {
+  method: "coverage-volume peaks and sentiment shifts on the topic timeline",
+  n: 64,
+  events: [
+    { t: 0, date: "Jun 20", label: "First reports", volume: 6, sentiment: -0.05 },
+    { t: 4, date: "Jun 24", label: "Summit opens", volume: 22, sentiment: 0.18 },
+    { t: 7, date: "Jun 27", label: "Talks stall", volume: 31, sentiment: -0.34 },
+    { t: 11, date: "Jul 01", label: "Draft accord", volume: 18, sentiment: 0.12 },
+    { t: 15, date: "Jul 05", label: "Signed", volume: 27, sentiment: 0.29 },
+  ],
+};
+
+function EventAxisPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "event_axis",
+    DEMO_EVENT_AXIS,
+    (r) =>
+      Array.isArray(r.events) && r.events.length > 0
+        ? (r as unknown as typeof DEMO_EVENT_AXIS)
+        : null,
+    { topic: props.panel.params?.topic, days: daysParam(props.panel) },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <TimelineAxis events={d.events} />
+      <AnalyticCaption method={d.method} n={d.n} />
     </GenPanel>
   );
 }
@@ -1530,6 +1562,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   documents: DocumentsPanel,
   trending: TrendingPanel,
   clusters: ClustersPanel,
+  event_axis: EventAxisPanel,
   watchlists: WatchlistsPanel,
   timeline: TimelinePanel,
   sentiment_heatmap: SentimentHeatmapPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -127,6 +127,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
     ),
     PanelDef(
+        type="event_axis",
+        title="Coverage timeline",
+        description="A topic's notable coverage moments on a dated axis, each marker sized by coverage volume and colored by sentiment; relative timing and clustering are read directly, not inferred from a list.",
+        endpoint=None,
+        facets=("events", "trend"),
+        tables=("news_articles",),
+        default_span=6,
+        topic_param="topic",
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="watchlists",
         title="Watchlist",
         description="Tracked entities and topics with mention velocity and alerts.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -203,3 +203,10 @@ class TestPlan:
         assert "sentiment_trend" in types
         trend = next(p for p in spec.panels if p.type == "sentiment_trend")
         assert trend.params["topic"] == "climate policy"
+
+    def test_event_axis_selected_for_timeline_intent(self):
+        spec = plan("timeline of events on climate policy")
+        types = [p.type for p in spec.panels]
+        assert "event_axis" in types
+        axis = next(p for p in spec.panels if p.type == "event_axis")
+        assert axis.params["topic"] == "climate policy"


### PR DESCRIPTION
## Summary

Adds the `event_axis` panel and a reusable `TimelineAxis` chart primitive: events placed on a true dated horizontal axis, each marker sized by coverage volume and colored by sentiment. This is the only panel with a real time axis, so relative timing and clustering are read directly rather than inferred from a list (the existing `anomaly_timeline` is a list of only the flagged windows).

## What changed

- New `apps/web/src/components/charts/TimelineAxis.tsx`. Markers positioned by timestamp (uneven spacing is the point), radius by volume, color by sentiment. Sentiment is never color-alone: the connecting stalk is solid for positive and dashed for negative, and each label carries the signed value. Labels alternate above and below the axis with a stalk so they do not collide; markers carry a native hover tooltip.
- `src/genui/catalog.py`: `event_axis` PanelDef (facets events and trend, topic and days params).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer with a demo fixture and a defensive live-adapter, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `event_axis` for a timeline intent and carries the topic param.

## Verification

- `pytest tests/unit/genui` (planner, codegen, smoke): 67 passed.
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the real component in a browser: five date-spaced markers, volume-scaled sizes, sentiment colors (gray/green/red), alternating labels with solid and dashed stalks, signed values, no collision.
- Sentiment color pair validated with the dataviz validator; polarity carries secondary encoding (stalk style, sign label).

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_