### PR TITLE
C2: image reuse detection + provenance/reuse OSINT tools

### DIFF
--- a/src/analytics/image_reuse.py
+++ b/src/analytics/image_reuse.py
@@ -1,0 +1,199 @@
+"""
+Image reuse detection (Track C / C2).
+
+The most common image failure in open sources is not fakery but **recycling** —
+a real photo attached to the wrong event, place, or year. This module clusters
+stored image assets by perceptual-hash distance (C1's dHash) and flags clusters
+whose near-duplicate images appear across **multiple distinct documents**: a
+reuse finding, citing every appearance.
+
+Findings follow the statistical-honesty contract (``n`` = appearances, method,
+the hash-distance threshold as a declared assumption) and the OSINT evidence
+discipline (every appearance is a citation). A high-confidence conflicting reuse
+is a ledger entry; below the confidence bar it stays a flagged suggestion.
+
+Reads ``image_assets`` + ``image_appearances`` from an injected connection, so
+the read-only warehouse (the MCP server) and a writable store both work.
+
+See ``docs/architecture/OSINT_IMAGERY_PLAN.md`` §3.2.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.analytics.honesty import analytic_envelope
+from src.ingestion.assets.provenance import hamming_distance
+
+DEFAULT_MAX_DISTANCE = 6  # dHash bits; ~<=6/64 is a robust near-duplicate
+MAX_ASSETS = 2000  # clustering is O(n^2); cap and report if exceeded
+
+METHOD = "perceptual-hash (dHash) near-duplicate clustering"
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _assumptions(max_distance: int, extra: Optional[List[str]] = None) -> List[str]:
+    base = [
+        f"near-duplicate threshold = {max_distance} dHash bits (of 64)",
+        "EXIF and appearance context are file-claimed, not verified",
+        "a reuse finding flags recycling, not fakery; review each before acting",
+    ]
+    return base + (extra or [])
+
+
+def _load_assets(conn) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT sha256, phash FROM image_assets WHERE phash IS NOT NULL ORDER BY sha256 LIMIT ?",
+        [MAX_ASSETS + 1],
+    ).fetchall()
+    return [{"sha256": r[0], "phash": r[1]} for r in rows]
+
+
+def _appearances(conn, sha256: str) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT document_id, first_seen_at, context FROM image_appearances WHERE sha256 = ? ORDER BY first_seen_at NULLS LAST, document_id",
+        [sha256],
+    ).fetchall()
+    return [{"document_id": r[0], "first_seen_at": r[1], "context": r[2], "cited": True} for r in rows]
+
+
+def _cluster(assets: List[Dict[str, Any]], max_distance: int) -> List[List[int]]:
+    """Union-find clustering by pairwise pHash hamming distance <= threshold."""
+    n = len(assets)
+    parent = list(range(n))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            dist = hamming_distance(assets[i]["phash"], assets[j]["phash"])
+            if dist is not None and dist <= max_distance:
+                union(i, j)
+
+    groups: Dict[int, List[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return list(groups.values())
+
+
+def find_reuse(conn, max_distance: int = DEFAULT_MAX_DISTANCE, topic: Optional[str] = None) -> Dict[str, Any]:
+    """Reuse findings: near-duplicate image clusters spanning >=2 documents.
+
+    Each finding carries its assets, every appearance (cited), and the count of
+    distinct documents it spans. A finding is ``conflicting`` (ledger-worthy)
+    when it spans distinct documents; confidence scales with distinctness.
+    """
+    if not _table_exists(conn, "image_assets") or not _table_exists(conn, "image_appearances"):
+        return analytic_envelope(n=0, method=METHOD, assumptions=_assumptions(max_distance), findings=[], note="no image provenance available")
+
+    assets = _load_assets(conn)
+    truncated = len(assets) > MAX_ASSETS
+    assets = assets[:MAX_ASSETS]
+    clusters = _cluster(assets, max_distance)
+
+    findings: List[Dict[str, Any]] = []
+    total_appearances = 0
+    for group in clusters:
+        members = [assets[i] for i in group]
+        appearances: List[Dict[str, Any]] = []
+        for m in members:
+            appearances.extend(_appearances(conn, m["sha256"]))
+        distinct_docs = sorted({a["document_id"] for a in appearances})
+        if len(distinct_docs) < 2:
+            continue  # not reused across documents
+        if topic and not any(topic.lower() in (a.get("context") or "").lower() for a in appearances):
+            continue
+        total_appearances += len(appearances)
+        findings.append({
+            "asset_shas": [m["sha256"] for m in members],
+            "distinct_document_count": len(distinct_docs),
+            "documents": distinct_docs,
+            "appearances": appearances,
+            "conflicting": True,
+            "confidence": "high" if len(distinct_docs) >= 3 else "medium",
+        })
+
+    findings.sort(key=lambda f: f["distinct_document_count"], reverse=True)
+    extra = ["asset cap exceeded; clustering limited"] if truncated else None
+    return analytic_envelope(
+        n=total_appearances,
+        method=METHOD,
+        assumptions=_assumptions(max_distance, extra),
+        findings=findings,
+        finding_count=len(findings),
+        truncated=truncated,
+    )
+
+
+def image_provenance(conn, sha256: str) -> Dict[str, Any]:
+    """Provenance for one asset: metadata claims (EXIF/pHash/C2PA) + appearances."""
+    if not _table_exists(conn, "image_assets"):
+        return {"error": "no image provenance available"}
+    import json
+
+    row = conn.execute(
+        "SELECT sha256, mime, width, height, phash, exif, c2pa FROM image_assets WHERE sha256 = ?",
+        [sha256],
+    ).fetchone()
+    if row is None:
+        return {"error": f"asset not found: {sha256}"}
+    exif = json.loads(row[5]) if isinstance(row[5], str) else row[5]
+    c2pa = json.loads(row[6]) if isinstance(row[6], str) else row[6]
+    return {
+        "sha256": row[0],
+        "mime": row[1],
+        "width": row[2],
+        "height": row[3],
+        "phash": row[4],
+        "exif": exif or {},
+        "exif_note": "EXIF is claimed by the file, not verified",
+        "c2pa": c2pa,
+        "appearances": _appearances(conn, sha256),
+    }
+
+
+def image_reuse(conn, sha256: str, max_distance: int = DEFAULT_MAX_DISTANCE) -> Dict[str, Any]:
+    """Near-duplicates of one asset and where they appear (honesty-enveloped)."""
+    if not _table_exists(conn, "image_assets"):
+        return analytic_envelope(n=0, method=METHOD, assumptions=_assumptions(max_distance), near_duplicates=[])
+    target = conn.execute("SELECT phash FROM image_assets WHERE sha256 = ?", [sha256]).fetchone()
+    if target is None or target[0] is None:
+        return analytic_envelope(n=0, method=METHOD, assumptions=_assumptions(max_distance), near_duplicates=[], note="asset unknown or unhashed")
+    target_hash = target[0]
+    near: List[Dict[str, Any]] = []
+    appearances_total = 0
+    for asset in _load_assets(conn):
+        if asset["sha256"] == sha256:
+            continue
+        dist = hamming_distance(target_hash, asset["phash"])
+        if dist is not None and dist <= max_distance:
+            apps = _appearances(conn, asset["sha256"])
+            appearances_total += len(apps)
+            near.append({"sha256": asset["sha256"], "distance": dist, "appearances": apps})
+    near.sort(key=lambda x: x["distance"])
+    return analytic_envelope(
+        n=appearances_total,
+        method=METHOD,
+        assumptions=_assumptions(max_distance),
+        sha256=sha256,
+        near_duplicates=near,
+        near_duplicate_count=len(near),
+    )

--- a/tests/unit/analytics/test_image_reuse.py
+++ b/tests/unit/analytics/test_image_reuse.py
@@ -1,0 +1,128 @@
+"""Unit tests for image reuse detection (C2)."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.analytics.honesty import validate_analytic_output
+from src.analytics.image_reuse import find_reuse, image_provenance, image_reuse
+from src.ingestion.assets.store import ImageAssetStore
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+
+def _img(shift=0, size=48):
+    im = Image.new("RGB", (size, size))
+    px = im.load()
+    for y in range(size):
+        for x in range(size):
+            v = (x * 5 + shift) % 256
+            px[x, y] = (v, v, v)
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _rescale(data, size):
+    im = Image.open(io.BytesIO(data)).resize((size, size))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def conn():
+    duckdb = pytest.importorskip("duckdb")
+    return duckdb.connect(":memory:")
+
+
+def test_no_provenance_tables_degrades(conn):
+    res = find_reuse(conn)
+    assert res["findings"] == []
+    assert validate_analytic_output(res) == []
+
+
+def test_recycled_photo_pair_is_a_finding(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="news:floods2024", context="flood", now_ms=1)
+    store.ingest(photo, document_id="blog:fire2019", context="fire", now_ms=2)
+    res = find_reuse(conn)
+    assert validate_analytic_output(res) == []
+    assert res["finding_count"] == 1
+    finding = res["findings"][0]
+    assert finding["distinct_document_count"] == 2
+    assert set(finding["documents"]) == {"news:floods2024", "blog:fire2019"}
+    # Both appearances are cited.
+    assert all(a["cited"] for a in finding["appearances"])
+    assert finding["conflicting"] is True
+
+
+def test_rescaled_near_duplicate_clusters(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="doc:a", now_ms=1)
+    store.ingest(_rescale(photo, 120), document_id="doc:b", now_ms=2)
+    res = find_reuse(conn)
+    # The rescaled copy is a near-duplicate -> one cluster spanning both docs.
+    assert res["finding_count"] == 1
+    assert res["findings"][0]["distinct_document_count"] == 2
+
+
+def test_unrelated_images_not_flagged(conn):
+    store = ImageAssetStore(conn)
+    store.ingest(_img(shift=0), document_id="doc:a", now_ms=1)
+    store.ingest(_img(shift=140), document_id="doc:b", now_ms=2)
+    assert find_reuse(conn)["finding_count"] == 0
+
+
+def test_same_image_one_document_not_reuse(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="doc:a", now_ms=1)
+    store.ingest(photo, document_id="doc:a", now_ms=1)  # same doc again
+    assert find_reuse(conn)["finding_count"] == 0
+
+
+def test_confidence_scales_with_distinct_docs(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    for i, doc in enumerate(["a", "b", "c"]):
+        store.ingest(photo, document_id=f"doc:{doc}", now_ms=i)
+    finding = find_reuse(conn)["findings"][0]
+    assert finding["distinct_document_count"] == 3
+    assert finding["confidence"] == "high"
+
+
+def test_topic_filter(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="doc:a", context="flooding in region", now_ms=1)
+    store.ingest(photo, document_id="doc:b", context="wildfire coverage", now_ms=2)
+    assert find_reuse(conn, topic="flood")["finding_count"] == 1
+    assert find_reuse(conn, topic="election")["finding_count"] == 0
+
+
+def test_image_provenance_query(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="doc:a", context="ctx", now_ms=1)
+    prov = image_provenance(conn, store.digest(photo))
+    assert prov["phash"] is not None
+    assert prov["exif_note"].startswith("EXIF is claimed")
+    assert [a["document_id"] for a in prov["appearances"]] == ["doc:a"]
+    assert image_provenance(conn, "0" * 64)["error"]
+
+
+def test_image_reuse_for_asset(conn):
+    store = ImageAssetStore(conn)
+    photo = _img()
+    store.ingest(photo, document_id="doc:a", now_ms=1)
+    store.ingest(_rescale(photo, 100), document_id="doc:b", now_ms=2)
+    res = image_reuse(conn, store.digest(photo))
+    assert validate_analytic_output(res) == []
+    assert res["near_duplicate_count"] == 1
+    assert res["near_duplicates"][0]["appearances"][0]["document_id"] == "doc:b"

--- a/tests/unit/tools/test_osint_imagery_panels.py
+++ b/tests/unit/tools/test_osint_imagery_panels.py
@@ -1,0 +1,72 @@
+"""C2: the OSINT imagery panel annotations validate through discovery."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class _StubMCP:
+    def __init__(self, name):
+        self.name = name
+
+    def tool(self, *args, **kwargs):
+        # Support both @mcp.tool and @mcp.tool(...) forms.
+        if args and callable(args[0]) and not kwargs:
+            args[0]._mcp_meta = None
+            return args[0]
+
+        def deco(fn):
+            fn._mcp_meta = kwargs.get("meta")
+            fn._mcp_output_schema = kwargs.get("output_schema")
+            return fn
+        return deco
+
+    def run(self):  # pragma: no cover
+        pass
+
+
+@pytest.fixture()
+def server(monkeypatch):
+    stub = types.ModuleType("fastmcp")
+    stub.FastMCP = _StubMCP
+    monkeypatch.setitem(sys.modules, "fastmcp", stub)
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "osint_mcp_server", REPO_ROOT / "tools" / "osint_mcp" / "server.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "tool_name,panel_type",
+    [
+        ("image_provenance", "image_provenance"),
+        ("image_reuse_findings", "image_reuse_ledger"),
+    ],
+)
+def test_imagery_panel_annotations_validate(server, tool_name, panel_type):
+    from src.genui.discovery import panel_def_from_annotation
+
+    fn = getattr(server, tool_name)
+    tool = {"name": tool_name, "description": tool_name, "meta": fn._mcp_meta, "has_output_schema": True}
+    panel = panel_def_from_annotation("neuronews-osint", tool)
+    assert panel is not None, f"{tool_name} annotation must be valid"
+    assert panel.type == panel_type
+    assert "image_assets" in panel.tables
+    assert panel.ui_flag == "osint"
+
+
+def test_imagery_tools_degrade_without_warehouse(server, monkeypatch):
+    monkeypatch.setattr(server, "_warehouse_ro", lambda: (_ for _ in ()).throw(FileNotFoundError("no db")))
+    assert "error" in server.image_provenance("abc")
+    assert "error" in server.image_reuse_findings()

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -470,5 +470,118 @@ if _gated_enabled():
             con.close()
 
 
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "sha256": {"type": "string"},
+            "phash": {"type": ["string", "null"]},
+            "exif": {"type": "object"},
+            "appearances": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"data": {"panel": "image_provenance", "rest_route": None}, "panel": {
+        "type": "image_provenance",
+        "title": "Image provenance",
+        "description": "What an image claims about itself (EXIF, file-claimed not verified), its content credentials, and every document it appears in.",
+        "endpoint": None,
+        "facets": ["entities", "library"],
+        "tables": ["image_assets", "image_appearances"],
+        "ui_flag": "osint",
+        "default_span": 6,
+    }},
+)
+def image_provenance(sha256: str) -> dict:
+    """Provenance for one image asset: EXIF (file-claimed), pHash, C2PA, and
+    every document the asset appears in.
+
+    Args:
+        sha256: the asset's content hash.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.image_reuse import image_provenance as _ip
+
+        return _ip(con, sha256)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema=honesty_output_schema(
+        {
+            "findings": {"type": "array"},
+            "finding_count": {"type": "integer"},
+            "truncated": {"type": "boolean"},
+        }
+    ),
+    meta={"data": {"panel": "image_reuse_ledger", "rest_route": None}, "panel": {
+        "type": "image_reuse_ledger",
+        "title": "Image reuse",
+        "description": "Recycled images: near-duplicate photos appearing across multiple documents, each finding citing every appearance. Flags recycling, not fakery.",
+        "endpoint": None,
+        "facets": ["entities", "conflict", "library"],
+        "tables": ["image_assets", "image_appearances"],
+        "ui_flag": "osint",
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def image_reuse_findings(topic: Optional[str] = None) -> dict:
+    """Reuse findings across the corpus: near-duplicate image clusters spanning
+    multiple documents, honesty-enveloped and citing each appearance.
+
+    Args:
+        topic: optional case-insensitive filter on appearance context.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.image_reuse import find_reuse
+
+        return find_reuse(con, topic=topic)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool(
+    output_schema=honesty_output_schema(
+        {
+            "sha256": {"type": "string"},
+            "near_duplicates": {"type": "array"},
+            "near_duplicate_count": {"type": "integer"},
+        }
+    ),
+)
+def image_reuse(sha256: str) -> dict:
+    """Near-duplicates of one asset and where each appears.
+
+    Args:
+        sha256: the asset's content hash.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.image_reuse import image_reuse as _ir
+
+        return _ir(con, sha256)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Overview

The **Track C payoff** — closes #774, part of #765. Builds on C1's provenance (#799, merged). Detects **recycled images**: the same or near-duplicate photo attached to different documents — the most common open-source image failure (recycling, not fakery).

## Changes

- **`src/analytics/image_reuse.py`**:
  - `find_reuse` — union-find clustering of assets by dHash hamming distance; a cluster spanning **≥2 distinct documents** is a reuse finding **citing every appearance**, honesty-enveloped (`n` = appearances, method, the distance threshold as a declared assumption). Confidence scales with distinct-document count. Assumptions state plainly that it flags *recycling, not fakery* and that EXIF/context are file-claimed.
  - `image_provenance` — EXIF (file-claimed, with the caveat baked in), pHash, C2PA slot, and every appearance.
  - `image_reuse` — near-duplicates of one asset and where each appears.
  - Reads `image_assets` + `image_appearances` from an injected connection, so the read-only warehouse (MCP server) and a writable store both work.
- **`tools/osint_mcp/server.py`** — `image_provenance` and `image_reuse_findings` tools with ADR-001 panel annotations (`image_provenance` + `image_reuse_ledger` panels), plus `image_reuse`; all under the `osint` `ui_flag`.

## Testing

- 12 tests, offline (Pillow present): recycled-photo pair → one finding citing both appearances; **rescaled near-duplicate clusters with its original**; unrelated images not flagged; same-image-one-document not reuse; confidence scaling; topic filter; provenance + per-asset reuse queries; empty-warehouse degradation. **Every envelope passes `validate_analytic_output`**; both panel annotations validate through the real `panel_def_from_annotation` discovery validator (server imports cleanly under a fastmcp stub).
- **Exit criteria met**: a seeded recycled-photo pair produces a reuse finding citing both appearances.

## Note

Persisting *confirmed* findings into the OSINT contradiction ledger is a follow-up; findings compute on read here, following the cited/flagged discipline (like `contradiction_scan`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_