### PR TITLE
Remote MCP access: HTTP transport + fail-closed auth for the tool servers

### DIFF
--- a/docs/integrate-via-mcp.md
+++ b/docs/integrate-via-mcp.md
@@ -53,6 +53,44 @@ config:
 
 The full set is in [`.mcp.json`](../.mcp.json) — copy the entries you need.
 
+### Remote access (Streamable HTTP + auth)
+
+stdio works when the consuming project can spawn the server process locally.
+For anything else — another machine, a container, a hosted agent — every
+server also runs over **Streamable HTTP**, opt-in via env vars
+(`src/mcp_host/transport.py`):
+
+```bash
+NOESIS_MCP_TRANSPORT=http \
+NOESIS_MCP_HTTP_HOST=0.0.0.0 \
+NOESIS_MCP_HTTP_PORT=8110 \
+NOESIS_MCP_AUTH_TOKEN=your-shared-secret \
+python tools/statistics_mcp/server.py
+```
+
+- **stdio stays the default**; nothing changes for spawned-process setups.
+- **One port per server** — there is no bundled gateway; pick a port range
+  (e.g. 8100–8115) and run the servers you need. The default bind is
+  `127.0.0.1`, so exposure beyond localhost is a deliberate choice.
+- **Auth is fail-closed.** With `NOESIS_MCP_AUTH_TOKEN` set, every HTTP
+  request must present the token as a Bearer credential; if the installed
+  fastmcp offers no supported token verifier, the server **refuses to start**
+  rather than silently serving unauthenticated. Unset means open — intended
+  only for the localhost default.
+
+An HTTP client entry then looks like:
+
+```jsonc
+{
+  "mcpServers": {
+    "noesis-statistics": {
+      "url": "http://noesis-host:8110/mcp",
+      "headers": { "Authorization": "Bearer your-shared-secret" }
+    }
+  }
+}
+```
+
 ### Discipline the servers follow
 
 - **Read-only against the warehouse.** Read tools open DuckDB read-only, so they

