### PR TITLE
Chart type: fact-check scoreboard (grouped bars)

### DIFF
--- a/apps/web/src/components/charts/BarKit.tsx
+++ b/apps/web/src/components/charts/BarKit.tsx
@@ -1,0 +1,128 @@
+// BarKit — one accessible horizontal-bar primitive with two modes.
+//
+// diverging: signed values around a central zero baseline; positive extends
+//   right, negative left. Polarity is never color-alone: it is carried by side
+//   (which way the bar points), the signed value label, and color together.
+// grouped: several series per row, each a thin bar in a fixed-order categorical
+//   color, with a legend so identity is never color-alone.
+//
+// Bars are HTML so ends stay crisply rounded (4px) and text stays sharp; each
+// bar carries a native hover tooltip.
+
+import { ACCENT, palette, colors, fonts } from "../../theme";
+
+const CAT = [ACCENT, palette.violet, palette.amber, palette.blue, palette.teal];
+const LABEL_W = 104;
+const ROW_GAP = 8;
+
+export interface DivergingRow {
+  label: string;
+  value: number;
+}
+export interface GroupedRow {
+  label: string;
+  values: { key: string; value: number }[];
+}
+
+function signed(v: number, unit: string): string {
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}${unit}`;
+}
+
+export function DivergingBars({
+  rows,
+  unit = "",
+}: {
+  rows: DivergingRow[];
+  unit?: string;
+}) {
+  if (!rows.length) return null;
+  const maxAbs = Math.max(0.01, ...rows.map((r) => Math.abs(r.value)));
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: ROW_GAP }}>
+      {rows.map((r) => {
+        const pos = r.value >= 0;
+        const col = pos ? palette.pos : palette.neg;
+        const pct = (Math.abs(r.value) / maxAbs) * 50;
+        return (
+          <div key={r.label} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ width: LABEL_W, flex: "none", fontSize: 12, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {r.label}
+            </div>
+            <div style={{ position: "relative", flex: 1, height: 14 }}>
+              {/* zero baseline */}
+              <div style={{ position: "absolute", left: "50%", top: 0, bottom: 0, width: 1, background: colors.border3 }} />
+              <div
+                title={`${r.label}: ${signed(r.value, unit)}`}
+                style={{
+                  position: "absolute",
+                  top: 3,
+                  height: 8,
+                  width: `${pct}%`,
+                  background: col,
+                  left: pos ? "50%" : `${50 - pct}%`,
+                  borderRadius: pos ? "0 4px 4px 0" : "4px 0 0 4px",
+                }}
+              />
+              <div
+                style={{
+                  position: "absolute",
+                  top: -1,
+                  [pos ? "left" : "right"]: pos ? `calc(50% + ${pct}% + 4px)` : `calc(50% + ${pct}% + 4px)`,
+                  fontFamily: fonts.mono,
+                  fontSize: 10.5,
+                  color: col,
+                }}
+              >
+                {signed(r.value, unit)}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function GroupedBars({
+  rows,
+  series,
+  unit = "",
+}: {
+  rows: GroupedRow[];
+  series: string[];
+  unit?: string;
+}) {
+  if (!rows.length) return null;
+  const max = Math.max(0.01, ...rows.flatMap((r) => r.values.map((v) => v.value)));
+  const colorOf = (key: string) => CAT[Math.max(0, series.indexOf(key)) % CAT.length];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: ROW_GAP }}>
+        {rows.map((r) => (
+          <div key={r.label} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ width: LABEL_W, flex: "none", fontSize: 12, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {r.label}
+            </div>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 2 }}>
+              {r.values.map((v) => (
+                <div
+                  key={v.key}
+                  title={`${r.label} · ${v.key}: ${v.value}${unit}`}
+                  style={{ height: 6, width: `${Math.max(1.5, (v.value / max) * 100)}%`, background: colorOf(v.key), borderRadius: "0 4px 4px 0" }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 2 }}>
+        {series.map((s) => (
+          <span key={s} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontFamily: fonts.mono, fontSize: 9.5, color: palette.faint }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: colorOf(s) }} />
+            {s}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -21,6 +21,7 @@ export type PanelType =
   | "sentiment_trend"
   | "entity_graph"
   | "claims"
+  | "claim_verdicts"
   | "stance"
   | "frames"
   | "positions"
@@ -90,6 +91,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "sentiment_trend", title: "Sentiment trajectory", facets: ["sentiment", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "entity_graph", title: "Entity graph", facets: ["entities", "actors", "overview"], defaultSpan: 6, daysParam: true, maxDays: 30 },
   { type: "claims", title: "Extracted claims", facets: ["claims", "conflict"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
+  { type: "claim_verdicts", title: "Fact-check scoreboard", facets: ["claims", "sources"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "stance", title: "Stance breakdown", facets: ["stance", "conflict", "sentiment"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "frames", title: "Framing by source", facets: ["sources", "claims"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "positions", title: "Actor positions", facets: ["actors", "stance"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -37,6 +37,8 @@ import TimelineAxis from "../components/charts/TimelineAxis";
 import type { TimelineEvent } from "../components/charts/TimelineAxis";
 import Sankey from "../components/charts/Sankey";
 import type { SankeyNode, SankeyLink } from "../components/charts/Sankey";
+import { GroupedBars } from "../components/charts/BarKit";
+import type { GroupedRow } from "../components/charts/BarKit";
 import GenPanel from "./GenPanel";
 import type { OutletScore } from "../types";
 import type { PanelSpec, PanelType } from "./spec";
@@ -1605,6 +1607,36 @@ function CoverageFlowPanel(props: PanelProps) {
   );
 }
 
+const CLAIM_VERDICT_SERIES = ["verified", "disputed", "unverified"];
+const DEMO_CLAIM_VERDICTS: { method: string; n: number; rows: GroupedRow[] } = {
+  method: "fact-check verdicts over claims mined per source",
+  n: 128,
+  rows: [
+    { label: "Reuters", values: [{ key: "verified", value: 14 }, { key: "disputed", value: 2 }, { key: "unverified", value: 5 }] },
+    { label: "Bloomberg", values: [{ key: "verified", value: 11 }, { key: "disputed", value: 3 }, { key: "unverified", value: 7 }] },
+    { label: "The Guardian", values: [{ key: "verified", value: 8 }, { key: "disputed", value: 6 }, { key: "unverified", value: 9 }] },
+    { label: "Substack blogs", values: [{ key: "verified", value: 3 }, { key: "disputed", value: 9 }, { key: "unverified", value: 18 }] },
+  ],
+};
+
+function ClaimVerdictsPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "claim_verdicts",
+    DEMO_CLAIM_VERDICTS,
+    (r) =>
+      Array.isArray(r.rows) && r.rows.length > 0
+        ? (r as unknown as typeof DEMO_CLAIM_VERDICTS)
+        : null,
+    { topic: props.panel.params?.topic, source_type: props.panel.params?.source_type },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <GroupedBars rows={d.rows} series={CLAIM_VERDICT_SERIES} />
+      <AnalyticCaption method={d.method} n={d.n} />
+    </GenPanel>
+  );
+}
+
 const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   note: NotePanel,
   kpi_row: KpiRowPanel,
@@ -1620,6 +1652,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   sentiment_trend: SentimentTrendPanel,
   entity_graph: EntityGraphPanel,
   claims: ClaimsPanel,
+  claim_verdicts: ClaimVerdictsPanel,
   stance: StancePanel,
   frames: FramesPanel,
   positions: PositionsPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -217,6 +217,17 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         source_type_param="source_type",
     ),
     PanelDef(
+        type="claim_verdicts",
+        title="Fact-check scoreboard",
+        description="Verified, disputed and unverified claim counts per source, as grouped bars; which outlets carry corroborated claims and which carry unchecked ones is read directly.",
+        endpoint=None,
+        facets=("claims", "sources"),
+        tables=("argument_claims",),
+        default_span=6,
+        topic_param="topic",
+        source_type_param="source_type",
+    ),
+    PanelDef(
         type="stance",
         title="Stance breakdown",
         description="Supportive / critical / neutral stance mix per topic.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -215,3 +215,10 @@ class TestPlan:
         spec = plan("how coverage breaks down across sources and sentiment")
         types = [p.type for p in spec.panels]
         assert "coverage_flow" in types
+
+    def test_claim_verdicts_selected_for_factcheck_intent(self):
+        spec = plan("verified and unverified claims by source on climate policy")
+        types = [p.type for p in spec.panels]
+        assert "claim_verdicts" in types
+        panel = next(p for p in spec.panels if p.type == "claim_verdicts")
+        assert panel.params["topic"] == "climate policy"


### PR DESCRIPTION
## Summary

Adds the `claim_verdicts` panel and a reusable `BarKit` chart primitive (grouped + diverging modes). The panel shows verified / disputed / unverified claim counts per source as grouped bars, so which outlets carry corroborated claims and which carry unchecked ones is read directly.

Repointed from the original "sentiment by source" idea (#749): sentiment is the shallowest cut the platform has, so this uses the fact-check/claims data instead. The BarKit primitive still ships both grouped and diverging modes for future panels.

## What changed

- New `apps/web/src/components/charts/BarKit.tsx`. Grouped mode: several series per row in fixed-order categorical colors with a legend so identity is never color-alone. Diverging mode: baseline at zero, positive right and negative left, polarity anchored by side, sign label and color together. Bars are HTML so ends stay crisply rounded (4px) and text stays sharp; each bar carries a native hover tooltip.
- `src/genui/catalog.py`: `claim_verdicts` PanelDef (facets claims and sources, topic and source_type params).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer using the grouped mode with a demo fixture and a defensive live-adapter, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `claim_verdicts` for a fact-check-by-source intent and carries the topic param.

## Verification

- `pytest tests/unit/genui` (planner, codegen, smoke): 69 passed.
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the real component in a browser: four sources each with verified/disputed/unverified grouped bars, proportional widths, legend present, no overflow. The story reads at a glance (a wire service skews verified, a blog aggregator skews unverified).
- Grouped categorical palette validated with the dataviz validator (CVD separation well above threshold); legend carries identity.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_