### PR TITLE
Dependabot re-baseline: config + security floor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Keeps the dependency baseline from decaying again (issue #820).
+# The npm ecosystem is intentionally absent: the frontend (apps/web) was
+# removed in #817, taking its package-lock.json — and the bulk of the old
+# alert count — with it.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      security-and-patches:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ boto3>=1.26.0
 botocore>=1.29.0
 
 # Web Framework
-fastapi>=0.68.0
-starlette>=0.27.0
-uvicorn>=0.15.0
+fastapi>=0.109.1
+starlette>=0.40.0
+uvicorn>=0.23.0
 
 # Data Processing
 pandas>=1.3.0
@@ -41,10 +41,10 @@ spacy>=3.7.0
 wordcloud>=1.9.0
 
 # Scrapers
-scrapy>=2.5.0
+scrapy>=2.11.2
 
 # AsyncIO Scraping
-aiohttp>=3.8.0
+aiohttp>=3.10.11
 aiofiles>=23.0.0
 playwright>=1.40.0
 asyncio-throttle>=1.0.2
@@ -57,7 +57,7 @@ plotly>=5.17.0,<6.0.0
 networkx>=3.1
 
 # Rate Limiting & Security (Issue #59)
-redis>=4.5.0
+redis>=4.5.4
 pydantic[email]>=2.0.0
 
 # Observability & Monitoring (Issue #236)
@@ -65,10 +65,10 @@ prometheus_client>=0.17.0
 
 # Utilities
 python-dateutil>=2.8.2
-requests>=2.28.0
+requests>=2.32.4
 python-dotenv>=0.19.0
 bcrypt>=4.0.0
-PyJWT>=2.8.0
+PyJWT>=2.10.1
 pyotp>=2.9.0  # TOTP/MFA (src/api/auth/totp_mfa.py)
 websockets>=10.0 # Added for Neptune testing/mocking
 email-validator>=2.1.0


### PR DESCRIPTION
## Overview

Closes #820. The default branch's alert count (785 at peak) was dominated by `apps/web`'s npm tree, deleted in #817 — those alerts resolve on Dependabot's re-scan. This PR handles the remainder and stops the baseline decaying again.

## Changes

- **`.github/dependabot.yml`** — weekly `pip` + `github-actions` update PRs, grouped security updates. npm is intentionally absent: no JS manifests remain in the repo.
- **`requirements.txt`** — raised 8 security floors that still *permitted* known-vulnerable versions:
  - `fastapi>=0.109.1`, `starlette>=0.40.0` (CVE-2024-47874 multipart DoS fixed in 0.40.0)
  - `aiohttp>=3.10.11` (request-smuggling/traversal fixes through 3.10.x)
  - `requests>=2.32.4` (CVE-2024-35195, CVE-2024-47081)
  - `scrapy>=2.11.2` (2.11.1/2.11.2 security releases)
  - `redis>=4.5.4` (CVE-2023-28859), `PyJWT>=2.10.1` (partial-match `iss` fix), `uvicorn>=0.23.0`

## Why this is zero-churn

Every pin is a `>=` range, so pip already resolves to the latest release — these bumps change what the manifest **permits**, not what installs. The runtime dependency set is unchanged; the floors just stop admitting vulnerable resolutions (and quiet manifest-based alerts).

## Honest caveat

I can't view the Dependabot alert list from this session (no security-events scope), so the audit targeted the well-known CVE floors on packages `src/` and `tools/` actually import, rather than working from the alert list itself. The new weekly config surfaces anything I missed as its own PR. The remaining exit criterion — confirming the count drops to a reviewed baseline — needs one look at the Security tab after this merges and Dependabot re-scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_