### PR TITLE
Chart panel: claim-to-verdict flow (Sankey, non-sentiment)

### DIFF
--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -24,6 +24,7 @@ export type PanelType =
   | "claim_verdicts"
   | "claims_trend"
   | "evidence_axis"
+  | "claim_flow"
   | "stance"
   | "frames"
   | "positions"
@@ -96,6 +97,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "claim_verdicts", title: "Fact-check scoreboard", facets: ["claims", "sources"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "claims_trend", title: "Corroboration over time", facets: ["claims", "trend"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "evidence_axis", title: "Claim timeline", facets: ["claims", "events"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
+  { type: "claim_flow", title: "Claim to verdict flow", facets: ["claims", "sources"], defaultSpan: 6, topicParam: true, daysParam: true, maxDays: 90 },
   { type: "stance", title: "Stance breakdown", facets: ["stance", "conflict", "sentiment"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "frames", title: "Framing by source", facets: ["sources", "claims"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },
   { type: "positions", title: "Actor positions", facets: ["actors", "stance"], defaultSpan: 6, topicParam: true, sourceTypeParam: true },

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -1607,6 +1607,54 @@ function CoverageFlowPanel(props: PanelProps) {
   );
 }
 
+const DEMO_CLAIM_FLOW: { method: string; n: number; nodes: SankeyNode[]; links: SankeyLink[] } = {
+  method: "claims routed from source to claim type to fact-check verdict",
+  n: 128,
+  nodes: [
+    { id: "wire", layer: 0, label: "Wire services" },
+    { id: "blog", layer: 0, label: "Blogs" },
+    { id: "stat", layer: 1, label: "Statistical" },
+    { id: "causal", layer: 1, label: "Causal" },
+    { id: "predict", layer: 1, label: "Predictive" },
+    { id: "verified", layer: 2, label: "Verified" },
+    { id: "disputed", layer: 2, label: "Disputed" },
+    { id: "unverified", layer: 2, label: "Unverified" },
+  ],
+  links: [
+    { source: "wire", target: "stat", value: 16 },
+    { source: "wire", target: "causal", value: 9 },
+    { source: "wire", target: "predict", value: 5 },
+    { source: "blog", target: "causal", value: 11 },
+    { source: "blog", target: "predict", value: 14 },
+    { source: "stat", target: "verified", value: 12 },
+    { source: "stat", target: "disputed", value: 3 },
+    { source: "stat", target: "unverified", value: 1 },
+    { source: "causal", target: "verified", value: 6 },
+    { source: "causal", target: "disputed", value: 8 },
+    { source: "causal", target: "unverified", value: 6 },
+    { source: "predict", target: "disputed", value: 4 },
+    { source: "predict", target: "unverified", value: 15 },
+  ],
+};
+
+function ClaimFlowPanel(props: PanelProps) {
+  const { d, source, isLoading } = useLiveOrDemo(
+    "claim_flow",
+    DEMO_CLAIM_FLOW,
+    (r) =>
+      Array.isArray(r.nodes) && Array.isArray(r.links) && r.links.length > 0
+        ? (r as unknown as typeof DEMO_CLAIM_FLOW)
+        : null,
+    { topic: props.panel.params?.topic, days: daysParam(props.panel) },
+  );
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      <Sankey nodes={d.nodes} links={d.links} />
+      <AnalyticCaption method={d.method} n={d.n} />
+    </GenPanel>
+  );
+}
+
 const CLAIM_VERDICT_SERIES = ["verified", "disputed", "unverified"];
 const DEMO_CLAIM_VERDICTS: { method: string; n: number; rows: GroupedRow[] } = {
   method: "fact-check verdicts over claims mined per source",
@@ -1736,6 +1784,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   outlet_ranking: OutletRankingPanel,
   outlet_clusters: OutletClustersPanel,
   coverage_flow: CoverageFlowPanel,
+  claim_flow: ClaimFlowPanel,
   actors: ActorsPanel,
   anomaly_timeline: AnomalyTimelinePanel,
   lead_lag: LeadLagPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "claim_flow", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -252,6 +252,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         max_days=90,
     ),
     PanelDef(
+        type="claim_flow",
+        title="Claim to verdict flow",
+        description="How claims flow from source to claim type to fact-check verdict, ribbon width proportional to claim counts; which sources produce which kinds of claims and how those check out is read at a glance.",
+        endpoint=None,
+        facets=("claims", "sources"),
+        tables=("argument_claims",),
+        default_span=6,
+        topic_param="topic",
+        days_param="days",
+        max_days=90,
+    ),
+    PanelDef(
         type="stance",
         title="Stance breakdown",
         description="Supportive / critical / neutral stance mix per topic.",

--- a/tests/unit/genui/test_genui_planner.py
+++ b/tests/unit/genui/test_genui_planner.py
@@ -236,3 +236,8 @@ class TestPlan:
         assert "evidence_axis" in types
         panel = next(p for p in spec.panels if p.type == "evidence_axis")
         assert panel.params["topic"] == "climate policy"
+
+    def test_claim_flow_selected_for_claim_flow_intent(self):
+        spec = plan("how claims flow from each source to a verdict")
+        types = [p.type for p in spec.panels]
+        assert "claim_flow" in types


### PR DESCRIPTION
## Summary

Adds the `claim_flow` panel: claims flowing from source to claim type to fact-check verdict, ribbon width proportional to claim counts. Points the flow chart at the claims layer instead of ending in sentiment buckets.

## What changed

- Reuses the existing generic `Sankey` primitive unchanged; only the demo fixture and a defensive live-adapter are new.
- `src/genui/catalog.py`: `claim_flow` PanelDef (facets claims and sources, topic and days params).
- Regenerated `catalog.gen.ts` and the contract enum via the codegen.
- `apps/web/src/genui/registry.tsx`: renderer (layer 0 sources, layer 1 claim types, layer 2 verdicts) registered in REGISTRY.
- `tests/unit/genui/test_genui_planner.py`: asserts the planner selects `claim_flow` for a claim-flow intent.

## Verification

- `pytest tests/unit/genui`: green.
- `python scripts/genui/codegen.py --check`: current.
- `npm run typecheck` and `npm run build`: clean.
- Rendered the component: 13 flow-conserving ribbons from two sources through three claim types to three verdicts, node labels and legend present (the Sankey layout itself was visually verified when the primitive first landed).

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_