### PR TITLE
Candidate: video keyframes + on-screen text OCR (#782)

### DIFF
--- a/src/ingestion/connectors/media/keyframes.py
+++ b/src/ingestion/connectors/media/keyframes.py
@@ -1,0 +1,126 @@
+"""
+Video keyframes + on-screen text OCR (candidate track #782).
+
+Talks and news broadcasts put load-bearing numbers on screen (chyrons, slides,
+lower thirds), not in speech — the transcript misses them entirely. This module
+turns keyframes into timestamp-linked ``Document`` segments alongside the
+transcript, so a semantic query returns the slide the words never say.
+
+Following the media connector's precedent, each keyframe becomes one
+``Document`` whose ``content`` is the OCR'd on-screen text and whose
+``content_ref`` is a Media Fragment URI (``base#t=<seconds>``) a player can seek.
+
+Frame extraction (scene-change sampling) and OCR are **injected** — they need
+heavy binaries (ffmpeg, tesseract) that stay out of the tool servers — so this
+module is testable offline and degrades to nothing when they are unavailable.
+
+See ``docs/architecture/BEYOND_TEXT_ROADMAP.md`` §4.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+from services.ingest.common.document_model import Document
+
+logger = logging.getLogger(__name__)
+
+# Cap keyframes per video so a long recording cannot stall a harvest.
+DEFAULT_MAX_KEYFRAMES = 200
+
+# Injected callables:
+#   FrameSampler(video_ref) -> List[(timestamp_s, image_bytes)]  (scene changes)
+#   Ocr(image_bytes) -> str                                      (on-screen text)
+FrameSampler = Callable[[str], List["Keyframe"]]
+Ocr = Callable[[bytes], Optional[str]]
+
+
+@dataclass
+class Keyframe:
+    timestamp_s: float
+    image_bytes: Optional[bytes] = None
+    ocr_text: Optional[str] = None
+
+
+def media_fragment(base_uri: str, timestamp_s: float) -> str:
+    """A point-in-time Media Fragment URI (W3C): ``base#t=<seconds>``."""
+    return f"{base_uri}#t={timestamp_s:.3f}"
+
+
+def _keyframe_id(media_id: str, timestamp_s: float) -> str:
+    return f"{media_id}#kf={timestamp_s:.3f}"
+
+
+def keyframe_document(
+    parent: Document,
+    media_ref: str,
+    media_id: str,
+    keyframe: Keyframe,
+    ingested_at: int,
+) -> Document:
+    """Build a Document for one keyframe's on-screen text."""
+    text = (keyframe.ocr_text or "").strip()
+    return Document(
+        document_id=_keyframe_id(media_id, keyframe.timestamp_s),
+        source_type=parent.source_type,  # inherit (transcript); enum untouched
+        language=parent.language,
+        ingested_at=ingested_at,
+        source_id=parent.source_id,
+        url=parent.url,
+        title=parent.title,
+        content=text or None,
+        content_ref=media_fragment(media_ref, keyframe.timestamp_s),
+        authors=list(parent.authors),
+        created_at=parent.created_at,
+        metadata={
+            "modality": "keyframe",
+            "parent_document_id": parent.document_id,
+            "start_s": keyframe.timestamp_s,
+            "on_screen_text": True,
+        },
+    )
+
+
+def ocr_keyframes(keyframes: List[Keyframe], ocr: Optional[Ocr]) -> List[Keyframe]:
+    """Fill ``ocr_text`` for keyframes that have image bytes, via the injected
+    OCR. Without an OCR backend, keyframes pass through unchanged (no text)."""
+    if ocr is None:
+        return keyframes
+    out: List[Keyframe] = []
+    for kf in keyframes:
+        text = kf.ocr_text
+        if text is None and kf.image_bytes:
+            try:
+                text = ocr(kf.image_bytes)
+            except Exception:  # noqa: BLE001 - a bad frame is skipped, not fatal
+                logger.debug("keyframe OCR failed at %.3fs", kf.timestamp_s, exc_info=True)
+                text = None
+        out.append(Keyframe(timestamp_s=kf.timestamp_s, image_bytes=kf.image_bytes, ocr_text=text))
+    return out
+
+
+def keyframe_documents(
+    parent: Document,
+    media_ref: str,
+    media_id: str,
+    keyframes: List[Keyframe],
+    ocr: Optional[Ocr] = None,
+    ingested_at: Optional[int] = None,
+    max_keyframes: int = DEFAULT_MAX_KEYFRAMES,
+    min_chars: int = 2,
+) -> List[Document]:
+    """Emit a Document per keyframe that carries legible on-screen text.
+
+    Keyframes are OCR'd (via the injected backend), capped, and only those with
+    at least ``min_chars`` of text become documents — a blank frame adds nothing.
+    """
+    ts = ingested_at if ingested_at is not None else parent.ingested_at
+    frames = ocr_keyframes(keyframes[:max_keyframes], ocr)
+    documents: List[Document] = []
+    for kf in frames:
+        if not kf.ocr_text or len(kf.ocr_text.strip()) < min_chars:
+            continue
+        documents.append(keyframe_document(parent, media_ref, media_id, kf, ts))
+    return documents

--- a/tests/unit/ingestion/connectors/media/test_keyframes.py
+++ b/tests/unit/ingestion/connectors/media/test_keyframes.py
@@ -1,0 +1,79 @@
+"""Unit tests for video keyframes + on-screen OCR (#782)."""
+
+from __future__ import annotations
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.media.keyframes import (
+    Keyframe,
+    keyframe_documents,
+    media_fragment,
+    ocr_keyframes,
+)
+
+
+def _parent():
+    return Document(
+        document_id="media:ep42",
+        source_type="transcript",
+        language="en",
+        ingested_at=1000,
+        title="Episode 42",
+        url="https://ex.com/ep42",
+    )
+
+
+def test_media_fragment_point_uri():
+    assert media_fragment("file:///ep42.mp4", 742.3) == "file:///ep42.mp4#t=742.300"
+
+
+def test_ocr_fills_text_via_injected_backend():
+    frames = [Keyframe(timestamp_s=10.0, image_bytes=b"img")]
+    ocr = lambda b: "GDP +3.4% in 2024"
+    out = ocr_keyframes(frames, ocr)
+    assert out[0].ocr_text == "GDP +3.4% in 2024"
+
+
+def test_no_ocr_backend_passes_through():
+    frames = [Keyframe(timestamp_s=10.0, image_bytes=b"img")]
+    assert ocr_keyframes(frames, None)[0].ocr_text is None
+
+
+def test_keyframe_documents_emitted_with_fragment_refs():
+    parent = _parent()
+    frames = [
+        Keyframe(timestamp_s=12.5, image_bytes=b"a"),
+        Keyframe(timestamp_s=30.0, image_bytes=b"b"),
+    ]
+    ocr = lambda b: "Unemployment 3.4%" if b == b"a" else "Q4 revenue $1.2B"
+    docs = keyframe_documents(parent, "file:///ep42.mp4", "media:ep42", frames, ocr=ocr)
+    assert len(docs) == 2
+    d0 = docs[0]
+    assert d0.source_type == "transcript"  # inherited
+    assert d0.metadata["modality"] == "keyframe"
+    assert d0.metadata["parent_document_id"] == "media:ep42"
+    assert d0.metadata["start_s"] == 12.5
+    assert d0.content == "Unemployment 3.4%"
+    assert d0.content_ref == "file:///ep42.mp4#t=12.500"
+
+
+def test_blank_frames_skipped():
+    parent = _parent()
+    frames = [Keyframe(timestamp_s=1.0, image_bytes=b"a"), Keyframe(timestamp_s=2.0, image_bytes=b"b")]
+    ocr = lambda b: "   " if b == b"a" else "Real on-screen text"
+    docs = keyframe_documents(parent, "m.mp4", "media:ep42", frames, ocr=ocr)
+    assert len(docs) == 1  # the blank frame adds nothing
+    assert docs[0].content == "Real on-screen text"
+
+
+def test_no_ocr_yields_no_documents():
+    parent = _parent()
+    frames = [Keyframe(timestamp_s=1.0, image_bytes=b"a")]
+    # No OCR backend -> no on-screen text -> no keyframe documents.
+    assert keyframe_documents(parent, "m.mp4", "media:ep42", frames, ocr=None) == []
+
+
+def test_max_keyframes_caps():
+    parent = _parent()
+    frames = [Keyframe(timestamp_s=float(i), image_bytes=b"x") for i in range(500)]
+    docs = keyframe_documents(parent, "m.mp4", "media:ep42", frames, ocr=lambda b: "text here", max_keyframes=5)
+    assert len(docs) == 5


### PR DESCRIPTION
## Overview

Implements candidate track **#782** (part of #765) — the last of the ten candidate tracks. Talks and broadcasts put load-bearing numbers on screen (chyrons, slides, lower thirds), not in speech; the transcript misses them. This turns keyframes into timestamp-linked `Document` segments alongside the transcript.

## Changes

- **`src/ingestion/connectors/media/keyframes.py`** — each keyframe becomes one `Document` whose `content` is the OCR'd on-screen text and whose `content_ref` is a **point Media Fragment URI** (`base#t=<seconds>`) — the media connector's segment pattern applied to frames. `source_type` is inherited (`transcript`); `metadata.modality='keyframe'` with `start_s`.
  - Frame sampling and OCR are **injected** (they need ffmpeg/tesseract, kept out of the tool servers), so the module is testable offline and degrades to nothing when unavailable.
  - Blank frames are skipped; keyframes are capped per video.

## Testing

- 7 tests: point fragment URI, injected OCR + pass-through-without-backend, document emission with fragment refs + inherited `source_type`, blank-frame skip, no-OCR-no-docs, and the per-video cap.

## Note

Real scene-change sampling + OCR run on the injected backends (ffmpeg + tesseract) in the media connector's harvest path; this PR is the emission core and its degradation discipline, mirroring how B1's describer handles its optional model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_