### PR TITLE
Adopt Recharts: convert LineBand (proof of concept)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@neuronews/web",
+  "name": "@noesis/web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@neuronews/web",
+      "name": "@noesis/web",
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
@@ -15,6 +15,7 @@
         "lucide-react": "^1.23.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "recharts": "^3.9.2",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -836,6 +837,32 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1193,6 +1220,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
@@ -1264,6 +1303,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1308,6 +1410,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1595,6 +1703,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1612,6 +1841,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1643,6 +1878,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1692,6 +1937,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1819,6 +2070,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2334,6 +2604,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2366,6 +2666,57 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -2605,6 +2956,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2725,12 +3082,43 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^1.23.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "recharts": "^3.9.2",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {

--- a/apps/web/src/components/charts/LineBand.tsx
+++ b/apps/web/src/components/charts/LineBand.tsx
@@ -1,15 +1,22 @@
-// LineBand — a single time series drawn as a 2px line over a shaded
-// confidence band (lo..hi). One series, so no legend: the panel title names
-// it. Polarity is never color-alone — a neutral-gray zero baseline anchors the
-// sign and the latest value is direct-labeled and tinted by sign. The band is
-// always shown, so the series is never a bare point estimate.
-//
-// Marks are drawn in a 0..100 SVG box with preserveAspectRatio="none" so the
-// plot fills the panel width; the line uses a non-scaling stroke and the dots,
-// value label and date ticks are HTML overlays so text and markers stay crisp
-// and round regardless of the horizontal stretch.
+// LineBand — a single time series drawn as a line over a shaded confidence
+// band (lo..hi), built on Recharts. One series, so no legend: the panel title
+// names it. Polarity is never color-alone: a neutral zero baseline anchors the
+// sign for a diverging series, and the latest value is direct-labeled and
+// tinted by sign. The band is shown whenever present, so the series is never a
+// bare point estimate. Hovering any point reveals its value and interval.
 
-import { ACCENT, palette, fonts } from "../../theme";
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+  ReferenceDot,
+  ResponsiveContainer,
+} from "recharts";
+import { ACCENT, colors, palette, fonts } from "../../theme";
 
 export interface LinePoint {
   label: string; // x-axis label (e.g. a date)
@@ -29,10 +36,51 @@ interface Props {
   signed?: boolean;
 }
 
-const INSET_X = 2; // % horizontal padding so end dots are not clipped
-const PAD_Y = 8; // % vertical padding around the value range
+interface Row {
+  label: string;
+  value: number;
+  band?: [number, number];
+}
 
-export default function LineBand({ points, height = 118, unit = "", signed = true }: Props) {
+function signedFmt(signed: boolean, unit: string) {
+  return (v: number) => `${signed && v >= 0 ? "+" : ""}${v.toFixed(2)}${unit}`;
+}
+
+function BandTooltip(props: {
+  active?: boolean;
+  payload?: Array<{ payload: Row }>;
+  label?: string;
+  signed: boolean;
+  unit: string;
+}) {
+  const { active, payload, label, signed, unit } = props;
+  if (!active || !payload || !payload.length) return null;
+  const row = payload[0].payload;
+  const fmt = signedFmt(signed, unit);
+  return (
+    <div
+      style={{
+        background: "#0B151Ef2",
+        border: `1px solid ${colors.border2}`,
+        borderRadius: 4,
+        padding: "5px 8px",
+        fontFamily: fonts.mono,
+        fontSize: 10.5,
+        color: colors.text,
+      }}
+    >
+      <div style={{ color: palette.faint, marginBottom: 2 }}>{label}</div>
+      <div style={{ color: ACCENT, fontWeight: 600 }}>{fmt(row.value)}</div>
+      {row.band ? (
+        <div style={{ color: palette.neu }}>
+          [{row.band[0].toFixed(2)}, {row.band[1].toFixed(2)}]
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function LineBand({ points, height = 128, unit = "", signed = true }: Props) {
   if (points.length < 2) {
     return (
       <div
@@ -51,141 +99,86 @@ export default function LineBand({ points, height = 118, unit = "", signed = tru
     );
   }
 
+  const hasBand = points.some((p) => p.lo != null && p.hi != null);
+  const data: Row[] = points.map((p) => ({
+    label: p.label,
+    value: p.value,
+    band: p.lo != null && p.hi != null ? [p.lo, p.hi] : undefined,
+  }));
+
   const values = points.map((p) => p.value);
-  const los = points.map((p) => (p.lo ?? p.value));
-  const his = points.map((p) => (p.hi ?? p.value));
+  const los = points.map((p) => p.lo ?? p.value);
+  const his = points.map((p) => p.hi ?? p.value);
   // Diverging series pin zero into the domain so the baseline is meaningful;
   // a rate/volume series lets the domain follow the data.
   const lo = Math.min(...(signed ? [0] : []), ...los, ...values);
   const hi = Math.max(...(signed ? [0] : []), ...his, ...values);
-  const span = hi - lo || 1;
+  const pad = (hi - lo || 1) * 0.08;
 
-  const x = (i: number) => INSET_X + (i / (points.length - 1)) * (100 - 2 * INSET_X);
-  const y = (v: number) => PAD_Y + (1 - (v - lo) / span) * (100 - 2 * PAD_Y);
-
-  const linePts = points.map((p, i) => `${x(i)},${y(p.value)}`).join(" ");
-  // Band polygon: hi across, then lo back.
-  const bandPts =
-    points.map((p, i) => `${x(i)},${y(p.hi ?? p.value)}`).join(" ") +
-    " " +
-    points
-      .slice()
-      .reverse()
-      .map((p, ri) => {
-        const i = points.length - 1 - ri;
-        return `${x(i)},${y(p.lo ?? p.value)}`;
-      })
-      .join(" ");
-
-  const zeroY = y(0);
-  const showZero = lo <= 0 && hi >= 0;
   const last = points[points.length - 1];
   const lastSign = !signed ? ACCENT : last.value >= 0 ? palette.pos : palette.neg;
-  const hasBand = points.some((p) => p.lo != null && p.hi != null);
-  const fmt = (v: number) => `${signed && v >= 0 ? "+" : ""}${v.toFixed(2)}${unit}`;
-
-  // Which x labels to show: first, last, and a couple in between.
-  const tickEvery = Math.max(1, Math.round((points.length - 1) / 3));
+  const showZero = lo <= 0 && hi >= 0;
+  const fmt = signedFmt(signed, unit);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-      <div style={{ position: "relative", width: "100%", height }}>
-        <svg
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          width="100%"
-          height={height}
-          style={{ display: "block", overflow: "visible" }}
-        >
-          {hasBand ? <polygon points={bandPts} fill={`${ACCENT}22`} stroke="none" /> : null}
-          {/* zero baseline — neutral, recessive; only when the domain spans zero */}
-          {showZero ? (
-            <line
-              x1="0"
-              x2="100"
-              y1={zeroY}
-              y2={zeroY}
-              stroke={palette.neu}
-              strokeWidth={1}
-              strokeDasharray="3 3"
-              vectorEffect="non-scaling-stroke"
-              opacity={0.5}
-            />
-          ) : null}
-          <polyline
-            points={linePts}
-            fill="none"
-            stroke={ACCENT}
-            strokeWidth={2}
-            strokeLinejoin="round"
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
+    <ResponsiveContainer width="100%" height={height}>
+      <ComposedChart data={data} margin={{ top: 10, right: 44, bottom: 2, left: 4 }}>
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          interval="preserveStartEnd"
+          minTickGap={44}
+          padding={{ left: 14, right: 6 }}
+          tick={{ fill: palette.faint, fontFamily: fonts.mono, fontSize: 9 }}
+        />
+        <YAxis hide domain={[lo - pad, hi + pad]} />
+        {showZero ? (
+          <ReferenceLine y={0} stroke={palette.neu} strokeDasharray="3 3" strokeOpacity={0.5} />
+        ) : null}
+        {hasBand ? (
+          <Area
+            type="monotone"
+            dataKey="band"
+            stroke="none"
+            fill={ACCENT}
+            fillOpacity={0.13}
+            connectNulls
+            isAnimationActive={false}
+            activeDot={false}
           />
-        </svg>
-
-        {/* dot overlay — round + crisp, native hover tooltip per point */}
-        {points.map((p, i) => (
-          <div
-            key={i}
-            title={`${p.label} · ${fmt(p.value)}${
-              p.lo != null && p.hi != null ? ` [${p.lo.toFixed(2)}, ${p.hi.toFixed(2)}]` : ""
-            }`}
-            style={{
-              position: "absolute",
-              left: `${x(i)}%`,
-              top: `${y(p.value)}%`,
-              width: i === points.length - 1 ? 8 : 5,
-              height: i === points.length - 1 ? 8 : 5,
-              marginLeft: i === points.length - 1 ? -4 : -2.5,
-              marginTop: i === points.length - 1 ? -4 : -2.5,
-              borderRadius: "50%",
-              background: i === points.length - 1 ? lastSign : ACCENT,
-              boxShadow: `0 0 0 2px ${"#0B151E"}`,
-              cursor: "default",
-            }}
-          />
-        ))}
-
+        ) : null}
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke={ACCENT}
+          strokeWidth={2}
+          dot={{ r: 2.5, fill: ACCENT, strokeWidth: 0 }}
+          activeDot={{ r: 4, fill: ACCENT, stroke: colors.card, strokeWidth: 2 }}
+          isAnimationActive={false}
+        />
         {/* latest value, direct-labeled and tinted by sign */}
-        <div
-          style={{
-            position: "absolute",
-            right: 0,
-            top: `${Math.min(84, Math.max(0, y(last.value) - 16))}%`,
+        <ReferenceDot
+          x={last.label}
+          y={last.value}
+          r={4}
+          fill={lastSign}
+          stroke={colors.card}
+          strokeWidth={2}
+          label={{
+            value: fmt(last.value),
+            position: "right",
+            fill: lastSign,
             fontFamily: fonts.mono,
             fontSize: 11,
             fontWeight: 600,
-            color: lastSign,
-            background: "#0B151Ecc",
-            padding: "0 3px",
-            borderRadius: 3,
           }}
-        >
-          {fmt(last.value)}
-        </div>
-      </div>
-
-      {/* x-axis ticks */}
-      <div style={{ position: "relative", height: 12 }}>
-        {points.map((p, i) =>
-          i % tickEvery === 0 || i === points.length - 1 ? (
-            <div
-              key={i}
-              style={{
-                position: "absolute",
-                left: `${x(i)}%`,
-                transform: "translateX(-50%)",
-                fontFamily: fonts.mono,
-                fontSize: 9,
-                color: palette.faint,
-                whiteSpace: "nowrap",
-              }}
-            >
-              {p.label}
-            </div>
-          ) : null,
-        )}
-      </div>
-    </div>
+        />
+        <Tooltip
+          cursor={{ stroke: palette.neu, strokeOpacity: 0.35 }}
+          content={<BandTooltip signed={signed} unit={unit} />}
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
   );
 }


### PR DESCRIPTION
## Overview

Adopts Recharts as the charting library and converts the first primitive,
`LineBand`, as a proof of concept before migrating the rest. The goal is more
chart functionality (interactivity, less bespoke geometry) now that matching the
hand-rolled SVG aesthetic is no longer a requirement.

## Changes

- Add `recharts@^3.9.2`.
- Rewrite `apps/web/src/components/charts/LineBand.tsx` as a Recharts
  `ComposedChart` (range `Area` band, `Line`, zero `ReferenceLine`, custom
  `Tooltip`, sign-tinted `ReferenceDot` label).
- Public interface is unchanged (`points` / `unit` / `signed`), so the two
  consuming panels (`sentiment_trend`, `claims_trend`) need no edits.

## What is preserved vs added

Preserved (dataviz semantics of the original):

- Single accent line over a shaded confidence band.
- Neutral dashed zero baseline for a diverging series (polarity never color
  alone).
- Latest value direct-labeled and tinted by sign.

Added for free from the library:

- Hover tooltips showing the value and its interval.
- Active-point highlight and responsive resizing.

Removed: roughly 190 lines of manual SVG coordinate math, replaced by a
declarative chart.

## Tradeoff to weigh before a full migration

Recharts pulls in d3 dependencies. Importing it into the main bundle grows it
from about 393 KB to 763 KB raw (about 117 KB to 225 KB gzipped, roughly
+110 KB over the wire). A full chart migration should code-split the chart
panels into a lazily loaded vendor chunk so the initial canvas load is not
penalized.

## Verification

- `tsc --noEmit` passes and `vite build` succeeds.
- Rendered both consuming shapes in a real browser (Recharts needs DOM
  measurement): a signed sentiment series with the zero baseline and a green
  `+0.27` latest label, and an unsigned corroboration-count series with a cyan
  `21.00` label. Confidence band, line, dots, and date-axis all render on-theme.

## Notes

- Frontend only. No planner, catalog, codegen, or contract changes.
- If this looks good, the next steps are to convert the remaining primitives
  (`TimelineAxis`, `Sankey`, `BarKit`, `Heatmap`, `Sparkline`) and add the
  code-splitting described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_