### PR TITLE
Frontend renderers for the evidence panels (A2/A4/C2)

### DIFF
--- a/apps/web/src/genui/catalog.gen.ts
+++ b/apps/web/src/genui/catalog.gen.ts
@@ -49,7 +49,12 @@ export type PanelType =
   | "relationship_path"
   | "evidence_timeline"
   | "provenance_trace"
-  | "figure_evidence";
+  | "figure_evidence"
+  | "series_explorer"
+  | "claim_vs_data"
+  | "data_check_ledger"
+  | "image_provenance"
+  | "image_reuse_ledger";
 
 export type Facet =
   | "overview"
@@ -124,6 +129,11 @@ export const PANEL_CATALOG: PanelDef[] = [
   { type: "evidence_timeline", title: "Evidence timeline", facets: ["events", "trend", "claims"], defaultSpan: 6, topicParam: true },
   { type: "provenance_trace", title: "Provenance trace", facets: ["claims", "sources", "library"], defaultSpan: 6, topicParam: true },
   { type: "figure_evidence", title: "Figure evidence", facets: ["library"], defaultSpan: 6, topicParam: true },
+  { type: "series_explorer", title: "Statistical series", facets: [], defaultSpan: 6, topicParam: true },
+  { type: "claim_vs_data", title: "Claims vs data", facets: [], defaultSpan: 6, topicParam: true },
+  { type: "data_check_ledger", title: "Data-check ledger", facets: [], defaultSpan: 6, topicParam: true },
+  { type: "image_provenance", title: "Image provenance", facets: [], defaultSpan: 6 },
+  { type: "image_reuse_ledger", title: "Image reuse", facets: [], defaultSpan: 6, topicParam: true },
 ];
 
 export const PANEL_DEFS: Partial<Record<PanelType, PanelDef>> = Object.fromEntries(

--- a/apps/web/src/genui/registry.tsx
+++ b/apps/web/src/genui/registry.tsx
@@ -331,6 +331,153 @@ function FigureEvidencePanel(props: PanelProps) {
   );
 }
 
