### PR TITLE
A4: claim-vs-data resolution, honesty-gated check, ledger + panels

### DIFF
--- a/src/analytics/claim_check.py
+++ b/src/analytics/claim_check.py
@@ -1,0 +1,428 @@
+"""
+Claim-vs-data checking (Track A / A4).
+
+The payoff of Track A: a quantitative assertion (parsed by
+``src.argument_mining.quantities``) is resolved to candidate statistical series
+in the observation store and checked against the data, producing a
+**supported / contradicted / unverifiable** finding under the statistical-honesty
+contract (``src.analytics.honesty``).
+
+Verdicts are three-valued and conservative. A bare boolean is a contract
+violation; an assertion that resolves to no series above the match threshold, or
+whose series lacks the needed observations, is ``unverifiable`` — never a guess.
+
+Every result is an :func:`analytic_envelope` (``n`` = observations used,
+``method``, ``assumptions`` including match confidence, the series definition,
+and the vintage checked) with an interval on the observed headline value.
+
+See ``docs/architecture/EVIDENCE_DATASETS_PLAN.md`` §3.5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from src.analytics.honesty import analytic_envelope, interval
+
+DEFAULT_MATCH_THRESHOLD = 0.35
+DEFAULT_REL_TOLERANCE = 0.05  # 5% fallback tolerance for magnitude checks
+
+_STOPWORDS = {
+    "the", "a", "an", "of", "in", "on", "to", "and", "for", "by", "its",
+    "their", "our", "this", "that", "total", "rate", "percent", "index",
+    "has", "have", "is", "was", "now",
+}
+
+
+def _tokens(text: Optional[str]) -> List[str]:
+    if not text:
+        return []
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return [w for w in words if w not in _STOPWORDS and len(w) > 2]
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@dataclass
+class Candidate:
+    series_id: str
+    title: str
+    unit: Optional[str]
+    geography: Optional[str]
+    match_confidence: float
+
+
+def resolve_series(conn, assertion, threshold: float = DEFAULT_MATCH_THRESHOLD) -> List[Candidate]:
+    """Rank stored series by compatibility with an assertion.
+
+    Scoring: subject/title token overlap (base), plus credit for matching unit
+    and geography. Candidates below ``threshold`` are dropped, so a poor match
+    surfaces as "no candidate" (``unverifiable``) rather than a wrong series.
+    """
+    if not _table_exists(conn, "dataset_series"):
+        return []
+    subj = _tokens(getattr(assertion, "subject", None))
+    a_unit = getattr(assertion, "unit", None)
+    a_geo = getattr(assertion, "geography", None)
+
+    rows = conn.execute(
+        "SELECT series_id, title, unit, geography FROM dataset_series"
+    ).fetchall()
+    candidates: List[Candidate] = []
+    for series_id, title, unit, geography in rows:
+        title_tokens = set(_tokens(title))
+        if not subj or not title_tokens:
+            overlap = 0.0
+        else:
+            overlap = len(set(subj) & title_tokens) / len(set(subj))
+        score = 0.6 * overlap
+        # Geography: a positive match helps; a definite mismatch is fatal.
+        if a_geo and geography:
+            if a_geo == geography:
+                score += 0.25
+            else:
+                continue  # different country: not this series
+        if a_unit and unit and a_unit == unit:
+            score += 0.15
+        score = min(score, 1.0)
+        if score >= threshold:
+            candidates.append(Candidate(series_id, title, unit, geography, round(score, 3)))
+    candidates.sort(key=lambda c: c.match_confidence, reverse=True)
+    return candidates
+
+
+def _observations(conn, series_id: str, as_of: Optional[int]) -> Dict[str, Optional[float]]:
+    if as_of is None:
+        latest = conn.execute(
+            "SELECT MAX(as_of) FROM dataset_observations WHERE series_id = ?", [series_id]
+        ).fetchone()
+        if not latest or latest[0] is None:
+            return {}
+        as_of = latest[0]
+    rows = conn.execute(
+        "SELECT period, value FROM dataset_observations WHERE series_id = ? AND as_of = ? ORDER BY period",
+        [series_id, as_of],
+    ).fetchall()
+    return {p: v for p, v in rows}
+
+
+def _latest_as_of(conn, series_id: str) -> Optional[int]:
+    row = conn.execute(
+        "SELECT MAX(as_of) FROM dataset_observations WHERE series_id = ?", [series_id]
+    ).fetchone()
+    return row[0] if row else None
+
+
+def revision_tolerance(conn, series_id: str, period: str) -> Optional[float]:
+    """Max absolute spread of a period's value across stored vintages, used as
+    the tolerance for magnitude checks. None when only one vintage exists."""
+    rows = conn.execute(
+        "SELECT value FROM dataset_observations WHERE series_id = ? AND period = ? AND value IS NOT NULL",
+        [series_id, period],
+    ).fetchall()
+    vals = [r[0] for r in rows]
+    if len(vals) < 2:
+        return None
+    return max(vals) - min(vals)
+
+
+def _prior_period(periods: List[str], period: str) -> Optional[str]:
+    ordered = sorted(periods)
+    if period not in ordered:
+        return None
+    i = ordered.index(period)
+    return ordered[i - 1] if i > 0 else None
+
+
+def _unverifiable(reason: str, assertion, series_id: Optional[str] = None) -> Dict[str, Any]:
+    return analytic_envelope(
+        n=0,
+        method="claim-vs-data check",
+        assumptions=[reason],
+        verdict="unverifiable",
+        reason=reason,
+        subject=getattr(assertion, "subject", None),
+        direction=getattr(assertion, "direction", None),
+        series_id=series_id,
+    )
+
+
+def check_assertion(
+    conn,
+    assertion,
+    series_id: Optional[str] = None,
+    as_of: Optional[int] = None,
+    threshold: float = DEFAULT_MATCH_THRESHOLD,
+) -> Dict[str, Any]:
+    """Check one assertion against the data. Returns an honesty envelope with a
+    three-valued ``verdict``."""
+    if not _table_exists(conn, "dataset_observations"):
+        return _unverifiable("no dataset observations harvested", assertion)
+
+    match_confidence = None
+    if series_id is None:
+        candidates = resolve_series(conn, assertion, threshold=threshold)
+        if not candidates:
+            return _unverifiable("no matching series above threshold", assertion)
+        top = candidates[0]
+        series_id = top.series_id
+        match_confidence = top.match_confidence
+        series_title = top.title
+    else:
+        row = conn.execute(
+            "SELECT title FROM dataset_series WHERE series_id = ?", [series_id]
+        ).fetchone()
+        series_title = row[0] if row else series_id
+
+    if as_of is None:
+        as_of = _latest_as_of(conn, series_id)
+    obs = _observations(conn, series_id, as_of)
+    if not obs:
+        return _unverifiable("series has no observations at this vintage", assertion, series_id)
+
+    direction = getattr(assertion, "direction", None)
+    period = getattr(assertion, "period", None)
+    a_value = getattr(assertion, "value", None)
+
+    assumptions = [
+        f"series: {series_title}",
+        f"vintage as_of={as_of}",
+    ]
+    if match_confidence is not None:
+        assumptions.append(f"series match confidence={match_confidence}")
+
+    # --- comparison-to-a-value directions (exceeds / below / equals) --------
+    if direction in ("exceeds", "below", "equals") and a_value is not None:
+        if period and ".." not in period:
+            # A claim about a specific period is unverifiable if that period is
+            # absent — never silently substitute the latest observation.
+            if period not in obs or obs.get(period) is None:
+                return _unverifiable("no observation for the claimed period", assertion, series_id)
+            target_period = period
+        else:
+            target_period = sorted(obs)[-1] if obs else None
+        if target_period is None or obs.get(target_period) is None:
+            return _unverifiable("no observation for the claimed period", assertion, series_id)
+        observed = obs[target_period]
+        rev_tol = revision_tolerance(conn, series_id, target_period)
+        if rev_tol is not None:
+            tol = rev_tol
+            assumptions.append(f"magnitude tolerance={round(tol, 6)} (from revision spread)")
+        else:
+            tol = abs(observed) * DEFAULT_REL_TOLERANCE
+            assumptions.append(f"magnitude tolerance={round(tol, 6)} (5% fallback)")
+        if direction == "exceeds":
+            verdict = "supported" if observed > a_value + tol else ("contradicted" if observed < a_value - tol else "unverifiable")
+        elif direction == "below":
+            verdict = "supported" if observed < a_value - tol else ("contradicted" if observed > a_value + tol else "unverifiable")
+        else:  # equals
+            verdict = "supported" if abs(observed - a_value) <= tol else "contradicted"
+        return analytic_envelope(
+            n=1,
+            method="claim-vs-data check (magnitude)",
+            assumptions=assumptions,
+            verdict=verdict,
+            subject=getattr(assertion, "subject", None),
+            direction=direction,
+            claimed_value=a_value,
+            observed=interval(observed, observed - tol, observed + tol),
+            period=target_period,
+            series_id=series_id,
+            series_title=series_title,
+            match_confidence=match_confidence,
+        )
+
+    # --- movement directions (rose / fell / unchanged) ----------------------
+    if direction in ("rose", "fell", "unchanged"):
+        if period and ".." in period:
+            start, end = period.split("..", 1)
+            p_from, p_to = start, end
+        elif period:
+            # A claim about a specific period is unverifiable if that period is
+            # absent — do not silently fall back to the latest observations.
+            if period not in obs:
+                return _unverifiable("no observation for the claimed period", assertion, series_id)
+            p_to = period
+            p_from = _prior_period(list(obs), period)
+        else:
+            ordered = sorted(obs)
+            p_to = ordered[-1] if ordered else None
+            p_from = ordered[-2] if len(ordered) >= 2 else None
+        if p_from is None or p_to is None or obs.get(p_from) is None or obs.get(p_to) is None:
+            return _unverifiable("not enough observations to measure movement", assertion, series_id)
+        delta = obs[p_to] - obs[p_from]
+        tol = abs(obs[p_from]) * DEFAULT_REL_TOLERANCE
+        assumptions.append(f"movement {p_from}->{p_to}; delta={round(delta, 6)}")
+        if direction == "rose":
+            verdict = "supported" if delta > tol else ("contradicted" if delta < -tol else "unverifiable")
+        elif direction == "fell":
+            verdict = "supported" if delta < -tol else ("contradicted" if delta > tol else "unverifiable")
+        else:  # unchanged
+            verdict = "supported" if abs(delta) <= tol else "contradicted"
+        return analytic_envelope(
+            n=2,
+            method="claim-vs-data check (movement)",
+            assumptions=assumptions,
+            verdict=verdict,
+            subject=getattr(assertion, "subject", None),
+            direction=direction,
+            delta=delta,
+            observed=interval(obs[p_to], min(obs[p_from], obs[p_to]), max(obs[p_from], obs[p_to])),
+            period_from=p_from,
+            period_to=p_to,
+            series_id=series_id,
+            series_title=series_title,
+            match_confidence=match_confidence,
+        )
+
+    return _unverifiable(f"unhandled direction {direction!r}", assertion, series_id)
+
+
+# --- persistence -----------------------------------------------------------
+
+_CHECKS_DDL = """
+CREATE TABLE IF NOT EXISTS claim_data_checks (
+    check_id        TEXT PRIMARY KEY,
+    claim_id        TEXT,
+    subject         TEXT,
+    direction       TEXT,
+    series_id       TEXT,
+    as_of           BIGINT,
+    verdict         TEXT NOT NULL,
+    match_confidence DOUBLE,
+    envelope        JSON NOT NULL,
+    created_at      BIGINT
+)
+"""
+
+
+def ensure_checks_table(conn) -> None:
+    conn.execute(_CHECKS_DDL)
+
+
+def record_check(
+    conn,
+    envelope: Dict[str, Any],
+    claim_id: Optional[str] = None,
+    now_ms: Optional[int] = None,
+) -> str:
+    """Persist a check envelope into ``claim_data_checks`` (idempotent by
+    check_id). Returns the check_id."""
+    ensure_checks_table(conn)
+    series_id = envelope.get("series_id")
+    as_of = None
+    for a in envelope.get("assumptions", []):
+        if a.startswith("vintage as_of="):
+            try:
+                as_of = int(a.split("=", 1)[1])
+            except ValueError:
+                as_of = None
+    key_src = f"{claim_id}|{series_id}|{as_of}|{envelope.get('direction')}|{envelope.get('period') or envelope.get('period_to')}"
+    check_id = "chk:" + hashlib.md5(key_src.encode()).hexdigest()[:16]
+    conn.execute(
+        """
+        INSERT INTO claim_data_checks
+            (check_id, claim_id, subject, direction, series_id, as_of, verdict, match_confidence, envelope, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (check_id) DO UPDATE SET
+            verdict = excluded.verdict,
+            match_confidence = excluded.match_confidence,
+            envelope = excluded.envelope,
+            created_at = excluded.created_at
+        """,
+        [
+            check_id,
+            claim_id,
+            envelope.get("subject"),
+            envelope.get("direction"),
+            series_id,
+            as_of,
+            envelope.get("verdict", "unverifiable"),
+            envelope.get("match_confidence"),
+            json.dumps(envelope),
+            now_ms,
+        ],
+    )
+    return check_id
+
+
+def claim_vs_data(conn, topic: Optional[str] = None, limit: int = 40) -> Dict[str, Any]:
+    """Panel payload: recent checks with the detail a claim-vs-data panel needs
+    (verdict, observed interval, series, match confidence), parsed from the
+    stored envelope."""
+    if not _table_exists(conn, "claim_data_checks"):
+        return {"checks": [], "count": 0, "note": "no checks recorded"}
+    clauses: List[str] = []
+    params: List[Any] = []
+    if topic:
+        clauses.append("LOWER(subject) LIKE ?")
+        params.append(f"%{topic.lower()}%")
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    capped = max(1, min(limit, 200))
+    rows = conn.execute(
+        f"""
+        SELECT check_id, claim_id, subject, direction, series_id, verdict, match_confidence, envelope
+        FROM claim_data_checks{where}
+        ORDER BY created_at DESC NULLS LAST, check_id
+        LIMIT {capped}
+        """,
+        params,
+    ).fetchall()
+    checks: List[Dict[str, Any]] = []
+    for check_id, claim_id, subject, direction, series_id, verdict, mc, envelope in rows:
+        env = json.loads(envelope) if isinstance(envelope, str) else (envelope or {})
+        checks.append({
+            "check_id": check_id,
+            "claim_id": claim_id,
+            "subject": subject,
+            "direction": direction,
+            "series_id": series_id,
+            "series_title": env.get("series_title"),
+            "verdict": verdict,
+            "match_confidence": mc,
+            "observed": env.get("observed"),
+            "period": env.get("period") or env.get("period_to"),
+            "assumptions": env.get("assumptions", []),
+        })
+    return {"checks": checks, "count": len(checks)}
+
+
+def data_check_ledger(conn, verdict: Optional[str] = None, topic: Optional[str] = None, limit: int = 40) -> Dict[str, Any]:
+    """The quantitative wing of the contradiction ledger: recorded checks,
+    optionally filtered by verdict (e.g. 'contradicted') or subject topic."""
+    if not _table_exists(conn, "claim_data_checks"):
+        return {"checks": [], "count": 0, "note": "no checks recorded"}
+    clauses: List[str] = []
+    params: List[Any] = []
+    if verdict:
+        clauses.append("verdict = ?")
+        params.append(verdict)
+    if topic:
+        clauses.append("LOWER(subject) LIKE ?")
+        params.append(f"%{topic.lower()}%")
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    capped = max(1, min(limit, 200))
+    rows = conn.execute(
+        f"""
+        SELECT check_id, claim_id, subject, direction, series_id, verdict, match_confidence
+        FROM claim_data_checks{where}
+        ORDER BY created_at DESC NULLS LAST, check_id
+        LIMIT {capped}
+        """,
+        params,
+    ).fetchall()
+    keys = ["check_id", "claim_id", "subject", "direction", "series_id", "verdict", "match_confidence"]
+    checks = [dict(zip(keys, r)) for r in rows]
+    return {"checks": checks, "count": len(checks), "verdict": verdict}

--- a/tests/unit/analytics/test_claim_check.py
+++ b/tests/unit/analytics/test_claim_check.py
@@ -1,0 +1,150 @@
+"""Unit tests for claim-vs-data checking (A4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ingest.common.series_model import Observation, SeriesRecord
+from src.analytics.claim_check import (
+    check_assertion,
+    claim_vs_data,
+    data_check_ledger,
+    record_check,
+    resolve_series,
+)
+from src.analytics.honesty import validate_analytic_output
+from src.argument_mining.quantities import QuantityExtractor
+from src.ingestion.connectors.dataset.store import ObservationStore
+
+
+@pytest.fixture()
+def conn():
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect(":memory:")
+    store = ObservationStore(c)
+    store.upsert(
+        SeriesRecord(
+            series_id="wb:SL.UEM.TOTL.ZS:DE",
+            provider="worldbank",
+            title="Unemployment, total (% of labor force) - Germany",
+            frequency="annual",
+            as_of=100,
+            observations=[Observation("2022", 3.13), Observation("2023", 3.02), Observation("2024", 3.40)],
+            unit="percent",
+            geography="DE",
+        )
+    )
+    return c
+
+
+def _assert(text):
+    return QuantityExtractor().extract(text)[0]
+
+
+def test_resolver_ranks_and_thresholds(conn):
+    cands = resolve_series(conn, _assert("Unemployment in Germany rose in 2024."))
+    assert cands and cands[0].series_id == "wb:SL.UEM.TOTL.ZS:DE"
+    assert 0.0 < cands[0].match_confidence <= 1.0
+    # A geography mismatch excludes the series entirely.
+    assert resolve_series(conn, _assert("Unemployment in France rose in 2024.")) == []
+
+
+def test_movement_supported(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."))
+    assert env["verdict"] == "supported"
+    assert env["direction"] == "rose"
+    assert env["n"] == 2
+    assert validate_analytic_output(env, interval_fields=["observed"]) == []
+
+
+def test_movement_contradicted(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany fell in 2024."))
+    assert env["verdict"] == "contradicted"
+    assert validate_analytic_output(env, interval_fields=["observed"]) == []
+
+
+def test_magnitude_supported(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany exceeded 3 percent in 2024."))
+    assert env["verdict"] == "supported"
+    assert env["claimed_value"] == 3.0
+    assert validate_analytic_output(env, interval_fields=["observed"]) == []
+
+
+def test_magnitude_contradicted(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany exceeded 10 percent in 2024."))
+    assert env["verdict"] == "contradicted"
+
+
+def test_unverifiable_no_series(conn):
+    env = check_assertion(conn, _assert("Chocolate consumption tripled in 2024."))
+    assert env["verdict"] == "unverifiable"
+    assert env["n"] == 0
+    # An unverifiable envelope is still a valid honesty output (no interval req).
+    assert validate_analytic_output(env) == []
+
+
+def test_unverifiable_missing_period(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany exceeded 3 percent in 1990."))
+    assert env["verdict"] == "unverifiable"
+
+
+def test_verdict_is_three_valued_never_boolean(conn):
+    for text in [
+        "Unemployment in Germany rose in 2024.",
+        "Unemployment in Germany fell in 2024.",
+        "Chocolate consumption tripled in 2024.",
+    ]:
+        env = check_assertion(conn, _assert(text))
+        assert env["verdict"] in ("supported", "contradicted", "unverifiable")
+        assert not isinstance(env["verdict"], bool)
+
+
+def test_record_and_ledger(conn):
+    supported = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."))
+    contradicted = check_assertion(conn, _assert("Unemployment in Germany fell in 2024."))
+    record_check(conn, supported, claim_id="c1", now_ms=1)
+    record_check(conn, contradicted, claim_id="c2", now_ms=2)
+    # Ledger defaults to contradicted checks.
+    led = data_check_ledger(conn, verdict="contradicted")
+    assert led["count"] == 1
+    assert led["checks"][0]["series_id"] == "wb:SL.UEM.TOTL.ZS:DE"
+    assert data_check_ledger(conn, verdict=None)["count"] == 2
+
+
+def test_record_is_idempotent(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."))
+    id1 = record_check(conn, env, claim_id="c1", now_ms=1)
+    id2 = record_check(conn, env, claim_id="c1", now_ms=1)
+    assert id1 == id2
+    assert data_check_ledger(conn, verdict=None)["count"] == 1
+
+
+def test_claim_vs_data_panel_payload(conn):
+    env = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."))
+    record_check(conn, env, claim_id="c1", now_ms=1)
+    payload = claim_vs_data(conn, topic="unemployment")
+    assert payload["count"] == 1
+    check = payload["checks"][0]
+    assert check["verdict"] == "supported"
+    assert check["observed"] is not None
+    assert check["series_title"] and "Germany" in check["series_title"]
+
+
+def test_check_pins_vintage_for_replay(conn):
+    # A newer vintage revises 2024 downward so the movement reverses.
+    ObservationStore(conn).upsert(
+        SeriesRecord(
+            series_id="wb:SL.UEM.TOTL.ZS:DE",
+            provider="worldbank",
+            title="Unemployment - Germany",
+            frequency="annual",
+            as_of=200,
+            observations=[Observation("2023", 3.02), Observation("2024", 2.40)],
+            unit="percent",
+            geography="DE",
+        )
+    )
+    latest = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."))
+    assert latest["verdict"] == "contradicted"  # 3.02 -> 2.40 under latest vintage
+    pinned = check_assertion(conn, _assert("Unemployment in Germany rose in 2024."), as_of=100)
+    assert pinned["verdict"] == "supported"  # 3.02 -> 3.40 under the original vintage

--- a/tests/unit/tools/test_statistics_mcp.py
+++ b/tests/unit/tools/test_statistics_mcp.py
@@ -75,6 +75,35 @@ def test_annotated_tool_declares_output_schema(server):
     assert server.series_explorer._mcp_output_schema is not None
 
 
+@pytest.mark.parametrize(
+    "tool_name,expected_type,expected_table",
+    [
+        ("claim_vs_data", "claim_vs_data", "claim_data_checks"),
+        ("data_check_ledger", "data_check_ledger", "claim_data_checks"),
+    ],
+)
+def test_a4_panel_annotations_validate(server, tool_name, expected_type, expected_table):
+    from src.genui.discovery import panel_def_from_annotation
+
+    fn = getattr(server, tool_name)
+    tool = {
+        "name": tool_name,
+        "description": tool_name,
+        "meta": fn._mcp_meta,
+        "has_output_schema": True,
+    }
+    panel = panel_def_from_annotation("neuronews-statistics", tool)
+    assert panel is not None, f"{tool_name} annotation must be valid"
+    assert panel.type == expected_type
+    assert expected_table in panel.tables
+
+
+def test_a4_tools_degrade_without_warehouse(server, monkeypatch):
+    monkeypatch.setattr(server, "_warehouse_ro", lambda: (_ for _ in ()).throw(FileNotFoundError("no db")))
+    assert server.claim_vs_data()["checks"] == []
+    assert server.data_check_ledger()["checks"] == []
+
+
 def test_tools_degrade_gracefully_without_warehouse(server, monkeypatch):
     # No warehouse file -> tools return empty/valid payloads, never raise.
     monkeypatch.setattr(server, "_warehouse_ro", lambda: (_ for _ in ()).throw(FileNotFoundError("no db")))

--- a/tools/statistics_mcp/server.py
+++ b/tools/statistics_mcp/server.py
@@ -198,6 +198,98 @@ def series_explorer(topic: Optional[str] = None) -> dict:
         con.close()
 
 
+_CHECK_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "check_id": {"type": "string"},
+        "subject": {"type": ["string", "null"]},
+        "direction": {"type": ["string", "null"]},
+        "series_id": {"type": ["string", "null"]},
+        "verdict": {"type": "string"},
+        "match_confidence": {"type": ["number", "null"]},
+    },
+    "additionalProperties": True,
+}
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "checks": {"type": "array", "items": _CHECK_ITEM_SCHEMA},
+            "count": {"type": "integer"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"data": {"panel": "claim_vs_data", "rest_route": None}, "panel": {
+        "type": "claim_vs_data",
+        "title": "Claims vs data",
+        "description": "Quantitative claims checked against official statistical series: the claim, the resolved series with its observed interval, and a supported / contradicted / unverifiable verdict under the statistical-honesty contract.",
+        "endpoint": None,
+        "facets": ["claims", "library"],
+        "tables": ["claim_data_checks", "dataset_series"],
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def claim_vs_data(topic: Optional[str] = None) -> dict:
+    """Recent claim-vs-data checks with verdicts and observed intervals.
+
+    Args:
+        topic: optional case-insensitive substring of the claim subject.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:  # noqa: BLE001
+        return {"checks": [], "count": 0, "note": str(exc)}
+    try:
+        from src.analytics.claim_check import claim_vs_data as _cvd
+
+        return _cvd(con, topic)
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "checks": {"type": "array", "items": _CHECK_ITEM_SCHEMA},
+            "count": {"type": "integer"},
+            "verdict": {"type": ["string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    meta={"data": {"panel": "data_check_ledger", "rest_route": None}, "panel": {
+        "type": "data_check_ledger",
+        "title": "Data-check ledger",
+        "description": "The quantitative wing of the contradiction ledger: claims the data contradicts, each citing the series and vintage checked.",
+        "endpoint": None,
+        "facets": ["claims", "library"],
+        "tables": ["claim_data_checks"],
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def data_check_ledger(verdict: Optional[str] = "contradicted", topic: Optional[str] = None) -> dict:
+    """Recorded checks, defaulting to the contradicted ones (the ledger).
+
+    Args:
+        verdict: filter by verdict; defaults to 'contradicted'. Pass null for all.
+        topic: optional case-insensitive substring of the claim subject.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:  # noqa: BLE001
+        return {"checks": [], "count": 0, "note": str(exc)}
+    try:
+        from src.analytics.claim_check import data_check_ledger as _dcl
+
+        return _dcl(con, verdict=verdict, topic=topic)
+    finally:
+        con.close()
+
+
 @mcp.tool(
     output_schema={
         "type": "object",


### PR DESCRIPTION
## Overview

The **payoff of Track A** — closes #772, part of #765. A quantitative assertion (A3, merged) is resolved to candidate statistical series (A1/A2, merged) and checked against the data, producing a **supported / contradicted / unverifiable** finding under the statistical-honesty contract. The contradiction ledger can now disagree with a *source*, not just record where sources disagree with each other.

## Changes

**`src/analytics/claim_check.py`**
- `resolve_series` — lexical subject/title token overlap plus unit and geography compatibility, ranked with a match confidence. A **geography mismatch is fatal**; a below-threshold match yields *no candidate* → `unverifiable`, never a wrong series.
- `check_assertion` — two check families:
  - **movement** (`rose`/`fell`/`unchanged`) via period deltas;
  - **magnitude** (`exceeds`/`below`/`equals`) via value + a tolerance taken from the series' **own revision spread** (falling back to 5%).
  - A claim about a *specific absent period* is `unverifiable` — never silently checked against the latest observation.
  - Every result is an `analytic_envelope` (`n` / `method` / `assumptions` including match confidence, the series definition, and the vintage) with an **interval on the observed value**. Verdicts are three-valued; a bare boolean is a contract violation.
- `claim_data_checks` table + `record_check` (idempotent by a stable hash, **pins the vintage** so a check is replayable); `claim_vs_data` and `data_check_ledger` panel queries.

**`tools/statistics_mcp/server.py`** — `claim_vs_data` and `data_check_ledger` tools with ADR-001 panel annotations (the ledger defaults to the contradicted checks — the quantitative wing of the contradiction ledger).

## Testing

- 24 tests, all offline:
  - resolver ranking + geography-mismatch exclusion;
  - supported / contradicted / unverifiable across movement and magnitude, **every envelope passing `validate_analytic_output`** (with `observed` as a checked interval field);
  - three-valued-never-boolean guard; missing-period → unverifiable;
  - ledger filtering, idempotent re-record;
  - **vintage pinning**: the same claim flips verdict between vintages, and `as_of=` replays the original;
  - both new panel annotations validated through the real `panel_def_from_annotation` discovery validator, plus no-warehouse degradation.
- **Exit criteria met**: a seeded corpus claim gets a verdict with a full honesty envelope and renders in `claim_vs_data`; a contradicted claim shows up in the ledger citing the series and vintage.

## Note

Cross-linking into the OSINT `claim_conflicts` ledger (claim-vs-*claim*) is a separate integration; A4 owns the claim-vs-*data* ledger, which is the distinct thing the plan calls for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_