### PR TITLE
Chart type: coverage flow (Sankey)

### DIFF
--- a/apps/web/src/components/charts/Sankey.tsx
+++ b/apps/web/src/components/charts/Sankey.tsx
@@ -1,0 +1,191 @@
+// Sankey — a layered flow diagram. Nodes are stacked per layer with height
+// proportional to the flow through them; links are ribbons whose thickness is
+// the flow value. A link takes its color from its source node, so a first-layer
+// category (e.g. a source type) is followed by eye through the diagram; the
+// legend maps those colors. Node bars and labels are crisp HTML overlays; only
+// the ribbons live in the SVG (their fills tolerate the horizontal stretch that
+// lets the diagram fill the panel width).
+
+import { ACCENT, palette, colors, fonts } from "../../theme";
+
+export interface SankeyNode {
+  id: string;
+  layer: number;
+  label: string;
+}
+export interface SankeyLink {
+  source: string;
+  target: string;
+  value: number;
+}
+
+// Categorical hues for the first layer, in fixed order (validated CVD-safe).
+const CAT = [ACCENT, palette.violet, palette.amber, palette.blue, palette.teal, palette.pos];
+const NODE_W = 7; // px width of a node bar
+const GAP = 6; // px vertical gap between stacked nodes
+const PAD_Y = 4; // px top/bottom padding
+
+export default function Sankey({
+  nodes,
+  links,
+  height = 210,
+}: {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+  height?: number;
+}) {
+  if (!nodes.length || !links.length) {
+    return (
+      <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: palette.faint, fontFamily: fonts.mono, fontSize: 11.5 }}>
+        no flow to chart
+      </div>
+    );
+  }
+
+  const layerNums = Array.from(new Set(nodes.map((n) => n.layer))).sort((a, b) => a - b);
+  const layerIndex = new Map(layerNums.map((l, i) => [l, i]));
+  const nLayers = layerNums.length;
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+
+  // Node value = max(incoming, outgoing) so flow-conserving nodes are exact.
+  const outSum = new Map<string, number>();
+  const inSum = new Map<string, number>();
+  for (const l of links) {
+    outSum.set(l.source, (outSum.get(l.source) ?? 0) + l.value);
+    inSum.set(l.target, (inSum.get(l.target) ?? 0) + l.value);
+  }
+  const value = (id: string) => Math.max(outSum.get(id) ?? 0, inSum.get(id) ?? 0);
+
+  // Nodes per layer, and the tallest layer's total value -> px-per-unit scale.
+  const perLayer = layerNums.map((l) => nodes.filter((n) => n.layer === l));
+  let maxUnits = 1;
+  perLayer.forEach((ns) => {
+    maxUnits = Math.max(maxUnits, ns.reduce((s, n) => s + value(n.id), 0));
+  });
+  const maxNodes = Math.max(...perLayer.map((ns) => ns.length));
+  const scale = (height - 2 * PAD_Y - (maxNodes - 1) * GAP) / maxUnits;
+
+  // Colors: first-layer nodes get categorical hues; later nodes are muted.
+  const nodeColor = new Map<string, string>();
+  perLayer[0].forEach((n, i) => nodeColor.set(n.id, CAT[i % CAT.length]));
+  for (let li = 1; li < nLayers; li++) {
+    perLayer[li].forEach((n) => nodeColor.set(n.id, colors.border4));
+  }
+
+  // Vertical layout: stack each layer's nodes, centered.
+  const box = new Map<string, { y0: number; y1: number }>();
+  perLayer.forEach((ns) => {
+    const total = ns.reduce((s, n) => s + value(n.id) * scale, 0) + (ns.length - 1) * GAP;
+    let y = PAD_Y + (height - 2 * PAD_Y - total) / 2;
+    ns.forEach((n) => {
+      const h = value(n.id) * scale;
+      box.set(n.id, { y0: y, y1: y + h });
+      y += h + GAP;
+    });
+  });
+
+  const xOf = (layer: number) => {
+    const i = layerIndex.get(layer)!;
+    const inset = 3;
+    return nLayers === 1 ? 50 : inset + (i / (nLayers - 1)) * (100 - 2 * inset);
+  };
+
+  // Running offsets so a node's links stack along its band.
+  const outOff = new Map<string, number>();
+  const inOff = new Map<string, number>();
+  const ribbons = links
+    .slice()
+    .sort((a, b) => (byId.get(a.source)!.layer - byId.get(b.source)!.layer))
+    .map((l, i) => {
+      const s = byId.get(l.source)!;
+      const t = byId.get(l.target)!;
+      const sBox = box.get(l.source)!;
+      const tBox = box.get(l.target)!;
+      const th = l.value * scale;
+      const so = outOff.get(l.source) ?? 0;
+      const to = inOff.get(l.target) ?? 0;
+      outOff.set(l.source, so + th);
+      inOff.set(l.target, to + th);
+      const sx = xOf(s.layer);
+      const tx = xOf(t.layer);
+      const sy0 = sBox.y0 + so;
+      const sy1 = sy0 + th;
+      const ty0 = tBox.y0 + to;
+      const ty1 = ty0 + th;
+      const mx = (sx + tx) / 2;
+      // Ribbon: top edge cubic, down target side, bottom edge cubic back.
+      const d = `M ${sx} ${sy0} C ${mx} ${sy0}, ${mx} ${ty0}, ${tx} ${ty0} L ${tx} ${ty1} C ${mx} ${ty1}, ${mx} ${sy1}, ${sx} ${sy1} Z`;
+      return {
+        d,
+        color: nodeColor.get(l.source)!,
+        title: `${s.label} to ${t.label}: ${l.value}`,
+        key: `${l.source}-${l.target}-${i}`,
+      };
+    });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ position: "relative", width: "100%", height }}>
+        <svg viewBox={`0 0 100 ${height}`} preserveAspectRatio="none" width="100%" height={height} style={{ position: "absolute", inset: 0, display: "block" }}>
+          {ribbons.map((r) => (
+            <path key={r.key} d={r.d} fill={r.color} fillOpacity={0.26} stroke="none">
+              <title>{r.title}</title>
+            </path>
+          ))}
+        </svg>
+
+        {/* node bars + labels */}
+        {nodes.map((n) => {
+          const b = box.get(n.id)!;
+          const x = xOf(n.layer);
+          const li = layerIndex.get(n.layer)!;
+          const labelRight = li < nLayers - 1;
+          return (
+            <div key={n.id}>
+              <div
+                title={`${n.label}: ${value(n.id)}`}
+                style={{
+                  position: "absolute",
+                  left: `${x}%`,
+                  top: b.y0,
+                  height: Math.max(2, b.y1 - b.y0),
+                  width: NODE_W,
+                  marginLeft: -NODE_W / 2,
+                  borderRadius: 2,
+                  background: nodeColor.get(n.id),
+                  boxShadow: `0 0 0 1px ${colors.card}`,
+                }}
+              />
+              <div
+                style={{
+                  position: "absolute",
+                  left: `${x}%`,
+                  top: (b.y0 + b.y1) / 2,
+                  transform: `translateY(-50%) ${labelRight ? "" : "translateX(-100%)"}`,
+                  marginLeft: labelRight ? NODE_W : -NODE_W,
+                  whiteSpace: "nowrap",
+                  fontSize: 10.5,
+                  color: colors.textMuted,
+                  fontFamily: fonts.sans,
+                  pointerEvents: "none",
+                }}
+              >
+                {n.label}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* legend: first-layer identity */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+        {perLayer[0].map((n) => (
+          <span key={n.id} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontFamily: fonts.mono, fontSize: 9.5, color: palette.faint }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: nodeColor.get(n.id) }} />
+            {n.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -28,6 +28,7 @@ export type PanelType =
   | "drift"
   | "outlet_ranking"
   | "outlet_clusters"
+  | "coverage_flow"
   | "actors"
   | "lead_lag"
   | "narrative_thread"
@@ -96,6 +97,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "drift", title: "Stance drift", facets: ["trend", "stance"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "outlet_ranking", title: "Outlet transparency ranking", facets: ["sources"], defaultSpan: 6, sourceTypeParam: true },
   { type: "outlet_clusters", title: "Outlet clusters", facets: ["sources", "entities"], defaultSpan: 6, sourceTypeParam: true },
+  { type: "coverage_flow", title: "Coverage flow", facets: ["sources", "overview"], defaultSpan: 6, daysParam: true, maxDays: 90 },
   { type: "actors", title: "Key actors", facets: ["actors", "entities"], defaultSpan: 6, sourceTypeParam: true },
   { type: "lead_lag", title: "Who leads, who follows", facets: ["sources", "trend"], defaultSpan: 6, topicParam: true },
   { type: "narrative_thread", title: "Narrative threads", facets: ["events", "overview"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -35,6 +35,8 @@ import LineBand from "../components/charts/LineBand";
 import type { LinePoint } from "../components/charts/LineBand";
 import TimelineAxis from "../components/charts/TimelineAxis";
 import type { TimelineEvent } from "../components/charts/TimelineAxis";
+import Sankey from "../components/charts/Sankey";
+import type { SankeyNode, SankeyLink } from "../components/charts/Sankey";
 import GenPanel from "./GenPanel";
 import type { OutletScore } from "../types";
 import type { PanelSpec, PanelType } from "./spec";
@@ -1555,6 +1557,54 @@ function UnknownPanel(props: PanelProps) {
   );
 }
 
+const DEMO_COVERAGE_FLOW: { method: string; n: number; nodes: SankeyNode[]; links: SankeyLink[] } = {
+  method: "share of coverage from source type to category to sentiment",
+  n: 64,
+  nodes: [
+    { id: "news", layer: 0, label: "News" },
+    { id: "blog", layer: 0, label: "Blogs" },
+    { id: "econ", layer: 1, label: "Economy" },
+    { id: "tech", layer: 1, label: "Technology" },
+    { id: "energy", layer: 1, label: "Energy" },
+    { id: "pos", layer: 2, label: "Positive" },
+    { id: "neu", layer: 2, label: "Neutral" },
+    { id: "neg", layer: 2, label: "Negative" },
+  ],
+  links: [
+    { source: "news", target: "econ", value: 18 },
+    { source: "news", target: "tech", value: 12 },
+    { source: "news", target: "energy", value: 8 },
+    { source: "blog", target: "econ", value: 6 },
+    { source: "blog", target: "tech", value: 10 },
+    { source: "econ", target: "pos", value: 9 },
+    { source: "econ", target: "neu", value: 8 },
+    { source: "econ", target: "neg", value: 7 },
+    { source: "tech", target: "pos", value: 13 },
+    { source: "tech", target: "neu", value: 6 },
+    { source: "tech", target: "neg", value: 3 },
+    { source: "energy", target: "neu", value: 3 },
+    { source: "energy", target: "neg", value: 5 },
+  ],
+};
+
+function CoverageFlowPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "coverage_flow",
+    DEMO_COVERAGE_FLOW,
+    (r) =>
+      Array.isArray(r.nodes) && Array.isArray(r.links) && r.links.length > 0
+        ? (r as unknown as typeof DEMO_COVERAGE_FLOW)
+        : null,
+    { days: daysParam(props.panel) },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <Sankey nodes={d.nodes} links={d.links} />
+      <AnalyticCaption method={d.method} n={d.n} />
+    </GenPanel>
+  );
+}
+
 const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   note: NotePanel,
   kpi_row: KpiRowPanel,
@@ -1577,6 +1627,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   drift: DriftPanel,
   outlet_ranking: OutletRankingPanel,
   outlet_clusters: OutletClustersPanel,
+  coverage_flow: CoverageFlowPanel,
   actors: ActorsPanel,
   anomaly_timeline: AnomalyTimelinePanel,
   lead_lag: LeadLagPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -292,6 +292,17 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         source_type_param="source_type",
     ),
     PanelDef(
+        type="coverage_flow",
+        title="Coverage flow",
+        description="How the corpus composes as a flow from source type to category to sentiment; ribbon width is the share of coverage, so routing and proportion are read at a glance rather than from a table.",
+        endpoint=None,
+        facets=("sources", "overview"),
+        tables=("news_articles",),
+        default_span=6,
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="actors",
         title="Key actors",
         description="Most-mentioned speakers, subjects and authors.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -210,3 +210,8 @@ class TestPlan:
         assert "event_axis" in types
         axis = next(p for p in spec.panels if p.type == "event_axis")
         assert axis.params["topic"] == "climate policy"
+
+    def test_coverage_flow_selected_for_composition_intent(self):
+        spec = plan("how coverage breaks down across sources and sentiment")
+        types = [p.type for p in spec.panels]
+        assert "coverage_flow" in types


### PR DESCRIPTION
## Summary

Adds the `coverage_flow` panel and a reusable `Sankey` chart primitive: a layered flow from source type to category to sentiment, ribbon width proportional to the share of coverage. This is the first aggregate flow view of the corpus (the existing `provenance_trace` shows a single artifact's chain as a list).

## What changed

- New `apps/web/src/components/charts/Sankey.tsx`. Nodes are stacked per layer with height proportional to the flow through them (flow-conserving); links are ribbons whose thickness is the flow value. Each link takes its color from its source node so a first-layer source type is followed by eye through the diagram and mapped by the legend. Node bars and labels are crisp HTML overlays; only the ribbons live in the SVG. Links carry a native hover tooltip.
- `src/genui/catalog.py`: `coverage_flow` PanelDef (facets sources and overview, days param).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer with a demo fixture and a defensive live-adapter, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `coverage_flow` for a coverage-composition intent.

## Verification

- `pytest tests/unit/genui` (planner, codegen, smoke): 68 passed.
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the real component in a browser: two source nodes with source-colored ribbons flowing through three categories to three sentiment buckets, widths proportional, labels readable, legend present, no overflow.
- First-layer categorical palette validated with the dataviz validator (CVD separation well above threshold); links carry node identity plus the legend.

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_