### PR TITLE
Fetch layer: ingest-time snapshotting, liveness, retention for archived citations

### DIFF
--- a/src/ingestion/snapshots.py
+++ b/src/ingestion/snapshots.py
@@ -149,3 +149,84 @@ def resolve_citation(store: SnapshotStore, url: str, live_ok: bool = False) -> D
         }
     # Dead link and no snapshot: the flagged state the evidence discipline shows.
     return {"url": url, "cited": False, "archived": False, "source": "none"}
+
+
+# --------------------------------------------------------------------------- #
+# Wiring (#825): ingest-path snapshotting, liveness, retention.
+#
+# Posture: snapshots are an operator-side archive so *the operator's own
+# citations* survive link rot — they are never republished or served to third
+# parties. Snapshot only what a connector already fetched (no second fetch, so
+# the robots/rate posture is whatever the fetching connector already honoured).
+# --------------------------------------------------------------------------- #
+
+
+def snapshot_document(store: SnapshotStore, document: Any, html: Optional[str], fetched_at: int) -> Optional[Dict[str, Any]]:
+    """Archive the page a connector just fetched for ``document``.
+
+    The ingest-path hook: connectors that pulled a URL call this with the HTML
+    they already have — never a second fetch. No-op (None) for documents
+    without a URL (books, uploads, notes)."""
+    url = getattr(document, "url", None) or (document.get("url") if isinstance(document, dict) else None)
+    if not url:
+        return None
+    return store.snapshot(url, html, fetched_at=fetched_at)
+
+
+def check_liveness(url: str, http_head: Optional[Any] = None, timeout: float = 10.0) -> bool:
+    """Whether a URL currently resolves (HEAD, 2xx/3xx). Injectable checker;
+    any network failure counts as dead — the archive fallback then applies."""
+    if http_head is not None:
+        try:
+            return bool(http_head(url))
+        except Exception:  # noqa: BLE001 - a failing checker means "not live"
+            return False
+    try:  # pragma: no cover - trivial network shim
+        import urllib.request
+
+        request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            return 200 <= resp.status < 400
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def resolve_citation_live(
+    store: SnapshotStore, url: str, http_head: Optional[Any] = None
+) -> Dict[str, Any]:
+    """resolve_citation with the liveness check performed here: live links
+    resolve live; dead links fall back to the archive; dead-and-unsnapshotted
+    stays the flagged uncited state."""
+    return resolve_citation(store, url, live_ok=check_liveness(url, http_head=http_head))
+
+
+def prune_snapshots(
+    store: SnapshotStore,
+    now_ms: int,
+    max_age_ms: Optional[int] = None,
+    keep_latest: bool = True,
+) -> int:
+    """Retention: drop snapshots older than ``max_age_ms``, by default always
+    keeping each URL's latest so a citation never loses its last archive copy.
+    Returns rows deleted. ``max_age_ms=None`` prunes nothing."""
+    if max_age_ms is None:
+        return 0
+    cutoff = now_ms - max_age_ms
+    if keep_latest:
+        result = store._conn.execute(
+            """
+            DELETE FROM url_snapshots
+            WHERE fetched_at < ?
+              AND fetched_at < (
+                  SELECT MAX(s2.fetched_at) FROM url_snapshots s2
+                  WHERE s2.url = url_snapshots.url
+              )
+            """,
+            [cutoff],
+        )
+    else:
+        result = store._conn.execute(
+            "DELETE FROM url_snapshots WHERE fetched_at < ?", [cutoff]
+        )
+    row = result.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0