+const VERDICT_COLORS: Record<string, string> = {
+  supported: palette.teal,
+  contradicted: palette.amber,
+  unverifiable: palette.neu,
+};
+
+function SeriesExplorerPanel(props: PanelProps) {
+  const topic = props.panel.params?.topic;
+  const { data, source, isLoading } = useDataPlanePanel("series_explorer", {
+    topic: typeof topic === "string" ? topic : undefined,
+  });
+  const series = Array.isArray(data?.series) ? (data!.series as Record<string, unknown>[]) : [];
+  const rows = series.slice(0, 6);
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {rows.length === 0 ? (
+        <Empty text="No statistical series harvested" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {rows.map((s, i) => (
+            <div key={String(s.series_id)} style={{ display: "flex", gap: 10, alignItems: "baseline", padding: "7px 0", borderBottom: i < rows.length - 1 ? "1px solid #12242e" : "none" }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={rowTitle}>{String(s.title ?? s.series_id)}</div>
+                <div style={{ ...mono, marginTop: 3 }}>{String(s.provider ?? "")}{s.geography ? ` · ${String(s.geography)}` : ""}{s.observation_count != null ? ` · ${String(s.observation_count)} obs` : ""}</div>
+              </div>
+              {s.latest_value != null ? (
+                <span style={{ fontFamily: fonts.mono, fontSize: 12, color: palette.teal }}>{String(s.latest_value)}{s.unit === "percent" ? "%" : ""}</span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
+function ClaimVsDataPanel(props: PanelProps) {
+  const topic = props.panel.params?.topic;
+  const { data, source, isLoading } = useDataPlanePanel("claim_vs_data", {
+    topic: typeof topic === "string" ? topic : undefined,
+  });
+  const checks = Array.isArray(data?.checks) ? (data!.checks as Record<string, unknown>[]) : [];
+  const rows = checks.slice(0, 5);
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {rows.length === 0 ? (
+        <Empty text="No claim-vs-data checks yet" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {rows.map((c, i) => {
+            const verdict = String(c.verdict ?? "unverifiable");
+            return (
+              <div key={String(c.check_id ?? i)} style={{ display: "flex", gap: 10, alignItems: "baseline" }}>
+                <span style={chip(VERDICT_COLORS[verdict] ?? palette.neu)}>{verdict.toUpperCase()}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={rowTitle}>{String(c.subject ?? "")} <span style={{ color: palette.neu }}>({String(c.direction ?? "")})</span></div>
+                  {c.series_title ? <div style={{ ...mono, marginTop: 3 }}>{String(c.series_title)}</div> : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
+function DataCheckLedgerPanel(props: PanelProps) {
+  const topic = props.panel.params?.topic;
+  const { data, source, isLoading } = useDataPlanePanel("data_check_ledger", {
+    topic: typeof topic === "string" ? topic : undefined,
+  });
+  const checks = Array.isArray(data?.checks) ? (data!.checks as Record<string, unknown>[]) : [];
+  const rows = checks.slice(0, 6);
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {rows.length === 0 ? (
+        <Empty text="No contradicted claims on record" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {rows.map((c, i) => (
+            <div key={String(c.check_id ?? i)} style={{ display: "flex", gap: 10, alignItems: "baseline", padding: "7px 0", borderBottom: i < rows.length - 1 ? "1px solid #12242e" : "none" }}>
+              <span style={chip(palette.amber)}>CONTRADICTED</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={rowTitle}>{String(c.subject ?? "")}</div>
+                <div style={{ ...mono, marginTop: 3 }}>{String(c.series_id ?? "")}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
+function ImageProvenancePanel(props: PanelProps) {
+  const { data, source, isLoading } = useDataPlanePanel("image_provenance", {});
+  const appearances = Array.isArray(data?.appearances) ? (data!.appearances as Record<string, unknown>[]) : [];
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {data == null ? (
+        <Empty text="Select an image to trace its provenance" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <div style={mono}>phash {String(data.phash ?? "—")}</div>
+          <div style={{ fontSize: 11, color: palette.neu }}>EXIF is claimed by the file, not verified</div>
+          <div style={{ marginTop: 4, fontSize: 12 }}>Appears in {appearances.length} document{appearances.length === 1 ? "" : "s"}:</div>
+          {appearances.slice(0, 5).map((a, i) => (
+            <div key={i} style={mono}>{String(a.document_id)}</div>
+          ))}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
+function ImageReuseLedgerPanel(props: PanelProps) {
+  const topic = props.panel.params?.topic;
+  const { data, source, isLoading } = useDataPlanePanel("image_reuse_ledger", {
+    topic: typeof topic === "string" ? topic : undefined,
+  });
+  const findings = Array.isArray(data?.findings) ? (data!.findings as Record<string, unknown>[]) : [];
+  const rows = findings.slice(0, 5);
+  return (
+    <GenPanel {...props} source={source} isLoading={isLoading}>
+      {rows.length === 0 ? (
+        <Empty text="No recycled images detected" />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {rows.map((f, i) => {
+            const docs = Array.isArray(f.documents) ? (f.documents as string[]) : [];
+            return (
+              <div key={i} style={{ display: "flex", gap: 10, alignItems: "baseline" }}>
+                <span style={chip(palette.amber)}>{String(f.confidence ?? "").toUpperCase() || "REUSE"}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={rowTitle}>Reused across {String(f.distinct_document_count ?? docs.length)} documents</div>
+                  <div style={{ ...mono, marginTop: 3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{docs.join(" · ")}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </GenPanel>
+  );
+}
+
 const WATCH_TYPE_COLORS: Record<string, string> = {
   Entity: ACCENT,
   Topic: palette.amber,
@@ -1848,6 +1995,11 @@ const REGISTRY: Record<PanelType, ComponentType<PanelProps>> = {
   articles: ArticlesPanel,
   documents: DocumentsPanel,
   figure_evidence: FigureEvidencePanel,
+  series_explorer: SeriesExplorerPanel,
+  claim_vs_data: ClaimVsDataPanel,
+  data_check_ledger: DataCheckLedgerPanel,
+  image_provenance: ImageProvenancePanel,
+  image_reuse_ledger: ImageReuseLedgerPanel,
   trending: TrendingPanel,
   clusters: ClustersPanel,
   event_axis: EventAxisPanel,

--- a/contracts/schemas/jsonschema/ui-spec-v1.json
+++ b/contracts/schemas/jsonschema/ui-spec-v1.json
@@ -60,7 +60,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "claim_flow", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace", "figure_evidence"],
+            "enum": ["note", "kpi_row", "articles", "documents", "anomaly_timeline", "trending", "clusters", "event_axis", "watchlists", "timeline", "sentiment_heatmap", "topic_sentiment", "sentiment_trend", "entity_graph", "claims", "claim_verdicts", "claims_trend", "evidence_axis", "claim_flow", "stance", "frames", "positions", "controversy", "drift", "outlet_ranking", "outlet_clusters", "coverage_flow", "actors", "lead_lag", "narrative_thread", "drift_trajectory", "forecast", "venues", "citation_graph", "literature_claims", "provisioned_kg", "corroboration", "reliability_card", "contradiction_ledger", "entity_dossier", "relationship_path", "evidence_timeline", "provenance_trace", "figure_evidence", "series_explorer", "claim_vs_data", "data_check_ledger", "image_provenance", "image_reuse_ledger"],
             "description": "Renderer key in the frontend panel registry"
           },
           "title": {

--- a/src/genui/catalog.py
+++ b/src/genui/catalog.py
@@ -537,6 +537,59 @@ PANEL_CATALOG: Tuple[PanelDef, ...] = (
         default_span=6,
         topic_param="topic",
     ),
+    # Evidence panels backed by discovery tools (Track A / C). Empty facets so
+    # the heuristic planner never auto-selects them (they surface via discovery
+    # and the LLM planner); the catalog entry exists so the frontend registry
+    # has a PanelType and renderer for each.
+    PanelDef(
+        type="series_explorer",
+        title="Statistical series",
+        description="Official statistical series harvested as evidence, each with a compact latest-vintage summary.",
+        endpoint=None,
+        facets=(),
+        tables=("dataset_series", "dataset_observations"),
+        default_span=6,
+        topic_param="topic",
+    ),
+    PanelDef(
+        type="claim_vs_data",
+        title="Claims vs data",
+        description="Quantitative claims checked against official statistical series, with a supported / contradicted / unverifiable verdict.",
+        endpoint=None,
+        facets=(),
+        tables=("claim_data_checks", "dataset_series"),
+        default_span=6,
+        topic_param="topic",
+    ),
+    PanelDef(
+        type="data_check_ledger",
+        title="Data-check ledger",
+        description="The quantitative wing of the contradiction ledger: claims the data contradicts, each citing the series and vintage checked.",
+        endpoint=None,
+        facets=(),
+        tables=("claim_data_checks",),
+        default_span=6,
+        topic_param="topic",
+    ),
+    PanelDef(
+        type="image_provenance",
+        title="Image provenance",
+        description="What an image claims about itself (EXIF, file-claimed), its content credentials, and every document it appears in.",
+        endpoint=None,
+        facets=(),
+        tables=("image_assets", "image_appearances"),
+        default_span=6,
+    ),
+    PanelDef(
+        type="image_reuse_ledger",
+        title="Image reuse",
+        description="Recycled images: near-duplicate photos appearing across multiple documents, each finding citing every appearance.",
+        endpoint=None,
+        facets=(),
+        tables=("image_assets", "image_appearances"),
+        default_span=6,
+        topic_param="topic",
+    ),
 )
 
 PANEL_TYPES: Tuple[str, ...] = tuple(p.type for p in PANEL_CATALOG)


### PR DESCRIPTION
## Overview

Wires the five backend-complete, discovery-surfaced evidence panels to frontend renderers, so they render on the canvas instead of the `UnknownPanel` stub. Follows up the beyond-text tracks (#765): `series_explorer` (A2), `claim_vs_data` + `data_check_ledger` (A4), `image_provenance` + `image_reuse_ledger` (C2).

## Changes

- **`src/genui/catalog.py`** (+ regenerated `catalog.gen.ts` / `ui-spec-v1.json`) — a `PanelDef` per type so the frontend `PanelType` union and registry can key on them. **Facets are empty**, so the heuristic planner never auto-selects them (they surface via discovery and the LLM planner) — this keeps the planner goldens byte-for-byte unchanged.
- **`apps/web/src/genui/registry.tsx`** — five renderers, each fetching via `useDataPlanePanel` and degrading to an empty state:
  - `SeriesExplorerPanel` — series with provider/geography/obs-count and latest value;
  - `ClaimVsDataPanel` — verdict-coloured chips (supported/contradicted/unverifiable) + series;
  - `DataCheckLedgerPanel` — the contradicted-claims ledger;
  - `ImageProvenancePanel` — phash, the file-claimed-EXIF caveat, appearances;
  - `ImageReuseLedgerPanel` — reuse clusters with distinct-document counts.

## Testing

- **Frontend `tsc --noEmit` passes.**
- **Codegen in sync** (`test_codegen.py` green).
- **Genui suite failure count unchanged** — 6 failed / 350 passed both before and after (the 6 are pre-existing planner-eval baseline drift; empty facets guarantee no planner behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_