### PR TITLE
B2: article and upload images as figure documents

### DIFF
--- a/src/ingestion/describers/__init__.py
+++ b/src/ingestion/describers/__init__.py
@@ -11,6 +11,12 @@ from src.ingestion.describers.figures import (
     figure_document,
     figure_documents,
 )
+from src.ingestion.describers.article_images import (
+    ImageRef,
+    article_figure_documents,
+    extract_image_refs,
+    image_upload_figure_document,
+)
 from src.ingestion.describers.vision import FigureDescription, VisionDescriber
 
 __all__ = [
@@ -20,4 +26,8 @@ __all__ = [
     "extract_figure_captions",
     "figure_document",
     "figure_documents",
+    "ImageRef",
+    "extract_image_refs",
+    "article_figure_documents",
+    "image_upload_figure_document",
 ]

--- a/src/ingestion/describers/article_images.py
+++ b/src/ingestion/describers/article_images.py
@@ -1,0 +1,149 @@
+"""
+Article and upload images as figure documents (Track B / B2).
+
+Extends the B1 figure path from paper figures to the images news, blog, and web
+documents carry — the lead photo (`og:image`) and inline `<img>` images — and to
+standalone image uploads. Each becomes a searchable, citable figure `Document`
+through the same describer + asset-store path, so the pipeline stays text-native.
+
+The HTTP image fetcher is injectable so the whole path runs offline in tests.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.describers.figures import FigureCandidate, figure_documents
+from src.ingestion.describers.vision import VisionDescriber
+
+logger = logging.getLogger(__name__)
+
+_OG_IMAGE_RE = re.compile(
+    r"""<meta[^>]+(?:property|name)\s*=\s*["'](?:og:image|twitter:image)["'][^>]*>""",
+    re.IGNORECASE,
+)
+_CONTENT_RE = re.compile(r"""content\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_IMG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_SRC_RE = re.compile(r"""\bsrc\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_ALT_RE = re.compile(r"""\balt\s*=\s*["']([^"']*)["']""", re.IGNORECASE)
+
+_IMAGE_EXT = (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp")
+
+
+@dataclass
+class ImageRef:
+    """An image referenced by a document: its URL, alt/caption context, and role."""
+
+    url: str
+    context: str = ""
+    is_lead: bool = False
+
+
+def extract_image_refs(html: Optional[str]) -> List[ImageRef]:
+    """Extract the lead image (og:image/twitter:image) and inline <img> images
+    from article HTML, deduped by URL with the lead first."""
+    if not html:
+        return []
+    refs: List[ImageRef] = []
+    seen = set()
+
+    for tag in _OG_IMAGE_RE.findall(html):
+        m = _CONTENT_RE.search(tag)
+        if m and m.group(1) not in seen:
+            seen.add(m.group(1))
+            refs.append(ImageRef(url=m.group(1), context="lead image", is_lead=True))
+
+    for tag in _IMG_RE.findall(html):
+        src = _SRC_RE.search(tag)
+        if not src:
+            continue
+        url = src.group(1)
+        if url in seen or url.startswith("data:"):
+            continue
+        seen.add(url)
+        alt = _ALT_RE.search(tag)
+        refs.append(ImageRef(url=url, context=(alt.group(1).strip() if alt else "")))
+
+    return refs
+
+
+def _looks_like_image(url: str) -> bool:
+    return url.lower().split("?")[0].endswith(_IMAGE_EXT)
+
+
+def article_figure_documents(
+    parent: Document,
+    html: Optional[str] = None,
+    image_refs: Optional[List[ImageRef]] = None,
+    fetch_image: Optional[Callable[[str], Optional[bytes]]] = None,
+    describer: Optional[VisionDescriber] = None,
+    asset_store=None,
+    max_images: int = 8,
+    ingested_at: Optional[int] = None,
+) -> List[Document]:
+    """Emit figure Documents for an article's images.
+
+    Images are fetched via ``fetch_image`` (injectable; skipped when None so a
+    caption-style figure with no bytes is still emitted from context). The lead
+    image is labeled "Figure 1"; inline images follow. Reuses the B1 emission so
+    the asset store + describer behaviour is identical to paper figures.
+    """
+    refs = image_refs if image_refs is not None else extract_image_refs(html)
+    refs = [r for r in refs if r.url and (_looks_like_image(r.url) or r.is_lead)][:max_images]
+    if not refs:
+        return []
+
+    candidates: List[FigureCandidate] = []
+    for i, ref in enumerate(refs):
+        label = "Figure 1 (lead image)" if ref.is_lead else f"Figure {i + 1}"
+        image_bytes = None
+        if fetch_image is not None:
+            try:
+                image_bytes = fetch_image(ref.url)
+            except Exception:  # noqa: BLE001 - a broken image URL is skipped, not fatal
+                logger.debug("article_images: fetch failed for %s", ref.url, exc_info=True)
+                image_bytes = None
+        caption = ref.context or f"image from {parent.title or parent.document_id}"
+        candidates.append(FigureCandidate(label=label, caption=caption, image_bytes=image_bytes))
+
+    return figure_documents(
+        parent,
+        candidates=candidates,
+        describer=describer,
+        asset_store=asset_store,
+        ingested_at=ingested_at,
+        max_figures=max_images,
+    )
+
+
+def image_upload_figure_document(
+    parent: Document,
+    image_bytes: bytes,
+    mime: str = "image/png",
+    caption: str = "",
+    describer: Optional[VisionDescriber] = None,
+    asset_store=None,
+    ingested_at: Optional[int] = None,
+) -> Optional[Document]:
+    """A standalone uploaded image becomes one figure Document whose parent is
+    the upload itself."""
+    if not image_bytes:
+        return None
+    candidate = FigureCandidate(
+        label="Figure 1",
+        caption=caption or f"uploaded image {parent.title or parent.document_id}",
+        image_bytes=image_bytes,
+        mime=mime,
+    )
+    docs = figure_documents(
+        parent,
+        candidates=[candidate],
+        describer=describer,
+        asset_store=asset_store,
+        ingested_at=ingested_at,
+    )
+    return docs[0] if docs else None

--- a/tests/unit/ingestion/describers/test_article_images.py
+++ b/tests/unit/ingestion/describers/test_article_images.py
@@ -1,0 +1,121 @@
+"""Unit tests for article/upload image figure documents (B2)."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.describers.article_images import (
+    article_figure_documents,
+    extract_image_refs,
+    image_upload_figure_document,
+)
+
+
+def _png(w=8, h=8):
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0)
+    return sig + struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr + struct.pack(">I", zlib.crc32(b"IHDR" + ihdr) & 0xFFFFFFFF)
+
+
+def _article(source_type="news"):
+    return Document(
+        document_id="news:42",
+        source_type=source_type,
+        language="en",
+        ingested_at=5000,
+        title="Big Story",
+        url="https://example.com/story",
+        content="body",
+    )
+
+
+def test_extract_og_image_and_inline():
+    html = (
+        '<html><head>'
+        '<meta property="og:image" content="https://cdn.example.com/lead.jpg">'
+        '</head><body>'
+        '<img src="https://cdn.example.com/inline1.png" alt="a chart">'
+        '<img src="data:image/png;base64,AAA">'  # data URI skipped
+        '</body></html>'
+    )
+    refs = extract_image_refs(html)
+    urls = [r.url for r in refs]
+    assert urls == ["https://cdn.example.com/lead.jpg", "https://cdn.example.com/inline1.png"]
+    assert refs[0].is_lead is True
+    assert refs[1].context == "a chart"
+
+
+def test_lead_photo_becomes_cited_figure_document(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    from src.ingestion.assets.store import ImageAssetStore
+
+    store = ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figs"))
+    html = '<meta property="og:image" content="https://cdn.example.com/lead.jpg">'
+    parent = _article()
+
+    docs = article_figure_documents(
+        parent,
+        html=html,
+        fetch_image=lambda url: _png(),  # injected fetch, offline
+        asset_store=store,
+    )
+    assert len(docs) == 1
+    fig = docs[0]
+    assert fig.source_type == "news"  # inherits parent
+    assert fig.metadata["modality"] == "image"
+    assert fig.metadata["parent_document_id"] == "news:42"
+    assert "lead image" in fig.metadata["figure_label"].lower()
+    # The photo was stored and the figure cites it via content_ref.
+    assert fig.content_ref is not None
+    assert store.count() == 1
+
+
+def test_no_fetch_still_emits_caption_style_figure():
+    parent = _article()
+    html = '<meta property="og:image" content="https://cdn.example.com/lead.jpg">'
+    docs = article_figure_documents(parent, html=html)  # no fetch_image
+    assert len(docs) == 1
+    assert docs[0].content_ref is None
+    assert docs[0].metadata["describer"] is None
+
+
+def test_max_images_caps():
+    parent = _article()
+    imgs = "".join(f'<img src="https://x/{i}.png" alt="i{i}">' for i in range(20))
+    docs = article_figure_documents(parent, html=f"<body>{imgs}</body>", max_images=3)
+    assert len(docs) == 3
+
+
+def test_non_image_urls_filtered():
+    parent = _article()
+    html = '<img src="https://x/tracker.gif?u=1" alt="ok"><img src="https://x/script.js">'
+    refs = extract_image_refs(html)
+    # Both are extracted as refs, but the .js is filtered at emission.
+    docs = article_figure_documents(parent, html=html)
+    labels = [d.metadata["figure_label"] for d in docs]
+    assert len(docs) == 1  # only the .gif survives the image-extension filter
+
+
+def test_image_upload_figure_document(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    from src.ingestion.assets.store import ImageAssetStore
+
+    store = ImageAssetStore(duckdb.connect(":memory:"), root=str(tmp_path / "figs"))
+    parent = Document(
+        document_id="upload:abc", source_type="note", language="en",
+        ingested_at=1, title="my photo",
+    )
+    fig = image_upload_figure_document(parent, _png(), mime="image/png", asset_store=store)
+    assert fig is not None
+    assert fig.source_type == "note"
+    assert fig.metadata["parent_document_id"] == "upload:abc"
+    assert fig.content_ref is not None
+
+
+def test_image_upload_empty_bytes_returns_none():
+    parent = _article()
+    assert image_upload_figure_document(parent, b"") is None


### PR DESCRIPTION
## Overview

Second **Track B** deliverable — closes #770, part of #765. Builds on B1 (#798, merged). Extends the figure path from paper figures to the images news/blog/web documents carry, and to standalone image uploads.

## Changes

- **`src/ingestion/describers/article_images.py`**:
  - `extract_image_refs` — parses the **lead image** (`og:image` / `twitter:image`) and inline `<img>` images from article HTML; alt text becomes context, `data:` URIs are skipped, the lead comes first.
  - `article_figure_documents` — fetches image bytes via an **injectable getter** (offline in tests) and reuses B1's `figure_documents`, so the asset-store + describer behaviour is identical to paper figures; the lead photo is labeled the lead figure. Non-image URLs are filtered; a broken URL is skipped, not fatal.
  - `image_upload_figure_document` — a standalone uploaded image becomes one figure `Document` whose parent is the upload.
  - Figure documents **inherit the parent `source_type`**, so a news lead photo is a searchable `news` figure.

## Design note

The news connector wraps RSS and the upload connector handles text formats, so these are reusable primitives the connector harvest paths call with article HTML / uploaded bytes, rather than a rewrite of either connector — keeping the change testable and self-contained.

## Testing

- 7 new tests, all offline: og:image + inline extraction (data-URI skip, alt→context), **lead photo → stored, cited figure document**, caption-style figure without bytes, `max_images` cap, non-image-URL filtering, and the standalone image-upload figure. B1's 12 tests unchanged.
- **Exit criteria met**: a news article's lead photo becomes a searchable, cited figure document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_