### PR TITLE
C0: imagery abuse analysis + review-gate configuration

### DIFF
--- a/docs/osint-abuse-analysis.md
+++ b/docs/osint-abuse-analysis.md
@@ -46,6 +46,51 @@ verdict; the caveat and the surfaced evidence exist precisely so a reviewer
 rejects such cases. Calibration against a labeled fixture (gate criterion 2)
 should set `min_similarity` before the flag is turned on in any real deployment.
 
+## Imagery: reverse_image_search and geolocate_image (Track C / C4)
+
+This is the imagery threat model that [`OSINT_IMAGERY_PLAN.md`](architecture/OSINT_IMAGERY_PLAN.md)
+§2 (guardrail 4) requires *before* the C4 gated external tier ships. The
+corpus-internal imagery capabilities already merged — EXIF extraction (C1),
+perceptual-hash reuse detection (C2), and C2PA verification (C3) — are **not**
+gated: they read only the operator's own ingested assets, add no external calls,
+and identify *images*, never people. Only the C4 external tier is gated, for the
+same reason `geolocate_claims` is: pointing a capability at the outside world is
+where the abuse surface is.
+
+**Permanent non-goal (not a setting).** No face recognition and no person
+identification of any kind — not via an adapter, not behind a flag. The
+perceptual-hash pipeline matches *images*; the geolocation assist reasons about
+*places*. Changing this line requires revisiting this analysis, not a PR.
+
+### reverse_image_search
+
+**What it does (when built).** Submits an asset to an external reverse-image
+provider and returns where else the image appears on the open web, as
+*suggestions* for an operator to confirm.
+
+| Misuse | Mitigation (in design) |
+|---|---|
+| Treating a match as fact | Results enter the review queue as `cited: false` (the flagged state the evidence discipline already renders) and become citable only on operator confirmation. Nothing model- or provider-suggested flows into a dossier, timeline, or the ledger unconfirmed. |
+| De-anonymizing a person via their photo | The tool submits *corpus images* (figures, article photos) for provenance, never operator-supplied photos of individuals; combined with the permanent no-person-identification non-goal, there is no "who is this person" path. |
+| Unbounded external calls / cost / leakage | Key-gated, rate-limited, and allowlisted per the agent-host budget model; **no default provider ships**, so the tier is inert until an operator supplies one. Off by default. |
+
+### geolocate_image
+
+**What it does (when built).** A VLM proposes visible-landmark hypotheses for
+where a *scene* was photographed — a suggestion for a human to verify.
+
+| Misuse | Mitigation (in design) |
+|---|---|
+| Passing a guess off as a location | Output is suggestion-grade, plainly labeled, and never auto-cited; operator confirmation through the review gate is what makes it citable. |
+| Locating a person | Reasons about the *place in the scene*, never the subject; the person non-goal applies. No EXIF-GPS is treated as fact (it is file-claimed, per C1). |
+| Inferring movement patterns | Operates per-image; it does not join across a person's photos to build a track. |
+
+**Residual risk.** A confirmed reverse-search hit or landmark guess is only as
+good as the operator who confirms it; the gate makes confirmation an explicit,
+audited step rather than an automatic inference. The budget/allowlist posture
+bounds cost and egress but cannot prevent an operator from misusing a *confirmed*
+result — the same residual that applies to every review-gated OSINT tool.
+
 ## Gate status
 
 Criteria 1 (purpose limitation in code), 3 (evidence discipline: cited,
@@ -54,3 +99,12 @@ labeled fixture) and 5 (human-in-the-loop opt-in) are satisfied operationally by
 keeping the tools behind the off-by-default flag: a deployment enables them only
 after calibrating the thresholds and accepting this analysis. The absence test
 (`tests/unit/osint/test_investigations.py`) proves they stay off until then.
+
+The **imagery external tier** (C4: `reverse_image_search`, `geolocate_image`)
+inherits the same five criteria and the same off-by-default posture. Its
+purpose-limitation (criterion 1) is the permanent no-person-identification
+non-goal plus the corpus-images-only submission rule; its evidence discipline
+(criterion 3) is the review queue, where a suggestion is `cited: false` until an
+operator confirms it. C4 must not ship until this section is reviewed and
+attached to its enabling PR, and no default reverse-search provider may be
+bundled — the tier stays inert until an operator supplies a key and provider.

--- a/docs/osint-review-gate.md
+++ b/docs/osint-review-gate.md
@@ -21,10 +21,17 @@ the enforcement of criterion 5.
 |---|---|---|
 | `geolocate_claims` | Location inference is the most abusable OSINT primitive. | Strictly event-geography derived from document content (where an event is reported to have happened), never person location. |
 | `narrative_coordination` | Coordinated-behavior detection is highly false-positive-prone and can smear coincidental cohorts. | Findings flag a cohort for human review, never accuse; every edge cited; a calibrated null model, not a threshold on raw co-occurrence. |
+| `reverse_image_search` (Track C / C4) | Any capability pointed at the open web is where the imagery abuse surface is. | Submits *corpus images* only; results enter the review queue as `cited: false` until an operator confirms; key-gated, rate-limited, allowlisted, **no default provider**. No person identification, ever. |
+| `geolocate_image` (Track C / C4) | Scene geolocation can be misread as person location. | Reasons about the *place in the scene*, never the subject; suggestion-grade, never auto-cited; EXIF-GPS stays file-claimed, not fact. |
 
 `src/osint/investigations.py` names them in `GATED_TOOLS`; `is_gated(tool)`
 returns True for both. They are registered on `tools/osint_mcp/server.py` only
-behind the `NOESIS_OSINT_GATED_TOOLS` flag (off by default).
+behind the `NOESIS_OSINT_GATED_TOOLS` flag (off by default). The imagery
+external tier (C4) is analysed in
+[`osint-abuse-analysis.md`](osint-abuse-analysis.md) ("Imagery") and inherits
+the same five criteria; the corpus-internal imagery tools (`image_provenance`,
+`image_reuse_findings`) are **not** gated — they read only the operator's own
+assets and identify images, never people.
 
 ## Gate criteria (must all pass before either tool is served)
 


### PR DESCRIPTION
## Overview

Track C **governance deliverable** — closes #780, part of #765. The gated external tier (C4, #776) must not be designed ahead of its threat model, so this is the analysis-first deliverable that C4 is blocked on. Extends the repo's existing OSINT governance docs rather than inventing a new format.

## Changes

- **`docs/osint-abuse-analysis.md`** — a new **Imagery** section covering the C4 external tools (`reverse_image_search`, `geolocate_image`) in the doc's established per-tool misuse/mitigation table format, plus:
  - the **permanent no-person-identification non-goal** (not a setting — changing it requires revisiting the analysis, not a PR);
  - the corpus-internal/external split (C1–C3 read the operator's own assets and identify *images*, so they aren't gated; only C4, which points at the open web, is);
  - updated **Gate status**: C4 inherits the same five criteria and off-by-default posture, must not ship until this section is reviewed on its enabling PR, and bundles **no default provider**.
- **`docs/osint-review-gate.md`** — the gated-tools table gains the two imagery tools with their ship constraints, cross-linked to the abuse analysis, and notes the corpus-internal imagery tools are explicitly *not* gated.

## Testing

Documentation only — no code. Reviewed for consistency with the existing `geolocate_claims` / `narrative_coordination` gate treatment and with `OSINT_IMAGERY_PLAN.md` §2 guardrails.

**Exit criteria met**: the abuse analysis covers imagery and the gate config is documented; C4 implementation can cite both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_