### PR TITLE
Fetch layer: ffmpeg keyframe sampler + tesseract OCR for the media connector

### DIFF
--- a/src/ingestion/connectors/media/backends.py
+++ b/src/ingestion/connectors/media/backends.py
@@ -1,0 +1,153 @@
+"""
+ffmpeg + tesseract backends for video keyframes and on-screen OCR (#823).
+
+The keyframe core (``keyframes.py``) takes an injected frame sampler and OCR;
+this module supplies the real ones, both subprocess-based because they need
+system binaries the tool servers must never import:
+
+* :class:`FfmpegSceneSampler` — scene-change keyframes via
+  ``ffmpeg -vf "select='gt(scene,T)',showinfo"``, timestamps parsed from
+  showinfo's ``pts_time``.
+* :class:`TesseractOcr` — on-screen text via ``tesseract <frame> stdout``.
+
+Skip-with-warning discipline throughout: an absent binary means the factory
+returns ``None`` (harvest degrades to transcript-only) and a failed frame
+returns ``None``/no frames — never an exception up through ``harvest()``.
+Runners and binary lookups are injectable, so everything is offline-testable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from src.ingestion.connectors.media.keyframes import Keyframe
+
+logger = logging.getLogger(__name__)
+
+# showinfo log lines carry the presentation timestamp of each selected frame.
+_PTS_RE = re.compile(r"pts_time:\s*([0-9]+(?:\.[0-9]+)?)")
+
+DEFAULT_SCENE_THRESHOLD = 0.3
+DEFAULT_MAX_FRAMES = 60
+
+Runner = Callable[..., "subprocess.CompletedProcess"]
+
+
+class FfmpegSceneSampler:
+    """Scene-change keyframe sampler over the ffmpeg CLI."""
+
+    def __init__(
+        self,
+        scene_threshold: float = DEFAULT_SCENE_THRESHOLD,
+        max_frames: int = DEFAULT_MAX_FRAMES,
+        runner: Optional[Runner] = None,
+        which: Callable[[str], Optional[str]] = shutil.which,
+    ):
+        self._threshold = scene_threshold
+        self._max_frames = max_frames
+        self._runner = runner or subprocess.run
+        self._which = which
+
+    @property
+    def available(self) -> bool:
+        return self._which("ffmpeg") is not None
+
+    def __call__(self, media_bytes: bytes, file_ext: str = "mp4") -> List[Keyframe]:
+        """Sample scene-change keyframes from media bytes.
+
+        Returns ``[]`` (with a warning) when ffmpeg is absent or fails, so a
+        harvest degrades to transcript-only rather than aborting.
+        """
+        if not self.available:
+            logger.warning("keyframes: ffmpeg not found — skipping keyframe sampling")
+            return []
+        with tempfile.TemporaryDirectory(prefix="noesis-kf-") as tmp:
+            media_path = Path(tmp) / f"input.{file_ext.lstrip('.')}"
+            media_path.write_bytes(media_bytes)
+            pattern = str(Path(tmp) / "frame-%04d.png")
+            cmd = [
+                "ffmpeg", "-hide_banner", "-nostdin",
+                "-i", str(media_path),
+                "-vf", f"select='gt(scene,{self._threshold})',showinfo",
+                "-vsync", "vfr",
+                "-frames:v", str(self._max_frames),
+                pattern,
+            ]
+            try:
+                proc = self._runner(cmd, capture_output=True, text=True, timeout=600)
+            except Exception:  # noqa: BLE001 - a broken run degrades, never raises
+                logger.warning("keyframes: ffmpeg run failed", exc_info=True)
+                return []
+            if getattr(proc, "returncode", 1) != 0:
+                logger.warning("keyframes: ffmpeg exited %s", getattr(proc, "returncode", "?"))
+                return []
+            timestamps = [float(m) for m in _PTS_RE.findall(proc.stderr or "")]
+            frames: List[Keyframe] = []
+            for i, frame_path in enumerate(sorted(Path(tmp).glob("frame-*.png"))):
+                ts = timestamps[i] if i < len(timestamps) else float(i)
+                frames.append(Keyframe(timestamp_s=ts, image_bytes=frame_path.read_bytes()))
+            return frames[: self._max_frames]
+
+
+class TesseractOcr:
+    """On-screen text extraction over the tesseract CLI."""
+
+    def __init__(
+        self,
+        runner: Optional[Runner] = None,
+        which: Callable[[str], Optional[str]] = shutil.which,
+        lang: Optional[str] = None,
+    ):
+        self._runner = runner or subprocess.run
+        self._which = which
+        self._lang = lang
+
+    @property
+    def available(self) -> bool:
+        return self._which("tesseract") is not None
+
+    def __call__(self, image_bytes: bytes) -> Optional[str]:
+        """OCR one frame; None when tesseract is absent or the frame fails."""
+        if not self.available:
+            return None
+        with tempfile.TemporaryDirectory(prefix="noesis-ocr-") as tmp:
+            image_path = Path(tmp) / "frame.png"
+            image_path.write_bytes(image_bytes)
+            cmd = ["tesseract", str(image_path), "stdout"]
+            if self._lang:
+                cmd += ["-l", self._lang]
+            try:
+                proc = self._runner(cmd, capture_output=True, text=True, timeout=120)
+            except Exception:  # noqa: BLE001
+                logger.debug("keyframes: tesseract run failed", exc_info=True)
+                return None
+            if getattr(proc, "returncode", 1) != 0:
+                return None
+            text = (proc.stdout or "").strip()
+            return text or None
+
+
+def keyframes_enabled() -> bool:
+    """Env kill switch (issue #823): on by default, NOESIS_MEDIA_KEYFRAMES=off
+    disables keyframe extraction in the media connector."""
+    return os.getenv("NOESIS_MEDIA_KEYFRAMES", "on").strip().lower() not in ("off", "0", "false")
+
+
+def default_backends() -> tuple:
+    """(sampler, ocr) — each None (with a warning) when its binary is absent."""
+    sampler = FfmpegSceneSampler()
+    ocr = TesseractOcr()
+    if not sampler.available:
+        logger.warning("keyframes: ffmpeg not installed — media harvests stay transcript-only")
+        sampler = None
+    if not ocr.available:
+        logger.warning("keyframes: tesseract not installed — keyframes would carry no text; skipping")
+        ocr = None
+    return (sampler, ocr)

--- a/src/ingestion/connectors/media/connector.py
+++ b/src/ingestion/connectors/media/connector.py
@@ -139,11 +139,17 @@ class MediaConnector(Connector):
         language: Optional[str] = None,
         hf_token: Optional[str] = None,
         diarize: bool = False,
+        frame_sampler: Optional[Any] = None,
+        ocr: Optional[Any] = None,
     ) -> None:
         self._model_size = model_size
         self._language = language
         self._hf_token = hf_token
         self._diarize = diarize
+        # Keyframe backends (#823): injectable for tests; None means "resolve
+        # the real ffmpeg/tesseract backends lazily at parse time".
+        self._frame_sampler = frame_sampler
+        self._ocr = ocr
 
     def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
         if query is None:
@@ -197,4 +203,58 @@ class MediaConnector(Connector):
             meta.segments = assign_speakers(content, meta.segments, self._hf_token)
             meta.speakers = sorted({s.speaker for s in meta.segments if s.speaker})
 
-        return media_metadata_to_documents(meta, raw.fetched_at)
+        documents = media_metadata_to_documents(meta, raw.fetched_at)
+        documents.extend(
+            self._keyframe_documents(content, locator, title, file_ext, raw.fetched_at)
+        )
+        return documents
+
+    def _keyframe_documents(
+        self, content: bytes, locator: str, title: str, file_ext: str, ingested_at: int
+    ) -> List[Document]:
+        """On-screen-text keyframe documents for a video (#823).
+
+        Video only, on by default, disabled by NOESIS_MEDIA_KEYFRAMES=off.
+        Degrades to [] when ffmpeg/tesseract are absent — a harvest never
+        aborts on missing binaries.
+        """
+        if f".{file_ext.lstrip('.')}" not in _VIDEO_EXTENSIONS:
+            return []
+        from src.ingestion.connectors.media.backends import default_backends, keyframes_enabled
+        from src.ingestion.connectors.media.keyframes import keyframe_documents
+        from src.ingestion.connectors.media.models import media_id
+
+        if not keyframes_enabled():
+            return []
+        sampler = self._frame_sampler
+        ocr = self._ocr
+        if sampler is None or ocr is None:
+            default_sampler, default_ocr = default_backends()
+            sampler = sampler or default_sampler
+            ocr = ocr or default_ocr
+        if sampler is None or ocr is None:
+            return []  # missing binary: transcript-only, already warned
+
+        try:
+            frames = sampler(content, file_ext=file_ext)
+        except TypeError:
+            frames = sampler(content)  # samplers without the file_ext kwarg
+        if not frames:
+            return []
+
+        is_url = _is_url(locator)
+        doc_id = media_id(
+            url=locator if is_url else None,
+            file_path=None if is_url else str(Path(locator).resolve()),
+            title=title,
+        )
+        parent = Document(
+            document_id=doc_id,
+            source_type=self.source_type,
+            language=self._language or "en",
+            ingested_at=ingested_at,
+            title=title,
+            url=locator if is_url else None,
+        )
+        media_ref = locator if is_url else f"file://{Path(locator).resolve()}"
+        return keyframe_documents(parent, media_ref, doc_id, frames, ocr=ocr, ingested_at=ingested_at)

--- a/tests/unit/ingestion/connectors/media/test_backends.py
+++ b/tests/unit/ingestion/connectors/media/test_backends.py
@@ -1,0 +1,157 @@
+"""Unit tests for the ffmpeg/tesseract keyframe backends (#823) — offline."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from src.ingestion.connectors.media.backends import (
+    FfmpegSceneSampler,
+    TesseractOcr,
+    keyframes_enabled,
+)
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _fake_ffmpeg_runner(frame_payloads, stderr):
+    """A runner that writes fake frame files into ffmpeg's output dir."""
+
+    def runner(cmd, **kwargs):
+        pattern = Path(cmd[-1])  # frame-%04d.png
+        out_dir = pattern.parent
+        for i, payload in enumerate(frame_payloads, start=1):
+            (out_dir / f"frame-{i:04d}.png").write_bytes(payload)
+        return _completed(stderr=stderr)
+
+    return runner
+
+
+def test_sampler_returns_frames_with_pts_timestamps():
+    stderr = (
+        "[Parsed_showinfo] n:0 pts_time:12.500 something\n"
+        "[Parsed_showinfo] n:1 pts_time:47.250 something\n"
+    )
+    sampler = FfmpegSceneSampler(
+        runner=_fake_ffmpeg_runner([b"frameA", b"frameB"], stderr),
+        which=lambda name: "/usr/bin/ffmpeg",
+    )
+    frames = sampler(b"video-bytes", file_ext="mp4")
+    assert [(f.timestamp_s, f.image_bytes) for f in frames] == [
+        (12.5, b"frameA"),
+        (47.25, b"frameB"),
+    ]
+
+
+def test_sampler_absent_binary_returns_empty():
+    sampler = FfmpegSceneSampler(runner=lambda *a, **k: _completed(), which=lambda name: None)
+    assert sampler.available is False
+    assert sampler(b"video") == []
+
+
+def test_sampler_nonzero_exit_returns_empty():
+    sampler = FfmpegSceneSampler(
+        runner=lambda cmd, **k: _completed(returncode=1),
+        which=lambda name: "/usr/bin/ffmpeg",
+    )
+    assert sampler(b"video") == []
+
+
+def test_sampler_caps_frames():
+    stderr = "".join(f"pts_time:{i}.0\n" for i in range(10))
+    sampler = FfmpegSceneSampler(
+        max_frames=3,
+        runner=_fake_ffmpeg_runner([b"x"] * 10, stderr),
+        which=lambda name: "/usr/bin/ffmpeg",
+    )
+    assert len(sampler(b"video")) == 3
+
+
+def test_ocr_reads_stdout():
+    ocr = TesseractOcr(
+        runner=lambda cmd, **k: _completed(stdout="GDP +3.4% in 2024\n"),
+        which=lambda name: "/usr/bin/tesseract",
+    )
+    assert ocr(b"frame") == "GDP +3.4% in 2024"
+
+
+def test_ocr_absent_binary_and_blank_output():
+    assert TesseractOcr(runner=lambda *a, **k: _completed(), which=lambda n: None)(b"f") is None
+    ocr = TesseractOcr(runner=lambda cmd, **k: _completed(stdout="   \n"), which=lambda n: "/usr/bin/tesseract")
+    assert ocr(b"frame") is None
+
+
+def test_keyframes_enabled_env(monkeypatch):
+    monkeypatch.delenv("NOESIS_MEDIA_KEYFRAMES", raising=False)
+    assert keyframes_enabled() is True
+    monkeypatch.setenv("NOESIS_MEDIA_KEYFRAMES", "off")
+    assert keyframes_enabled() is False
+
+
+def test_connector_emits_transcript_and_keyframes(monkeypatch):
+    """A video harvest yields transcript segments AND keyframe documents."""
+    from src.ingestion.connectors.media import connector as media_connector
+    from src.ingestion.connectors.media.keyframes import Keyframe
+    from src.ingestion.connectors.media.models import MediaMetadata, TranscriptSegment
+
+    monkeypatch.delenv("NOESIS_MEDIA_KEYFRAMES", raising=False)
+
+    def fake_transcribe(content, **kwargs):
+        return MediaMetadata(
+            title="", segments=[TranscriptSegment(start_s=0, end_s=5, text="spoken words")]
+        )
+
+    monkeypatch.setattr(media_connector, "transcribe", fake_transcribe)
+    sampler = lambda content, file_ext="mp4": [Keyframe(timestamp_s=30.0, image_bytes=b"img")]
+    ocr = lambda image_bytes: "Unemployment 3.4%"
+
+    conn = media_connector.MediaConnector(frame_sampler=sampler, ocr=ocr)
+    raw = media_connector.RawDocument(
+        ref=media_connector.SourceRef(locator="https://ex.com/ep42.mp4", title="ep42"),
+        content=b"videobytes",
+        content_type="video/mp4",
+    )
+    docs = conn.parse(raw)
+    transcript = [d for d in docs if d.metadata.get("modality") != "keyframe"]
+    keyframes = [d for d in docs if d.metadata.get("modality") == "keyframe"]
+    assert len(transcript) == 1 and transcript[0].content == "spoken words"
+    assert len(keyframes) == 1
+    assert keyframes[0].content == "Unemployment 3.4%"
+    assert keyframes[0].content_ref.endswith("#t=30.000")
+
+
+def test_connector_audio_gets_no_keyframes(monkeypatch):
+    from src.ingestion.connectors.media import connector as media_connector
+    from src.ingestion.connectors.media.models import MediaMetadata, TranscriptSegment
+
+    monkeypatch.setattr(
+        media_connector, "transcribe",
+        lambda content, **k: MediaMetadata(title="", segments=[TranscriptSegment(0, 3, "audio words")]),
+    )
+    called = []
+    conn = media_connector.MediaConnector(frame_sampler=lambda *a, **k: called.append(1) or [], ocr=lambda b: "x")
+    raw = media_connector.RawDocument(
+        ref=media_connector.SourceRef(locator="https://ex.com/ep.mp3", title="ep"),
+        content=b"audiobytes", content_type="audio/mp3",
+    )
+    docs = conn.parse(raw)
+    assert called == []  # sampler never invoked for audio
+    assert all(d.metadata.get("modality") != "keyframe" for d in docs)
+
+
+def test_connector_env_off_disables_keyframes(monkeypatch):
+    from src.ingestion.connectors.media import connector as media_connector
+    from src.ingestion.connectors.media.models import MediaMetadata
+
+    monkeypatch.setenv("NOESIS_MEDIA_KEYFRAMES", "off")
+    monkeypatch.setattr(media_connector, "transcribe", lambda c, **k: MediaMetadata(title="", segments=[]))
+    conn = media_connector.MediaConnector(
+        frame_sampler=lambda *a, **k: [1 / 0], ocr=lambda b: "x"  # would raise if ever called
+    )
+    raw = media_connector.RawDocument(
+        ref=media_connector.SourceRef(locator="https://ex.com/ep.mp4", title="ep"),
+        content=b"videobytes", content_type="video/mp4",
+    )
+    assert conn.parse(raw) == []


### PR DESCRIPTION
## Overview

Closes #823. Supplies the injected backends the keyframe core (PR #816) anticipated — real ffmpeg scene sampling and tesseract OCR — and wires them into the media connector so a video harvest yields transcript segments **and** keyframe documents in one pass.

## Changes

- **`src/ingestion/connectors/media/backends.py`**:
  - `FfmpegSceneSampler` — `ffmpeg -vf "select='gt(scene,T)',showinfo"` via an injectable subprocess runner; timestamps parsed from showinfo's `pts_time`; frames capped per video; **degrades to `[]` with a warning** on an absent binary or failed run.
  - `TesseractOcr` — `tesseract <frame> stdout`; `None` on absence/failure/blank.
  - `keyframes_enabled()` — on by default, `NOESIS_MEDIA_KEYFRAMES=off` disables. `default_backends()` resolves both with skip-warnings.
- **`media/connector.py`** — `parse()` emits keyframe documents alongside transcript segments for **video formats only**; backends injectable, defaults lazily resolved; transcript-only degradation when binaries are missing; audio never invokes the sampler.

## Testing

- 39 media tests green, all offline via injected runners: pts parsing, absent-binary/nonzero-exit degradation, the frame cap, OCR stdout/blank/absence, the **one-pass transcript+keyframe harvest** (keyframe carries the OCR text and a `#t=30.000` Media Fragment `content_ref`), the audio no-op, and the env kill switch.

## Note

Neither binary exists in the sandbox, so the subprocess paths are exercised through fake runners; the command lines follow the documented ffmpeg/tesseract CLIs. First run on a machine with the binaries is the live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_