### PR TITLE
C1: image asset extraction — EXIF, perceptual hash, appearances

### DIFF
--- a/src/ingestion/assets/__init__.py
+++ b/src/ingestion/assets/__init__.py
@@ -8,6 +8,19 @@ See ``docs/architecture/VISUAL_EVIDENCE_PLAN.md`` (Track B) and
 from __future__ import annotations
 
 from src.ingestion.assets.imageinfo import extension_for, sniff
+from src.ingestion.assets.provenance import (
+    extract_exif,
+    hamming_distance,
+    perceptual_hash,
+)
 from src.ingestion.assets.store import ImageAsset, ImageAssetStore
 
-__all__ = ["ImageAsset", "ImageAssetStore", "sniff", "extension_for"]
+__all__ = [
+    "ImageAsset",
+    "ImageAssetStore",
+    "sniff",
+    "extension_for",
+    "perceptual_hash",
+    "hamming_distance",
+    "extract_exif",
+]

--- a/src/ingestion/assets/provenance.py
+++ b/src/ingestion/assets/provenance.py
@@ -1,0 +1,111 @@
+"""
+Image provenance extraction (Track C / C1): perceptual hash + EXIF.
+
+Corpus-internal, local, model-free. Two signals per image:
+
+* A **perceptual hash** (dHash) robust to recompression/resizing/mild crops, for
+  near-duplicate ("recycled photo") detection in C2.
+* **EXIF** metadata, recorded as *claims made by the file* — never verified fact
+  (EXIF is trivially editable), so callers and panels must present it as such.
+
+Pillow is imported lazily (it is already an indirect dependency via
+``pdf2image``); if it is unavailable or an image cannot be decoded, extraction
+degrades to ``None`` / ``{}`` rather than raising, so ingestion never breaks on a
+bad image. Heavy work stays out of the tool servers by living here, called from
+the batch/backfill path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+HASH_SIZE = 8  # dHash over a (HASH_SIZE+1 x HASH_SIZE) grid -> HASH_SIZE^2 bits
+
+
+def _load_image(image_bytes: bytes):
+    """Open image bytes with Pillow, or return None if unavailable/undecodable."""
+    try:
+        import io
+
+        from PIL import Image  # lazy: optional heavy dependency
+
+        return Image.open(io.BytesIO(image_bytes))
+    except Exception:  # noqa: BLE001 - missing Pillow or a bad image both degrade
+        logger.debug("provenance: could not open image", exc_info=True)
+        return None
+
+
+def perceptual_hash(image_bytes: bytes, hash_size: int = HASH_SIZE) -> Optional[str]:
+    """dHash as a hex string, or None when the image can't be decoded.
+
+    Grayscale, resized to ``(hash_size+1, hash_size)``; each bit is whether a
+    pixel is brighter than its right neighbour. Robust to scale and small edits.
+    """
+    img = _load_image(image_bytes)
+    if img is None:
+        return None
+    try:
+        gray = img.convert("L").resize((hash_size + 1, hash_size))
+        px = gray.load()
+        bits = 0
+        for row in range(hash_size):
+            for col in range(hash_size):
+                bits = (bits << 1) | (1 if px[col, row] > px[col + 1, row] else 0)
+        width_hex = (hash_size * hash_size + 3) // 4
+        return format(bits, f"0{width_hex}x")
+    except Exception:  # noqa: BLE001
+        logger.debug("provenance: perceptual_hash failed", exc_info=True)
+        return None
+
+
+def hamming_distance(a: Optional[str], b: Optional[str]) -> Optional[int]:
+    """Bit distance between two hex hashes, or None if either is missing/misshaped."""
+    if not a or not b or len(a) != len(b):
+        return None
+    try:
+        return bin(int(a, 16) ^ int(b, 16)).count("1")
+    except ValueError:
+        return None
+
+
+def extract_exif(image_bytes: bytes) -> Dict[str, Any]:
+    """Return EXIF tags as file-*claimed* metadata (never verified), or {}.
+
+    GPS is decoded into a nested ``GPSInfo`` mapping when present. Values are
+    stringified defensively so the result is always JSON-serializable.
+    """
+    img = _load_image(image_bytes)
+    if img is None:
+        return {}
+    try:
+        from PIL import ExifTags  # lazy
+
+        raw = getattr(img, "getexif", lambda: None)()
+        if not raw:
+            return {}
+        tag_names = ExifTags.TAGS
+        gps_names = ExifTags.GPSTAGS
+        out: Dict[str, Any] = {}
+        for tag_id, value in raw.items():
+            name = tag_names.get(tag_id, str(tag_id))
+            if name == "GPSInfo" and isinstance(value, dict):
+                out["GPSInfo"] = {gps_names.get(k, str(k)): _coerce(v) for k, v in value.items()}
+            else:
+                out[name] = _coerce(value)
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("provenance: extract_exif failed", exc_info=True)
+        return {}
+
+
+def _coerce(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    if isinstance(value, (str, int, float)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_coerce(v) for v in value]
+    return str(value)

--- a/src/ingestion/assets/store.py
+++ b/src/ingestion/assets/store.py
@@ -45,6 +45,18 @@ CREATE TABLE IF NOT EXISTS image_assets (
 )
 """
 