--- a/src/mcp_host/transport.py
+++ b/src/mcp_host/transport.py
@@ -1,0 +1,110 @@
+"""
+Shared transport runner for the MCP tool servers (#819).
+
+Noesis is consumed through its MCP servers, so they need to be reachable from
+other projects — not just spawnable over stdio. Every ``tools/*_mcp/server.py``
+ends by calling :func:`run_server`, which keeps **stdio as the default** and
+adds an opt-in Streamable HTTP transport behind env vars (the pattern the
+retired ``noesis_mcp`` server established):
+
+* ``NOESIS_MCP_TRANSPORT`` — ``stdio`` (default) or ``http``.
+* ``NOESIS_MCP_HTTP_HOST`` — bind host, default ``127.0.0.1`` (localhost-only
+  unless the operator deliberately widens it).
+* ``NOESIS_MCP_HTTP_PORT`` — bind port, default ``8100``. Each server gets its
+  own port; there is no shared default topology.
+* ``NOESIS_MCP_AUTH_TOKEN`` — when set, every HTTP request must present the
+  token as a Bearer credential. **Fail-closed**: if the installed fastmcp
+  version offers no supported token-verification API, startup *raises* rather
+  than serving unauthenticated — an operator who asked for auth never silently
+  gets an open server. Unset means open, for the localhost-only default.
+
+Import-safe: no fastmcp import at module load (the auth provider is resolved
+lazily, only when a token is configured), so this module follows the tool
+servers' stdlib-only-at-import discipline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 8100
+
+TRANSPORT_ENV = "NOESIS_MCP_TRANSPORT"
+HOST_ENV = "NOESIS_MCP_HTTP_HOST"
+PORT_ENV = "NOESIS_MCP_HTTP_PORT"
+TOKEN_ENV = "NOESIS_MCP_AUTH_TOKEN"
+
+
+class TransportConfigError(RuntimeError):
+    """The transport env configuration cannot be served safely."""
+
+
+def resolve_transport() -> dict:
+    """Read the transport configuration from the environment."""
+    transport = (os.getenv(TRANSPORT_ENV, "stdio") or "stdio").strip().lower()
+    if transport not in ("stdio", "http"):
+        raise TransportConfigError(
+            f"{TRANSPORT_ENV}={transport!r} is not supported (use 'stdio' or 'http')"
+        )
+    cfg: dict = {"transport": transport}
+    if transport == "http":
+        cfg["host"] = os.getenv(HOST_ENV, DEFAULT_HTTP_HOST).strip() or DEFAULT_HTTP_HOST
+        raw_port = os.getenv(PORT_ENV, str(DEFAULT_HTTP_PORT)).strip()
+        try:
+            cfg["port"] = int(raw_port)
+        except ValueError:
+            raise TransportConfigError(f"{PORT_ENV}={raw_port!r} is not a valid port")
+        cfg["token"] = os.getenv(TOKEN_ENV, "").strip() or None
+    return cfg
+
+
+def _build_token_verifier(token: str) -> Any:
+    """A fastmcp static-token verifier for ``token``.
+
+    Resolved lazily against the import paths fastmcp has shipped it under.
+    Raises :class:`TransportConfigError` when none is available — the caller
+    must NOT fall back to serving without auth.
+    """
+    last_error: Optional[Exception] = None
+    for path in (
+        "fastmcp.server.auth",
+        "fastmcp.server.auth.providers.jwt",
+        "fastmcp.server.auth.verifiers",
+    ):
+        try:
+            module = __import__(path, fromlist=["StaticTokenVerifier"])
+            verifier_cls = getattr(module, "StaticTokenVerifier", None)
+            if verifier_cls is not None:
+                return verifier_cls(
+                    tokens={token: {"client_id": "noesis-operator", "scopes": []}}
+                )
+        except Exception as exc:  # noqa: BLE001 - try the next known location
+            last_error = exc
+    raise TransportConfigError(
+        f"{TOKEN_ENV} is set but the installed fastmcp exposes no supported "
+        "StaticTokenVerifier; refusing to serve HTTP without the requested auth. "
+        f"(last import error: {last_error})"
+    )
+
+
+def run_server(mcp: Any) -> None:
+    """Run a FastMCP server on the configured transport.
+
+    stdio (the default) behaves exactly as before. ``http`` binds the
+    configured host/port; with ``NOESIS_MCP_AUTH_TOKEN`` set, a static Bearer
+    token verifier is attached first, and startup fails if it cannot be.
+    """
+    cfg = resolve_transport()
+    if cfg["transport"] == "stdio":
+        mcp.run()
+        return
+
+    if cfg["token"]:
+        verifier = _build_token_verifier(cfg["token"])
+        # FastMCP reads server auth from its `auth` attribute (constructor
+        # arg); the servers construct `mcp` at import, so attach before run.
+        mcp.auth = verifier
+
+    mcp.run(transport="http", host=cfg["host"], port=cfg["port"])

--- a/tests/unit/mcp_host/test_transport.py
+++ b/tests/unit/mcp_host/test_transport.py
@@ -1,0 +1,130 @@
+"""Unit tests for the shared MCP transport runner (#819)."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src.mcp_host.transport import (
+    HOST_ENV,
+    PORT_ENV,
+    TOKEN_ENV,
+    TRANSPORT_ENV,
+    TransportConfigError,
+    resolve_transport,
+    run_server,
+)
+
+
+class _FakeMCP:
+    """Records how run() was invoked and what auth was attached."""
+
+    def __init__(self):
+        self.run_calls = []
+        self.auth = None
+
+    def run(self, **kwargs):
+        self.run_calls.append(kwargs)
+
+
+class _FakeVerifier:
+    def __init__(self, tokens):
+        self.tokens = tokens
+
+
+@pytest.fixture()
+def clean_env(monkeypatch):
+    for var in (TRANSPORT_ENV, HOST_ENV, PORT_ENV, TOKEN_ENV):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _install_fake_auth_module(monkeypatch):
+    """A fastmcp.server.auth module exposing StaticTokenVerifier."""
+    fastmcp = types.ModuleType("fastmcp")
+    server = types.ModuleType("fastmcp.server")
+    auth = types.ModuleType("fastmcp.server.auth")
+    auth.StaticTokenVerifier = _FakeVerifier
+    fastmcp.server = server
+    server.auth = auth
+    monkeypatch.setitem(sys.modules, "fastmcp", fastmcp)
+    monkeypatch.setitem(sys.modules, "fastmcp.server", server)
+    monkeypatch.setitem(sys.modules, "fastmcp.server.auth", auth)
+
+
+def test_default_is_stdio(clean_env):
+    mcp = _FakeMCP()
+    run_server(mcp)
+    assert mcp.run_calls == [{}]  # plain mcp.run(), exactly as before
+    assert mcp.auth is None
+
+
+def test_http_transport_binds_configured_host_port(clean_env):
+    clean_env.setenv(TRANSPORT_ENV, "http")
+    clean_env.setenv(HOST_ENV, "0.0.0.0")
+    clean_env.setenv(PORT_ENV, "8123")
+    mcp = _FakeMCP()
+    run_server(mcp)
+    assert mcp.run_calls == [{"transport": "http", "host": "0.0.0.0", "port": 8123}]
+    assert mcp.auth is None  # no token -> open (localhost posture is the operator's call)
+
+
+def test_http_defaults_are_localhost_8100(clean_env):
+    clean_env.setenv(TRANSPORT_ENV, "http")
+    cfg = resolve_transport()
+    assert cfg["host"] == "127.0.0.1"
+    assert cfg["port"] == 8100
+
+
+def test_http_with_token_attaches_verifier(clean_env):
+    _install_fake_auth_module(clean_env)
+    clean_env.setenv(TRANSPORT_ENV, "http")
+    clean_env.setenv(TOKEN_ENV, "s3cret")
+    mcp = _FakeMCP()
+    run_server(mcp)
+    assert isinstance(mcp.auth, _FakeVerifier)
+    assert "s3cret" in mcp.auth.tokens
+    assert mcp.run_calls[0]["transport"] == "http"
+
+
+def test_token_without_verifier_fails_closed(clean_env):
+    # No fastmcp auth module importable -> startup must raise, never serve open.
+    for mod in ("fastmcp", "fastmcp.server", "fastmcp.server.auth",
+                "fastmcp.server.auth.providers.jwt", "fastmcp.server.auth.verifiers"):
+        clean_env.setitem(sys.modules, mod, None)  # forces ImportError
+    clean_env.setenv(TRANSPORT_ENV, "http")
+    clean_env.setenv(TOKEN_ENV, "s3cret")
+    mcp = _FakeMCP()
+    with pytest.raises(TransportConfigError):
+        run_server(mcp)
+    assert mcp.run_calls == []  # the server never started
+
+
+def test_unknown_transport_rejected(clean_env):
+    clean_env.setenv(TRANSPORT_ENV, "carrier-pigeon")
+    with pytest.raises(TransportConfigError):
+        resolve_transport()
+
+
+def test_bad_port_rejected(clean_env):
+    clean_env.setenv(TRANSPORT_ENV, "http")
+    clean_env.setenv(PORT_ENV, "not-a-port")
+    with pytest.raises(TransportConfigError):
+        resolve_transport()
+
+
+def test_every_tool_server_uses_run_server():
+    """All 16 servers route their main guard through the shared runner."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[3]
+    servers = sorted((repo_root / "tools").glob("*_mcp/server.py"))
+    assert len(servers) == 16
+    for server in servers:
+        text = server.read_text()
+        assert "from src.mcp_host.transport import run_server" in text, server
+        assert "run_server(mcp)" in text, server
+        # The old direct-run pattern is gone from the main guard.
+        assert 'if __name__ == "__main__":\n    mcp.run()' not in text, server

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -1186,4 +1186,6 @@ def stance_significance(a: str, b: str, topic: str) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/blog_mcp/server.py
+++ b/tools/blog_mcp/server.py
@@ -368,4 +368,6 @@ def harvest_feed(url: str, name: str = "", limit: int = 10) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/contract_mcp/server.py
+++ b/tools/contract_mcp/server.py
@@ -430,4 +430,6 @@ def validate(stage: str, sample: Any) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/dataset_mcp/server.py
+++ b/tools/dataset_mcp/server.py
@@ -298,4 +298,6 @@ def check_criteria() -> dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()  # stdio transport by default
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/domain_packs_mcp/server.py
+++ b/tools/domain_packs_mcp/server.py
@@ -345,4 +345,6 @@ def get_ui_flags(pack: Optional[str] = None) -> dict:
 # --------------------------------------------------------------------------- #
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/kg_mcp/server.py
+++ b/tools/kg_mcp/server.py
@@ -356,4 +356,6 @@ def kg_centrality(kg: Optional[str] = None, top: int = 20) -> dict:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/lineage_mcp/server.py
+++ b/tools/lineage_mcp/server.py
@@ -282,4 +282,6 @@ def run_history(job: str, namespace: Optional[str] = None, limit: int = 5) -> di
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/monitoring_mcp/server.py
+++ b/tools/monitoring_mcp/server.py
@@ -111,4 +111,6 @@ def trigger_sample() -> dict:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -541,4 +541,6 @@ def image_reuse(sha256: str) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1725,4 +1725,6 @@ def speaker_balance(media: Optional[str] = None) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()  # stdio transport by default
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/provisioning_mcp/server.py
+++ b/tools/provisioning_mcp/server.py
@@ -395,4 +395,6 @@ def kg_view(kg: Optional[str] = None) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/research_mcp/server.py
+++ b/tools/research_mcp/server.py
@@ -145,4 +145,6 @@ def literature_claims(topic: Optional[str] = None) -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/schema_mcp/server.py
+++ b/tools/schema_mcp/server.py
@@ -511,4 +511,6 @@ def list_mock_exports() -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/security_mcp/server.py
+++ b/tools/security_mcp/server.py
@@ -254,4 +254,6 @@ def check_secret(service: str, key: str) -> dict:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/sources_mcp/server.py
+++ b/tools/sources_mcp/server.py
@@ -192,4 +192,6 @@ def outlet_clusters(source_type: Optional[str] = None) -> list:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http

--- a/tools/statistics_mcp/server.py
+++ b/tools/statistics_mcp/server.py
@@ -297,4 +297,6 @@ def stats() -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    from src.mcp_host.transport import run_server
+
+    run_server(mcp)  # stdio by default; HTTP via NOESIS_MCP_TRANSPORT=http


### PR DESCRIPTION
## Overview

Closes #819. Noesis is consumed via its MCP servers, so they must be reachable from other projects — not only spawnable over stdio. The only server that had HTTP + auth (`noesis_mcp`) was removed with the UI; this brings the pattern back for all 16 subsystem servers, shared rather than copy-pasted.

## Changes

- **`src/mcp_host/transport.py`** — `run_server(mcp)`, now the main-guard entry of all 16 tool servers:
  - **stdio stays the default** — nothing changes for spawned-process setups.
  - `NOESIS_MCP_TRANSPORT=http` serves Streamable HTTP on `NOESIS_MCP_HTTP_HOST`/`PORT` (default `127.0.0.1:8100`, one port per server — exposure beyond localhost is a deliberate operator choice).
  - `NOESIS_MCP_AUTH_TOKEN` attaches a static Bearer verifier before serving. **Fail-closed**: if the installed fastmcp exposes no supported `StaticTokenVerifier`, startup **raises** rather than silently serving unauthenticated — an operator who asked for auth never gets an open server.
  - Import-safe: no fastmcp import at module load (the verifier resolves lazily), preserving the tool servers' stdlib-only-at-import discipline.
- **`tools/*_mcp/server.py`** (16) — main guards route through `run_server`.
- **`docs/integrate-via-mcp.md`** — remote-access section: env vars, per-server port topology, the fail-closed posture, and an HTTP client config example.

## Testing

- 39 mcp_host tests green: stdio default (plain `mcp.run()`, exactly as before), host/port binding, default `127.0.0.1:8100`, verifier attachment with the token, **the fail-closed path** (server never starts), bad transport/port rejection, and a guard test asserting all 16 servers use the shared runner.
- All 16 servers compile; the new Unit Tests CI gate (#826) covers `tests/unit/mcp_host` and `tests/unit/tools`.

## Note

The verifier import is tried against the paths fastmcp has shipped `StaticTokenVerifier` under; on a fastmcp version with none of them, HTTP+token startup fails with a clear message (by design). A live two-machine round-trip needs a real deployment — the sandbox can't install fastmcp (system PyJWT conflict), so enforcement-behavior is covered by the stub tests plus the fail-closed guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_