### PR TITLE
B0: content-addressed image asset store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,4 @@ dbt_packages/
 data/tls/server.key
 data/tls/server.crt
 data/backups/*.enc
+artifacts/figures/

--- a/src/ingestion/assets/__init__.py
+++ b/src/ingestion/assets/__init__.py
@@ -1,0 +1,13 @@
+"""
+Image asset store: content-addressed storage shared by Tracks B and C.
+
+See ``docs/architecture/VISUAL_EVIDENCE_PLAN.md`` (Track B) and
+``docs/architecture/OSINT_IMAGERY_PLAN.md`` (Track C).
+"""
+
+from __future__ import annotations
+
+from src.ingestion.assets.imageinfo import extension_for, sniff
+from src.ingestion.assets.store import ImageAsset, ImageAssetStore
+
+__all__ = ["ImageAsset", "ImageAssetStore", "sniff", "extension_for"]

--- a/src/ingestion/assets/imageinfo.py
+++ b/src/ingestion/assets/imageinfo.py
@@ -1,0 +1,110 @@
+"""
+Stdlib-only image sniffing: MIME type and pixel dimensions from the header bytes.
+
+Kept dependency-free on purpose — the asset store is imported by connectors and
+(via Track C) by the tool servers, which must stay import-safe. Supports the
+formats the ingestion paths actually encounter (PNG, JPEG, GIF, BMP, WebP);
+unknown formats return ``(None, None, None)`` rather than raising, so an
+unrecognized image is still stored, just without dimensions.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional, Tuple
+
+# (mime, width, height); any element may be None when undeterminable.
+ImageInfo = Tuple[Optional[str], Optional[int], Optional[int]]
+
+# Canonical extension per MIME type, for the content-addressed path.
+_EXT_BY_MIME = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/bmp": "bmp",
+    "image/webp": "webp",
+    "image/tiff": "tiff",
+    "image/svg+xml": "svg",
+}
+
+
+def extension_for(mime: Optional[str]) -> str:
+    """Filesystem extension for a MIME type; 'bin' when unknown."""
+    return _EXT_BY_MIME.get(mime or "", "bin")
+
+
+def sniff(data: bytes) -> ImageInfo:
+    """Return ``(mime, width, height)`` for an image byte string."""
+    if len(data) < 4:
+        return (None, None, None)
+
+    # PNG: 8-byte signature, then IHDR with width/height as big-endian u32.
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        if len(data) >= 24 and data[12:16] == b"IHDR":
+            width, height = struct.unpack(">II", data[16:24])
+            return ("image/png", width, height)
+        return ("image/png", None, None)
+
+    # GIF: 'GIF87a'/'GIF89a', then width/height as little-endian u16.
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        if len(data) >= 10:
+            width, height = struct.unpack("<HH", data[6:10])
+            return ("image/gif", width, height)
+        return ("image/gif", None, None)
+
+    # BMP: 'BM', dimensions as little-endian i32 at offset 18/22.
+    if data[:2] == b"BM":
+        if len(data) >= 26:
+            width, height = struct.unpack("<ii", data[18:26])
+            return ("image/bmp", abs(width), abs(height))
+        return ("image/bmp", None, None)
+
+    # WebP: RIFF container with 'WEBP'.
+    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return ("image/webp", *_webp_dimensions(data))
+
+    # JPEG: SOI marker, then scan for a start-of-frame marker.
+    if data[:2] == b"\xff\xd8":
+        return ("image/jpeg", *_jpeg_dimensions(data))
+
+    return (None, None, None)
+
+
+def _jpeg_dimensions(data: bytes) -> Tuple[Optional[int], Optional[int]]:
+    i = 2
+    n = len(data)
+    while i + 9 < n:
+        if data[i] != 0xFF:
+            i += 1
+            continue
+        marker = data[i + 1]
+        # SOF0..SOF15 carry dimensions, excluding DHT(0xC4)/DAC(0xCC)/RSTn.
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            height, width = struct.unpack(">HH", data[i + 5:i + 9])
+            return (width, height)
+        if i + 3 >= n:
+            break
+        segment_len = struct.unpack(">H", data[i + 2:i + 4])[0]
+        i += 2 + segment_len
+    return (None, None)
+
+
+def _webp_dimensions(data: bytes) -> Tuple[Optional[int], Optional[int]]:
+    fmt = data[12:16]
+    try:
+        if fmt == b"VP8 " and len(data) >= 30:
+            width = struct.unpack("<H", data[26:28])[0] & 0x3FFF
+            height = struct.unpack("<H", data[28:30])[0] & 0x3FFF
+            return (width, height)
+        if fmt == b"VP8L" and len(data) >= 25:
+            bits = struct.unpack("<I", data[21:25])[0]
+            width = (bits & 0x3FFF) + 1
+            height = ((bits >> 14) & 0x3FFF) + 1
+            return (width, height)
+        if fmt == b"VP8X" and len(data) >= 30:
+            width = (data[24] | (data[25] << 8) | (data[26] << 16)) + 1
+            height = (data[27] | (data[28] << 8) | (data[29] << 16)) + 1
+            return (width, height)
+    except struct.error:
+        return (None, None)
+    return (None, None)

--- a/src/ingestion/assets/store.py
+++ b/src/ingestion/assets/store.py
@@ -1,0 +1,170 @@
+"""
+Content-addressed image asset store (B0 — shared substrate for Tracks B and C).
+
+Both the vision describer (Track B, figures/images become citable documents) and
+image provenance (Track C, EXIF/perceptual-hash/C2PA) need one place where image
+bytes live and one identity for an image. This is that place:
+
+* Bytes are written under ``artifacts/figures/`` at a path derived from the
+  SHA-256 of the content, so the same image is stored once no matter how many
+  sources it arrives from (content addressing).
+* An ``image_assets`` DuckDB table indexes each asset (sha256, path, mime,
+  dimensions, first-seen parent). The Track C columns (``phash``/``exif``/
+  ``c2pa``) are present but nullable, so C1 populates them without a migration.
+
+``content_ref`` is the stable, relative pointer a figure ``Document`` carries;
+surfaces dereference it to render the actual image next to a citation.
+
+Multi-parent tracking (the same asset appearing in several documents) is Track
+C's ``image_appearances`` table; here an asset records only its first-seen
+parent, and re-``put`` of the same bytes is idempotent (it never overwrites it).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from src.ingestion.assets.imageinfo import extension_for, sniff
+
+_ASSETS_DDL = """
+CREATE TABLE IF NOT EXISTS image_assets (
+    sha256              TEXT PRIMARY KEY,
+    path                TEXT NOT NULL,
+    mime                TEXT,
+    width               INTEGER,
+    height              INTEGER,
+    parent_document_id  TEXT,
+    first_seen_at       BIGINT,
+    -- Reserved for Track C (#771); nullable so C1 needs no migration.
+    phash               TEXT,
+    exif                JSON,
+    c2pa                JSON
+)
+"""
+
+
+@dataclass
+class ImageAsset:
+    """An indexed image asset."""
+
+    sha256: str
+    path: str  # relative content_ref, e.g. artifacts/figures/ab/ab12...png
+    mime: Optional[str]
+    width: Optional[int]
+    height: Optional[int]
+    parent_document_id: Optional[str]
+    first_seen_at: Optional[int]
+
+    @property
+    def content_ref(self) -> str:
+        """The stable pointer a figure Document carries in ``content_ref``."""
+        return self.path
+
+
+class ImageAssetStore:
+    """Content-addressed image store: filesystem for bytes, DuckDB for the index."""
+
+    def __init__(self, conn: Any, root: str = "artifacts/figures"):
+        """Wrap an open DuckDB connection and a filesystem root. The caller owns
+        both lifecycles (in-memory DB + tmp root in tests; a file DB + repo path
+        in production)."""
+        self._conn = conn
+        self._root = root
+        os.makedirs(self._root, exist_ok=True)
+        self._conn.execute(_ASSETS_DDL)
+
+    @classmethod
+    def open(cls, db_path: str = ":memory:", root: str = "artifacts/figures") -> "ImageAssetStore":
+        import duckdb
+
+        return cls(duckdb.connect(db_path), root=root)
+
+    @staticmethod
+    def digest(data: bytes) -> str:
+        return hashlib.sha256(data).hexdigest()
+
+    def _rel_path(self, sha256: str, mime: Optional[str]) -> str:
+        # Shard by the first two hex chars to keep any one directory small.
+        return os.path.join(self._root, sha256[:2], f"{sha256}.{extension_for(mime)}")
+
+    def put(
+        self,
+        data: bytes,
+        parent_document_id: Optional[str] = None,
+        now_ms: Optional[int] = None,
+        mime_hint: Optional[str] = None,
+    ) -> ImageAsset:
+        """Store image bytes and index them, returning the asset.
+
+        Idempotent by content: storing the same bytes again returns the existing
+        asset unchanged (the original ``parent_document_id`` and ``first_seen_at``
+        are preserved), so the same image from a second source does not create a
+        second asset or clobber provenance.
+        """
+        sha256 = self.digest(data)
+        existing = self.get(sha256)
+        if existing is not None:
+            return existing
+
+        mime, width, height = sniff(data)
+        mime = mime or mime_hint
+        rel_path = self._rel_path(sha256, mime)
+        abs_path = os.path.abspath(rel_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        if not os.path.exists(abs_path):
+            with open(abs_path, "wb") as f:
+                f.write(data)
+
+        self._conn.execute(
+            """
+            INSERT INTO image_assets (sha256, path, mime, width, height, parent_document_id, first_seen_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (sha256) DO NOTHING
+            """,
+            [sha256, rel_path, mime, width, height, parent_document_id, now_ms],
+        )
+        stored = self.get(sha256)
+        assert stored is not None  # just inserted
+        return stored
+
+    def get(self, sha256: str) -> Optional[ImageAsset]:
+        row = self._conn.execute(
+            """
+            SELECT sha256, path, mime, width, height, parent_document_id, first_seen_at
+            FROM image_assets WHERE sha256 = ?
+            """,
+            [sha256],
+        ).fetchone()
+        if row is None:
+            return None
+        return ImageAsset(*row)
+
+    def exists(self, sha256: str) -> bool:
+        return self.get(sha256) is not None
+
+    def read_bytes(self, sha256: str) -> Optional[bytes]:
+        """Return the stored bytes for an asset, or None if unknown/missing."""
+        asset = self.get(sha256)
+        if asset is None:
+            return None
+        abs_path = os.path.abspath(asset.path)
+        if not os.path.exists(abs_path):
+            return None
+        with open(abs_path, "rb") as f:
+            return f.read()
+
+    def list_assets(self, parent_document_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        clause = " WHERE parent_document_id = ?" if parent_document_id is not None else ""
+        params = [parent_document_id] if parent_document_id is not None else []
+        rows = self._conn.execute(
+            f"SELECT sha256, path, mime, width, height, parent_document_id, first_seen_at FROM image_assets{clause} ORDER BY sha256",
+            params,
+        ).fetchall()
+        keys = ["sha256", "path", "mime", "width", "height", "parent_document_id", "first_seen_at"]
+        return [dict(zip(keys, row)) for row in rows]
+
+    def count(self) -> int:
+        return self._conn.execute("SELECT COUNT(*) FROM image_assets").fetchone()[0]

--- a/tests/unit/ingestion/assets/test_asset_store.py
+++ b/tests/unit/ingestion/assets/test_asset_store.py
@@ -1,0 +1,91 @@
+"""Unit tests for the content-addressed image asset store."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.ingestion.assets.store import ImageAssetStore
+from tests.unit.ingestion.assets.test_imageinfo import make_gif, make_png
+
+
+@pytest.fixture()
+def store(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    return ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figures"))
+
+
+def test_put_stores_bytes_and_indexes(store):
+    data = make_png(640, 480)
+    asset = store.put(data, parent_document_id="paper:123", now_ms=1000)
+    assert asset.sha256 == ImageAssetStore.digest(data)
+    assert asset.mime == "image/png"
+    assert (asset.width, asset.height) == (640, 480)
+    assert asset.parent_document_id == "paper:123"
+    # content_ref is the stable relative pointer, and the bytes are on disk.
+    assert asset.content_ref == asset.path
+    assert os.path.exists(os.path.abspath(asset.path))
+    assert store.read_bytes(asset.sha256) == data
+
+
+def test_content_addressed_path_shape(store):
+    asset = store.put(make_png(10, 10))
+    # artifacts root / first-two-hex-chars / <sha>.png
+    parts = asset.path.replace("\\", "/").split("/")
+    assert parts[-2] == asset.sha256[:2]
+    assert parts[-1] == f"{asset.sha256}.png"
+
+
+def test_same_bytes_from_two_sources_dedupe(store):
+    data = make_png(100, 100)
+    first = store.put(data, parent_document_id="news:A", now_ms=1000)
+    second = store.put(data, parent_document_id="blog:B", now_ms=2000)
+    # One asset, stable content_ref; first-seen provenance preserved.
+    assert store.count() == 1
+    assert second.sha256 == first.sha256
+    assert second.content_ref == first.content_ref
+    assert second.parent_document_id == "news:A"
+    assert second.first_seen_at == 1000
+
+
+def test_distinct_images_are_distinct_assets(store):
+    a = store.put(make_png(10, 10))
+    b = store.put(make_gif(10, 10))
+    assert a.sha256 != b.sha256
+    assert store.count() == 2
+
+
+def test_get_and_exists(store):
+    asset = store.put(make_png(10, 10))
+    assert store.exists(asset.sha256)
+    assert store.get(asset.sha256).sha256 == asset.sha256
+    assert store.get("0" * 64) is None
+    assert not store.exists("0" * 64)
+
+
+def test_list_by_parent(store):
+    store.put(make_png(10, 10), parent_document_id="doc:1")
+    store.put(make_gif(10, 10), parent_document_id="doc:2")
+    assert len(store.list_assets()) == 2
+    assert len(store.list_assets(parent_document_id="doc:1")) == 1
+
+
+def test_reserved_track_c_columns_present(store):
+    # C1 (#771) must be able to populate phash/exif/c2pa without a migration.
+    store.put(make_png(10, 10))
+    cols = [r[1] for r in store._conn.execute("PRAGMA table_info('image_assets')").fetchall()]
+    assert {"phash", "exif", "c2pa"}.issubset(set(cols))
+
+
+def test_persists_to_file(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    db_path = str(tmp_path / "assets.duckdb")
+    root = str(tmp_path / "figures")
+    store = ImageAssetStore(duckdb.connect(db_path), root=root)
+    data = make_png(20, 20)
+    sha = store.put(data).sha256
+    store._conn.close()
+    reopened = ImageAssetStore(duckdb.connect(db_path), root=root)
+    assert reopened.exists(sha)
+    assert reopened.read_bytes(sha) == data

--- a/tests/unit/ingestion/assets/test_imageinfo.py
+++ b/tests/unit/ingestion/assets/test_imageinfo.py
@@ -1,0 +1,53 @@
+"""Unit tests for stdlib image sniffing."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+from src.ingestion.assets.imageinfo import extension_for, sniff
+
+
+def make_png(width: int, height: int) -> bytes:
+    """A minimal but valid PNG (signature + IHDR) with the given dimensions."""
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunk = struct.pack(">I", len(ihdr_data)) + b"IHDR" + ihdr_data
+    chunk += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data) & 0xFFFFFFFF)
+    return sig + chunk
+
+
+def make_gif(width: int, height: int) -> bytes:
+    return b"GIF89a" + struct.pack("<HH", width, height) + b"\x00" * 4
+
+
+def make_jpeg(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    # An APP0 segment then an SOF0 frame carrying height/width.
+    app0 = b"\xff\xe0" + struct.pack(">H", 16) + b"JFIF\x00" + b"\x01\x01\x00" + b"\x00\x01\x00\x01\x00\x00"
+    sof0 = b"\xff\xc0" + struct.pack(">H", 17) + b"\x08" + struct.pack(">HH", height, width) + b"\x03" + b"\x00" * 9
+    return soi + app0 + sof0
+
+
+def test_png_dimensions():
+    assert sniff(make_png(640, 480)) == ("image/png", 640, 480)
+
+
+def test_gif_dimensions():
+    assert sniff(make_gif(120, 90)) == ("image/gif", 120, 90)
+
+
+def test_jpeg_dimensions():
+    assert sniff(make_jpeg(800, 600)) == ("image/jpeg", 800, 600)
+
+
+def test_unknown_format_is_safe():
+    assert sniff(b"not an image at all") == (None, None, None)
+    assert sniff(b"\x00\x01") == (None, None, None)
+
+
+def test_extension_for():
+    assert extension_for("image/png") == "png"
+    assert extension_for("image/jpeg") == "jpg"
+    assert extension_for(None) == "bin"
+    assert extension_for("application/x-weird") == "bin"


### PR DESCRIPTION
## Overview

Shared substrate for **Track B (visual evidence)** and **Track C (OSINT imagery)** — closes #779, part of #765. Both the vision describer (figures become searchable, citable documents) and image provenance (EXIF / perceptual-hash / C2PA) need one home for image bytes and one identity per image. This is that root; extracting it means B1 (#768) and C1 (#771) share a dependency instead of C reaching into B's connector work.

See [`docs/architecture/VISUAL_EVIDENCE_PLAN.md`](https://github.com/Ikey168/Noesis/blob/main/docs/architecture/VISUAL_EVIDENCE_PLAN.md) §3.2.

## Changes

- **`src/ingestion/assets/imageinfo.py`** — stdlib-only MIME + pixel-dimension sniffing (PNG, JPEG, GIF, BMP, WebP). Kept dependency-free (no Pillow) so the store stays import-safe for the tool servers that Track C will load it into; unknown formats degrade to `(None, None, None)` rather than raising, so an unrecognized image is still stored.
- **`src/ingestion/assets/store.py`** — `ImageAssetStore`: bytes on the filesystem under `artifacts/figures/` (content-addressed by SHA-256, sharded by the first two hex chars), a DuckDB `image_assets` index. `put()` is **idempotent by content** — the same image from a second source dedupes to one asset and preserves first-seen provenance. `content_ref` is the stable relative pointer a figure `Document` carries. The Track C columns (`phash` / `exif` / `c2pa`) are present-but-nullable, so C1 populates them without a migration.
- **`.gitignore`** — ignores the local `artifacts/figures/` asset bytes.

## Design notes

- Multi-parent tracking (one asset appearing across several documents) is deliberately **not** here — that's Track C's `image_appearances` table (#771). B0 records only the first-seen parent, which is what the exit criterion needs.
- No new third-party dependency; the sniffer is ~110 lines of `struct` parsing with tests over generated PNG/JPEG/GIF headers.

## Testing

- 13 unit tests, all passing, fully offline (in-memory + on-disk DuckDB, `tmp_path` asset root):
  - image sniffing for PNG/JPEG/GIF and safe handling of non-images;
  - content-addressed path shape, byte round-trip, get/exists/list-by-parent;
  - **dedupe across sources** (same bytes, two parents → one asset, stable `content_ref`, first-seen provenance kept);
  - reserved Track C columns present; file-backed persistence across reopen.
- **Exit criteria met**: two ingests of the same bytes from different sources yield one stored asset with a stable `content_ref` (verified end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_