+# Track C (#771): every document an asset appears in, so a recycled image is
+# visible as one asset with multiple appearances.
+_APPEARANCES_DDL = """
+CREATE TABLE IF NOT EXISTS image_appearances (
+    sha256          TEXT NOT NULL,
+    document_id     TEXT NOT NULL,
+    first_seen_at   BIGINT,
+    context         TEXT,
+    PRIMARY KEY (sha256, document_id)
+)
+"""
+
 
 @dataclass
 class ImageAsset:
@@ -75,6 +87,7 @@ class ImageAssetStore:
         self._root = root
         os.makedirs(self._root, exist_ok=True)
         self._conn.execute(_ASSETS_DDL)
+        self._conn.execute(_APPEARANCES_DDL)
 
     @classmethod
     def open(cls, db_path: str = ":memory:", root: str = "artifacts/figures") -> "ImageAssetStore":
@@ -168,3 +181,119 @@ class ImageAssetStore:
 
     def count(self) -> int:
         return self._conn.execute("SELECT COUNT(*) FROM image_assets").fetchone()[0]
+
+    # --- Track C (#771): appearances + provenance extraction ---------------
+
+    def record_appearance(
+        self,
+        sha256: str,
+        document_id: str,
+        context: Optional[str] = None,
+        now_ms: Optional[int] = None,
+    ) -> None:
+        """Record that an asset appears in a document (idempotent per pair)."""
+        self._conn.execute(
+            """
+            INSERT INTO image_appearances (sha256, document_id, first_seen_at, context)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (sha256, document_id) DO NOTHING
+            """,
+            [sha256, document_id, now_ms, context],
+        )
+
+    def appearances(self, sha256: str) -> List[Dict[str, Any]]:
+        """Every document an asset appears in, earliest first."""
+        rows = self._conn.execute(
+            """
+            SELECT sha256, document_id, first_seen_at, context
+            FROM image_appearances WHERE sha256 = ?
+            ORDER BY first_seen_at NULLS LAST, document_id
+            """,
+            [sha256],
+        ).fetchall()
+        keys = ["sha256", "document_id", "first_seen_at", "context"]
+        return [dict(zip(keys, r)) for r in rows]
+
+    def enrich(
+        self,
+        sha256: str,
+        phash: Optional[str] = None,
+        exif: Optional[Dict[str, Any]] = None,
+        c2pa: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Populate the reserved provenance columns for an asset (only the
+        provided ones; None leaves a column unchanged)."""
+        import json
+
+        sets: List[str] = []
+        params: List[Any] = []
+        if phash is not None:
+            sets.append("phash = ?")
+            params.append(phash)
+        if exif is not None:
+            sets.append("exif = ?")
+            params.append(json.dumps(exif))
+        if c2pa is not None:
+            sets.append("c2pa = ?")
+            params.append(json.dumps(c2pa))
+        if not sets:
+            return
+        params.append(sha256)
+        self._conn.execute(f"UPDATE image_assets SET {', '.join(sets)} WHERE sha256 = ?", params)
+
+    def get_provenance(self, sha256: str) -> Optional[Dict[str, Any]]:
+        """Return the provenance columns (phash/exif/c2pa) for an asset."""
+        import json
+
+        row = self._conn.execute(
+            "SELECT phash, exif, c2pa FROM image_assets WHERE sha256 = ?", [sha256]
+        ).fetchone()
+        if row is None:
+            return None
+        phash, exif, c2pa = row
+        return {
+            "phash": phash,
+            "exif": json.loads(exif) if isinstance(exif, str) else exif,
+            "c2pa": json.loads(c2pa) if isinstance(c2pa, str) else c2pa,
+        }
+
+    def ingest(
+        self,
+        data: bytes,
+        document_id: Optional[str] = None,
+        context: Optional[str] = None,
+        now_ms: Optional[int] = None,
+        mime_hint: Optional[str] = None,
+        extract: bool = True,
+    ) -> ImageAsset:
+        """Store bytes, record the appearance, and (by default) extract phash +
+        EXIF. The one call a connector uses per encountered image: dedupes by
+        content, tracks every source the image appears in, and populates
+        provenance the first time.
+        """
+        asset = self.put(data, parent_document_id=document_id, now_ms=now_ms, mime_hint=mime_hint)
+        if document_id is not None:
+            self.record_appearance(asset.sha256, document_id, context=context, now_ms=now_ms)
+        if extract and self.get_provenance(asset.sha256).get("phash") is None:
+            from src.ingestion.assets.provenance import extract_exif, perceptual_hash
+
+            self.enrich(asset.sha256, phash=perceptual_hash(data), exif=extract_exif(data))
+        return asset
+
+    def backfill_provenance(self, limit: Optional[int] = None) -> int:
+        """Compute phash + EXIF for stored assets missing a phash. Returns the
+        number enriched. The batch path for assets ingested before C1."""
+        from src.ingestion.assets.provenance import extract_exif, perceptual_hash
+
+        clause = f" LIMIT {int(limit)}" if limit else ""
+        rows = self._conn.execute(
+            f"SELECT sha256 FROM image_assets WHERE phash IS NULL{clause}"
+        ).fetchall()
+        enriched = 0
+        for (sha256,) in rows:
+            data = self.read_bytes(sha256)
+            if data is None:
+                continue
+            self.enrich(sha256, phash=perceptual_hash(data), exif=extract_exif(data))
+            enriched += 1
+        return enriched

--- a/tests/unit/ingestion/assets/test_provenance.py
+++ b/tests/unit/ingestion/assets/test_provenance.py
@@ -1,0 +1,93 @@
+"""Unit tests for image provenance extraction (C1): pHash + EXIF."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.ingestion.assets.provenance import extract_exif, hamming_distance, perceptual_hash
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+
+def _png_bytes(img) -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _gradient(width=64, height=64, shift=0):
+    img = Image.new("RGB", (width, height))
+    px = img.load()
+    for y in range(height):
+        for x in range(width):
+            v = (x * 4 + shift) % 256
+            px[x, y] = (v, v, v)
+    return img
+
+
+def test_phash_is_stable_and_hex():
+    data = _png_bytes(_gradient())
+    h1 = perceptual_hash(data)
+    h2 = perceptual_hash(data)
+    assert h1 == h2
+    assert len(h1) == 16  # 64-bit dHash -> 16 hex chars
+    int(h1, 16)  # valid hex
+
+
+def test_phash_survives_rescale():
+    original = _gradient(64, 64)
+    rescaled = original.resize((200, 200))
+    h_orig = perceptual_hash(_png_bytes(original))
+    h_scaled = perceptual_hash(_png_bytes(rescaled))
+    # A rescaled copy of the same image is a near-duplicate (small distance).
+    assert hamming_distance(h_orig, h_scaled) <= 4
+
+
+def test_phash_distinguishes_different_images():
+    a = perceptual_hash(_png_bytes(_gradient(64, 64, shift=0)))
+    b = perceptual_hash(_png_bytes(_gradient(64, 64, shift=128)))
+    assert hamming_distance(a, b) is not None
+    # Shifted gradient differs meaningfully.
+    assert hamming_distance(a, b) >= 1
+
+
+def test_phash_none_for_undecodable():
+    assert perceptual_hash(b"not an image") is None
+
+
+def test_hamming_distance_guards():
+    assert hamming_distance(None, "ab") is None
+    assert hamming_distance("ab", "abcd") is None
+    assert hamming_distance("00", "ff") == 8
+
+
+def test_extract_exif_empty_when_absent():
+    # A freshly-generated PNG carries no EXIF.
+    assert extract_exif(_png_bytes(_gradient())) == {}
+
+
+def test_extract_exif_reads_tags():
+    img = _gradient(32, 32)
+    exif = Image.Exif()
+    exif[271] = "TestMake"  # Make
+    exif[272] = "TestModel"  # Model
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+    got = extract_exif(buf.getvalue())
+    assert got.get("Make") == "TestMake"
+    assert got.get("Model") == "TestModel"
+
+
+def test_extract_exif_json_serializable():
+    import json
+
+    img = _gradient(16, 16)
+    exif = Image.Exif()
+    exif[305] = "Software v1"  # Software
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+    got = extract_exif(buf.getvalue())
+    json.dumps(got)  # must not raise

--- a/tests/unit/ingestion/assets/test_store_provenance.py
+++ b/tests/unit/ingestion/assets/test_store_provenance.py
@@ -1,0 +1,86 @@
+"""Unit tests for the store's Track C additions: appearances + enrichment (C1)."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.ingestion.assets.store import ImageAssetStore
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+
+def _img_bytes(shift=0):
+    img = Image.new("RGB", (48, 48))
+    px = img.load()
+    for y in range(48):
+        for x in range(48):
+            v = (x * 5 + shift) % 256
+            px[x, y] = (v, v, v)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def store(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    return ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figs"))
+
+
+def test_recycled_image_one_asset_many_appearances(store):
+    data = _img_bytes()
+    store.ingest(data, document_id="news:outletA", context="story about floods", now_ms=1000)
+    store.ingest(data, document_id="blog:outletB", context="unrelated story", now_ms=2000)
+    # One asset (content dedupe), two appearances.
+    assert store.count() == 1
+    apps = store.appearances(store.digest(data))
+    assert [a["document_id"] for a in apps] == ["news:outletA", "blog:outletB"]
+    assert apps[0]["context"] == "story about floods"
+
+
+def test_ingest_extracts_phash_and_exif(store):
+    data = _img_bytes()
+    asset = store.ingest(data, document_id="doc:1")
+    prov = store.get_provenance(asset.sha256)
+    assert prov["phash"] is not None and len(prov["phash"]) == 16
+    assert prov["exif"] == {}  # generated PNG has no EXIF, but the column is set to {}
+
+
+def test_appearance_idempotent(store):
+    data = _img_bytes()
+    store.ingest(data, document_id="doc:1", now_ms=1)
+    store.ingest(data, document_id="doc:1", now_ms=1)
+    assert len(store.appearances(store.digest(data))) == 1
+
+
+def test_enrich_updates_only_given_columns(store):
+    data = _img_bytes()
+    asset = store.put(data)
+    store.enrich(asset.sha256, phash="deadbeefdeadbeef")
+    assert store.get_provenance(asset.sha256)["phash"] == "deadbeefdeadbeef"
+    store.enrich(asset.sha256, exif={"Make": "X"})
+    prov = store.get_provenance(asset.sha256)
+    assert prov["phash"] == "deadbeefdeadbeef"  # unchanged
+    assert prov["exif"] == {"Make": "X"}
+
+
+def test_backfill_provenance(store):
+    # Two assets stored via put() (no extraction), then backfilled.
+    a = store.put(_img_bytes(shift=0))
+    b = store.put(_img_bytes(shift=100))
+    assert store.get_provenance(a.sha256)["phash"] is None
+    enriched = store.backfill_provenance()
+    assert enriched == 2
+    assert store.get_provenance(a.sha256)["phash"] is not None
+    assert store.get_provenance(b.sha256)["phash"] is not None
+    # Idempotent: nothing left to backfill.
+    assert store.backfill_provenance() == 0
+
+
+def test_ingest_without_document_id_still_stores(store):
+    asset = store.ingest(_img_bytes())
+    assert store.count() == 1
+    assert store.appearances(asset.sha256) == []  # no appearance without a doc id


### PR DESCRIPTION
## Overview

First **Track C (OSINT imagery)** deliverable — closes #771, part of #765. Builds on the B0 asset store (#792, merged). Image provenance starts corpus-internal, local, and model-free, under the Track C guardrails ([`OSINT_IMAGERY_PLAN.md`](https://github.com/Ikey168/Noesis/blob/main/docs/architecture/OSINT_IMAGERY_PLAN.md) §2).

## Changes

- **`src/ingestion/assets/provenance.py`**:
  - `perceptual_hash` — a **dHash** (grayscale, 9×8, adjacent-pixel comparison → 64-bit hex) robust to recompression/rescale/mild crops, for the recycled-photo detection C2 will do.
  - `extract_exif` — EXIF recorded as **claims made by the file, never verified fact** (EXIF is trivially editable; panels must present it as such); GPS decoded into a nested map; values stringified so the result is always JSON-serializable.
  - Pillow is imported **lazily** (already an indirect dependency via `pdf2image`); a missing Pillow or an undecodable image degrades to `None`/`{}` rather than raising. `hamming_distance` helper for C2.
- **`src/ingestion/assets/store.py`**:
  - `image_appearances` table (`sha256`, `document_id`, `first_seen_at`, `context`) so a recycled image is **one asset with many appearances**; `record_appearance` / `appearances`.
  - `enrich` / `get_provenance` populate the reserved `phash` / `exif` / `c2pa` columns; `ingest()` convenience (put + appearance + extract, first-time only); `backfill_provenance()` for assets stored before C1.
  - Migration-free: the new table is additive and the provenance columns were already reserved nullable in B0.

## Testing

- 14 new tests, all offline (Pillow present): pHash stability, **survives-rescale near-duplicate** (hamming ≤ 4), distinguishes different images, undecodable → `None`; EXIF empty-when-absent, tag reading, JSON-serializable; store appearances (recycled image → one asset/two appearances), idempotent appearance, selective enrich, backfill idempotency, and no-doc-id ingest.
- **B0's 13 tests still pass unchanged** (backward-compatible store extension).
- **Exit criteria met**: re-ingesting the same photo from two outlets yields one asset with two appearances; EXIF renders as file-claimed metadata.

## Note

Pillow is the enabling dependency (already pulled in transitively by `pdf2image`); the lazy import keeps the store import-safe for the tool servers, with extraction degrading cleanly if Pillow is ever absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_