### PR TITLE
Fetch layer: SEC EDGAR XBRL provider for the filings connector

### DIFF
--- a/src/ingestion/connectors/edgar.py
+++ b/src/ingestion/connectors/edgar.py
@@ -1,0 +1,202 @@
+"""
+SEC EDGAR fetch layer for the filings connector (#821).
+
+The filings mapper (``src.ingestion.connectors.filings``) turns a normalized
+:class:`Filing` into a document, ``provider="filing"`` series, and KG
+relations. This module supplies the real-world fetch in front of it, over two
+public SEC endpoints:
+
+* ``data.sec.gov/api/xbrl/companyfacts/CIK##########.json`` — every reported
+  XBRL fact for a filer, mapped into :class:`FilingFact`s for a small set of
+  load-bearing us-gaap concepts.
+* ``data.sec.gov/submissions/CIK##########.json`` — filer metadata (name,
+  recent filings) for the narrative document.
+
+SEC fair-access rules require a descriptive ``User-Agent`` — set
+``NOESIS_EDGAR_USER_AGENT`` (e.g. ``"noesis-operator contact@example.com"``);
+without it the connector skips with a warning rather than sending anonymous
+traffic. The HTTP getter is injectable, so parsing is fully offline-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+from src.ingestion.connectors.filings import Filing, FilingFact
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT_ENV = "NOESIS_EDGAR_USER_AGENT"
+
+_FACTS_URL = "https://data.sec.gov/api/xbrl/companyfacts/CIK{cik}.json"
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+
+# The load-bearing us-gaap concepts, in preference order per connector concept.
+# Revenue tags moved across taxonomy versions, so both common tags are tried.
+CONCEPT_MAP: Dict[str, tuple] = {
+    "Revenue": (
+        "RevenueFromContractWithCustomerExcludingAssessedTax",
+        "Revenues",
+        "SalesRevenueNet",
+    ),
+    "NetIncome": ("NetIncomeLoss",),
+    "Assets": ("Assets",),
+    "Liabilities": ("Liabilities",),
+    "OperatingIncome": ("OperatingIncomeLoss",),
+}
+
+# XBRL unit -> dataset-series unit.
+_UNIT_MAP = {"USD": "usd", "EUR": "eur", "GBP": "gbp"}
+
+
+def _http_get(url: str, user_agent: str) -> str:
+    import urllib.request
+
+    request = urllib.request.Request(url, headers={"User-Agent": user_agent})
+    with urllib.request.urlopen(request, timeout=30) as resp:  # noqa: S310 - fixed SEC hosts
+        return resp.read().decode("utf-8")
+
+
+def normalize_cik(raw: Union[str, int]) -> str:
+    """A zero-padded 10-digit CIK from any int/str form ('320193' -> '0000320193')."""
+    digits = re.sub(r"\D", "", str(raw))
+    if not digits:
+        raise ValueError(f"not a CIK: {raw!r}")
+    return digits.zfill(10)
+
+
+def _fact_period(fact: Dict[str, Any]) -> Optional[str]:
+    """Contract period for one XBRL fact: 'YYYY' for a fiscal year, 'YYYY-Qn'
+    for a quarter. None for facts without a usable frame."""
+    fy = fact.get("fy")
+    fp = (fact.get("fp") or "").upper()
+    if fy is None or not fp:
+        return None
+    if fp == "FY":
+        return str(fy)
+    m = re.match(r"^Q([1-4])$", fp)
+    if m:
+        return f"{fy}-Q{m.group(1)}"
+    return None
+
+
+class EdgarClient:
+    """Thin, injectable-HTTP client over the public EDGAR JSON endpoints."""
+
+    def __init__(
+        self,
+        user_agent: Optional[str] = None,
+        http_get: Optional[Callable[[str, str], str]] = None,
+    ):
+        self._user_agent = (
+            user_agent if user_agent is not None else os.getenv(USER_AGENT_ENV, "")
+        ).strip()
+        self._http_get = http_get or _http_get
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._user_agent)
+
+    def _get_json(self, url: str) -> Any:
+        return json.loads(self._http_get(url, self._user_agent))
+
+    def resolve_ticker(self, ticker: str) -> Optional[str]:
+        """Ticker -> zero-padded CIK via the SEC ticker table, or None."""
+        table = self._get_json(_TICKERS_URL)
+        wanted = ticker.strip().upper()
+        for entry in (table or {}).values():
+            if str(entry.get("ticker", "")).upper() == wanted:
+                return normalize_cik(entry["cik_str"])
+        return None
+
+    def company_facts(self, cik: str) -> Dict[str, Any]:
+        return self._get_json(_FACTS_URL.format(cik=normalize_cik(cik)))
+
+    def submissions(self, cik: str) -> Dict[str, Any]:
+        return self._get_json(_SUBMISSIONS_URL.format(cik=normalize_cik(cik)))
+
+
+def facts_to_filing_facts(payload: Dict[str, Any], forms: tuple = ("10-K", "10-Q")) -> List[FilingFact]:
+    """Map a companyfacts payload to :class:`FilingFact`s for the mapped concepts.
+
+    Only facts reported on the given forms are used; for a (concept, period)
+    reported more than once (amendments, restatements), the most recently
+    filed value wins.
+    """
+    us_gaap = (payload.get("facts") or {}).get("us-gaap") or {}
+    chosen: Dict[tuple, tuple] = {}  # (concept, period) -> (filed, value, unit)
+    for concept, tags in CONCEPT_MAP.items():
+        for tag in tags:
+            tag_facts = us_gaap.get(tag)
+            if not tag_facts:
+                continue
+            for xbrl_unit, entries in (tag_facts.get("units") or {}).items():
+                unit = _UNIT_MAP.get(xbrl_unit)
+                if unit is None:
+                    continue
+                for entry in entries:
+                    if entry.get("form") not in forms:
+                        continue
+                    period = _fact_period(entry)
+                    value = entry.get("val")
+                    if period is None or value is None:
+                        continue
+                    key = (concept, period)
+                    filed = str(entry.get("filed") or "")
+                    if key not in chosen or filed > chosen[key][0]:
+                        chosen[key] = (filed, float(value), unit)
+            if any(k[0] == concept for k in chosen):
+                break  # this tag produced data; skip the fallback tags
+    return [
+        FilingFact(concept=concept, value=value, period=period, unit=unit)
+        for (concept, period), (_filed, value, unit) in sorted(chosen.items())
+    ]
+
+
+def harvest_filing(
+    query: Union[str, int],
+    client: Optional[EdgarClient] = None,
+    forms: tuple = ("10-K", "10-Q"),
+) -> Optional[Filing]:
+    """Fetch a filer from EDGAR (by ticker or CIK) as a normalized Filing.
+
+    Skip-with-warning discipline: with no ``NOESIS_EDGAR_USER_AGENT``
+    configured, returns None rather than sending anonymous traffic. Returns
+    None likewise for an unresolvable ticker.
+    """
+    client = client or EdgarClient()
+    if not client.configured:
+        logger.warning("EDGAR: no %s configured — skipping harvest", USER_AGENT_ENV)
+        return None
+
+    raw = str(query).strip()
+    if re.fullmatch(r"\d{1,10}", raw):
+        cik = normalize_cik(raw)
+    else:
+        cik = client.resolve_ticker(raw)
+        if cik is None:
+            logger.warning("EDGAR: ticker %r did not resolve to a CIK", raw)
+            return None
+
+    facts_payload = client.company_facts(cik)
+    submissions = client.submissions(cik)
+
+    filer = submissions.get("name") or facts_payload.get("entityName") or f"CIK {cik}"
+    description = (submissions.get("sicDescription") or "").strip()
+    narrative = f"{filer}: EDGAR filer profile." + (f" Industry: {description}." if description else "")
+    officers: List[str] = []  # officer data needs per-filing parsing; out of scope here
+
+    return Filing(
+        filer=str(filer),
+        filing_id=f"edgar-{cik}",
+        cik=cik,
+        facts=facts_to_filing_facts(facts_payload, forms=forms),
+        narrative=narrative,
+        officers=officers,
+        source_url=_FACTS_URL.format(cik=cik),
+    )

--- a/tests/unit/ingestion/connectors/test_edgar.py
+++ b/tests/unit/ingestion/connectors/test_edgar.py
@@ -1,0 +1,137 @@
+"""Unit tests for the SEC EDGAR fetch layer (#821) — offline, fixture-driven."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.ingestion.connectors.edgar import (
+    EdgarClient,
+    facts_to_filing_facts,
+    harvest_filing,
+    normalize_cik,
+)
+
+# Shape-accurate trims of the three EDGAR payloads.
+COMPANY_FACTS = {
+    "cik": 320193,
+    "entityName": "Acme Corp",
+    "facts": {
+        "us-gaap": {
+            "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                "units": {
+                    "USD": [
+                        {"fy": 2022, "fp": "FY", "form": "10-K", "val": 17.2e9, "filed": "2023-02-01"},
+                        {"fy": 2023, "fp": "FY", "form": "10-K", "val": 18.5e9, "filed": "2024-02-01"},
+                        # An amendment refiling FY2023 later — must win.
+                        {"fy": 2023, "fp": "FY", "form": "10-K", "val": 18.6e9, "filed": "2024-06-01"},
+                        {"fy": 2024, "fp": "Q1", "form": "10-Q", "val": 4.4e9, "filed": "2024-05-01"},
+                        # An 8-K row that must be ignored (form filter).
+                        {"fy": 2024, "fp": "Q2", "form": "8-K", "val": 9.9e9, "filed": "2024-08-01"},
+                    ]
+                }
+            },
+            "NetIncomeLoss": {
+                "units": {
+                    "USD": [
+                        {"fy": 2023, "fp": "FY", "form": "10-K", "val": 2.1e9, "filed": "2024-02-01"},
+                    ]
+                }
+            },
+            # A share-count unit that must be ignored (unit filter).
+            "Assets": {
+                "units": {
+                    "shares": [
+                        {"fy": 2023, "fp": "FY", "form": "10-K", "val": 123, "filed": "2024-02-01"},
+                    ]
+                }
+            },
+        }
+    },
+}
+SUBMISSIONS = {"cik": "320193", "name": "Acme Corp", "sicDescription": "Widgets"}
+TICKERS = {"0": {"cik_str": 320193, "ticker": "ACME", "title": "Acme Corp"}}
+
+
+def _client(user_agent="test tester@example.com"):
+    def fake_get(url, ua):
+        assert ua == user_agent  # the UA header reaches every request
+        if "companyfacts" in url:
+            return json.dumps(COMPANY_FACTS)
+        if "submissions" in url:
+            return json.dumps(SUBMISSIONS)
+        if "company_tickers" in url:
+            return json.dumps(TICKERS)
+        raise AssertionError(f"unexpected url {url}")
+
+    return EdgarClient(user_agent=user_agent, http_get=fake_get)
+
+
+def test_normalize_cik():
+    assert normalize_cik("320193") == "0000320193"
+    assert normalize_cik(320193) == "0000320193"
+    assert normalize_cik("CIK0000320193") == "0000320193"
+    with pytest.raises(ValueError):
+        normalize_cik("no-digits")
+
+
+def test_facts_mapping_filters_and_amendments():
+    facts = facts_to_filing_facts(COMPANY_FACTS)
+    by_key = {(f.concept, f.period): f for f in facts}
+    # FY2023 revenue takes the later-filed amendment value.
+    assert by_key[("Revenue", "2023")].value == 18.6e9
+    assert by_key[("Revenue", "2022")].value == 17.2e9
+    # The quarterly row maps to the contract quarter form.
+    assert by_key[("Revenue", "2024-Q1")].value == 4.4e9
+    assert by_key[("Revenue", "2024-Q1")].unit == "usd"
+    # The 8-K row and the shares-unit Assets row are excluded.
+    assert ("Revenue", "2024-Q2") not in by_key
+    assert not any(f.concept == "Assets" for f in facts)
+    assert by_key[("NetIncome", "2023")].value == 2.1e9
+
+
+def test_harvest_by_ticker_end_to_end():
+    filing = harvest_filing("ACME", client=_client())
+    assert filing is not None
+    assert filing.cik == "0000320193"
+    assert filing.filer == "Acme Corp"
+    assert filing.filing_id == "edgar-0000320193"
+    assert any(f.concept == "Revenue" for f in filing.facts)
+    assert "Widgets" in filing.narrative
+
+
+def test_harvest_by_cik():
+    filing = harvest_filing("320193", client=_client())
+    assert filing is not None and filing.cik == "0000320193"
+
+
+def test_no_user_agent_skips(monkeypatch):
+    monkeypatch.delenv("NOESIS_EDGAR_USER_AGENT", raising=False)
+    client = EdgarClient(user_agent="", http_get=lambda u, a: "{}")
+    assert client.configured is False
+    assert harvest_filing("ACME", client=client) is None
+
+
+def test_unresolvable_ticker_returns_none():
+    filing = harvest_filing("NOPE", client=_client())
+    assert filing is None
+
+
+def test_feeds_the_filings_mapper_and_a4_check():
+    duckdb = pytest.importorskip("duckdb")
+    from src.analytics.claim_check import check_assertion
+    from src.argument_mining.quantities import QuantityExtractor
+    from src.ingestion.connectors.dataset.store import ObservationStore
+    from src.ingestion.connectors.filings import filing_to_series
+
+    filing = harvest_filing("ACME", client=_client())
+    conn = duckdb.connect(":memory:")
+    store = ObservationStore(conn)
+    for series in filing_to_series(filing, as_of=1):
+        store.upsert(series)
+    assertion = QuantityExtractor().extract("Acme Corp Revenue rose in 2023.")[0]
+    env = check_assertion(conn, assertion)
+    # 17.2e9 (2022) -> 18.6e9 (2023): the harvested filing supports the claim.
+    assert env["verdict"] == "supported"
+    assert env["series_id"] == "filing:acme-corp:revenue"