--- a/tests/unit/ingestion/test_snapshot_wiring.py
+++ b/tests/unit/ingestion/test_snapshot_wiring.py
@@ -1,0 +1,89 @@
+"""Unit tests for snapshot wiring: ingest hook, liveness, retention (#825)."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.snapshots import (
+    SnapshotStore,
+    check_liveness,
+    prune_snapshots,
+    resolve_citation_live,
+    snapshot_document,
+)
+
+
+@pytest.fixture()
+def store():
+    duckdb = pytest.importorskip("duckdb")
+    return SnapshotStore(duckdb.connect(":memory:"))
+
+
+def _doc(url="https://ex.com/story"):
+    return Document(
+        document_id="news:1", source_type="news", language="en",
+        ingested_at=100, url=url, title="Story",
+    )
+
+
+def test_snapshot_document_archives_fetched_page(store):
+    out = snapshot_document(store, _doc(), "<p>the article body</p>", fetched_at=100)
+    assert out is not None and out["chars"] > 0
+    snap = store.latest("https://ex.com/story")
+    assert snap.text == "the article body"
+
+
+def test_snapshot_document_noop_without_url(store):
+    doc = Document(document_id="note:1", source_type="note", language="en", ingested_at=1)
+    assert snapshot_document(store, doc, "<p>x</p>", fetched_at=1) is None
+
+
+def test_snapshot_document_accepts_dicts(store):
+    out = snapshot_document(store, {"url": "https://ex.com/d"}, "<p>dict doc</p>", fetched_at=5)
+    assert out is not None
+    assert store.has("https://ex.com/d")
+
+
+def test_check_liveness_injectable():
+    assert check_liveness("https://ex.com", http_head=lambda url: True) is True
+    assert check_liveness("https://ex.com", http_head=lambda url: False) is False
+    # A raising checker counts as dead, never as an error.
+    def boom(url):
+        raise ConnectionError("down")
+    assert check_liveness("https://ex.com", http_head=boom) is False
+
+
+def test_resolve_citation_live_paths(store):
+    store.snapshot("https://ex.com/gone", "<p>archived body</p>", fetched_at=100)
+    live = resolve_citation_live(store, "https://ex.com/gone", http_head=lambda u: True)
+    assert live["source"] == "live" and live["cited"] is True
+    dead = resolve_citation_live(store, "https://ex.com/gone", http_head=lambda u: False)
+    assert dead["source"] == "archive" and dead["cited"] is True
+    assert dead["text"] == "archived body"
+    never = resolve_citation_live(store, "https://ex.com/never", http_head=lambda u: False)
+    assert never["cited"] is False and never["source"] == "none"
+
+
+def test_prune_keeps_each_urls_latest(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=100)
+    store.snapshot("https://ex.com/a", "<p>v2</p>", fetched_at=200)
+    store.snapshot("https://ex.com/b", "<p>only</p>", fetched_at=100)
+    deleted = prune_snapshots(store, now_ms=10_000, max_age_ms=5_000)
+    # Both old rows are past cutoff, but each URL's latest survives.
+    assert deleted == 1
+    assert store.latest("https://ex.com/a").text == "v2"
+    assert store.latest("https://ex.com/b").text == "only"  # last copy never pruned
+
+
+def test_prune_without_policy_is_noop(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=1)
+    assert prune_snapshots(store, now_ms=10_000, max_age_ms=None) == 0
+    assert store.has("https://ex.com/a")
+
+
+def test_prune_keep_latest_false_drops_all_old(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=100)
+    deleted = prune_snapshots(store, now_ms=10_000, max_age_ms=5_000, keep_latest=False)
+    assert deleted == 1
+    assert store.latest("https://ex.com/a") is None


### PR DESCRIPTION
## Overview

Closes #825. Wires the snapshot core (PR #808) into the ingest path: archive-at-ingest, liveness-checked citation resolution, and retention.

## Changes

Additions to **`src/ingestion/snapshots.py`**:

- `snapshot_document(store, document, html, fetched_at)` — the ingest-path hook: connectors that pulled a URL archive **the HTML they already have** (never a second fetch, so the robots/rate posture is whatever the fetching connector already honoured). No-op for URL-less documents (books, uploads, notes). Posture documented in the module: an operator-side archive so the operator's own citations survive link rot — never republished.
- `check_liveness(url, http_head?)` — injectable HEAD check; any failure counts as dead, so the archive fallback applies. `resolve_citation_live()` performs the check and resolves live / archive / flagged-uncited.
- `prune_snapshots(store, now, max_age_ms, keep_latest=True)` — retention that by default **always keeps each URL's latest snapshot**, so a citation never loses its last archive copy; `max_age_ms=None` prunes nothing.

## Testing

- 16 tests green (including the core suite): the ingest hook (Document + dict payloads, URL-less no-op), injectable and raising liveness checkers, live/archive/uncited resolution, and retention keeping each URL's latest while `keep_latest=False` drops all old rows.

## Note

The re-fetch scheduler (#824, next PR) shares this fetch pass: each scheduled re-fetch both diffs for corrections and refreshes the archive with one fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_