### PR TITLE
Fetch layer: CSV polling-aggregate source for polls-as-evidence

### DIFF
--- a/src/ingestion/connectors/dataset/poll_source.py
+++ b/src/ingestion/connectors/dataset/poll_source.py
@@ -1,0 +1,145 @@
+"""
+Polling aggregate source for polls-as-evidence (#822).
+
+The polls core (``polls.py``) checks opinion claims against stored
+``PollReading``s. This module feeds it from a real source: a **CSV polling
+aggregate** in the layout the major public aggregates publish (one row per
+poll: pollster, dates, sample size, mode, margin of error, question, and one
+column per answer option).
+
+The column mapping is configurable so any aggregate export fits; the default
+mapping matches the common `pollster/end_date/sample_size/moe/...` layout.
+Methodology fields are preserved per reading — never averaged away silently.
+The fetch is injectable, so parsing is fully offline-testable; operators must
+check the aggregate's licensing terms before wiring a live URL (documented in
+the integration guide).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from src.ingestion.connectors.dataset.polls import PollMethodology, PollReading, poll_to_series
+from src.ingestion.connectors.dataset.store import ObservationStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PollColumnMap:
+    """Which CSV columns carry what. ``options`` maps answer-option columns
+    (e.g. ``{"support": "yes_pct", "oppose": "no_pct"}``)."""
+
+    topic: str = "topic"
+    pollster: str = "pollster"
+    end_date: str = "end_date"          # fieldwork end, YYYY-MM-DD -> period YYYY-MM
+    sample_size: str = "sample_size"
+    mode: str = "methodology"
+    margin_of_error: str = "moe"
+    population: str = "population"
+    question: str = "question"
+    options: Dict[str, str] = field(default_factory=lambda: {"support": "support_pct", "oppose": "oppose_pct"})
+
+
+def _to_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip().replace("%", "")
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _to_int(value: Optional[str]) -> Optional[int]:
+    number = _to_float(value)
+    return int(number) if number is not None else None
+
+
+def _period(end_date: Optional[str]) -> Optional[str]:
+    if not end_date:
+        return None
+    text = str(end_date).strip()
+    if len(text) >= 7 and text[4] in "-/":
+        return f"{text[:4]}-{text[5:7]}"
+    return None
+
+
+def parse_poll_csv(
+    csv_text: str,
+    column_map: Optional[PollColumnMap] = None,
+    topic: Optional[str] = None,
+) -> List[PollReading]:
+    """Parse an aggregate CSV into PollReadings, one per (row, answer option).
+
+    Rows missing a period or a numeric option value are skipped (logged), never
+    guessed. ``topic`` overrides/provides the topic when the CSV lacks a topic
+    column (a single-question aggregate export).
+    """
+    cmap = column_map or PollColumnMap()
+    readings: List[PollReading] = []
+    reader = csv.DictReader(io.StringIO(csv_text))
+    for row in reader:
+        row_topic = (row.get(cmap.topic) or topic or "").strip()
+        period = _period(row.get(cmap.end_date))
+        if not row_topic or period is None:
+            logger.debug("poll_source: skipping row without topic/period: %r", row)
+            continue
+        methodology = PollMethodology(
+            sample_n=_to_int(row.get(cmap.sample_size)),
+            mode=(row.get(cmap.mode) or "").strip() or None,
+            margin_of_error=_to_float(row.get(cmap.margin_of_error)),
+            house=(row.get(cmap.pollster) or "").strip() or None,
+            population=(row.get(cmap.population) or "").strip() or None,
+            question=(row.get(cmap.question) or "").strip() or None,
+        )
+        for option, column in cmap.options.items():
+            pct = _to_float(row.get(column))
+            if pct is None:
+                continue
+            readings.append(
+                PollReading(
+                    topic=row_topic,
+                    option=option,
+                    support_pct=pct,
+                    period=period,
+                    methodology=methodology,
+                )
+            )
+    return readings
+
+
+def harvest_polls(
+    url: str,
+    store: ObservationStore,
+    fetch: Optional[Callable[[str], str]] = None,
+    column_map: Optional[PollColumnMap] = None,
+    topic: Optional[str] = None,
+    as_of: int = 0,
+) -> int:
+    """Fetch an aggregate CSV and store every reading as a poll series.
+
+    One series per (poll house, topic, option); readings from the same house
+    across waves accumulate as observations. Returns readings stored. With no
+    ``fetch`` injected, uses urllib (operators: check the aggregate's terms).
+    """
+    if fetch is None:
+        def fetch(u: str) -> str:  # pragma: no cover - trivial network shim
+            import urllib.request
+
+            with urllib.request.urlopen(u, timeout=30) as resp:  # noqa: S310
+                return resp.read().decode("utf-8")
+
+    readings = parse_poll_csv(fetch(url), column_map=column_map, topic=topic)
+    stored = 0
+    for reading in readings:
+        house_slug = (reading.methodology.house or "aggregate").lower().replace(" ", "-")
+        store.upsert(poll_to_series(reading, poll_id=f"{house_slug}-{reading.period}", as_of=as_of, source_url=url))
+        stored += 1
+    return stored

--- a/tests/unit/ingestion/connectors/dataset/test_poll_source.py
+++ b/tests/unit/ingestion/connectors/dataset/test_poll_source.py
@@ -1,0 +1,76 @@
+"""Unit tests for the CSV polling-aggregate source (#822) — offline."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.connectors.dataset.poll_source import (
+    PollColumnMap,
+    harvest_polls,
+    parse_poll_csv,
+)
+from src.ingestion.connectors.dataset.store import ObservationStore
+
+CSV = """topic,pollster,end_date,sample_size,methodology,moe,population,question,support_pct,oppose_pct
+carbon tax,ACME Polling,2024-03-15,1200,online,3.0,adults,Do you support a carbon tax?,57,38
+carbon tax,Beta Research,2024-03-20,900,phone,3.5,likely voters,Do you support a carbon tax?,52,41
+wealth tax,ACME Polling,2024-03-15,1200,online,3.0,adults,Do you support a wealth tax?,61,
+bad row,,not-a-date,,,,,,,
+"""
+
+
+def test_parse_readings_with_methodology():
+    readings = parse_poll_csv(CSV)
+    # 2 options x 2 carbon-tax rows + 1 wealth-tax support (oppose empty, skipped).
+    assert len(readings) == 5
+    first = next(r for r in readings if r.methodology.house == "ACME Polling" and r.topic == "carbon tax" and r.option == "support")
+    assert first.support_pct == 57.0
+    assert first.period == "2024-03"
+    assert first.methodology.sample_n == 1200
+    assert first.methodology.margin_of_error == 3.0
+    assert first.methodology.question == "Do you support a carbon tax?"
+    # Distinct houses keep distinct methodology — never averaged together.
+    beta = next(r for r in readings if r.methodology.house == "Beta Research")
+    assert beta.methodology.mode == "phone" and beta.methodology.sample_n == 900
+
+
+def test_bad_rows_skipped_not_guessed():
+    readings = parse_poll_csv(CSV)
+    assert not any(r.topic == "bad row" for r in readings)
+
+
+def test_topic_override_for_single_question_export():
+    csv_text = "pollster,end_date,sample_size,methodology,moe,population,question,support_pct,oppose_pct\nACME,2024-04-01,1000,online,3.0,adults,Q?,55,40\n"
+    readings = parse_poll_csv(csv_text, topic="carbon tax")
+    assert len(readings) == 2
+    assert all(r.topic == "carbon tax" for r in readings)
+
+
+def test_custom_column_map():
+    csv_text = "subject,firm,fieldwork_end,n,how,err,pop,wording,yes,no\ncarbon tax,ACME,2024-05-02,800,online,4.0,adults,Q?,58,35\n"
+    cmap = PollColumnMap(
+        topic="subject", pollster="firm", end_date="fieldwork_end", sample_size="n",
+        mode="how", margin_of_error="err", population="pop", question="wording",
+        options={"support": "yes", "oppose": "no"},
+    )
+    readings = parse_poll_csv(csv_text, column_map=cmap)
+    assert len(readings) == 2
+    assert readings[0].methodology.margin_of_error == 4.0
+
+
+def test_harvest_end_to_end_check_opinion():
+    duckdb = pytest.importorskip("duckdb")
+    from src.ingestion.connectors.dataset.polls import check_opinion
+
+    conn = duckdb.connect(":memory:")
+    store = ObservationStore(conn)
+    stored = harvest_polls("https://aggregate.example/polls.csv", store, fetch=lambda url: CSV, as_of=1)
+    assert stored == 5
+
+    env = check_opinion(conn, "A majority support the carbon tax.", topic="carbon tax")
+    # Latest reading resolves with its own MOE as tolerance and question wording declared.
+    assert env["verdict"] in ("supported", "unverifiable")
+    assert any("question" in a for a in env["assumptions"])
+    # The 70% claim contradicts every harvested reading.
+    env_high = check_opinion(conn, "More than 70% support the carbon tax.", topic="carbon tax")
+    assert env_high["verdict"] == "contradicted"


### PR DESCRIPTION
## Overview

Closes #822. Feeds the polls-as-evidence core (PR #810) from a real polling aggregate.

## Changes

- **`src/ingestion/connectors/dataset/poll_source.py`**:
  - `parse_poll_csv()` maps the common aggregate CSV layout (pollster / end_date / sample_size / methodology / moe / population / question + one column per answer option) into `PollReading`s, with a configurable `PollColumnMap` so any export fits.
  - **Methodology preserved per reading and per house — never averaged away**; rows missing a period or a numeric option value are skipped, not guessed; fieldwork end dates → `YYYY-MM` periods.
  - `harvest_polls()` fetches (injectable) and stores one poll series per (house, topic, option); a `topic` override supports single-question exports.
  - Licensing posture documented: operators check the aggregate's terms before wiring a live URL.

## Testing

- 15 tests green (including the polls core suite): methodology preservation across houses, bad-row skipping, topic override, custom column map — and an end-to-end `harvest → check_opinion` run where "more than 70% support" is **contradicted** by every harvested reading, with the poll's MOE and question wording in the envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_