### PR TITLE
C4: gated imagery external tier (review-queued, no default provider)

### DIFF
--- a/src/osint/imagery_gated.py
+++ b/src/osint/imagery_gated.py
@@ -1,0 +1,223 @@
+"""
+Review-gated imagery tools (Track C / C4).
+
+The external imagery tier: ``reverse_image_search`` and ``geolocate_image``.
+These point at the outside world, so they ship only behind the OSINT review gate
+(``docs/osint-review-gate.md``) and the imagery abuse analysis
+(``docs/osint-abuse-analysis.md``, "Imagery"), off by default. This module is
+the enforcement, not just the docs:
+
+* **Corpus images only.** Both tools take a corpus asset ``sha256`` that must
+  exist in ``image_assets`` — never an operator-supplied photo of a person.
+* **No person identification, ever.** A permanent non-goal (guardrail 2): there
+  is no person parameter and no identity output. The tools reason about images
+  and places, never subjects.
+* **Suggestions are not evidence.** Every result enters a review queue as
+  ``cited = False`` (the flagged state the evidence discipline renders) and
+  becomes citable only when an operator confirms it via :func:`confirm_suggestion`.
+* **No default provider.** ``reverse_image_search`` needs an injected provider;
+  with none configured the tier is inert (``no_provider_configured``).
+
+See ``docs/architecture/OSINT_IMAGERY_PLAN.md`` §3.3.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Permanent non-goal, asserted in code so it is not silently changed.
+PERSON_IDENTIFICATION_SUPPORTED = False
+
+_QUEUE_DDL = """
+CREATE TABLE IF NOT EXISTS imagery_review_queue (
+    suggestion_id   TEXT PRIMARY KEY,
+    kind            TEXT NOT NULL,
+    sha256          TEXT NOT NULL,
+    suggestion      JSON NOT NULL,
+    cited           BOOLEAN NOT NULL DEFAULT FALSE,
+    confirmed_by    TEXT,
+    confirmed_at    BIGINT,
+    created_at      BIGINT
+)
+"""
+
+
+def _ensure_queue(conn) -> None:
+    conn.execute(_QUEUE_DDL)
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _asset_bytes(conn, sha256: str) -> Optional[bytes]:
+    """Read a corpus asset's bytes by sha256, or None if it is not a corpus
+    image. This is the corpus-images-only guard: an unknown sha256 gets nothing."""
+    if not _table_exists(conn, "image_assets"):
+        return None
+    row = conn.execute("SELECT path FROM image_assets WHERE sha256 = ?", [sha256]).fetchone()
+    if row is None or not row[0]:
+        return None
+    path = os.path.abspath(row[0])
+    if not os.path.exists(path):
+        return None
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def _queue_suggestion(conn, kind: str, sha256: str, suggestion: Dict[str, Any], now_ms: Optional[int]) -> str:
+    _ensure_queue(conn)
+    key = f"{kind}|{sha256}|{json.dumps(suggestion, sort_keys=True)}"
+    suggestion_id = "sug:" + hashlib.md5(key.encode()).hexdigest()[:16]
+    conn.execute(
+        """
+        INSERT INTO imagery_review_queue (suggestion_id, kind, sha256, suggestion, cited, created_at)
+        VALUES (?, ?, ?, ?, FALSE, ?)
+        ON CONFLICT (suggestion_id) DO NOTHING
+        """,
+        [suggestion_id, kind, sha256, json.dumps(suggestion), now_ms],
+    )
+    return suggestion_id
+
+
+# Provider signatures (injected; no default ships):
+#   ReverseSearchProvider(image_bytes) -> List[{"url", "title"?, "published"?}]
+#   GeoVLM(image_bytes) -> List[{"landmark", "place"?, "confidence"?}]
+ReverseSearchProvider = Callable[[bytes], List[Dict[str, Any]]]
+GeoVLM = Callable[[bytes], List[Dict[str, Any]]]
+
+
+def reverse_image_search(
+    conn,
+    sha256: str,
+    provider: Optional[ReverseSearchProvider] = None,
+    now_ms: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Queue reverse-image-search *suggestions* for a corpus asset.
+
+    No default provider ships; with none configured the tier is inert. Results
+    are queued uncited — evidence only after operator confirmation.
+    """
+    if provider is None:
+        return {"status": "no_provider_configured", "sha256": sha256,
+                "note": "reverse image search has no default provider; supply one to enable"}
+    image_bytes = _asset_bytes(conn, sha256)
+    if image_bytes is None:
+        return {"status": "not_a_corpus_image", "sha256": sha256,
+                "note": "reverse search accepts corpus asset hashes only"}
+    try:
+        hits = provider(image_bytes) or []
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "provider_error", "error": str(exc)}
+    queued = []
+    for hit in hits:
+        suggestion = {"url": hit.get("url"), "title": hit.get("title"), "cited": False}
+        sid = _queue_suggestion(conn, "reverse_image_search", sha256, suggestion, now_ms)
+        queued.append({"suggestion_id": sid, **suggestion})
+    return {
+        "status": "queued",
+        "sha256": sha256,
+        "suggestions": queued,
+        "count": len(queued),
+        "note": "suggestions are uncited until an operator confirms them",
+    }
+
+
+def geolocate_image(
+    conn,
+    sha256: str,
+    vlm: Optional[GeoVLM] = None,
+    now_ms: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Queue visible-landmark geolocation *hypotheses* for a corpus asset.
+
+    Suggestion-grade, never auto-cited. Reasons about the place in the scene,
+    never the subject (no person identification).
+    """
+    if vlm is None:
+        return {"status": "no_backend_configured", "sha256": sha256,
+                "note": "geolocation assist needs a vision backend"}
+    image_bytes = _asset_bytes(conn, sha256)
+    if image_bytes is None:
+        return {"status": "not_a_corpus_image", "sha256": sha256}
+    try:
+        hypotheses = vlm(image_bytes) or []
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "backend_error", "error": str(exc)}
+    queued = []
+    for h in hypotheses:
+        suggestion = {
+            "landmark": h.get("landmark"),
+            "place": h.get("place"),
+            "confidence": h.get("confidence"),
+            "grade": "suggestion",
+            "cited": False,
+        }
+        sid = _queue_suggestion(conn, "geolocate_image", sha256, suggestion, now_ms)
+        queued.append({"suggestion_id": sid, **suggestion})
+    return {
+        "status": "queued",
+        "sha256": sha256,
+        "hypotheses": queued,
+        "count": len(queued),
+        "note": "visible-landmark hypotheses about the scene, not the subject; uncited until confirmed",
+    }
+
+
+def list_review_queue(conn, cited: Optional[bool] = None, kind: Optional[str] = None) -> Dict[str, Any]:
+    """The imagery review queue. By default lists everything; filter by cited
+    state or kind."""
+    if not _table_exists(conn, "imagery_review_queue"):
+        return {"items": [], "count": 0, "note": "review queue empty"}
+    clauses: List[str] = []
+    params: List[Any] = []
+    if cited is not None:
+        clauses.append("cited = ?")
+        params.append(cited)
+    if kind is not None:
+        clauses.append("kind = ?")
+        params.append(kind)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    rows = conn.execute(
+        f"SELECT suggestion_id, kind, sha256, suggestion, cited, confirmed_by FROM imagery_review_queue{where} ORDER BY created_at NULLS LAST, suggestion_id",
+        params,
+    ).fetchall()
+    items = []
+    for sid, k, sha, sug, is_cited, by in rows:
+        items.append({
+            "suggestion_id": sid,
+            "kind": k,
+            "sha256": sha,
+            "suggestion": json.loads(sug) if isinstance(sug, str) else sug,
+            "cited": bool(is_cited),
+            "confirmed_by": by,
+        })
+    return {"items": items, "count": len(items)}
+
+
+def confirm_suggestion(conn, suggestion_id: str, operator: str, now_ms: Optional[int] = None) -> Dict[str, Any]:
+    """Operator confirmation — the *only* thing that makes a suggestion citable."""
+    if not operator:
+        return {"status": "rejected", "note": "confirmation requires an operator identity"}
+    if not _table_exists(conn, "imagery_review_queue"):
+        return {"status": "not_found"}
+    row = conn.execute("SELECT suggestion_id FROM imagery_review_queue WHERE suggestion_id = ?", [suggestion_id]).fetchone()
+    if row is None:
+        return {"status": "not_found", "suggestion_id": suggestion_id}
+    conn.execute(
+        "UPDATE imagery_review_queue SET cited = TRUE, confirmed_by = ?, confirmed_at = ? WHERE suggestion_id = ?",
+        [operator, now_ms, suggestion_id],
+    )
+    return {"status": "confirmed", "suggestion_id": suggestion_id, "confirmed_by": operator, "cited": True}

--- a/src/osint/investigations.py
+++ b/src/osint/investigations.py
@@ -28,7 +28,12 @@ from src.osint import common
 
 # Tools held behind the explicit review gate; absent from the server until the
 # gate passes. Named here so enforcement is testable.
-GATED_TOOLS = ("geolocate_claims", "narrative_coordination")
+GATED_TOOLS = (
+    "geolocate_claims",
+    "narrative_coordination",
+    "reverse_image_search",
+    "geolocate_image",
+)
 
 
 def is_gated(tool_name: str) -> bool:

--- a/tests/unit/osint/test_imagery_gated.py
+++ b/tests/unit/osint/test_imagery_gated.py
@@ -1,0 +1,105 @@
+"""Unit tests for the gated imagery tier (C4): review-queue discipline."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.osint.imagery_gated import (
+    PERSON_IDENTIFICATION_SUPPORTED,
+    confirm_suggestion,
+    geolocate_image,
+    list_review_queue,
+    reverse_image_search,
+)
+
+
+@pytest.fixture()
+def conn_with_asset(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    PIL = pytest.importorskip("PIL")
+    from PIL import Image
+
+    from src.ingestion.assets.store import ImageAssetStore
+
+    conn = duckdb.connect(":memory:")
+    store = ImageAssetStore(conn, root=str(tmp_path / "figs"))
+    im = Image.new("RGB", (32, 32), (10, 20, 30))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    asset = store.ingest(buf.getvalue(), document_id="doc:a", now_ms=1)
+    return conn, asset.sha256
+
+
+def test_person_identification_is_permanently_off():
+    assert PERSON_IDENTIFICATION_SUPPORTED is False
+
+
+def test_reverse_search_no_default_provider(conn_with_asset):
+    conn, sha = conn_with_asset
+    res = reverse_image_search(conn, sha, provider=None)
+    assert res["status"] == "no_provider_configured"
+
+
+def test_reverse_search_rejects_non_corpus_hash(conn_with_asset):
+    conn, _ = conn_with_asset
+    res = reverse_image_search(conn, "0" * 64, provider=lambda b: [{"url": "http://x"}])
+    assert res["status"] == "not_a_corpus_image"
+
+
+def test_reverse_search_queues_uncited_suggestions(conn_with_asset):
+    conn, sha = conn_with_asset
+    provider = lambda b: [{"url": "https://other.example/story", "title": "Elsewhere"}]
+    res = reverse_image_search(conn, sha, provider=provider, now_ms=10)
+    assert res["status"] == "queued"
+    assert res["count"] == 1
+    assert res["suggestions"][0]["cited"] is False
+    # It is in the queue, uncited.
+    queue = list_review_queue(conn, cited=False)
+    assert queue["count"] == 1
+
+
+def test_geolocate_image_no_backend(conn_with_asset):
+    conn, sha = conn_with_asset
+    assert geolocate_image(conn, sha, vlm=None)["status"] == "no_backend_configured"
+
+
+def test_geolocate_image_queues_suggestion_grade(conn_with_asset):
+    conn, sha = conn_with_asset
+    vlm = lambda b: [{"landmark": "a bridge", "place": "somewhere", "confidence": 0.4}]
+    res = geolocate_image(conn, sha, vlm=vlm, now_ms=5)
+    assert res["status"] == "queued"
+    assert res["hypotheses"][0]["grade"] == "suggestion"
+    assert res["hypotheses"][0]["cited"] is False
+
+
+def test_confirmation_is_the_only_path_to_cited(conn_with_asset):
+    conn, sha = conn_with_asset
+    provider = lambda b: [{"url": "https://other.example/story"}]
+    res = reverse_image_search(conn, sha, provider=provider, now_ms=10)
+    sid = res["suggestions"][0]["suggestion_id"]
+    # Before confirmation: uncited.
+    assert list_review_queue(conn, cited=True)["count"] == 0
+    # Confirmation requires an operator identity.
+    assert confirm_suggestion(conn, sid, operator="")["status"] == "rejected"
+    # Operator confirms -> becomes cited.
+    out = confirm_suggestion(conn, sid, operator="analyst-1", now_ms=20)
+    assert out["status"] == "confirmed" and out["cited"] is True
+    cited = list_review_queue(conn, cited=True)
+    assert cited["count"] == 1
+    assert cited["items"][0]["confirmed_by"] == "analyst-1"
+
+
+def test_confirm_unknown_suggestion(conn_with_asset):
+    conn, _ = conn_with_asset
+    # Ensure the queue table exists first.
+    reverse_image_search(conn, "0" * 64, provider=lambda b: [])
+    assert confirm_suggestion(conn, "sug:nope", operator="x")["status"] in ("not_found",)
+
+
+def test_tools_are_registered_as_gated():
+    from src.osint.investigations import is_gated
+
+    assert is_gated("reverse_image_search")
+    assert is_gated("geolocate_image")

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -469,6 +469,58 @@ if _gated_enabled():
         finally:
             con.close()
 
+    # -- Track C / C4: imagery external tier (review-queued, no default provider)
+    def _warehouse_rw():
+        import duckdb
+
+        from src.config.env import warehouse_path
+        path = warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
+        return duckdb.connect(path)
+
+    @mcp.tool
+    def reverse_image_search(sha256: str) -> dict:
+        """Queue reverse-image-search suggestions for a corpus asset (review-
+        gated). No default provider ships, so this returns no_provider_configured
+        until one is supplied; results are uncited until an operator confirms.
+
+        Args:
+            sha256: a corpus image asset hash (never an operator-supplied photo).
+        """
+        try:
+            con = _warehouse_rw()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            from src.osint.imagery_gated import reverse_image_search as _ris
+
+            return _ris(con, sha256, provider=None)  # no default provider
+        except Exception as exc:
+            return {"error": str(exc)}
+        finally:
+            con.close()
+
+    @mcp.tool
+    def geolocate_image(sha256: str) -> dict:
+        """Queue visible-landmark geolocation hypotheses for a corpus asset
+        (review-gated). Suggestion-grade, about the scene not the subject, never
+        auto-cited; needs a vision backend to produce anything.
+
+        Args:
+            sha256: a corpus image asset hash.
+        """
+        try:
+            con = _warehouse_rw()
+        except Exception as exc:
+            return {"error": str(exc)}
+        try:
+            from src.osint.imagery_gated import geolocate_image as _geo
+
+            return _geo(con, sha256, vlm=None)  # no default backend
+        except Exception as exc:
+            return {"error": str(exc)}
+        finally:
+            con.close()
+
 
 @mcp.tool(
     output_schema={


### PR DESCRIPTION
## Overview

The final **Track C** deliverable — closes #776, part of #765. Unblocked by C0's abuse analysis (#801, merged). The external imagery tier ships only with its dual-use guardrails ([`OSINT_IMAGERY_PLAN.md`](https://github.com/Ikey168/Noesis/blob/main/docs/architecture/OSINT_IMAGERY_PLAN.md) §2) **enforced in code**, behind the existing `NOESIS_OSINT_GATED_TOOLS` flag (off by default).

## Changes

- **`src/osint/imagery_gated.py`** — `reverse_image_search` and `geolocate_image`:
  - **Corpus images only** — a non-corpus `sha256` is refused (`not_a_corpus_image`), so an operator-supplied photo of a person is never accepted.
  - **No person identification, ever** — no person parameter, no identity output; `PERSON_IDENTIFICATION_SUPPORTED = False` asserted in code.
  - **No default provider/backend** — the tier is inert (`no_provider_configured` / `no_backend_configured`) until one is injected.
  - **Suggestions are not evidence** — results enter an `imagery_review_queue` as `cited = False` and become citable only via `confirm_suggestion`, which **requires an operator identity**. Operator confirmation is the only path to `cited`.
- **`src/osint/investigations.py`** — both names added to `GATED_TOOLS`, so the existing absence test enforces they stay off until the flag is on.
- **`tools/osint_mcp/server.py`** — both registered **inside the existing `if _gated_enabled()` block**, using a writable warehouse connection for the review queue.

## Testing

- 9 tests, offline: person-identification-off assertion, no-provider/no-backend inertness, corpus-only refusal, uncited queueing, suggestion-grade geolocation, **confirmation-as-the-only-path-to-cited** (rejects empty operator; confirmed suggestion becomes cited with `confirmed_by`), and gated registration.
- **Exit criteria met**: an external suggestion is visible only in the review queue until an operator confirms it, and confirmation is what makes it citable.

## Note on CI

Two pre-existing tests in `tests/unit/osint/test_investigations.py` (the gate on/off checks) import `fastmcp.client`, which isn't installed in my sandbox, so they error at import here — **identically on clean `main`**, unrelated to this change. In CI (with fastmcp present) they exercise exactly the gate behavior these tools participate in: added to `GATED_TOOLS` and placed inside the gated registration block, so they're absent when the flag is off and served when it's on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_