### PR TITLE
Chart panel: claim timeline (TimelineAxis, non-sentiment)

### DIFF
--- a/apps/web/src/components/charts/TimelineAxis.tsx
+++ b/apps/web/src/components/charts/TimelineAxis.tsx
@@ -11,10 +11,13 @@ export interface TimelineEvent {
   t: number; // position on the axis (e.g. day offset); larger = later
   date: string; // display label for the timestamp
   label: string; // what happened
-  volume: number; // coverage volume -> marker radius
-  sentiment: number; // -1..1 -> marker color + stalk style
+  volume: number; // magnitude -> marker radius
+  sentiment: number; // -1..1 -> marker color + stalk style (a signed signal)
+  tag?: string; // optional short caption shown instead of the signed value
 }
 
+const DEFAULT_LEGEND =
+  "marker size = coverage volume · color = sentiment (green up / red down) · dashed stalk = negative";
 const INSET = 7; // % horizontal padding so end markers are not clipped
 
 function sentColor(v: number): string {
@@ -30,9 +33,11 @@ function signed(v: number): string {
 export default function TimelineAxis({
   events,
   height = 150,
+  legend = DEFAULT_LEGEND,
 }: {
   events: TimelineEvent[];
   height?: number;
+  legend?: string;
 }) {
   if (!events.length) {
     return (
@@ -84,7 +89,7 @@ export default function TimelineAxis({
               />
               {/* marker */}
               <div
-                title={`${e.date} · ${e.label} · vol ${e.volume} · sentiment ${signed(e.sentiment)}`}
+                title={`${e.date} · ${e.label} · vol ${e.volume} · ${e.tag ?? signed(e.sentiment)}`}
                 style={{
                   position: "absolute",
                   left: `${cx}%`,
@@ -115,16 +120,14 @@ export default function TimelineAxis({
                   {e.label}
                 </div>
                 <div style={{ fontFamily: fonts.mono, fontSize: 9, color: palette.faint }}>
-                  {e.date} · <span style={{ color: col }}>{signed(e.sentiment)}</span>
+                  {e.date} · <span style={{ color: col }}>{e.tag ?? signed(e.sentiment)}</span>
                 </div>
               </div>
             </div>
           );
         })}
       </div>
-      <div style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.faint }}>
-        marker size = coverage volume · color = sentiment (green up / red down) · dashed stalk = negative
-      </div>
+      <div style={{ fontFamily: fonts.mono, fontSize: 10, color: palette.faint }}>{legend}</div>
     </div>
   );
 }

--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -23,6 +23,7 @@ export type PanelType =
   | "claims"
   | "claim_verdicts"
   | "claims_trend"
+  | "evidence_axis"
   | "stance"
   | "frames"
   | "positions"
@@ -94,6 +95,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "claims", title: "Extracted claims", facets: ["claims", "conflict"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "claim_verdicts", title: "Fact-check scoreboard", facets: ["claims", "sources"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "claims_trend", title: "Corroboration over time", facets: ["claims", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
+  { type: "evidence_axis", title: "Claim timeline", facets: ["claims", "events"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "stance", title: "Stance breakdown", facets: ["stance", "conflict", "sentiment"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "frames", title: "Framing by source", facets: ["sources", "claims"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "positions", title: "Actor positions", facets: ["actors", "stance"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1669,6 +1669,47 @@ function ClaimsTrendPanel(props: PanelProps) {
   );
 }
 
+// Verdict maps to the signed signal TimelineAxis colors by: verified positive
+// (green), disputed negative (red), unverified neutral (gray).
+const VERDICT_SIGNAL: Record<string, number> = { verified: 1, disputed: -1, unverified: 0 };
+const DEMO_EVIDENCE_AXIS: { method: string; n: number; events: TimelineEvent[] } = {
+  method: "dated claims with independent-source counts and fact-check verdicts",
+  n: 142,
+  events: [
+    { t: 0, date: "Jun 20", label: "Emissions cut pledged", volume: 5, sentiment: 1, tag: "verified" },
+    { t: 5, date: "Jun 25", label: "Cost figure cited", volume: 2, sentiment: -1, tag: "disputed" },
+    { t: 9, date: "Jun 29", label: "Jobs impact claim", volume: 1, sentiment: 0, tag: "unverified" },
+    { t: 13, date: "Jul 03", label: "Treaty text confirmed", volume: 6, sentiment: 1, tag: "verified" },
+    { t: 16, date: "Jul 06", label: "Funding source claim", volume: 3, sentiment: -1, tag: "disputed" },
+  ],
+};
+
+function EvidenceAxisPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "evidence_axis",
+    DEMO_EVIDENCE_AXIS,
+    (r) =>
+      Array.isArray(r.events) && r.events.length > 0
+        ? (r as unknown as typeof DEMO_EVIDENCE_AXIS)
+        : null,
+    { topic: props.panel.params?.topic, days: daysParam(props.panel) },
+  );
+  // Accept a live payload that carries a verdict tag but no signed signal.
+  const events = d.events.map((e) => ({
+    ...e,
+    sentiment: e.sentiment ?? (e.tag ? VERDICT_SIGNAL[e.tag] ?? 0 : 0),
+  }));
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <TimelineAxis
+        events={events}
+        legend="marker size = corroboration density · color = verdict (green verified / red disputed / gray unverified)"
+      />
+      <AnalyticCaption method={d.method} n={d.n} />
+    </GenPanel>
+  );
+}
+
 const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   note: NotePanel,
   kpi_row: KpiRowPanel,
@@ -1677,6 +1718,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   trending: TrendingPanel,
   clusters: ClustersPanel,
   event_axis: EventAxisPanel,
+  evidence_axis: EvidenceAxisPanel,
   watchlists: WatchlistsPanel,
   timeline: TimelinePanel,
   sentiment_heatmap: SentimentHeatmapPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -240,6 +240,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         max_days=90,
     ),
     PanelDef(
+        type="evidence_axis",
+        title="Claim timeline",
+        description="Cited claims on a dated axis, each marker sized by corroboration density (independent-source count) and colored by fact-check verdict; when the key claims landed and how they checked out is read directly.",
+        endpoint=None,
+        facets=("claims", "events"),
+        tables=("argument_claims",),
+        default_span=6,
+        topic_param="topic",
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="stance",
         title="Stance breakdown",
         description="Supportive / critical / neutral stance mix per topic.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -229,3 +229,10 @@ class TestPlan:
         assert "claims_trend" in types
         panel = next(p for p in spec.panels if p.type == "claims_trend")
         assert panel.params["topic"] == "climate policy"
+
+    def test_evidence_axis_selected_for_claim_timeline_intent(self):
+        spec = plan("timeline of claims and evidence on climate policy")
+        types = [p.type for p in spec.panels]
+        assert "evidence_axis" in types
+        panel = next(p for p in spec.panels if p.type == "evidence_axis")
+        assert panel.params["topic"] == "climate policy"


### PR DESCRIPTION
## Summary

Adds the `evidence_axis` panel: cited claims on a dated axis, each marker sized by corroboration density (independent-source count) and colored by fact-check verdict. Points the timeline axis at the evidence layer instead of sentiment-colored coverage.

## What changed

- Generalizes `TimelineAxis` with a `legend` prop (default keeps the sentiment legend used by `event_axis`) and an optional per-event `tag` shown instead of the signed value. Verdicts map to the signed signal the axis already colors by: verified positive (green), disputed negative (red), unverified neutral (gray), so the existing color and stalk logic is reused with an evidence-flavored legend and verdict captions.
- `src/genui/catalog.py`: `evidence_axis` PanelDef (facets claims and events, topic and days params).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer with a demo fixture (verdict tags) and a defensive live-adapter that fills the signed signal from the tag, registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `evidence_axis` for a claim-timeline intent.

## Verification

- `pytest tests/unit/genui`: 71 passed (the TimelineAxis change is backward-compatible; `event_axis` still uses the default legend and signed value).
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the component: markers show verdict captions (verified / disputed / unverified) with the correct green / red / gray colors and no signed-number leakage; the legend reads for evidence, not sentiment.

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_