### PR TITLE
Chart panel: corroboration over time (LineBand, non-sentiment)

### DIFF
--- a/apps/web/src/components/charts/LineBand.tsx
+++ b/apps/web/src/components/charts/LineBand.tsx
@@ -22,12 +22,17 @@ interface Props {
   points: LinePoint[];
   height?: number;
   unit?: string;
+  // Diverging series (default): domain includes zero, a zero baseline is drawn,
+  // and the latest value is signed and sign-tinted. Set false for a rate or
+  // volume: domain follows the data, the baseline shows only if the data spans
+  // zero, and the latest value is unsigned in the accent color.
+  signed?: boolean;
 }
 
 const INSET_X = 2; // % horizontal padding so end dots are not clipped
 const PAD_Y = 8; // % vertical padding around the value range
 
-export default function LineBand({ points, height = 118, unit = "" }: Props) {
+export default function LineBand({ points, height = 118, unit = "", signed = true }: Props) {
   if (points.length < 2) {
     return (
       <div
@@ -49,9 +54,10 @@ export default function LineBand({ points, height = 118, unit = "" }: Props) {
   const values = points.map((p) => p.value);
   const los = points.map((p) => (p.lo ?? p.value));
   const his = points.map((p) => (p.hi ?? p.value));
-  // Domain always includes zero so the baseline is meaningful for polarity.
-  const lo = Math.min(0, ...los, ...values);
-  const hi = Math.max(0, ...his, ...values);
+  // Diverging series pin zero into the domain so the baseline is meaningful;
+  // a rate/volume series lets the domain follow the data.
+  const lo = Math.min(...(signed ? [0] : []), ...los, ...values);
+  const hi = Math.max(...(signed ? [0] : []), ...his, ...values);
   const span = hi - lo || 1;
 
   const x = (i: number) => INSET_X + (i / (points.length - 1)) * (100 - 2 * INSET_X);
@@ -72,9 +78,11 @@ export default function LineBand({ points, height = 118, unit = "" }: Props) {
       .join(" ");
 
   const zeroY = y(0);
+  const showZero = lo <= 0 && hi >= 0;
   const last = points[points.length - 1];
-  const lastSign = last.value >= 0 ? palette.pos : palette.neg;
+  const lastSign = !signed ? ACCENT : last.value >= 0 ? palette.pos : palette.neg;
   const hasBand = points.some((p) => p.lo != null && p.hi != null);
+  const fmt = (v: number) => `${signed && v >= 0 ? "+" : ""}${v.toFixed(2)}${unit}`;
 
   // Which x labels to show: first, last, and a couple in between.
   const tickEvery = Math.max(1, Math.round((points.length - 1) / 3));
@@ -90,18 +98,20 @@ export default function LineBand({ points, height = 118, unit = "" }: Props) {
           style={{ display: "block", overflow: "visible" }}
         >
           {hasBand ? <polygon points={bandPts} fill={`${ACCENT}22`} stroke="none" /> : null}
-          {/* zero baseline — neutral, recessive */}
-          <line
-            x1="0"
-            x2="100"
-            y1={zeroY}
-            y2={zeroY}
-            stroke={palette.neu}
-            strokeWidth={1}
-            strokeDasharray="3 3"
-            vectorEffect="non-scaling-stroke"
-            opacity={0.5}
-          />
+          {/* zero baseline — neutral, recessive; only when the domain spans zero */}
+          {showZero ? (
+            <line
+              x1="0"
+              x2="100"
+              y1={zeroY}
+              y2={zeroY}
+              stroke={palette.neu}
+              strokeWidth={1}
+              strokeDasharray="3 3"
+              vectorEffect="non-scaling-stroke"
+              opacity={0.5}
+            />
+          ) : null}
           <polyline
             points={linePts}
             fill="none"
@@ -117,7 +127,7 @@ export default function LineBand({ points, height = 118, unit = "" }: Props) {
         {points.map((p, i) => (
           <div
             key={i}
-            title={`${p.label} · ${p.value >= 0 ? "+" : ""}${p.value.toFixed(2)}${unit}${
+            title={`${p.label} · ${fmt(p.value)}${
               p.lo != null && p.hi != null ? ` [${p.lo.toFixed(2)}, ${p.hi.toFixed(2)}]` : ""
             }`}
             style={{
@@ -151,9 +161,7 @@ export default function LineBand({ points, height = 118, unit = "" }: Props) {
             borderRadius: 3,
           }}
         >
-          {last.value >= 0 ? "+" : ""}
-          {last.value.toFixed(2)}
-          {unit}
+          {fmt(last.value)}
         </div>
       </div>
 

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -22,6 +22,7 @@ export type PanelType =
   | "entity_graph"
   | "claims"
   | "claim_verdicts"
+  | "claims_trend"
   | "stance"
   | "frames"
   | "positions"
@@ -92,6 +93,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "entity_graph", title: "Entity graph", facets: ["entities", "actors", "overview"], defaultSpan: 6, daysParam: true, maxDays: 30 },
   { type: "claims", title: "Extracted claims", facets: ["claims", "conflict"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "claim_verdicts", title: "Fact-check scoreboard", facets: ["claims", "sources"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
+  { type: "claims_trend", title: "Corroboration over time", facets: ["claims", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "stance", title: "Stance breakdown", facets: ["stance", "conflict", "sentiment"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "frames", title: "Framing by source", facets: ["sources", "claims"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "positions", title: "Actor positions", facets: ["actors", "stance"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1637,6 +1637,38 @@ function ClaimVerdictsPanel(props: PanelProps) {
   );
 }
 
+const DEMO_CLAIMS_TREND: { method: string; n: number; unit: string; points: LinePoint[] } = {
+  method: "share of claims with two or more independent sources, 7-day rolling",
+  n: 142,
+  unit: "",
+  points: [
+    { label: "Jun 21", value: 0.41, lo: 0.32, hi: 0.5 },
+    { label: "Jun 24", value: 0.46, lo: 0.37, hi: 0.55 },
+    { label: "Jun 27", value: 0.52, lo: 0.43, hi: 0.61 },
+    { label: "Jun 30", value: 0.49, lo: 0.4, hi: 0.58 },
+    { label: "Jul 03", value: 0.58, lo: 0.49, hi: 0.67 },
+    { label: "Jul 06", value: 0.63, lo: 0.53, hi: 0.73 },
+  ],
+};
+
+function ClaimsTrendPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "claims_trend",
+    DEMO_CLAIMS_TREND,
+    (r) =>
+      Array.isArray(r.points) && r.points.length > 1
+        ? (r as unknown as typeof DEMO_CLAIMS_TREND)
+        : null,
+    { topic: props.panel.params?.topic, days: daysParam(props.panel) },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <LineBand points={d.points} unit={d.unit} signed={false} />
+      <AnalyticCaption method={d.method} n={d.n} />
+    </GenPanel>
+  );
+}
+
 const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   note: NotePanel,
   kpi_row: KpiRowPanel,
@@ -1653,6 +1685,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   entity_graph: EntityGraphPanel,
   claims: ClaimsPanel,
   claim_verdicts: ClaimVerdictsPanel,
+  claims_trend: ClaimsTrendPanel,
   stance: StancePanel,
   frames: FramesPanel,
   positions: PositionsPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -228,6 +228,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         source_type_param="source_type",
     ),
     PanelDef(
+        type="claims_trend",
+        title="Corroboration over time",
+        description="The share of claims on a topic backed by independent sources, tracked over time as a line with a confidence band; whether the public record is getting better or worse corroborated is read directly.",
+        endpoint=None,
+        facets=("claims", "trend"),
+        tables=("argument_claims",),
+        default_span=6,
+        topic_param="topic",
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="stance",
         title="Stance breakdown",
         description="Supportive / critical / neutral stance mix per topic.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -222,3 +222,10 @@ class TestPlan:
         assert "claim_verdicts" in types
         panel = next(p for p in spec.panels if p.type == "claim_verdicts")
         assert panel.params["topic"] == "climate policy"
+
+    def test_claims_trend_selected_for_corroboration_over_time_intent(self):
+        spec = plan("how corroboration changed over time on climate policy")
+        types = [p.type for p in spec.panels]
+        assert "claims_trend" in types
+        panel = next(p for p in spec.panels if p.type == "claims_trend")
+        assert panel.params["topic"] == "climate policy"


### PR DESCRIPTION
## Summary

Adds the `claims_trend` panel: the share of claims on a topic backed by independent sources, tracked over time as a line with a confidence band. Points the line+band chart at the fact-check layer instead of sentiment.

## What changed

- Generalizes `LineBand` with a `signed` option (default true keeps the diverging behavior used by `sentiment_trend`). When false: the domain follows the data, the zero baseline shows only if the data spans zero, and the latest value is unsigned in the accent color, so the chart reads cleanly for a rate or volume.
- `src/genui/catalog.py`: `claims_trend` PanelDef (facets claims and trend, topic and days params).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer using `signed={false}` with a demo fixture and a defensive live-adapter, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `claims_trend` for a corroboration-over-time intent.

## Verification

- `pytest tests/unit/genui`: 70 passed (the LineBand change is backward-compatible; `sentiment_trend` still uses the default signed mode).
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the real component in a browser: a rising corroboration-rate line with a band, no forced zero baseline, latest value unsigned in the accent color.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_