### PR TITLE
A1: dataset-series-v1 contract, observation store + World Bank connector

### DIFF
--- a/contracts/schemas/jsonschema/dataset-series-v1.json
+++ b/contracts/schemas/jsonschema/dataset-series-v1.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://contracts.neuronews.com/schemas/dataset-series-v1.json",
+  "title": "DatasetSeries v1",
+  "description": "A statistical time series as harvested from an official provider (World Bank, FRED, Eurostat, ...). Statistical series are first-class evidence for checking quantitative claims; they are NOT documents (they are versioned, revisable, and numeric), so they carry their own contract rather than document-ingest-v1. Observations are vintaged by as_of so a claim check records which revision it ran against and is replayable. See docs/architecture/EVIDENCE_DATASETS_PLAN.md.",
+  "type": "object",
+  "properties": {
+    "series_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Provider-scoped, stable series identifier of the form '<provider>:<code>[:<geography>]', e.g. 'wb:SL.UEM.TOTL.ZS:DE'."
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Data provider short name (e.g. 'worldbank', 'fred', 'eurostat', 'document', 'filing')."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable series title, e.g. 'Unemployment, total (% of labor force) - Germany'."
+    },
+    "unit": {
+      "type": ["string", "null"],
+      "description": "Unit of the observation values, normalized where possible (e.g. 'percent', 'usd', 'index', 'count'). Null when unknown."
+    },
+    "frequency": {
+      "type": "string",
+      "enum": ["annual", "quarterly", "monthly", "weekly", "daily", "irregular"],
+      "description": "Observation frequency."
+    },
+    "geography": {
+      "type": ["string", "null"],
+      "description": "Geographic scope where applicable (ISO 3166 alpha-2 country code, or a provider region code). Null for non-geographic series."
+    },
+    "license": {
+      "type": ["string", "null"],
+      "description": "License/terms under which the series is published (e.g. 'CC-BY-4.0'). Rendered in the citation block."
+    },
+    "as_of": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Provider vintage of this harvest as milliseconds since the Unix epoch. Observations are keyed by (series_id, period, as_of) so revisions are retained."
+    },
+    "source_url": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "description": "URL the series was harvested from, for citation."
+    },
+    "observations": {
+      "type": "array",
+      "description": "The observed values, ordered by period ascending. May be empty (a series with no data yet).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Period label in a normalized form: 'YYYY' (annual), 'YYYY-Qn' (quarterly), 'YYYY-MM' (monthly), or 'YYYY-MM-DD' (daily/weekly)."
+          },
+          "value": {
+            "type": ["number", "null"],
+            "description": "Observed value, or null when the provider reports the period as missing."
+          }
+        },
+        "required": ["period", "value"],
+        "additionalProperties": false
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Provider-specific fields that do not fit the core record (e.g. seasonal adjustment, indicator code, source note).",
+      "additionalProperties": true,
+      "default": {}
+    }
+  },
+  "required": [
+    "series_id",
+    "provider",
+    "title",
+    "frequency",
+    "as_of",
+    "observations"
+  ],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "series_id": "wb:SL.UEM.TOTL.ZS:DE",
+      "provider": "worldbank",
+      "title": "Unemployment, total (% of total labor force) (modeled ILO estimate) - Germany",
+      "unit": "percent",
+      "frequency": "annual",
+      "geography": "DE",
+      "license": "CC-BY-4.0",
+      "as_of": 1767225600000,
+      "source_url": "https://api.worldbank.org/v2/country/DE/indicator/SL.UEM.TOTL.ZS?format=json",
+      "observations": [
+        {"period": "2022", "value": 3.13},
+        {"period": "2023", "value": 3.02},
+        {"period": "2024", "value": 3.4}
+      ],
+      "metadata": {"indicator": "SL.UEM.TOTL.ZS"}
+    }
+  ]
+}

