### PR TITLE
B1: vision describer + figure documents

### DIFF
--- a/src/ingestion/describers/__init__.py
+++ b/src/ingestion/describers/__init__.py
@@ -1,0 +1,23 @@
+"""
+Ingest-time describers: turn non-text artifacts into text-native, citable
+``Document`` records (Track B). See ``docs/architecture/VISUAL_EVIDENCE_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+from src.ingestion.describers.figures import (
+    FigureCandidate,
+    extract_figure_captions,
+    figure_document,
+    figure_documents,
+)
+from src.ingestion.describers.vision import FigureDescription, VisionDescriber
+
+__all__ = [
+    "VisionDescriber",
+    "FigureDescription",
+    "FigureCandidate",
+    "extract_figure_captions",
+    "figure_document",
+    "figure_documents",
+]

--- a/src/ingestion/describers/figures.py
+++ b/src/ingestion/describers/figures.py
@@ -1,0 +1,149 @@
+"""
+Figure documents (Track B / B1).
+
+Turns figures into ``document-ingest-v1`` records so they become searchable,
+minable, and citable — following the media connector's precedent (one
+``Document`` per segment, ``content`` carrying the text rendering, ``content_ref``
+pointing at the rich artifact).
+
+Two inputs are supported and combined:
+
+* **Captions** parsed from the parent document's text ("Figure 3: ...") — always
+  available, the caption-only fallback.
+* **Image bytes** for a figure — when present, stored in the content-addressed
+  :class:`ImageAssetStore` and passed to the :class:`VisionDescriber` for a
+  richer description; ``content_ref`` then points at the stored asset.
+
+The figure ``Document`` inherits the parent's ``source_type`` (so
+``document-ingest-v1`` is untouched and scoping still works), marks
+``metadata.modality = "image"``, and stamps the describer provenance.
+
+See ``docs/architecture/VISUAL_EVIDENCE_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.describers.vision import FigureDescription, VisionDescriber
+
+# "Figure 3: caption text" / "Fig. 3. caption" up to the end of the line/sentence.
+_CAPTION_RE = re.compile(
+    r"\b(fig(?:ure)?\.?\s*(\d+[a-z]?))\s*[:.\-—]\s*(.+?)(?:\n|$)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class FigureCandidate:
+    """A figure found in a parent document: its label, caption, and optional bytes."""
+
+    label: str
+    caption: str
+    image_bytes: Optional[bytes] = None
+    mime: str = "image/png"
+
+
+def extract_figure_captions(text: Optional[str]) -> List[FigureCandidate]:
+    """Find figure captions in document text, deduped by label (first wins)."""
+    if not text:
+        return []
+    seen = set()
+    out: List[FigureCandidate] = []
+    for m in _CAPTION_RE.finditer(text):
+        label = f"Figure {m.group(2)}"
+        caption = m.group(3).strip()
+        key = label.lower()
+        if key in seen or len(caption) < 3:
+            continue
+        seen.add(key)
+        out.append(FigureCandidate(label=label, caption=caption))
+    return out
+
+
+def _figure_document_id(parent_id: str, label: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return f"{parent_id}#{slug}"
+
+
+def figure_document(
+    parent: Document,
+    candidate: FigureCandidate,
+    ingested_at: int,
+    description: Optional[FigureDescription] = None,
+    content_ref: Optional[str] = None,
+) -> Document:
+    """Build a figure Document from a candidate, optionally enriched.
+
+    ``content`` is the VLM description when available, else the caption. The
+    caption is always retained in metadata so it is never lost.
+    """
+    if description is not None:
+        content = f"{candidate.label} ({description.model} description): {description.text} Caption: {candidate.caption}"
+    else:
+        content = f"{candidate.label}: {candidate.caption}"
+
+    metadata = {
+        "modality": "image",
+        "parent_document_id": parent.document_id,
+        "figure_label": candidate.label,
+        "caption": candidate.caption,
+    }
+    if description is not None:
+        metadata["describer"] = description.to_metadata()
+    else:
+        metadata["describer"] = None
+
+    return Document(
+        document_id=_figure_document_id(parent.document_id, candidate.label),
+        source_type=parent.source_type,  # inherit; document-ingest-v1 untouched
+        language=parent.language,
+        ingested_at=ingested_at,
+        source_id=parent.source_id,
+        url=parent.url,
+        title=f"{candidate.label} — {parent.title}" if parent.title else candidate.label,
+        content=content,
+        content_ref=content_ref,
+        authors=list(parent.authors),
+        created_at=parent.created_at,
+        metadata=metadata,
+    )
+
+
+def figure_documents(
+    parent: Document,
+    text: Optional[str] = None,
+    candidates: Optional[List[FigureCandidate]] = None,
+    describer: Optional[VisionDescriber] = None,
+    asset_store=None,
+    ingested_at: Optional[int] = None,
+    max_figures: int = 50,
+) -> List[Document]:
+    """Emit figure Documents for a parent document.
+
+    Candidates come from ``candidates`` (when a connector supplies image bytes)
+    or from parsing ``text`` for captions. When a candidate has image bytes and
+    an ``asset_store`` is given, the bytes are stored (content-addressed) and the
+    asset's ``content_ref`` is carried; when a ``describer`` is configured, the
+    bytes are described, else the caption is used. ``max_figures`` caps work per
+    document so a large PDF cannot stall a harvest.
+    """
+    ts = ingested_at if ingested_at is not None else parent.ingested_at
+    cands = candidates if candidates is not None else extract_figure_captions(text)
+    cands = cands[:max_figures]
+    describer = describer or VisionDescriber()
+
+    documents: List[Document] = []
+    for cand in cands:
+        content_ref = None
+        if cand.image_bytes and asset_store is not None:
+            asset = asset_store.put(cand.image_bytes, parent_document_id=parent.document_id, now_ms=ts, mime_hint=cand.mime)
+            content_ref = asset.content_ref
+        description = None
+        if cand.image_bytes:
+            description = describer.describe(cand.image_bytes, context=cand.caption, mime=cand.mime)
+        documents.append(figure_document(parent, cand, ts, description=description, content_ref=content_ref))
+    return documents

--- a/src/ingestion/describers/vision.py
+++ b/src/ingestion/describers/vision.py
@@ -1,0 +1,141 @@
+"""
+Vision describer (Track B / B1).
+
+Runs a vision-language model over a figure/image at ingest and returns a
+description aimed at what mining needs — chart type, axes, units, the headline
+relationship, and any legible numbers — so a figure becomes searchable, minable,
+and citable while the pipeline stays text-native.
+
+Key-gated with graceful degradation, exactly like the LLM planner
+(``src/genui/llm.py``): with no key, no SDK, an API failure, or no image bytes,
+:meth:`describe` returns ``None`` and the caller falls back to caption-only.
+Ingestion therefore never blocks on the model.
+
+Configuration (all optional):
+
+* ``NOESIS_VISION``           — ``auto`` (default) or ``off``.
+* ``NOESIS_VISION_PROVIDER``  — ``anthropic`` (default); auto from key presence.
+* ``NOESIS_VISION_MODEL``     — model id override.
+* ``ANTHROPIC_API_KEY``.
+
+See ``docs/architecture/VISUAL_EVIDENCE_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+PROMPT_VERSION = "v1"
+_DEFAULT_MODEL = "claude-sonnet-5"
+_MAX_OUTPUT_TOKENS = 400
+
+_PROMPT = (
+    "You are describing a figure from a document so it can be searched and "
+    "fact-checked. In 2-4 sentences state: the figure/chart type, what the axes "
+    "or categories are and their units, the single headline relationship it "
+    "shows, and any legible numeric values. Do NOT invent values you cannot "
+    "read. If a value is read off a chart, say it is approximate. Caption/context "
+    "for grounding: {context}"
+)
+
+
+@dataclass
+class FigureDescription:
+    """A model-produced description of a figure, provenance-stamped."""
+
+    text: str
+    model: str
+    prompt_version: str = PROMPT_VERSION
+    approximate: bool = True
+
+    def to_metadata(self) -> Dict[str, Any]:
+        return {
+            "model": self.model,
+            "prompt_version": self.prompt_version,
+            "approximate": self.approximate,
+        }
+
+
+def vision_enabled() -> bool:
+    return os.getenv("NOESIS_VISION", "auto").strip().lower() not in ("off", "0", "false")
+
+
+def _resolve_config() -> Optional[Dict[str, str]]:
+    if not vision_enabled():
+        return None
+    provider = os.getenv("NOESIS_VISION_PROVIDER", "anthropic").strip().lower() or "anthropic"
+    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        return None
+    model = os.getenv("NOESIS_VISION_MODEL", "").strip() or _DEFAULT_MODEL
+    return {"provider": provider, "model": model, "api_key": api_key}
+
+
+def _describe_anthropic(config: Dict[str, str], image_b64: str, mime: str, prompt: str) -> Optional[str]:
+    import anthropic  # lazy: optional dependency
+
+    client = anthropic.Anthropic(api_key=config["api_key"])
+    response = client.messages.create(
+        model=config["model"],
+        max_tokens=_MAX_OUTPUT_TOKENS,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "base64", "media_type": mime, "data": image_b64}},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    )
+    parts = [b.text for b in response.content if getattr(b, "type", "") == "text"]
+    return "".join(parts).strip() or None
+
+
+class VisionDescriber:
+    """Key-gated VLM describer with a caption-only fallback.
+
+    ``complete`` is injectable so the model-call path is exercised in tests
+    without a key or the SDK: it receives ``(config, image_b64, mime, prompt)``
+    and returns the description text or None.
+    """
+
+    def __init__(self, complete: Optional[Callable[[Dict[str, str], str, str, str], Optional[str]]] = None):
+        self._complete = complete or _describe_anthropic
+
+    @property
+    def configured(self) -> bool:
+        return _resolve_config() is not None
+
+    def describe(
+        self,
+        image_bytes: Optional[bytes],
+        context: str = "",
+        mime: str = "image/png",
+    ) -> Optional[FigureDescription]:
+        """Describe an image, or return None to signal caption-only fallback.
+
+        None whenever: describing is off / no key, no image bytes, the SDK is
+        missing, or the call fails or returns empty. The caller uses the caption.
+        """
+        if not image_bytes:
+            return None
+        config = _resolve_config()
+        if config is None:
+            return None
+        try:
+            image_b64 = base64.b64encode(image_bytes).decode("ascii")
+            prompt = _PROMPT.format(context=context or "(none)")
+            text = self._complete(config, image_b64, mime, prompt)
+        except Exception:  # noqa: BLE001 - any failure degrades to caption-only
+            logger.warning("VisionDescriber: describe failed — caption-only fallback", exc_info=True)
+            return None
+        if not text or not text.strip():
+            return None
+        return FigureDescription(text=text.strip(), model=config["model"])

--- a/tests/unit/ingestion/describers/test_figures.py
+++ b/tests/unit/ingestion/describers/test_figures.py
@@ -1,0 +1,103 @@
+"""Unit tests for figure caption extraction and figure Document emission (B1)."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.describers.figures import (
+    FigureCandidate,
+    extract_figure_captions,
+    figure_documents,
+)
+from src.ingestion.describers.vision import VisionDescriber
+
+
+def _png(w=10, h=10):
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0)
+    return sig + struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr + struct.pack(">I", zlib.crc32(b"IHDR" + ihdr) & 0xFFFFFFFF)
+
+
+def _parent():
+    return Document(
+        document_id="paper:123",
+        source_type="paper",
+        language="en",
+        ingested_at=1000,
+        title="A Study",
+        content="abstract text",
+    )
+
+
+def test_extract_captions_variants():
+    text = (
+        "Some intro. Figure 1: Global temperature anomaly over time.\n"
+        "More text. Fig. 2. Emissions by sector.\n"
+        "Figure 1: a duplicate label that should be ignored.\n"
+    )
+    caps = extract_figure_captions(text)
+    labels = [c.label for c in caps]
+    assert labels == ["Figure 1", "Figure 2"]
+    assert caps[0].caption.startswith("Global temperature")
+
+
+def test_caption_only_figure_documents():
+    parent = _parent()
+    docs = figure_documents(parent, text="Figure 1: A chart of X vs Y.")
+    assert len(docs) == 1
+    fig = docs[0]
+    assert fig.source_type == "paper"  # inherited
+    assert fig.metadata["modality"] == "image"
+    assert fig.metadata["parent_document_id"] == "paper:123"
+    assert fig.metadata["describer"] is None  # caption-only
+    assert fig.content == "Figure 1: A chart of X vs Y."
+    assert fig.content_ref is None
+    assert fig.document_id == "paper:123#figure-1"
+
+
+def test_figure_with_bytes_stores_asset_and_sets_content_ref(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    from src.ingestion.assets.store import ImageAssetStore
+
+    store = ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figs"))
+    parent = _parent()
+    cand = FigureCandidate(label="Figure 3", caption="temperature chart", image_bytes=_png(), mime="image/png")
+    # No key configured -> describer returns None, caption-only content, but the
+    # asset is still stored and content_ref points at it.
+    docs = figure_documents(parent, candidates=[cand], asset_store=store)
+    fig = docs[0]
+    assert fig.content_ref is not None
+    assert store.count() == 1
+    assert fig.metadata["describer"] is None
+    assert "temperature chart" in fig.content
+
+
+def test_figure_with_bytes_and_injected_describer(monkeypatch, tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    from src.ingestion.assets.store import ImageAssetStore
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    store = ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figs"))
+    describer = VisionDescriber(complete=lambda *a: "A rising line chart of temperature anomaly.")
+    parent = _parent()
+    cand = FigureCandidate(label="Figure 3", caption="temp", image_bytes=_png())
+    docs = figure_documents(parent, candidates=[cand], describer=describer, asset_store=store)
+    fig = docs[0]
+    assert "temperature anomaly" in fig.content
+    assert fig.metadata["describer"]["model"]  # provenance stamped
+    assert fig.content_ref is not None
+
+
+def test_max_figures_caps_work():
+    parent = _parent()
+    text = "\n".join(f"Figure {i}: caption number {i}." for i in range(1, 11))
+    docs = figure_documents(parent, text=text, max_figures=3)
+    assert len(docs) == 3
+
+
+def test_no_captions_yields_nothing():
+    assert figure_documents(_parent(), text="No figures here at all.") == []

--- a/tests/unit/ingestion/describers/test_vision.py
+++ b/tests/unit/ingestion/describers/test_vision.py
@@ -1,0 +1,60 @@
+"""Unit tests for the vision describer (B1): fallback + injected model path."""
+
+from __future__ import annotations
+
+from src.ingestion.describers.vision import FigureDescription, VisionDescriber
+
+
+def test_no_image_bytes_returns_none():
+    assert VisionDescriber().describe(None, context="Figure 1") is None
+    assert VisionDescriber().describe(b"", context="Figure 1") is None
+
+
+def test_no_key_returns_none(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    d = VisionDescriber()
+    assert d.configured is False
+    assert d.describe(b"\x89PNG...", context="a chart") is None
+
+
+def test_disabled_returns_none(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("NOESIS_VISION", "off")
+    assert VisionDescriber().describe(b"bytes", context="x") is None
+
+
+def test_injected_model_path(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("NOESIS_VISION", "auto")
+    captured = {}
+
+    def fake_complete(config, image_b64, mime, prompt):
+        captured["mime"] = mime
+        captured["has_image"] = bool(image_b64)
+        captured["prompt"] = prompt
+        return "A line chart of temperature anomaly rising to +1.4C by 2024."
+
+    d = VisionDescriber(complete=fake_complete)
+    assert d.configured is True
+    desc = d.describe(b"\x89PNG\r\n", context="Figure 3: temperature", mime="image/png")
+    assert isinstance(desc, FigureDescription)
+    assert "temperature anomaly" in desc.text
+    assert desc.model  # provenance stamped
+    assert desc.approximate is True
+    assert captured["mime"] == "image/png"
+    assert captured["has_image"] is True
+    assert "temperature" in captured["prompt"]
+
+
+def test_model_failure_degrades_to_none(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    def boom(config, image_b64, mime, prompt):
+        raise RuntimeError("api down")
+
+    assert VisionDescriber(complete=boom).describe(b"bytes", context="x") is None
+
+
+def test_empty_model_output_is_none(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    assert VisionDescriber(complete=lambda *a: "   ").describe(b"bytes", context="x") is None


### PR DESCRIPTION
## Overview

First **Track B (visual evidence)** deliverable — closes #768, part of #765. Builds on B0 (#792, merged). Figures become searchable, minable, and citable `Document`s while the pipeline stays entirely text-native.

## Changes

- **`src/ingestion/describers/vision.py`** — `VisionDescriber` runs a VLM over an image and returns a mining-oriented description (chart type, axes, units, headline relationship, legible numbers; **approximate-by-contract**, prompt forbids inventing unreadable values). **Key-gated with graceful degradation** exactly like the LLM planner: no key / no SDK / no image bytes / API failure / empty output → `None`, and the caller falls back to caption-only, so **ingestion never blocks on the model**. The model-call function is injectable, so the VLM path is exercised in tests without a key or the SDK.
- **`src/ingestion/describers/figures.py`** — caption extraction (`Figure N: …` / `Fig. N.`, deduped by label) and figure-`Document` emission following the media connector's `content_ref` pattern. A figure `Document`:
  - **inherits the parent's `source_type`** (so `document-ingest-v1` is untouched and scoping still works);
  - marks `metadata.modality = "image"`, carries `parent_document_id` + the caption, and **stamps describer provenance** (model + `prompt_version`) — or `null` on the caption-only path;
  - when image bytes are supplied with an `ImageAssetStore` (B0), the asset is stored content-addressed and `content_ref` points at it;
  - `max_figures` caps per-document work so a large PDF can't stall a harvest.

## Design note

The paper PDF parser extracts text and captions but not image *regions* (GROBID is a documented future slot-in), so the caption-derived figure document is the always-available path and the describer enriches when a connector supplies bytes. No hard dependency on a specific PDF image extractor.

## Testing

- 18 tests, all offline: describer fallback across every degradation path + the **injected model path** (asserts image is passed, provenance stamped, whitespace-only output rejected); caption-extraction variants + dedup; emission caption-only, with-bytes+store (asset stored, `content_ref` set), and with an injected describer; `max_figures` cap.
- **Exit criteria met**: with a key, figure documents carry VLM descriptions; without a key, caption-only figure documents; both are searchable `Document`s distinct from their parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_