### PR DESCRIPTION
## Overview

Closes #821. Supplies the real-world fetch in front of the filings mapper (PR #814): SEC EDGAR's public XBRL endpoints → normalized `Filing` → checkable evidence.

## Changes

- **`src/ingestion/connectors/edgar.py`**:
  - `EdgarClient` over `companyfacts` / `submissions` / `company_tickers` JSON endpoints, injectable HTTP getter.
  - `facts_to_filing_facts()` maps the load-bearing us-gaap concepts (Revenue with taxonomy-version tag fallbacks, NetIncome, Assets, Liabilities, OperatingIncome): **10-K/10-Q forms only**, USD/EUR/GBP units only, `fy`/`fp` frames → contract periods (`YYYY` / `YYYY-Qn`), and the **most recently filed value wins** per (concept, period) so amendments supersede.
  - `harvest_filing(ticker | CIK)` resolves the ticker table, fetches, and returns a `Filing` ready for `ingest_filing()`.
  - **SEC fair-access compliance**: a descriptive `User-Agent` is required via `NOESIS_EDGAR_USER_AGENT`; unset → skip-with-warning, never anonymous traffic.

## Testing

- 7 offline tests with shape-accurate fixtures: CIK normalization, form/unit filtering, **amendment-wins**, ticker + CIK harvests, no-UA skip, unresolvable ticker — and an end-to-end run where the harvested filing's revenue series **supports "Acme Corp Revenue rose in 2023" through the A4 resolver**.
- Covered by the new Unit Tests CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_