--- a/services/ingest/common/series_model.py
+++ b/services/ingest/common/series_model.py
@@ -1,0 +1,110 @@
+"""
+Statistical-series data model for the beyond-text expansion (Track A).
+
+A ``SeriesRecord`` is a statistical time series harvested from an official
+provider (World Bank, FRED, Eurostat, ...). Series are *evidence* for checking
+quantitative claims; they are deliberately **not** ``Document`` records, because
+they are versioned, revisable, and numeric rather than textual. The contract is
+``dataset-series-v1`` (``contracts/schemas/jsonschema/dataset-series-v1.json``).
+
+Observations are vintaged by ``as_of`` so a claim check records which revision
+it ran against and stays replayable.
+
+See ``docs/architecture/EVIDENCE_DATASETS_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from numbers import Real
+from typing import Any, Dict, List, Optional
+
+# Mirrored from the dataset-series-v1 contract enum.
+FREQUENCIES = ("annual", "quarterly", "monthly", "weekly", "daily", "irregular")
+
+
+@dataclass
+class Observation:
+    """One observed value at a period. ``value`` is None for a reported gap."""
+
+    period: str
+    value: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"period": self.period, "value": self.value}
+
+
+@dataclass
+class SeriesRecord:
+    """A statistical time series (dataset-series-v1)."""
+
+    series_id: str
+    provider: str
+    title: str
+    frequency: str
+    as_of: int  # milliseconds since epoch (provider vintage)
+    observations: List[Observation] = field(default_factory=list)
+    unit: Optional[str] = None
+    geography: Optional[str] = None
+    license: Optional[str] = None
+    source_url: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.series_id:
+            raise ValueError("series_id must be a non-empty string")
+        if not self.provider:
+            raise ValueError("provider must be a non-empty string")
+        if not self.title:
+            raise ValueError("title must be a non-empty string")
+        if self.frequency not in FREQUENCIES:
+            raise ValueError(
+                f"Invalid frequency {self.frequency!r}; expected one of {FREQUENCIES}"
+            )
+        if not isinstance(self.as_of, int) or isinstance(self.as_of, bool) or self.as_of < 0:
+            raise ValueError("as_of must be a non-negative integer (ms since epoch)")
+        # Coerce mapping observations (e.g. from_dict of a raw payload) to objects.
+        coerced: List[Observation] = []
+        for obs in self.observations:
+            if isinstance(obs, Observation):
+                coerced.append(obs)
+            elif isinstance(obs, dict):
+                coerced.append(Observation(period=obs["period"], value=obs.get("value")))
+            else:
+                raise ValueError(f"observation must be an Observation or dict, got {type(obs)!r}")
+            if not coerced[-1].period:
+                raise ValueError("observation.period must be a non-empty string")
+            val = coerced[-1].value
+            if val is not None and not isinstance(val, Real):
+                raise ValueError("observation.value must be a number or null")
+        self.observations = coerced
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a dataset-series-v1 payload dict."""
+        payload = asdict(self)
+        payload["observations"] = [o.to_dict() for o in self.observations]
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "SeriesRecord":
+        """Build a SeriesRecord from a dataset-series-v1 payload dict."""
+        known = {
+            "series_id",
+            "provider",
+            "title",
+            "frequency",
+            "as_of",
+            "observations",
+            "unit",
+            "geography",
+            "license",
+            "source_url",
+            "metadata",
+        }
+        kwargs = {k: v for k, v in payload.items() if k in known}
+        obs = kwargs.get("observations", []) or []
+        kwargs["observations"] = [
+            o if isinstance(o, Observation) else Observation(period=o["period"], value=o.get("value"))
+            for o in obs
+        ]
+        return cls(**kwargs)

