### PR TITLE
Canvas layout: fill vertically, then expand horizontally (masonry board)

### DIFF
--- a/apps/web/src/genui/Canvas.tsx
+++ b/apps/web/src/genui/Canvas.tsx
@@ -178,9 +178,9 @@ export default function Canvas({ canvas, onIntent }: Props) {
   }
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-6 pt-5">
+    <div className="flex h-full min-h-0 flex-col px-6 pb-4 pt-5">
       {/* Provenance strip */}
-      <div className="mb-4 flex flex-wrap items-center gap-2.5">
+      <div className="mb-3 flex shrink-0 flex-wrap items-center gap-2.5">
         <Badge variant="outline" className={planner.className} title={planner.hint}>
           {planner.label}
         </Badge>
@@ -228,11 +228,13 @@ export default function Canvas({ canvas, onIntent }: Props) {
       </div>
 
       {/* In-canvas refinement (M6): mutate this layout with a follow-up. */}
-      <div className="mb-4">
+      <div className="mb-3 shrink-0">
         <RefineBar spec={view} onRefined={setRefined} />
       </div>
 
-      <SpecRenderer spec={view} adaptive={adaptive} />
+      <div className="min-h-0 flex-1">
+        <SpecRenderer spec={view} adaptive={adaptive} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/genui/SavedCanvasView.tsx
+++ b/apps/web/src/genui/SavedCanvasView.tsx
@@ -38,8 +38,8 @@ export default function SavedCanvasView({ savedId, sharedToken }: Props) {
   }
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-6 pt-5">
-      <div className="mb-4 flex flex-wrap items-center gap-2.5">
+    <div className="flex h-full min-h-0 flex-col px-6 pb-4 pt-5">
+      <div className="mb-3 flex shrink-0 flex-wrap items-center gap-2.5">
         <Badge
           variant="outline"
           className={
@@ -57,7 +57,9 @@ export default function SavedCanvasView({ savedId, sharedToken }: Props) {
         ) : null}
       </div>
 
-      <SpecRenderer spec={spec} adaptive={adaptive} />
+      <div className="min-h-0 flex-1">
+        <SpecRenderer spec={spec} adaptive={adaptive} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/genui/SpecRenderer.tsx
+++ b/apps/web/src/genui/SpecRenderer.tsx
@@ -1,7 +1,8 @@
-// Renders a ui-spec-v1 layout: the plan note as a subtle strip, then a
-// 12-column grid of registry panels fitted to the request — spec spans are
-// treated as hints and each row is stretched to fill the full width, so a
-// focused intent yields a few large panels and a broad one a dense grid.
+// Renders a ui-spec-v1 layout as a masonry board: the plan note as a subtle
+// strip, then diverse-sized panels that fill the available height in columns
+// and expand to the right once a column is full. The board scrolls
+// horizontally, so a busy canvas grows sideways instead of into an endless
+// vertical scroll. Spec spans are treated as width hints per panel.
 
 import { panelComponent } from "./registry";
 import type { PanelSpec, UISpec } from "./spec";
@@ -10,9 +11,9 @@ import type { AdaptiveSignals } from "./signals";
 const MIN = 3;
 const MAX = 12;
 
-// Walk the panels row by row and stretch each row's last panel so every row
-// fills the 12-column grid — no dangling half-empty rows. Exported for the
-// command bar's live ghost preview, which mirrors the real layout.
+// Balance a row of spec spans to fill the 12-column grid. No longer used for
+// the main canvas layout (now a masonry column-flow), but kept for the command
+// bar's compact plan preview, which sketches the plan as a 12-column tile grid.
 export function fitSpans(panels: PanelSpec[]): number[] {
   const spans = panels.map((p) => Math.max(MIN, Math.min(MAX, p.span || 6)));
   let i = 0;
@@ -28,6 +29,15 @@ export function fitSpans(panels: PanelSpec[]): number[] {
   return spans;
 }
 
+// Map a spec span (1..12) to a panel width in pixels so panels keep diverse
+// sizes in the masonry. Clamped to a comfortable card range.
+const COL_MIN = 300;
+const COL_MAX = 560;
+export function widthFor(span: number): number {
+  const s = Math.max(MIN, Math.min(MAX, span || 6));
+  return Math.round(Math.max(COL_MIN, Math.min(COL_MAX, 200 + s * 30)));
+}
+
 interface Props {
   spec: UISpec;
   adaptive: AdaptiveSignals;
@@ -35,34 +45,37 @@ interface Props {
 
 export default function SpecRenderer({ spec, adaptive }: Props) {
   const note = spec.panels.find((p) => p.type === "note" && p.body);
-  const gridPanels = spec.panels.filter((p) => p.type !== "note");
-  const spans = fitSpans(gridPanels);
+  const panels = spec.panels.filter((p) => p.type !== "note");
 
   return (
-    <div>
+    <div className="flex h-full min-h-0 flex-col">
       {note ? (
         <p
-          className="mb-4 border-l-2 border-primary/40 pl-3 font-mono text-[11.5px] leading-relaxed text-muted-foreground"
+          className="mb-3 shrink-0 border-l-2 border-primary/40 pl-3 font-mono text-[11.5px] leading-relaxed text-muted-foreground"
           title={note.rationale || undefined}
         >
           {note.body}
         </p>
       ) : null}
-      <div className="grid grid-cols-12 gap-3">
-        {gridPanels.map((panel, i) => {
-          const Component = panelComponent(panel.type);
-          return (
-            <div key={panel.id} className="min-w-0" style={{ gridColumn: `span ${spans[i]}` }}>
-              <Component
-                panel={panel}
-                pinned={adaptive.isPinned(panel.type)}
-                onPin={() => adaptive.togglePin(panel.type)}
-                onDismiss={() => adaptive.dismiss(panel.type)}
-                onTouch={() => adaptive.touch(panel.type)}
-              />
-            </div>
-          );
-        })}
+      {/* Masonry board: panels stack top-to-bottom to fill the height, then a
+          new column starts on the right; the board scrolls horizontally. */}
+      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden pb-1">
+        <div className="flex h-full w-max flex-col flex-wrap content-start items-start gap-3">
+          {panels.map((panel) => {
+            const Component = panelComponent(panel.type);
+            return (
+              <div key={panel.id} className="min-w-0" style={{ width: widthFor(panel.span) }}>
+                <Component
+                  panel={panel}
+                  pinned={adaptive.isPinned(panel.type)}
+                  onPin={() => adaptive.togglePin(panel.type)}
+                  onDismiss={() => adaptive.dismiss(panel.type)}
+                  onTouch={() => adaptive.touch(panel.type)}
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Overview

Changes the dashboard so it fills the viewport height with diverse-sized panels
and then expands to the right (horizontal scroll) once a column is full, instead
of growing into an endless vertical scroll.

## Changes

- `SpecRenderer`: replace the 12-column row grid with a masonry column-flow. The
  board is a height-bounded flex column-wrap with horizontal overflow; panels
  stack top-to-bottom to fill the height, then a new column starts on the right.
  Each spec span maps to a panel width via a new `widthFor` helper, so panels
  keep diverse sizes (varied widths plus content-driven heights).
- `Canvas` and `SavedCanvasView`: restructure the intent and saved-canvas views
  into a flex column so the board has a bounded height to wrap against. The
  provenance header and refine bar are pinned; the board fills the remaining
  height.
- `fitSpans` is retained (still exported) for the command bar's compact plan
  preview, which sketches the plan as a 12-column tile grid.

## Verification

- `tsc --noEmit` passes and `vite build` succeeds.
- Drove the built app end to end in a real browser (demo data, no backend): a
  broad intent produced a full canvas whose panels fill the height in columns
  and extend past the right edge. Measured the board at 3516px wide versus
  1012px visible (about 2504px of horizontal scroll) and confirmed the rightmost
  columns (evidence-axis timeline, venue-credibility ranking, lead-lag) render
  fully after scrolling. Panels kept diverse widths and heights.

## Notes

- Frontend only. No planner, catalog, codegen, or contract changes.
- A single panel taller than the viewport would clip (the board hides vertical
  overflow to enforce the column model); panels are bounded in practice, so this
  is a rare edge case.
- Possible follow-up: a right-edge fade or persistent thin scrollbar to signal
  that more columns exist off-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCPyY83KU5eGWr1BNhFFY)_