### PR TITLE
Candidate: structured filings connector (#784)

### DIFF
--- a/src/ingestion/connectors/filings.py
+++ b/src/ingestion/connectors/filings.py
@@ -1,0 +1,122 @@
+"""
+Structured filings connector (candidate track #784).
+
+Filings (company registries, XBRL financial reports, procurement notices) are
+hybrid structured+text sources: entities, officers and ownership feed the
+knowledge graph; reported figures feed the Track A observation store. A filing's
+reported revenue thus becomes checkable evidence against a claim about that
+company — and against the official series.
+
+This module maps a normalized filing into three products: a narrative
+``Document``, ``dataset-series-v1`` ``SeriesRecord``s (``provider = "filing"``)
+for the reported facts, and lightweight filer/officer entity relations for the
+KG. Stdlib only.
+
+See ``docs/architecture/BEYOND_TEXT_ROADMAP.md`` §4.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from services.ingest.common.document_model import Document
+from services.ingest.common.series_model import Observation, SeriesRecord
+
+
+@dataclass
+class FilingFact:
+    """One reported numeric fact (an XBRL-style concept over a period)."""
+
+    concept: str        # e.g. "Revenue", "NetIncome"
+    value: float
+    period: str         # "2023" or "2023-Q4"
+    unit: Optional[str] = None
+
+
+@dataclass
+class Filing:
+    filer: str
+    filing_id: str
+    facts: List[FilingFact] = field(default_factory=list)
+    narrative: Optional[str] = None
+    officers: List[str] = field(default_factory=list)
+    cik: Optional[str] = None
+    filed_at: Optional[int] = None
+    source_url: Optional[str] = None
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-") or "x"
+
+
+def _group_facts(facts: List[FilingFact]) -> Dict[str, List[FilingFact]]:
+    by_concept: Dict[str, List[FilingFact]] = {}
+    for f in facts:
+        by_concept.setdefault(f.concept, []).append(f)
+    return by_concept
+
+
+def filing_to_series(filing: Filing, as_of: int = 0) -> List[SeriesRecord]:
+    """One series per reported concept (revenue, net income, ...) for the filer."""
+    series: List[SeriesRecord] = []
+    for concept, facts in _group_facts(filing.facts).items():
+        obs = [Observation(period=f.period, value=f.value) for f in sorted(facts, key=lambda x: x.period)]
+        unit = next((f.unit for f in facts if f.unit), None)
+        freq = "quarterly" if any("-Q" in f.period for f in facts) else "annual"
+        series.append(SeriesRecord(
+            series_id=f"filing:{_slug(filing.filer)}:{_slug(concept)}",
+            provider="filing",
+            title=f"{concept} — {filing.filer}",
+            frequency=freq,
+            as_of=as_of or (filing.filed_at or 0),
+            observations=obs,
+            unit=unit,
+            geography=None,
+            license="public filing",
+            source_url=filing.source_url,
+            metadata={"filer": filing.filer, "cik": filing.cik, "concept": concept},
+        ))
+    return series
+
+
+def filing_to_document(filing: Filing, ingested_at: int) -> Document:
+    """The filing's narrative as a document-ingest-v1 record."""
+    return Document(
+        document_id=f"filing:{filing.filing_id}",
+        source_type="note",  # a filing is a structured note; no new enum needed
+        language="en",
+        ingested_at=ingested_at,
+        source_id=filing.cik or filing.filer,
+        url=filing.source_url,
+        title=f"Filing: {filing.filer}",
+        content=filing.narrative,
+        authors=list(filing.officers),
+        created_at=filing.filed_at,
+        metadata={"filer": filing.filer, "cik": filing.cik, "officers": list(filing.officers)},
+    )
+
+
+@dataclass
+class EntityRelation:
+    subject: str
+    predicate: str
+    object: str
+
+
+def filing_entities(filing: Filing) -> List[EntityRelation]:
+    """Filer + officer relations for the KG (filer FILED_BY officers)."""
+    relations: List[EntityRelation] = []
+    for officer in filing.officers:
+        relations.append(EntityRelation(subject=officer, predicate="OFFICER_OF", object=filing.filer))
+    return relations
+
+
+def ingest_filing(filing: Filing, ingested_at: int = 0) -> Dict[str, Any]:
+    """Map a filing to its three products in one call."""
+    return {
+        "document": filing_to_document(filing, ingested_at),
+        "series": filing_to_series(filing, as_of=ingested_at),
+        "entities": filing_entities(filing),
+    }

--- a/tests/unit/ingestion/connectors/test_filings.py
+++ b/tests/unit/ingestion/connectors/test_filings.py
@@ -1,0 +1,92 @@
+"""Unit tests for the structured filings connector (#784)."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ingest.common.document_model import Document
+from services.ingest.common.series_model import SeriesRecord
+from src.ingestion.connectors.filings import (
+    Filing,
+    FilingFact,
+    filing_entities,
+    filing_to_document,
+    filing_to_series,
+    ingest_filing,
+)
+
+
+def _filing():
+    return Filing(
+        filer="Acme Corp",
+        filing_id="acme-2023-10K",
+        cik="0001234",
+        facts=[
+            FilingFact("Revenue", 17.2e9, "2022", "usd"),
+            FilingFact("Revenue", 18.5e9, "2023", "usd"),
+            FilingFact("NetIncome", 2.1e9, "2023", "usd"),
+        ],
+        narrative="Acme Corp reported strong growth.",
+        officers=["Jane Doe", "John Roe"],
+        filed_at=1000,
+        source_url="http://sec/x",
+    )
+
+
+def test_filing_to_series_one_per_concept():
+    series = filing_to_series(_filing())
+    ids = {s.series_id for s in series}
+    assert ids == {"filing:acme-corp:revenue", "filing:acme-corp:netincome"}
+    rev = next(s for s in series if s.series_id == "filing:acme-corp:revenue")
+    assert isinstance(rev, SeriesRecord)
+    assert rev.provider == "filing"
+    assert [(o.period, o.value) for o in rev.observations] == [("2022", 17.2e9), ("2023", 18.5e9)]
+    assert rev.unit == "usd"
+
+
+def test_filing_to_document():
+    doc = filing_to_document(_filing(), ingested_at=1)
+    assert isinstance(doc, Document)
+    assert doc.document_id == "filing:acme-2023-10K"
+    assert doc.metadata["filer"] == "Acme Corp"
+    assert "Jane Doe" in doc.authors
+
+
+def test_filing_entities():
+    rels = filing_entities(_filing())
+    assert {(r.subject, r.predicate, r.object) for r in rels} == {
+        ("Jane Doe", "OFFICER_OF", "Acme Corp"),
+        ("John Roe", "OFFICER_OF", "Acme Corp"),
+    }
+
+
+def test_ingest_filing_three_products():
+    out = ingest_filing(_filing(), ingested_at=1)
+    assert isinstance(out["document"], Document)
+    assert len(out["series"]) == 2
+    assert len(out["entities"]) == 2
+
+
+def test_reported_figure_is_checkable_evidence():
+    duckdb = pytest.importorskip("duckdb")
+    from src.analytics.claim_check import check_assertion
+    from src.argument_mining.quantities import QuantityExtractor
+    from src.ingestion.connectors.dataset.store import ObservationStore
+
+    conn = duckdb.connect(":memory:")
+    store = ObservationStore(conn)
+    for s in filing_to_series(_filing(), as_of=1):
+        store.upsert(s)
+    a = QuantityExtractor().extract("Acme Corp Revenue rose in 2023.")[0]
+    env = check_assertion(conn, a)
+    assert env["verdict"] == "supported"
+    assert env["series_id"] == "filing:acme-corp:revenue"
+
+
+def test_quarterly_frequency_inferred():
+    f = Filing(filer="X", filing_id="x", facts=[
+        FilingFact("Revenue", 1.0, "2023-Q1", "usd"),
+        FilingFact("Revenue", 1.1, "2023-Q2", "usd"),
+    ])
+    series = filing_to_series(f)
+    assert series[0].frequency == "quarterly"


### PR DESCRIPTION
## Overview

Implements candidate track **#784** (part of #765), on the merged A1 foundation. Filings (company registries, XBRL reports, procurement notices) are hybrid structured+text sources: reported figures feed the Track A observation store; entities feed the knowledge graph.

## Changes

- **`src/ingestion/connectors/filings.py`** — `Filing` + `FilingFact` models and three mappers:
  - `filing_to_series()` — one `dataset-series-v1` record per reported concept (revenue, net income, …) with `provider="filing"`, so a filing's revenue is **checkable evidence** against a claim about that company via the A4 resolver;
  - `filing_to_document()` — the narrative as a `document-ingest-v1` record (reusing `source_type="note"`, no new enum);
  - `filing_entities()` — `OFFICER_OF` relations for the KG;
  - `ingest_filing()` — returns all three products.

## Testing

- 6 tests including an **end-to-end A4 check**: a filing's reported revenue is stored and "Acme Corp Revenue rose in 2023" resolves against it with a `supported` verdict. Plus per-concept series, document mapping, entity relations, and quarterly-frequency inference.

## Note

This maps an already-normalized filing (facts + narrative + officers); the provider-specific fetch/parse (SEC EDGAR XBRL, a national registry, procurement feeds) is the scoping decision noted on the issue and slots in front of this mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_