### PR TITLE
Canvas UX: quiet provenance, purposeful empty states, balanced grid

### DIFF
--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -19,8 +19,8 @@ const STATUS_META: Record<BackendStatus, { className: string; dot: string; label
   offline: {
     className: "border-slate-500/30 bg-slate-500/10 text-slate-400",
     dot: "bg-slate-400",
-    label: "DEMO MODE",
-    hint: "Backend unreachable — panels fall back to the demo dataset",
+    label: "SAMPLE DATA",
+    hint: "Backend unreachable. Panels show a representative sample dataset.",
   },
 };
 

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         secondary: "border-transparent bg-secondary text-secondary-foreground",
         outline: "text-foreground",
         live: "border-emerald-400/30 bg-emerald-400/10 text-emerald-400",
-        demo: "border-slate-500/30 bg-slate-500/10 text-slate-400",
+        demo: "border-transparent bg-transparent px-1.5 text-muted-foreground/55",
         sync: "border-amber-400/30 bg-amber-400/10 text-amber-400",
       },
     },

--- a/apps/web/src/genui/Canvas.tsx
+++ b/apps/web/src/genui/Canvas.tsx
@@ -9,6 +9,7 @@ import SpecRenderer from "./SpecRenderer";
 import SavedCanvasView from "./SavedCanvasView";
 import CanvasActions from "./CanvasActions";
 import RefineBar from "./RefineBar";
+import SourceBadge from "./SourceBadge";
 import type { UISpec } from "./spec";
 import EntityGraph from "../components/charts/EntityGraph";
 import { useArticles, useClusters, useEntityGraph, useUiTelemetry } from "../lib/queries";