--- a/src/ingestion/connectors/README.md
+++ b/src/ingestion/connectors/README.md
@@ -56,3 +56,15 @@ class MyConnector(Connector):
 
 Planned connectors (tracked as issues): papers (#517), books (#521), blogs/RSS
 (#522), media/transcripts (#523), generic upload (#524).
+
+## Dataset connectors (statistical evidence)
+
+`dataset/` is a parallel connector family for **statistical series**, not
+documents. Statistical series (World Bank, FRED, Eurostat, ...) are versioned
+numeric evidence for checking quantitative claims, so they carry their own
+contract (`dataset-series-v1`) and emit `SeriesRecord`s rather than
+`Document`s. The interface mirrors this one (`discover` → `fetch` → `parse` →
+`harvest`) via `DatasetConnector`, and `ObservationStore` persists series into
+DuckDB with vintage-keyed observations. See
+[EVIDENCE_DATASETS_PLAN.md](../../../docs/architecture/EVIDENCE_DATASETS_PLAN.md)
+and the beyond-text roadmap (#765).

--- a/src/ingestion/connectors/dataset/__init__.py
+++ b/src/ingestion/connectors/dataset/__init__.py
@@ -1,0 +1,25 @@
+"""
+Dataset connectors: official statistics providers as ``dataset-series-v1``.
+
+Track A of the beyond-text expansion. Series are evidence for checking
+quantitative claims and are *not* documents; see
+``docs/architecture/EVIDENCE_DATASETS_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+from src.ingestion.connectors.dataset.base import (
+    DatasetConnector,
+    RawSeries,
+    SeriesRef,
+)
+from src.ingestion.connectors.dataset.store import ObservationStore
+from src.ingestion.connectors.dataset.worldbank import WorldBankConnector
+
+__all__ = [
+    "DatasetConnector",
+    "RawSeries",
+    "SeriesRef",
+    "ObservationStore",
+    "WorldBankConnector",
+]

--- a/src/ingestion/connectors/dataset/base.py
+++ b/src/ingestion/connectors/dataset/base.py
@@ -1,0 +1,98 @@
+"""
+Dataset connector framework (Track A of the beyond-text expansion).
+
+A dataset connector turns an official statistics provider (World Bank, FRED,
+Eurostat, ...) into normalized :class:`SeriesRecord` records
+(``dataset-series-v1``). It mirrors the document ``Connector`` interface —
+``discover`` -> ``fetch`` -> ``parse`` chained by ``harvest`` — but emits
+statistical series rather than ``Document`` records, because series are
+versioned numeric evidence, not text (see
+``docs/architecture/EVIDENCE_DATASETS_PLAN.md``).
+
+    discover(query) -> iterable of SeriesRef   (which series to harvest)
+    fetch(ref)      -> RawSeries               (pull the raw provider payload)
+    parse(raw)      -> list of SeriesRecord     (normalize to the contract)
+    harvest(query)  -> iterator of SeriesRecord (discover -> fetch -> parse)
+
+``harvest`` is resilient: a series that fails to fetch or parse is skipped and
+logged so one bad series does not abort the run.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+
+from services.ingest.common.series_model import SeriesRecord
+
+
+@dataclass
+class SeriesRef:
+    """A discoverable handle for a series to harvest (provider code + scope)."""
+
+    locator: str
+    title: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RawSeries:
+    """Raw payload fetched for a :class:`SeriesRef`, prior to normalization."""
+
+    ref: SeriesRef
+    content: Union[bytes, str]
+    content_type: Optional[str] = None
+    source_url: Optional[str] = None
+    fetched_at: int = field(default_factory=lambda: int(time.time() * 1000))
+
+
+class DatasetConnector(abc.ABC):
+    """Base class for statistics-provider connectors.
+
+    Subclasses set :attr:`provider` and implement :meth:`discover`,
+    :meth:`fetch`, and :meth:`parse`.
+    """
+
+    #: dataset-series-v1 provider short name this connector produces.
+    provider: str = ""
+
+    @abc.abstractmethod
+    def discover(self, query: Optional[Any] = None) -> Iterable[SeriesRef]:
+        """Enumerate the series to harvest (optionally narrowed by ``query``)."""
+
+    @abc.abstractmethod
+    def fetch(self, ref: SeriesRef) -> RawSeries:
+        """Pull the raw payload for a single :class:`SeriesRef`."""
+
+    @abc.abstractmethod
+    def parse(self, raw: RawSeries) -> List[SeriesRecord]:
+        """Normalize a :class:`RawSeries` into one or more series records."""
+
+    def harvest(self, query: Optional[Any] = None) -> Iterator[SeriesRecord]:
+        """Run discover -> fetch -> parse, yielding normalized series records.
+
+        Series that fail to fetch/parse are skipped (and logged) so one bad
+        series does not abort the whole run.
+        """
+        for ref in self.discover(query):
+            try:
+                raw = self.fetch(ref)
+            except Exception:  # noqa: BLE001 - resilience: skip unreachable series
+                self._on_error("fetch", ref)
+                continue
+            try:
+                records = self.parse(raw)
+            except Exception:  # noqa: BLE001 - resilience: skip unparseable series
+                self._on_error("parse", ref)
+                continue
+            for record in records:
+                yield record
+
+    def _on_error(self, stage: str, ref: SeriesRef) -> None:
+        logging.getLogger(self.__class__.__module__).warning(
+            "%s: %s stage failed for %s", self.__class__.__name__, stage, ref.locator,
+            exc_info=True,
+        )

--- a/src/ingestion/connectors/dataset/normalize.py
+++ b/src/ingestion/connectors/dataset/normalize.py
@@ -1,0 +1,99 @@
+"""
+Shared normalization for dataset connectors: units, frequency, and geography.
+
+Provider modules stay thin by delegating to these helpers so a claim can be
+resolved against a series regardless of which provider harvested it (e.g. a
+claim about "Germany" matches whether the series codes it ``DE`` or ``DEU``).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from services.ingest.common.series_model import FREQUENCIES
+
+# Provider frequency tokens -> the dataset-series-v1 enum.
+_FREQUENCY_ALIASES = {
+    "a": "annual",
+    "annual": "annual",
+    "year": "annual",
+    "yearly": "annual",
+    "q": "quarterly",
+    "quarter": "quarterly",
+    "quarterly": "quarterly",
+    "m": "monthly",
+    "month": "monthly",
+    "monthly": "monthly",
+    "w": "weekly",
+    "week": "weekly",
+    "weekly": "weekly",
+    "d": "daily",
+    "day": "daily",
+    "daily": "daily",
+}
+
+# Common unit strings -> a small normalized vocabulary. Unknown units pass
+# through unchanged (lower-cased) so nothing is silently dropped.
+_UNIT_ALIASES = {
+    "%": "percent",
+    "percent": "percent",
+    "pct": "percent",
+    "percentage": "percent",
+    "usd": "usd",
+    "us dollar": "usd",
+    "us dollars": "usd",
+    "$": "usd",
+    "index": "index",
+    "count": "count",
+    "number": "count",
+    "persons": "count",
+    "people": "count",
+}
+
+# ISO 3166 alpha-3 -> alpha-2 for the codes that appear in the first providers.
+# Extended as providers are added; unknown codes pass through unchanged.
+_ISO3_TO_ISO2 = {
+    "deu": "DE", "usa": "US", "gbr": "GB", "fra": "FR", "ita": "IT",
+    "esp": "ES", "nld": "NL", "bel": "BE", "che": "CH", "aut": "AT",
+    "swe": "SE", "nor": "NO", "dnk": "DK", "fin": "FI", "prt": "PT",
+    "irl": "IE", "pol": "PL", "grc": "GR", "can": "CA", "jpn": "JP",
+    "chn": "CN", "ind": "IN", "bra": "BR", "aus": "AU", "rus": "RU",
+}
+
+
+def normalize_frequency(raw: Optional[str]) -> str:
+    """Map a provider frequency token to the contract enum; default 'irregular'."""
+    if not raw:
+        return "irregular"
+    token = str(raw).strip().lower()
+    if token in FREQUENCIES:
+        return token
+    return _FREQUENCY_ALIASES.get(token, "irregular")
+
+
+def normalize_unit(raw: Optional[str]) -> Optional[str]:
+    """Normalize a unit string to the small vocabulary; unknown units lower-case
+    through unchanged. Returns None for an empty/None input."""
+    if raw is None:
+        return None
+    token = str(raw).strip()
+    if not token:
+        return None
+    return _UNIT_ALIASES.get(token.lower(), token.lower())
+
+
+def normalize_geography(raw: Optional[str]) -> Optional[str]:
+    """Normalize a geography code to ISO 3166 alpha-2 when recognized.
+
+    Accepts alpha-2 (returned upper-cased) or alpha-3 (mapped when known);
+    unrecognized codes pass through upper-cased so provider region codes (e.g.
+    Eurostat NUTS) are preserved rather than dropped."""
+    if raw is None:
+        return None
+    token = str(raw).strip()
+    if not token:
+        return None
+    lowered = token.lower()
+    if len(token) == 3 and lowered in _ISO3_TO_ISO2:
+        return _ISO3_TO_ISO2[lowered]
+    return token.upper()

--- a/src/ingestion/connectors/dataset/store.py
+++ b/src/ingestion/connectors/dataset/store.py
@@ -1,0 +1,197 @@
+"""
+Observation store for statistical series (Track A).
+
+Persists ``SeriesRecord``s into two DuckDB tables:
+
+* ``dataset_series`` — one row per series (the header fields), keyed by
+  ``series_id``.
+* ``dataset_observations`` — one row per ``(series_id, period, as_of)`` so
+  revisions (vintages) are retained and a claim check can pin the vintage it
+  ran against.
+
+Writes are idempotent: harvesting the same vintage twice upserts the same rows.
+Harvesting a newer vintage (a larger ``as_of``) appends new observation rows and
+refreshes the series header, leaving prior vintages in place.
+
+The store owns only its own tables and never mutates the shared corpus tables.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from services.ingest.common.series_model import Observation, SeriesRecord
+
+_SERIES_DDL = """
+CREATE TABLE IF NOT EXISTS dataset_series (
+    series_id   TEXT PRIMARY KEY,
+    provider    TEXT NOT NULL,
+    title       TEXT NOT NULL,
+    unit        TEXT,
+    frequency   TEXT NOT NULL,
+    geography   TEXT,
+    license     TEXT,
+    as_of       BIGINT NOT NULL,
+    source_url  TEXT,
+    metadata    JSON
+)
+"""
+
+_OBS_DDL = """
+CREATE TABLE IF NOT EXISTS dataset_observations (
+    series_id   TEXT NOT NULL,
+    period      TEXT NOT NULL,
+    as_of       BIGINT NOT NULL,
+    value       DOUBLE,
+    PRIMARY KEY (series_id, period, as_of)
+)
+"""
+
+
+class ObservationStore:
+    """DuckDB-backed store for ``dataset-series-v1`` series and observations."""
+
+    def __init__(self, conn: Any):
+        """Wrap an open DuckDB connection. The caller owns the connection
+        lifecycle (in-memory for tests, a file path in production)."""
+        self._conn = conn
+        self._ensure_schema()
+
+    @classmethod
+    def open(cls, path: str = ":memory:") -> "ObservationStore":
+        """Open (or create) a DuckDB database at ``path`` and wrap it."""
+        import duckdb
+
+        return cls(duckdb.connect(path))
+
+    def _ensure_schema(self) -> None:
+        self._conn.execute(_SERIES_DDL)
+        self._conn.execute(_OBS_DDL)
+
+    def upsert(self, record: SeriesRecord) -> int:
+        """Persist a series and its observations idempotently.
+
+        Returns the number of observation rows written for this vintage. The
+        series header is upserted to the record's values (last writer wins on a
+        given ``series_id``); observation rows are keyed by vintage so prior
+        vintages survive.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO dataset_series
+                (series_id, provider, title, unit, frequency, geography, license, as_of, source_url, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (series_id) DO UPDATE SET
+                provider = excluded.provider,
+                title = excluded.title,
+                unit = excluded.unit,
+                frequency = excluded.frequency,
+                geography = excluded.geography,
+                license = excluded.license,
+                as_of = excluded.as_of,
+                source_url = excluded.source_url,
+                metadata = excluded.metadata
+            """,
+            [
+                record.series_id,
+                record.provider,
+                record.title,
+                record.unit,
+                record.frequency,
+                record.geography,
+                record.license,
+                record.as_of,
+                record.source_url,
+                json.dumps(record.metadata or {}),
+            ],
+        )
+        written = 0
+        for obs in record.observations:
+            self._conn.execute(
+                """
+                INSERT INTO dataset_observations (series_id, period, as_of, value)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (series_id, period, as_of) DO UPDATE SET
+                    value = excluded.value
+                """,
+                [record.series_id, obs.period, record.as_of, obs.value],
+            )
+            written += 1
+        return written
+
+    def upsert_many(self, records: Iterable[SeriesRecord]) -> int:
+        """Upsert a batch of series; returns total observation rows written."""
+        return sum(self.upsert(r) for r in records)
+
+    def get_series(self, series_id: str) -> Optional[Dict[str, Any]]:
+        """Return the series header row as a dict, or None if absent."""
+        row = self._conn.execute(
+            """
+            SELECT series_id, provider, title, unit, frequency, geography, license, as_of, source_url, metadata
+            FROM dataset_series WHERE series_id = ?
+            """,
+            [series_id],
+        ).fetchone()
+        if row is None:
+            return None
+        keys = [
+            "series_id", "provider", "title", "unit", "frequency",
+            "geography", "license", "as_of", "source_url", "metadata",
+        ]
+        result = dict(zip(keys, row))
+        if isinstance(result.get("metadata"), str):
+            result["metadata"] = json.loads(result["metadata"])
+        return result
+
+    def list_series(self, provider: Optional[str] = None, geography: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List series headers, optionally filtered by provider and/or geography."""
+        clauses: List[str] = []
+        params: List[Any] = []
+        if provider is not None:
+            clauses.append("provider = ?")
+            params.append(provider)
+        if geography is not None:
+            clauses.append("geography = ?")
+            params.append(geography)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._conn.execute(
+            f"SELECT series_id, provider, title, unit, frequency, geography, license, as_of FROM dataset_series{where} ORDER BY series_id",
+            params,
+        ).fetchall()
+        keys = ["series_id", "provider", "title", "unit", "frequency", "geography", "license", "as_of"]
+        return [dict(zip(keys, row)) for row in rows]
+
+    def get_observations(
+        self, series_id: str, as_of: Optional[int] = None
+    ) -> List[Observation]:
+        """Return observations for a series at a given vintage.
+
+        With ``as_of`` omitted, the latest vintage present is used, so callers
+        get a coherent single-vintage series rather than a mix of revisions.
+        """
+        if as_of is None:
+            latest = self._conn.execute(
+                "SELECT MAX(as_of) FROM dataset_observations WHERE series_id = ?",
+                [series_id],
+            ).fetchone()
+            if latest is None or latest[0] is None:
+                return []
+            as_of = latest[0]
+        rows = self._conn.execute(
+            """
+            SELECT period, value FROM dataset_observations
+            WHERE series_id = ? AND as_of = ?
+            ORDER BY period
+            """,
+            [series_id, as_of],
+        ).fetchall()
+        return [Observation(period=r[0], value=r[1]) for r in rows]
+
+    def vintages(self, series_id: str) -> List[int]:
+        """List the distinct ``as_of`` vintages stored for a series, ascending."""
+        rows = self._conn.execute(
+            "SELECT DISTINCT as_of FROM dataset_observations WHERE series_id = ? ORDER BY as_of",
+            [series_id],
+        ).fetchall()
+        return [r[0] for r in rows]

--- a/src/ingestion/connectors/dataset/worldbank.py
+++ b/src/ingestion/connectors/dataset/worldbank.py
@@ -1,0 +1,148 @@
+"""
+World Bank dataset connector (Track A, first provider).
+
+Harvests World Bank Open Data indicator series (no API key required, global
+coverage) into ``dataset-series-v1`` records. The World Bank v2 API returns a
+two-element JSON array: ``[pagination, observations]``.
+
+The HTTP getter is injectable so ``fetch`` can be exercised without the network
+in tests; ``parse`` is pure (raw JSON text -> ``SeriesRecord``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+from services.ingest.common.series_model import Observation, SeriesRecord
+from src.ingestion.connectors.dataset.base import DatasetConnector, RawSeries, SeriesRef
+from src.ingestion.connectors.dataset.normalize import (
+    normalize_geography,
+    normalize_unit,
+)
+
+_API_BASE = "https://api.worldbank.org/v2"
+_LICENSE = "CC-BY-4.0"
+
+# discover() accepts a single spec or an iterable of them. A spec is either a
+# (indicator, geography) pair or a {"indicator", "geography"} mapping.
+IndicatorSpec = Union[Tuple[str, str], Dict[str, str]]
+
+
+def _default_http_get(url: str) -> str:
+    import urllib.request
+
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310 - fixed API host
+        return resp.read().decode("utf-8")
+
+
+def _iso_date_to_millis(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    text = value.strip()
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            dt = datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() * 1000)
+        except ValueError:
+            continue
+    return None
+
+
+def _spec_to_pair(spec: IndicatorSpec) -> Tuple[str, str]:
+    if isinstance(spec, dict):
+        return str(spec["indicator"]), str(spec["geography"])
+    indicator, geography = spec
+    return str(indicator), str(geography)
+
+
+class WorldBankConnector(DatasetConnector):
+    """Harvest World Bank indicator series (annual, no key)."""
+
+    provider = "worldbank"
+
+    def __init__(self, http_get: Optional[Callable[[str], str]] = None, per_page: int = 20000):
+        self._http_get = http_get or _default_http_get
+        self._per_page = per_page
+
+    def discover(self, query: Optional[Union[IndicatorSpec, Iterable[IndicatorSpec]]] = None) -> Iterable[SeriesRef]:
+        """Yield a SeriesRef per (indicator, geography) spec."""
+        if query is None:
+            return
+        specs: Iterable[IndicatorSpec]
+        if isinstance(query, dict) or (isinstance(query, tuple) and len(query) == 2 and all(isinstance(x, str) for x in query)):
+            specs = [query]  # a single spec
+        else:
+            specs = list(query)
+        for spec in specs:
+            indicator, geography = _spec_to_pair(spec)
+            yield SeriesRef(
+                locator=f"{indicator}/{geography}",
+                metadata={"indicator": indicator, "geography": geography},
+            )
+
+    def _url(self, indicator: str, geography: str) -> str:
+        return (
+            f"{_API_BASE}/country/{geography}/indicator/{indicator}"
+            f"?format=json&per_page={self._per_page}"
+        )
+
+    def fetch(self, ref: SeriesRef) -> RawSeries:
+        indicator = ref.metadata["indicator"]
+        geography = ref.metadata["geography"]
+        url = self._url(indicator, geography)
+        return RawSeries(
+            ref=ref,
+            content=self._http_get(url),
+            content_type="application/json",
+            source_url=url,
+        )
+
+    def parse(self, raw: RawSeries) -> List[SeriesRecord]:
+        payload = json.loads(raw.content if isinstance(raw.content, str) else raw.content.decode("utf-8"))
+        if not isinstance(payload, list) or len(payload) < 2 or payload[1] is None:
+            # World Bank signals "no data" with a message page and null body.
+            return []
+        page_meta: Dict[str, Any] = payload[0] if isinstance(payload[0], dict) else {}
+        rows: List[Dict[str, Any]] = payload[1]
+        if not rows:
+            return []
+
+        first = rows[0]
+        indicator = (first.get("indicator") or {}).get("id") or raw.ref.metadata.get("indicator")
+        indicator_name = (first.get("indicator") or {}).get("value") or indicator
+        country_name = (first.get("country") or {}).get("value")
+        geo_raw = (first.get("country") or {}).get("id") or first.get("countryiso3code") or raw.ref.metadata.get("geography")
+        geography = normalize_geography(geo_raw)
+
+        title = f"{indicator_name} - {country_name}" if country_name else str(indicator_name)
+        unit = normalize_unit("percent" if "%" in str(indicator_name) else first.get("unit") or None)
+        as_of = _iso_date_to_millis(page_meta.get("lastupdated")) or raw.fetched_at
+
+        observations: List[Observation] = []
+        for row in rows:
+            period = row.get("date")
+            if not period:
+                continue
+            value = row.get("value")
+            observations.append(Observation(period=str(period), value=value))
+        # World Bank returns most-recent-first; store ascending by period.
+        observations.sort(key=lambda o: o.period)
+
+        series_id = f"wb:{indicator}:{geography}" if geography else f"wb:{indicator}"
+        return [
+            SeriesRecord(
+                series_id=series_id,
+                provider=self.provider,
+                title=title,
+                frequency="annual",
+                as_of=as_of,
+                observations=observations,
+                unit=unit,
+                geography=geography,
+                license=_LICENSE,
+                source_url=raw.source_url,
+                metadata={"indicator": indicator},
+            )
+        ]

--- a/tests/unit/ingestion/connectors/dataset/test_observation_store.py
+++ b/tests/unit/ingestion/connectors/dataset/test_observation_store.py
@@ -1,0 +1,83 @@
+"""Unit tests for the DuckDB observation store, including vintage idempotency."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ingest.common.series_model import Observation, SeriesRecord
+from src.ingestion.connectors.dataset.store import ObservationStore
+
+
+def _record(as_of: int, obs, title="Unemployment - Germany") -> SeriesRecord:
+    return SeriesRecord(
+        series_id="wb:SL.UEM.TOTL.ZS:DE",
+        provider="worldbank",
+        title=title,
+        frequency="annual",
+        as_of=as_of,
+        observations=[Observation(p, v) for p, v in obs],
+        unit="percent",
+        geography="DE",
+        license="CC-BY-4.0",
+    )
+
+
+@pytest.fixture()
+def store():
+    duckdb = pytest.importorskip("duckdb")
+    return ObservationStore(duckdb.connect(":memory:"))
+
+
+def test_upsert_and_read_back(store):
+    written = store.upsert(_record(100, [("2023", 3.02), ("2024", 3.4)]))
+    assert written == 2
+    header = store.get_series("wb:SL.UEM.TOTL.ZS:DE")
+    assert header["provider"] == "worldbank"
+    assert header["geography"] == "DE"
+    assert header["metadata"] == {}
+    obs = store.get_observations("wb:SL.UEM.TOTL.ZS:DE")
+    assert [(o.period, o.value) for o in obs] == [("2023", 3.02), ("2024", 3.4)]
+
+
+def test_reharvest_same_vintage_is_idempotent(store):
+    rec = _record(100, [("2023", 3.02), ("2024", 3.4)])
+    store.upsert(rec)
+    store.upsert(rec)  # same vintage again
+    assert store.vintages("wb:SL.UEM.TOTL.ZS:DE") == [100]
+    obs = store.get_observations("wb:SL.UEM.TOTL.ZS:DE")
+    assert len(obs) == 2  # not duplicated
+
+
+def test_new_vintage_retained_alongside_prior(store):
+    store.upsert(_record(100, [("2024", 3.4)]))
+    # A later harvest revises 2024 and adds 2025.
+    store.upsert(_record(200, [("2024", 3.5), ("2025", 3.6)], title="Unemployment - Germany (rev)"))
+    assert store.vintages("wb:SL.UEM.TOTL.ZS:DE") == [100, 200]
+    # Default read returns the latest vintage as a coherent series.
+    latest = store.get_observations("wb:SL.UEM.TOTL.ZS:DE")
+    assert [(o.period, o.value) for o in latest] == [("2024", 3.5), ("2025", 3.6)]
+    # The prior vintage is still queryable for replay.
+    prior = store.get_observations("wb:SL.UEM.TOTL.ZS:DE", as_of=100)
+    assert [(o.period, o.value) for o in prior] == [("2024", 3.4)]
+    # Header reflects the newest harvest.
+    assert store.get_series("wb:SL.UEM.TOTL.ZS:DE")["as_of"] == 200
+    assert "rev" in store.get_series("wb:SL.UEM.TOTL.ZS:DE")["title"]
+
+
+def test_list_series_filters(store):
+    store.upsert(_record(100, [("2024", 3.4)]))
+    assert len(store.list_series()) == 1
+    assert len(store.list_series(provider="worldbank")) == 1
+    assert len(store.list_series(geography="FR")) == 0
+
+
+def test_persists_to_file(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    path = str(tmp_path / "series.duckdb")
+    store = ObservationStore(duckdb.connect(path))
+    store.upsert(_record(100, [("2024", 3.4)]))
+    store._conn.close()
+    # Reopen the same file and confirm the data survived.
+    reopened = ObservationStore(duckdb.connect(path))
+    assert reopened.get_series("wb:SL.UEM.TOTL.ZS:DE") is not None
+    assert [(o.period, o.value) for o in reopened.get_observations("wb:SL.UEM.TOTL.ZS:DE")] == [("2024", 3.4)]

--- a/tests/unit/ingestion/connectors/dataset/test_series_model.py
+++ b/tests/unit/ingestion/connectors/dataset/test_series_model.py
@@ -1,0 +1,97 @@
+"""Unit tests for the dataset-series-v1 model and its contract alignment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.ingest.common.series_model import Observation, SeriesRecord
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+SCHEMA_PATH = REPO_ROOT / "contracts" / "schemas" / "jsonschema" / "dataset-series-v1.json"
+
+
+def _valid_record() -> SeriesRecord:
+    return SeriesRecord(
+        series_id="wb:SL.UEM.TOTL.ZS:DE",
+        provider="worldbank",
+        title="Unemployment, total (% of labor force) - Germany",
+        frequency="annual",
+        as_of=1767225600000,
+        observations=[Observation("2023", 3.02), Observation("2024", 3.4)],
+        unit="percent",
+        geography="DE",
+        license="CC-BY-4.0",
+    )
+
+
+def test_roundtrip_to_dict_from_dict():
+    record = _valid_record()
+    payload = record.to_dict()
+    assert payload["series_id"] == "wb:SL.UEM.TOTL.ZS:DE"
+    assert payload["observations"] == [
+        {"period": "2023", "value": 3.02},
+        {"period": "2024", "value": 3.4},
+    ]
+    rebuilt = SeriesRecord.from_dict(payload)
+    assert rebuilt.to_dict() == payload
+
+
+def test_from_dict_ignores_unknown_keys():
+    payload = _valid_record().to_dict()
+    payload["_extra"] = "ignored"
+    rebuilt = SeriesRecord.from_dict(payload)
+    assert rebuilt.series_id == "wb:SL.UEM.TOTL.ZS:DE"
+
+
+def test_observations_accept_dicts():
+    record = SeriesRecord(
+        series_id="wb:X:DE",
+        provider="worldbank",
+        title="X",
+        frequency="annual",
+        as_of=1,
+        observations=[{"period": "2024", "value": None}],
+    )
+    assert record.observations[0].value is None
+    assert record.observations[0].period == "2024"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("series_id", ""),
+        ("provider", ""),
+        ("title", ""),
+        ("frequency", "fortnightly"),
+        ("as_of", -1),
+    ],
+)
+def test_invalid_fields_rejected(field, value):
+    kwargs = dict(
+        series_id="wb:X:DE",
+        provider="worldbank",
+        title="X",
+        frequency="annual",
+        as_of=1,
+    )
+    kwargs[field] = value
+    with pytest.raises(ValueError):
+        SeriesRecord(**kwargs)
+
+
+def test_record_validates_against_jsonschema():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.Draft7Validator(schema).validate(_valid_record().to_dict())
+
+
+def test_schema_example_validates_and_roundtrips():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    for example in schema.get("examples", []):
+        jsonschema.Draft7Validator(schema).validate(example)
+        # Every schema example must be constructible by the model.
+        SeriesRecord.from_dict(example)

--- a/tests/unit/ingestion/connectors/dataset/test_worldbank_connector.py
+++ b/tests/unit/ingestion/connectors/dataset/test_worldbank_connector.py
@@ -1,0 +1,105 @@
+"""Unit tests for the World Bank dataset connector (offline, injected HTTP)."""
+
+from __future__ import annotations
+
+import json
+
+from services.ingest.common.series_model import SeriesRecord
+from src.ingestion.connectors.dataset.worldbank import WorldBankConnector
+
+# A trimmed but shape-accurate World Bank v2 response for
+# GET /v2/country/DE/indicator/SL.UEM.TOTL.ZS?format=json — pagination page
+# first, then the observation rows (returned most-recent-first by the API).
+WB_PAYLOAD = json.dumps(
+    [
+        {"page": 1, "pages": 1, "per_page": 20000, "total": 3, "lastupdated": "2025-01-01"},
+        [
+            {
+                "indicator": {"id": "SL.UEM.TOTL.ZS", "value": "Unemployment, total (% of total labor force)"},
+                "country": {"id": "DE", "value": "Germany"},
+                "countryiso3code": "DEU",
+                "date": "2024",
+                "value": 3.4,
+            },
+            {
+                "indicator": {"id": "SL.UEM.TOTL.ZS", "value": "Unemployment, total (% of total labor force)"},
+                "country": {"id": "DE", "value": "Germany"},
+                "countryiso3code": "DEU",
+                "date": "2023",
+                "value": 3.02,
+            },
+            {
+                "indicator": {"id": "SL.UEM.TOTL.ZS", "value": "Unemployment, total (% of total labor force)"},
+                "country": {"id": "DE", "value": "Germany"},
+                "countryiso3code": "DEU",
+                "date": "2022",
+                "value": None,
+            },
+        ],
+    ]
+)
+
+
+def _connector(payload: str = WB_PAYLOAD) -> WorldBankConnector:
+    calls = []
+
+    def fake_get(url: str) -> str:
+        calls.append(url)
+        return payload
+
+    conn = WorldBankConnector(http_get=fake_get)
+    conn._calls = calls  # type: ignore[attr-defined]
+    return conn
+
+
+def test_harvest_builds_contract_series():
+    conn = _connector()
+    records = list(conn.harvest(("SL.UEM.TOTL.ZS", "DE")))
+    assert len(records) == 1
+    rec = records[0]
+    assert isinstance(rec, SeriesRecord)
+    assert rec.series_id == "wb:SL.UEM.TOTL.ZS:DE"
+    assert rec.provider == "worldbank"
+    assert rec.geography == "DE"
+    assert rec.frequency == "annual"
+    assert rec.unit == "percent"  # inferred from the "%" in the indicator name
+    assert rec.license == "CC-BY-4.0"
+    # Observations sorted ascending; the reported gap is preserved as None.
+    assert [(o.period, o.value) for o in rec.observations] == [
+        ("2022", None),
+        ("2023", 3.02),
+        ("2024", 3.4),
+    ]
+    # lastupdated 2025-01-01 -> ms epoch
+    assert rec.as_of == 1735689600000
+
+
+def test_url_targets_country_indicator_endpoint():
+    conn = _connector()
+    list(conn.harvest({"indicator": "SL.UEM.TOTL.ZS", "geography": "DE"}))
+    assert conn._calls  # type: ignore[attr-defined]
+    url = conn._calls[0]  # type: ignore[attr-defined]
+    assert "/country/DE/indicator/SL.UEM.TOTL.ZS" in url
+    assert "format=json" in url
+
+
+def test_multiple_specs_yield_multiple_series():
+    conn = _connector()
+    records = list(conn.harvest([("SL.UEM.TOTL.ZS", "DE"), ("SL.UEM.TOTL.ZS", "FR")]))
+    assert len(records) == 2
+
+
+def test_no_data_payload_yields_nothing():
+    # World Bank signals "no data" with a message page and a null body.
+    payload = json.dumps([{"message": [{"id": "120", "value": "no data"}]}, None])
+    conn = _connector(payload)
+    assert list(conn.harvest(("BAD.INDICATOR", "DE"))) == []
+
+
+def test_fetch_failure_is_skipped_not_raised():
+    def boom(url: str) -> str:
+        raise ConnectionError("network down")
+
+    conn = WorldBankConnector(http_get=boom)
+    # harvest() must swallow the fetch error and yield nothing rather than raise.
+    assert list(conn.harvest(("SL.UEM.TOTL.ZS", "DE"))) == []


### PR DESCRIPTION
## Overview

First deliverable of **Track A (statistical evidence)** in the beyond-text roadmap — closes #766, part of #765. Statistical series (World Bank, FRED, Eurostat, …) become the evidence quantitative claims are checked against. They are deliberately **not** documents: versioned, revisable, and numeric, so they carry their own contract rather than being forced through `document-ingest-v1`.

See [`docs/architecture/EVIDENCE_DATASETS_PLAN.md`](https://github.com/Ikey168/Noesis/blob/feat/dataset-series-contract/docs/architecture/EVIDENCE_DATASETS_PLAN.md).

## Changes

- **`contracts/schemas/jsonschema/dataset-series-v1.json`** — the series contract. Observations are vintaged by `as_of` (keyed `(series_id, period, as_of)`) so a claim check records which revision it ran against and stays replayable.
- **`services/ingest/common/series_model.py`** — `SeriesRecord` / `Observation` dataclasses with `__post_init__` validation and `to_dict` / `from_dict` round-trip, sitting beside `document_model.py`.
- **`src/ingestion/connectors/dataset/`**:
  - `base.py` — `DatasetConnector` mirroring the document connector interface (`discover → fetch → parse → harvest`, resilient skip-on-error) but emitting `SeriesRecord`s.
  - `normalize.py` — shared unit / frequency / geography normalization (e.g. ISO alpha-3 → alpha-2) so a claim resolves regardless of provider coding.
  - `worldbank.py` — World Bank provider (no API key, global coverage) with an **injectable HTTP getter** so it's exercised offline; pure `parse`.
  - `store.py` — `ObservationStore` over DuckDB with idempotent, vintage-keyed upserts; prior vintages retained for replay.

## Design notes

- Series flow straight to DuckDB, not the Kafka/Avro producer path, so the JSON-schema contract plus the model's `__post_init__` gate is the validation boundary here — the same pattern `src/genui` uses (pure-Python validation + a jsonschema test), rather than an Avro `.avsc`.
- FRED (#777) and Eurostat (#778) are follow-up providers; the MCP server + panels are A2 (#769).

## Testing

- 20 unit tests, all passing, fully offline (injected HTTP, in-memory + on-disk DuckDB):
  - model round-trip, field validation, and **jsonschema validation** of both model output and the schema's own example;
  - World Bank harvest (contract shape, ascending observations, reported-gap `null` preserved, `lastupdated` → vintage, multi-spec, no-data body, fetch-failure skipped);
  - store idempotency across re-harvest, new-vintage retention alongside prior, filtered listing, and file persistence.
- **Exit criteria met**: a World Bank unemployment series harvests into the store and is queryable; re-harvest is idempotent across vintages (verified end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_