### PR TITLE
B3: figure evidence surfacing — panel + query + renderer

### DIFF
--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -48,7 +48,8 @@ export type PanelType =
   | "entity_dossier"
   | "relationship_path"
   | "evidence_timeline"
-  | "provenance_trace";
+  | "provenance_trace"
+  | "figure_evidence";
 
 export type Facet =
   | "overview"
@@ -122,6 +123,7 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "relationship_path", title: "Connection path", facets: ["entities", "actors"], defaultSpan: 6 },
   { type: "evidence_timeline", title: "Evidence timeline", facets: ["events", "trend", "claims"], defaultSpan: 6, topicParam: true },
   { type: "provenance_trace", title: "Provenance trace", facets: ["claims", "sources", "library"], defaultSpan: 6, topicParam: true },
+  { type: "figure_evidence", title: "Figure evidence", facets: ["library"], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -281,6 +281,56 @@ function DocumentsPanel(props: PanelProps) {
   );
 }
 
+type FigureRow = {
+  document_id: string;
+  source_type?: string | null;
+  title?: string | null;
+  content?: string | null;
+  content_ref?: string | null;
+  parent_document_id?: string | null;
+  figure_label?: string | null;
+};
+
+function FigureEvidencePanel(props: PanelProps) {
+  const topic = props.panel.params?.topic;
+  const { data, source, isLoading } = useDataPlanePanel("figure_evidence", {
+    topic: typeof topic === "string" ? topic : undefined,
+  });
+  const figures = Array.isArray(data?.figures) ? (data!.figures as FigureRow[]) : [];
+  const rows = figures.slice(0, 4);
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {rows.length === 0 ? (
+        <Empty text="No figure evidence for this topic" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {rows.map((f, i) => {
+            const ref = f.content_ref ?? "";
+            const previewable = /^https?:\/\//i.test(ref);
+            return (
+              <div key={f.document_id} style={{ display: "flex", gap: 11, alignItems: "flex-start", padding: "8px 0", borderBottom: i < rows.length - 1 ? "1px solid #12242e" : "none" }}>
+                {previewable ? (
+                  <img src={ref} alt={f.figure_label ?? "figure"} style={{ width: 54, height: 54, objectFit: "cover", borderRadius: 4, flexShrink: 0, border: "1px solid #12242e" }} />
+                ) : (
+                  <span style={{ ...chip(palette.teal), flexShrink: 0 }}>{(f.figure_label ?? "FIGURE").toUpperCase()}</span>
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, lineHeight: 1.4, overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical" }}>
+                    {f.content ?? f.title ?? f.document_id}
+                  </div>
+                  {f.parent_document_id ? (
+                    <div style={{ ...mono, marginTop: 4 }}>cited: {f.parent_document_id}</div>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
 const WATCH_TYPE_COLORS: Record<string, string> = {
   Entity: ACCENT,
   Topic: palette.amber,
@@ -1797,6 +1847,7 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   kpi_row: KpiRowPanel,
   articles: ArticlesPanel,
   documents: DocumentsPanel,
+  figure_evidence: FigureEvidencePanel,
   trending: TrendingPanel,
   clusters: ClustersPanel,
   event_axis: EventAxisPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "claim_flow", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "claim_flow", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace", "figure_evidence"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -525,6 +525,18 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="claim_id",
     ),
+    # Figure evidence (Track B / B3): a specialized library panel placed last so
+    # it never displaces core panels in facet assembly.
+    PanelDef(
+        type="figure_evidence",
+        title="Figure evidence",
+        description="Figures and images matching the topic — chart/photo descriptions with an image preview, each cited to the document it came from.",
+        endpoint=None,
+        facets=("library",),
+        tables=("documents",),
+        default_span=6,
+        topic_param="topic",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)

--- a/src/ingestion/describers/figure_query.py
+++ b/src/ingestion/describers/figure_query.py
@@ -1,0 +1,70 @@
+"""
+Figure evidence panel query (Track B / B3).
+
+Panel-facing read over the ``documents`` corpus for figure documents (those the
+describers emitted with ``metadata.modality = "image"``). Returns each figure's
+description, its ``content_ref`` (for the image preview), and its
+``parent_document_id`` (the citation), so the ``figure_evidence`` panel can show
+figures matching a topic, each cited to its parent.
+
+Defensive: a warehouse without a ``documents`` table degrades to an empty but
+valid payload rather than raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+MAX_FIGURES = 60
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def figure_evidence(conn, topic: Optional[str] = None, limit: int = MAX_FIGURES) -> Dict[str, Any]:
+    """Figure documents matching an optional topic, each cited to its parent.
+
+    A figure is a corpus document whose ``metadata.modality`` is ``image``. The
+    topic filter is a case-insensitive substring over the figure content/title.
+    """
+    if not _table_exists(conn, "documents"):
+        return {"figures": [], "count": 0, "note": "no documents corpus"}
+
+    capped = max(1, min(limit, MAX_FIGURES))
+    clauses = ["json_extract_string(metadata, '$.modality') = 'image'"]
+    params: List[Any] = []
+    if topic:
+        clauses.append("(LOWER(content) LIKE ? OR LOWER(title) LIKE ?)")
+        needle = f"%{topic.lower()}%"
+        params.extend([needle, needle])
+    where = " AND ".join(clauses)
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT document_id, source_type, title, content, content_ref,
+                   json_extract_string(metadata, '$.parent_document_id') AS parent_document_id,
+                   json_extract_string(metadata, '$.figure_label') AS figure_label
+            FROM documents
+            WHERE {where}
+            ORDER BY document_id
+            LIMIT {capped + 1}
+            """,
+            params,
+        ).fetchall()
+    except Exception as exc:  # noqa: BLE001
+        msg = str(exc)
+        if "does not exist" in msg or "not found" in msg.lower():
+            return {"figures": [], "count": 0, "note": "no documents corpus"}
+        raise
+
+    truncated = len(rows) > capped
+    keys = ["document_id", "source_type", "title", "content", "content_ref", "parent_document_id", "figure_label"]
+    figures = [dict(zip(keys, r)) for r in rows[:capped]]
+    return {"figures": figures, "count": len(figures), "truncated": truncated}

--- a/tests/unit/ingestion/describers/test_figure_query.py
+++ b/tests/unit/ingestion/describers/test_figure_query.py
@@ -1,0 +1,114 @@
+"""Unit tests for the figure_evidence panel query (B3)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.ingestion.describers.figure_query import figure_evidence
+
+
+@pytest.fixture()
+def conn():
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect(":memory:")
+    c.execute(
+        """
+        CREATE TABLE documents (
+            document_id TEXT, source_type TEXT, title TEXT, content TEXT,
+            content_ref TEXT, metadata JSON
+        )
+        """
+    )
+    return c
+
+
+def _insert(conn, document_id, source_type, title, content, content_ref, metadata):
+    conn.execute(
+        "INSERT INTO documents VALUES (?, ?, ?, ?, ?, ?)",
+        [document_id, source_type, title, content, content_ref, json.dumps(metadata)],
+    )
+
+
+def test_no_documents_table_degrades():
+    duckdb = pytest.importorskip("duckdb")
+    empty = duckdb.connect(":memory:")
+    out = figure_evidence(empty)
+    assert out["figures"] == []
+    assert out["count"] == 0
+
+
+def test_returns_only_image_modality(conn):
+    _insert(conn, "paper:1#figure-1", "paper", "Figure 1 — A", "a chart of X", "artifacts/figures/aa/x.png",
+            {"modality": "image", "parent_document_id": "paper:1", "figure_label": "Figure 1"})
+    _insert(conn, "paper:1", "paper", "A paper", "the abstract text", None, {})  # not a figure
+    out = figure_evidence(conn)
+    assert out["count"] == 1
+    fig = out["figures"][0]
+    assert fig["document_id"] == "paper:1#figure-1"
+    assert fig["content_ref"] == "artifacts/figures/aa/x.png"
+    assert fig["parent_document_id"] == "paper:1"  # cited to parent
+    assert fig["figure_label"] == "Figure 1"
+
+
+def test_topic_filter(conn):
+    _insert(conn, "d1#f1", "news", "Fig", "temperature anomaly chart", "r1",
+            {"modality": "image", "parent_document_id": "d1"})
+    _insert(conn, "d2#f1", "news", "Fig", "unemployment bar chart", "r2",
+            {"modality": "image", "parent_document_id": "d2"})
+    assert figure_evidence(conn, topic="temperature")["count"] == 1
+    assert figure_evidence(conn, topic="chart")["count"] == 2
+    assert figure_evidence(conn, topic="election")["count"] == 0
+
+
+def test_figure_evidence_annotation_validates():
+    # Import the pipeline server under a fastmcp stub and validate the panel.
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[4]
+
+    class _StubMCP:
+        def __init__(self, name):
+            self.name = name
+
+        def tool(self, *args, **kwargs):
+            if args and callable(args[0]) and not kwargs:
+                args[0]._mcp_meta = None
+                return args[0]
+
+            def deco(fn):
+                fn._mcp_meta = kwargs.get("meta")
+                return fn
+            return deco
+
+        def run(self):  # pragma: no cover
+            pass
+
+    stub = types.ModuleType("fastmcp")
+    stub.FastMCP = _StubMCP
+    sys.modules["fastmcp"] = stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "pipeline_mcp_server_b3", repo_root / "tools" / "pipeline_mcp" / "server.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        from src.genui.discovery import panel_def_from_annotation
+
+        tool = {
+            "name": "figure_evidence",
+            "description": "figures",
+            "meta": module.figure_evidence._mcp_meta,
+            "has_output_schema": True,
+        }
+        panel = panel_def_from_annotation("neuronews-pipeline", tool)
+        assert panel is not None and panel.type == "figure_evidence"
+        assert "documents" in panel.tables
+        assert panel.topic_param == "topic"
+    finally:
+        sys.modules.pop("fastmcp", None)

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1728,5 +1728,62 @@ def trigger_cluster_narratives() -> dict:
         con.close()
 
 
+@mcp.tool(
+    output_schema={
+        "type": "object",
+        "properties": {
+            "figures": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "document_id": {"type": "string"},
+                        "source_type": {"type": ["string", "null"]},
+                        "title": {"type": ["string", "null"]},
+                        "content": {"type": ["string", "null"]},
+                        "content_ref": {"type": ["string", "null"]},
+                        "parent_document_id": {"type": ["string", "null"]},
+                        "figure_label": {"type": ["string", "null"]},
+                    },
+                    "additionalProperties": True,
+                },
+            },
+            "count": {"type": "integer"},
+            "truncated": {"type": "boolean"},
+        },
+        "additionalProperties": True,
+    },
+    meta={"data": {"panel": "figure_evidence", "rest_route": None}, "panel": {
+        "type": "figure_evidence",
+        "title": "Figure evidence",
+        "description": "Figures and images matching the topic — chart/photo descriptions with an image preview, each cited to the document it came from.",
+        "endpoint": None,
+        "facets": ["library", "entities"],
+        "tables": ["documents"],
+        "default_span": 6,
+        "topic_param": "topic",
+    }},
+)
+def figure_evidence(topic: Optional[str] = None) -> dict:
+    """Figure documents (metadata.modality='image') matching an optional topic,
+    each with its description, image content_ref, and parent-document citation.
+
+    Args:
+        topic: optional case-insensitive substring over the figure text.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"figures": [], "count": 0, "note": str(exc)}
+    try:
+        from src.ingestion.describers.figure_query import figure_evidence as _fe
+
+        return _fe(con, topic)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     mcp.run()  # stdio transport by default


### PR DESCRIPTION
## Overview

The final **Track B** deliverable — closes #773, part of #765. Completes the visual-evidence track by making the figure documents from B1/B2 visible on the canvas. Full-stack: query → tool → catalog → codegen → renderer.

## Changes

- **`src/ingestion/describers/figure_query.py`** — `figure_evidence()` reads the `documents` corpus for figures (`metadata.modality = 'image'`) matching a topic, returning each figure's description, `content_ref` (image preview) and `parent_document_id` (citation). Degrades to empty on a corpus-less warehouse.
- **`tools/pipeline_mcp/server.py`** — `figure_evidence` tool with an ADR-001 panel annotation, surfacing the panel through discovery.
- **`src/genui/catalog.py`** (+ regenerated `catalog.gen.ts` and `ui-spec-v1.json`) — the `figure_evidence` `PanelDef`, placed **last with only the `library` facet** so it never displaces core panels in the heuristic planner's facet assembly.
- **`apps/web/src/genui/registry.tsx`** — `FigureEvidencePanel` renderer: image preview for `http(s)` `content_ref` (caption chip otherwise), the figure description, and a `cited: <parent>` line.

## Testing

- 4 backend tests: the query (image-modality filter, topic filter, corpus-less degradation) and the panel annotation **validated through the real `panel_def_from_annotation` discovery validator** (pipeline server imported under a fastmcp stub).
- **Frontend `tsc --noEmit` passes** (renderer compiles).
- **Codegen in sync** (`test_codegen.py` green).
- **Zero new test failures**: the genui suite is 6-failed/350-passed **both with and without this change** — those 6 are pre-existing planner-eval baseline drift on `main`, confirmed by stash comparison, not caused here.
- **Exit criteria met**: an intent on a topic with figure evidence selects the `figure_evidence` panel; each figure is cited to its parent and previewable.

## Note

The other discovery-surfaced panels shipped earlier in this series (`series_explorer`, `claim_vs_data`, `data_check_ledger`, `image_provenance`, `image_reuse_ledger`) are backend-complete and appear in `GET /api/v1/ui/panels`; adding their frontend renderers (same catalog→codegen→registry pattern this PR establishes) is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_