### PR TITLE
Candidate: cross-modal contradiction detection (#785)

### DIFF
--- a/src/analytics/cross_modal.py
+++ b/src/analytics/cross_modal.py
@@ -1,0 +1,169 @@
+"""
+Cross-modal contradiction detection (candidate track #785).
+
+The contradiction ledger records where sources disagree with each other. With
+figures (Track B) and numbers (Track A) as evidence, it can also record where a
+document disagrees with *itself*: a figure description whose number contradicts
+the prose, a caption that misstates its own figure.
+
+For a parent document this compares the quantitative assertions parsed from its
+prose against those parsed from its figure documents (B1: ``metadata.modality =
+'image'``), and flags conflicts. Honesty-enveloped; each finding cites both the
+prose and the figure. The figure numbers carry the "approximate, read from
+chart" caveat, so a small gap is not a contradiction.
+
+Connection-injected; reuses the A3 quantity extractor.
+
+See ``docs/architecture/BEYOND_TEXT_ROADMAP.md`` §4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.analytics.honesty import analytic_envelope
+from src.argument_mining.quantities import QuantAssertion, QuantityExtractor
+
+METHOD = "cross-modal (prose vs figure) quantitative contradiction"
+ASSUMPTIONS = [
+    "figure values are approximate (read from chart); small gaps are not contradictions",
+    "assertions are matched by subject/unit overlap; a weak match is not flagged",
+    "only same-period, same-unit numeric disagreements are contradictions",
+]
+
+# A figure value must differ from the prose value by more than this relative
+# tolerance (on top of any unit/period agreement) to count as a contradiction.
+REL_TOLERANCE = 0.15
+
+
+def _subject_tokens(a: QuantAssertion) -> set:
+    import re
+
+    words = re.findall(r"[a-z0-9]+", (a.subject or "").lower())
+    return {w for w in words if len(w) > 2}
+
+
+def _matches(a: QuantAssertion, b: QuantAssertion) -> bool:
+    """Two assertions describe the same measured thing (subject overlap + a
+    compatible period and unit)."""
+    ta, tb = _subject_tokens(a), _subject_tokens(b)
+    if not ta or not tb:
+        return False
+    overlap = len(ta & tb) / min(len(ta), len(tb))
+    if overlap < 0.5:
+        return False
+    if a.period and b.period and a.period != b.period:
+        return False
+    if a.unit and b.unit and a.unit != b.unit:
+        return False
+    return True
+
+
+def _conflicts(prose: QuantAssertion, figure: QuantAssertion) -> Optional[str]:
+    """Return a conflict description if the two disagree, else None."""
+    # Direction conflict (one rose, the other fell).
+    if prose.direction in ("rose", "fell") and figure.direction in ("rose", "fell") and prose.direction != figure.direction:
+        return f"direction: prose says {prose.direction}, figure says {figure.direction}"
+    # Value conflict beyond tolerance.
+    if prose.value is not None and figure.value is not None:
+        base = max(abs(prose.value), abs(figure.value), 1e-9)
+        if abs(prose.value - figure.value) / base > REL_TOLERANCE:
+            return f"value: prose {prose.value} vs figure {figure.value}"
+    return None
+
+
+import re as _re
+
+_FIG_LABEL_RE = _re.compile(r"^\s*fig(?:ure)?\.?\s*\d+[a-z]?\s*(?:\([^)]*\))?\s*[:.\-—]?\s*", _re.IGNORECASE)
+
+
+def _strip_figure_label(text: str) -> str:
+    """Drop a leading 'Figure 3:' / 'Fig. 2.' so its number is not read as a
+    measured value."""
+    return _FIG_LABEL_RE.sub("", text or "")
+
+
+def contradictions_in(prose_text: Optional[str], figure_texts: List[str]) -> List[Dict[str, Any]]:
+    """Find quantitative conflicts between a document's prose and its figures."""
+    ex = QuantityExtractor()
+    prose_assertions = ex.extract_sentences((prose_text or "").split(". "))
+    figure_assertions: List[QuantAssertion] = []
+    for ft in figure_texts:
+        cleaned = _strip_figure_label(ft or "")
+        figure_assertions.extend(ex.extract_sentences(cleaned.split(". ")))
+
+    findings: List[Dict[str, Any]] = []
+    for pa in prose_assertions:
+        for fa in figure_assertions:
+            if not _matches(pa, fa):
+                continue
+            conflict = _conflicts(pa, fa)
+            if conflict:
+                findings.append({
+                    "subject": pa.subject,
+                    "conflict": conflict,
+                    "prose": pa.to_dict(),
+                    "figure": fa.to_dict(),
+                })
+    return findings
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def find_intra_document_contradictions(conn, parent_document_id: Optional[str] = None) -> Dict[str, Any]:
+    """Scan documents for prose-vs-figure quantitative contradictions.
+
+    Reads a parent document's prose and its figure documents (children with
+    ``metadata.modality = 'image'``) from the corpus, and flags conflicts, each
+    citing the parent and the figure.
+    """
+    if not _table_exists(conn, "documents"):
+        return analytic_envelope(n=0, method=METHOD, assumptions=ASSUMPTIONS, findings=[], note="no documents corpus")
+
+    # Parents: documents that have at least one figure child.
+    parent_clause = "AND d.document_id = ?" if parent_document_id else ""
+    params = [parent_document_id] if parent_document_id else []
+    parents = conn.execute(
+        f"""
+        SELECT DISTINCT d.document_id, d.content
+        FROM documents d
+        WHERE d.content IS NOT NULL {parent_clause}
+        """,
+        params,
+    ).fetchall()
+
+    findings: List[Dict[str, Any]] = []
+    scanned = 0
+    for doc_id, prose in parents:
+        figs = conn.execute(
+            """
+            SELECT document_id, content FROM documents
+            WHERE json_extract_string(metadata, '$.modality') = 'image'
+              AND json_extract_string(metadata, '$.parent_document_id') = ?
+            """,
+            [doc_id],
+        ).fetchall()
+        if not figs:
+            continue
+        scanned += 1
+        conflicts = contradictions_in(prose, [f[1] or "" for f in figs])
+        for c in conflicts:
+            c["parent_document_id"] = doc_id
+            c["cited"] = True
+            findings.append(c)
+
+    return analytic_envelope(
+        n=scanned,
+        method=METHOD,
+        assumptions=ASSUMPTIONS,
+        findings=findings,
+        finding_count=len(findings),
+    )

--- a/tests/unit/analytics/test_cross_modal.py
+++ b/tests/unit/analytics/test_cross_modal.py
@@ -1,0 +1,78 @@
+"""Unit tests for cross-modal contradiction detection (#785)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.analytics.cross_modal import contradictions_in, find_intra_document_contradictions
+from src.analytics.honesty import validate_analytic_output
+
+PROSE = "Unemployment in Germany rose to 3.4% in 2024."
+
+
+def test_direction_conflict():
+    findings = contradictions_in(PROSE, ["Figure 1: unemployment in Germany fell to 2.1% in 2024."])
+    assert len(findings) == 1
+    assert "direction" in findings[0]["conflict"]
+
+
+def test_value_conflict():
+    findings = contradictions_in(PROSE, ["Figure 1: unemployment in Germany rose to 8.0% in 2024."])
+    assert len(findings) == 1
+    assert "value" in findings[0]["conflict"]
+
+
+def test_agreement_within_tolerance_not_flagged():
+    # Figure says 3.5% vs prose 3.4% — within the approximate-figure tolerance.
+    assert contradictions_in(PROSE, ["Figure 1: unemployment in Germany rose to 3.5% in 2024."]) == []
+
+
+def test_unrelated_subject_not_matched():
+    assert contradictions_in(PROSE, ["Figure 1: GDP grew 2% in 2024."]) == []
+
+
+def test_figure_label_number_not_read_as_value():
+    # 'Figure 5' must not be read as a value of 5.
+    findings = contradictions_in("Sales rose to 100 units in 2023.", ["Figure 5: sales rose to 101 units in 2023."])
+    assert findings == []  # 100 vs 101, agreement (label 5 ignored)
+
+
+def test_different_period_not_compared():
+    assert contradictions_in(PROSE, ["Figure 1: unemployment in Germany rose to 9.0% in 2019."]) == []
+
+
+@pytest.fixture()
+def conn():
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect(":memory:")
+    c.execute("CREATE TABLE documents (document_id TEXT, content TEXT, metadata JSON)")
+    return c
+
+
+def _add(conn, doc_id, content, metadata):
+    conn.execute("INSERT INTO documents VALUES (?, ?, ?)", [doc_id, content, json.dumps(metadata)])
+
+
+def test_find_intra_document_contradictions(conn):
+    _add(conn, "paper:1", PROSE, {})
+    _add(conn, "paper:1#figure-1", "Figure 1: unemployment in Germany fell to 2.1% in 2024.",
+         {"modality": "image", "parent_document_id": "paper:1"})
+    env = find_intra_document_contradictions(conn)
+    assert validate_analytic_output(env) == []
+    assert env["finding_count"] == 1
+    finding = env["findings"][0]
+    assert finding["parent_document_id"] == "paper:1"
+    assert finding["cited"] is True
+
+
+def test_no_contradiction_when_figures_agree(conn):
+    _add(conn, "paper:2", PROSE, {})
+    _add(conn, "paper:2#figure-1", "Figure 1: unemployment in Germany rose to 3.4% in 2024.",
+         {"modality": "image", "parent_document_id": "paper:2"})
+    assert find_intra_document_contradictions(conn)["finding_count"] == 0
+
+
+def test_empty_corpus(conn):
+    assert find_intra_document_contradictions(conn)["findings"] == []


### PR DESCRIPTION
## Overview

Implements candidate track **#785** (part of #765), on the merged A4 + B1 foundation. The contradiction ledger records where sources disagree with each other; this extends it to disagreements *within* a single document — a figure whose number contradicts the prose beside it.

## Changes

- **`src/analytics/cross_modal.py`**:
  - `contradictions_in()` — extracts quantitative assertions (A3) from prose and from figure text, matches them by subject / unit / period overlap, and flags **direction conflicts** (rose vs fell) and **value conflicts beyond a tolerance** (figures are approximate-by-contract, so small gaps are not contradictions). A leading `Figure N:` label is stripped so its number isn't misread as a value.
  - `find_intra_document_contradictions()` — scans the corpus, pairing each parent document's prose with its figure children (B1: `metadata.modality='image'`), honesty-enveloped and **citing both** the prose and the figure.

## Testing

- 9 tests: direction/value conflicts, within-tolerance agreement, unrelated subject, the **figure-label-not-a-value** fix, different-period non-comparison, and the corpus scan (contradiction + agreement + empty). Envelopes pass `validate_analytic_output`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_