@@ -184,9 +185,7 @@ export default function Canvas({ canvas, onIntent }: Props) {
         <Badge variant="outline" className={planner.className} title={planner.hint}>
           {planner.label}
         </Badge>
-        <Badge variant={isLoading ? "sync" : source === "live" ? "live" : "demo"}>
-          {isLoading ? "SYNC" : source === "live" ? "LIVE" : "DEMO"}
-        </Badge>
+        <SourceBadge source={source} isLoading={isLoading} />
         <span className="font-grotesk text-sm font-semibold">{view.title}</span>
         {view.subtitle ? (
           <span className="font-mono text-[10.5px] text-muted-foreground">{view.subtitle}</span>

--- a/apps/web/src/genui/GenPanel.tsx
+++ b/apps/web/src/genui/GenPanel.tsx
@@ -4,8 +4,8 @@
 import type { ReactNode } from "react";
 import { Pin, X } from "lucide-react";
 import { Card } from "../components/ui/card";
-import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
+import SourceBadge from "./SourceBadge";
 import { cn } from "../lib/utils";
 import type { Source } from "../lib/queries";
 import type { PanelSpec } from "./spec";
@@ -35,7 +35,7 @@ export default function GenPanel({
   const adjustable = panel.type !== "note";
   return (
     <Card
-      className="hud-corners flex h-full min-w-0 flex-col transition-shadow duration-300 hover:shadow-[0_0_28px_-10px_hsl(var(--primary)/0.45)]"
+      className="hud-corners flex h-full min-h-[148px] min-w-0 flex-col transition-shadow duration-300 hover:shadow-[0_0_28px_-10px_hsl(var(--primary)/0.45)]"
       onClick={adjustable ? onTouch : undefined}
       title={panel.rationale || undefined}
     >
@@ -43,11 +43,7 @@ export default function GenPanel({
         <div className="min-w-0 flex-1 truncate font-grotesk text-[13.5px] font-semibold">
           {panel.title}
         </div>
-        {source ? (
-          <Badge variant={isLoading ? "sync" : source === "live" || source === "mcp" ? "live" : "demo"}>
-            {isLoading ? "SYNC" : source === "mcp" ? "MCP" : source === "live" ? "LIVE" : "DEMO"}
-          </Badge>
-        ) : null}
+        {source ? <SourceBadge source={source} isLoading={isLoading} /> : null}
         {adjustable ? (
           <>
             <Button

--- a/apps/web/src/genui/SourceBadge.tsx
+++ b/apps/web/src/genui/SourceBadge.tsx
@@ -1,0 +1,24 @@
+// Provenance indicator shared by the canvas header and every panel. Live and
+// proxied (MCP) data get a prominent green pill; the sample-data default recedes
+// to a quiet dotted marker so a fixtures-only canvas does not read as a mockup.
+
+import { Badge } from "../components/ui/badge";
+import type { Source } from "../lib/queries";
+
+interface Props {
+  source?: Source;
+  isLoading?: boolean;
+}
+
+export default function SourceBadge({ source, isLoading }: Props) {
+  if (isLoading) return <Badge variant="sync">SYNC</Badge>;
+  if (source === "live" || source === "mcp") {
+    return <Badge variant="live">{source === "mcp" ? "MCP" : "LIVE"}</Badge>;
+  }
+  return (
+    <Badge variant="demo" title="Sample data. Connect a live source to populate this panel.">
+      <span className="h-1.5 w-1.5 rounded-full bg-current opacity-60" aria-hidden="true" />
+      SAMPLE
+    </Badge>
+  );
+}

--- a/apps/web/src/genui/SpecRenderer.tsx
+++ b/apps/web/src/genui/SpecRenderer.tsx
@@ -7,12 +7,13 @@ import { panelComponent } from "./registry";
 import type { PanelSpec, UISpec } from "./spec";
 import type { AdaptiveSignals } from "./signals";
 
-const MIN = 3;
+const MIN = 4;
 const MAX = 12;
 
-// Walk the panels row by row and stretch each row's last panel so every row
-// fills the 12-column grid — no dangling half-empty rows. Exported for the
-// command bar's live ghost preview, which mirrors the real layout.
+// Walk the panels row by row and spread each row's leftover columns evenly
+// across its panels so every row fills the 12-column grid without a dangling
+// half-empty slot or one lopsided giant panel. Exported for the command bar's
+// live ghost preview, which mirrors the real layout.
 export function fitSpans(panels: PanelSpec[]): number[] {
   const spans = panels.map((p) => Math.max(MIN, Math.min(MAX, p.span || 6)));
   let i = 0;
@@ -23,7 +24,13 @@ export function fitSpans(panels: PanelSpec[]): number[] {
       used += spans[i];
       i += 1;
     }
-    if (i > start && used < MAX) spans[i - 1] += MAX - used;
+    const count = i - start;
+    // Distribute the remaining columns one at a time across the row, left
+    // first, so widths differ by at most one column instead of piling the
+    // slack onto the final panel.
+    for (let k = 0; k < MAX - used && count > 0; k += 1) {
+      spans[start + (k % count)] += 1;
+    }
   }
   return spans;
 }

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -4,7 +4,7 @@
 // rather than crashing the canvas.
 
 import type { CSSProperties, ComponentType } from "react";
-import { ACCENT, palette, fonts } from "../theme";
+import { ACCENT, colors, palette, fonts } from "../theme";
 import { sentColor, sentLabel } from "../lib/sentiment";
 import {
   useArticles,
@@ -67,20 +67,54 @@ function chip(color: string): CSSProperties {
   };
 }
 
+// Purposeful empty state: a faint dashed-frame glyph plus legible copy that
+// fills the panel body, so a slice with no rows reads as "nothing here yet"
+// rather than a broken or half-loaded panel.
 function Empty({ text }: { text: string }) {
   return (
     <div
       style={{
-        height: 90,
+        height: "100%",
+        minHeight: 96,
         display: "flex",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        color: "#5f7580",
-        fontFamily: fonts.mono,
-        fontSize: 11.5,
+        gap: 10,
+        textAlign: "center",
+        padding: "0 12px",
       }}
     >
-      {text}
+      <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true" style={{ opacity: 0.85 }}>
+        <rect
+          x="3.5"
+          y="3.5"
+          width="17"
+          height="17"
+          rx="3.5"
+          stroke={colors.border4}
+          strokeWidth="1.2"
+          strokeDasharray="2.5 3"
+        />
+        <path
+          d="M8 14.3l3-3.1 2.2 2.2 3-3.4"
+          stroke={colors.border4}
+          strokeWidth="1.3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span
+        style={{
+          fontFamily: fonts.mono,
+          fontSize: 11,
+          letterSpacing: "0.04em",
+          color: colors.textSubtle,
+          opacity: 0.85,
+        }}
+      >
+        {text}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Overview

Targeted UX pass on the generated canvas, addressing the three pain points that
made a fixtures-only canvas read as a broken mockup: loud demo badging, bare
empty states, and lopsided panel layout.

## Changes

Provenance

- New shared `SourceBadge` renders sample data as a quiet dotted "SAMPLE"
  marker while keeping LIVE / MCP / SYNC prominent. Used by both the panel
  chrome (`GenPanel`) and the canvas header (`Canvas`).
- `badge.tsx`: the `demo` variant is now transparent and low-contrast so a
  canvas full of sample panels recedes instead of shouting.
- `TopBar`: the offline connection pill reads "SAMPLE DATA" instead of
  "DEMO MODE".

Empty states

- `registry.tsx`: the `Empty` component is redesigned into an intentional
  state with a dashed-frame glyph and legible copy that fills the panel body,
  replacing the single bare gray line that looked half-loaded.

Layout and density

- `SpecRenderer.fitSpans` now spreads each row's leftover columns evenly across
  its panels instead of stretching only the last one, so rows no longer end in
  one lopsided giant panel.
- Raised the minimum panel span to 4 of 12 and added a card min-height floor so
  rows stay even and short panels do not collapse.

## Verification

- `tsc --noEmit` passes.
- Rendered a representative sparse canvas (server-side render to static HTML) to
  confirm the quiet SAMPLE marker versus the prominent LIVE pill, the new empty
  state, and the balanced two-row grid.

## Notes

- Frontend only. No new dependencies, no API or contract changes.
