### PR TITLE
Fetch layer: staged re-fetch scheduler for corrections tracking

### DIFF
--- a/src/ingestion/refetch.py
+++ b/src/ingestion/refetch.py
@@ -1,0 +1,182 @@
+"""
+Staged re-fetch scheduler for corrections tracking (#824).
+
+The corrections core (``corrections.py``) classifies how a document changed —
+but nothing *feeds* it. This module selects already-ingested documents whose
+age has crossed a re-fetch stage (default 1d / 7d / 30d after ingest), pulls
+their current content, and records revisions; when a snapshot store is
+supplied, each re-fetch also archives the page (#825 — one fetch serves both).
+
+Politeness: per-run and per-domain caps bound each run; the fetcher is
+injectable so scheduling logic is offline-testable and the runner never
+hard-codes a network client. A fetch failure skips the document (logged),
+never aborts the run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+from src.ingestion.corrections import ensure_schema, record_revision
+from src.ingestion.snapshots import SnapshotStore, snapshot_document
+
+logger = logging.getLogger(__name__)
+
+_DAY_MS = 24 * 60 * 60 * 1000
+# Staged re-fetch offsets after ingest (issue #824): 1d, 7d, 30d.
+DEFAULT_STAGES_MS = (1 * _DAY_MS, 7 * _DAY_MS, 30 * _DAY_MS)
+
+DEFAULT_LIMIT = 50
+DEFAULT_PER_DOMAIN = 5
+
+# Fetcher signature: url -> page content (str) or None on failure.
+Fetcher = Callable[[str], Optional[str]]
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchall())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def due_documents(
+    conn,
+    now_ms: int,
+    stages_ms: tuple = DEFAULT_STAGES_MS,
+    limit: int = DEFAULT_LIMIT,
+) -> List[Dict[str, Any]]:
+    """Documents whose age crossed a re-fetch stage not yet performed.
+
+    A document is due for stage ``k`` when ``now - ingested_at >= stages[k]``
+    and no revision has been recorded at-or-after ``ingested_at + stages[k]``
+    (revision 0, the ingest baseline, never satisfies a stage). Returns the
+    earliest-ingested first, capped at ``limit``.
+    """
+    if not _table_exists(conn, "documents"):
+        return []
+    ensure_schema(conn)
+    rows = conn.execute(
+        """
+        SELECT d.document_id, d.url, d.ingested_at
+        FROM documents d
+        WHERE d.url IS NOT NULL AND d.ingested_at IS NOT NULL
+        ORDER BY d.ingested_at
+        """
+    ).fetchall()
+    due: List[Dict[str, Any]] = []
+    for document_id, url, ingested_at in rows:
+        if len(due) >= limit:
+            break
+        for stage_index, offset in enumerate(stages_ms):
+            stage_at = int(ingested_at) + int(offset)
+            if now_ms < stage_at:
+                break  # later stages are further out
+            done = conn.execute(
+                """
+                SELECT COUNT(*) FROM document_revisions
+                WHERE document_id = ? AND revision > 0 AND fetched_at >= ?
+                """,
+                [document_id, stage_at],
+            ).fetchone()[0]
+            if done == 0:
+                due.append({
+                    "document_id": document_id,
+                    "url": url,
+                    "ingested_at": int(ingested_at),
+                    "stage": stage_index,
+                    "stage_at": stage_at,
+                })
+                break  # one stage per run per document
+    return due
+
+
+def _domain(url: str) -> str:
+    try:
+        return urlparse(url).netloc.lower() or "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def run_refetch(
+    conn,
+    fetcher: Fetcher,
+    now_ms: int,
+    stages_ms: tuple = DEFAULT_STAGES_MS,
+    limit: int = DEFAULT_LIMIT,
+    per_domain: int = DEFAULT_PER_DOMAIN,
+    snapshot_store: Optional[SnapshotStore] = None,
+) -> Dict[str, Any]:
+    """One scheduled re-fetch pass.
+
+    Fetches each due document's URL (respecting the per-domain cap), records a
+    revision when the content changed, and — when a snapshot store is supplied
+    — archives the fetched page in the same pass. A fetch failure or a fetcher
+    returning None skips that document (logged), never aborts the run.
+    """
+    due = due_documents(conn, now_ms, stages_ms=stages_ms, limit=limit)
+    domain_counts: Dict[str, int] = {}
+    checked = 0
+    skipped = 0
+    by_class: Dict[str, int] = {}
+    for item in due:
+        domain = _domain(item["url"])
+        if domain_counts.get(domain, 0) >= per_domain:
+            skipped += 1
+            continue
+        domain_counts[domain] = domain_counts.get(domain, 0) + 1
+        try:
+            content = fetcher(item["url"])
+        except Exception:  # noqa: BLE001 - one bad URL never aborts the run
+            logger.warning("refetch: fetch failed for %s", item["url"], exc_info=True)
+            content = None
+        if content is None:
+            skipped += 1
+            continue
+        checked += 1
+        result = record_revision(conn, item["document_id"], content, fetched_at=now_ms)
+        change = result["change_class"]
+        by_class[change] = by_class.get(change, 0) + 1
+        if snapshot_store is not None:
+            snapshot_document(snapshot_store, {"url": item["url"]}, content, fetched_at=now_ms)
+    return {
+        "due": len(due),
+        "checked": checked,
+        "skipped": skipped,
+        "changed": sum(v for k, v in by_class.items() if k != "unchanged"),
+        "by_class": by_class,
+    }
+
+
+def main() -> None:  # pragma: no cover - thin CLI wrapper
+    """Run one re-fetch pass against the warehouse: python -m src.ingestion.refetch"""
+    import os
+    import time
+    import urllib.request
+
+    import duckdb
+
+    from src.config.env import warehouse_path
+
+    path = warehouse_path(os.path.join("data", "neuronews.duckdb"))
+    conn = duckdb.connect(path)
+
+    def fetcher(url: str) -> Optional[str]:
+        try:
+            with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+                return resp.read().decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001
+            return None
+
+    store = SnapshotStore(conn)
+    summary = run_refetch(conn, fetcher, now_ms=int(time.time() * 1000), snapshot_store=store)
+    print(summary)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/ingestion/snapshots.py
+++ b/src/ingestion/snapshots.py
@@ -149,3 +149,84 @@ def resolve_citation(store: SnapshotStore, url: str, live_ok: bool = False) -> D
         }
     # Dead link and no snapshot: the flagged state the evidence discipline shows.
     return {"url": url, "cited": False, "archived": False, "source": "none"}
+
+
+# --------------------------------------------------------------------------- #
+# Wiring (#825): ingest-path snapshotting, liveness, retention.
+#
+# Posture: snapshots are an operator-side archive so *the operator's own
+# citations* survive link rot — they are never republished or served to third
+# parties. Snapshot only what a connector already fetched (no second fetch, so
+# the robots/rate posture is whatever the fetching connector already honoured).
+# --------------------------------------------------------------------------- #
+
+
+def snapshot_document(store: SnapshotStore, document: Any, html: Optional[str], fetched_at: int) -> Optional[Dict[str, Any]]:
+    """Archive the page a connector just fetched for ``document``.
+
+    The ingest-path hook: connectors that pulled a URL call this with the HTML
+    they already have — never a second fetch. No-op (None) for documents
+    without a URL (books, uploads, notes)."""
+    url = getattr(document, "url", None) or (document.get("url") if isinstance(document, dict) else None)
+    if not url:
+        return None
+    return store.snapshot(url, html, fetched_at=fetched_at)
+
+
+def check_liveness(url: str, http_head: Optional[Any] = None, timeout: float = 10.0) -> bool:
+    """Whether a URL currently resolves (HEAD, 2xx/3xx). Injectable checker;
+    any network failure counts as dead — the archive fallback then applies."""
+    if http_head is not None:
+        try:
+            return bool(http_head(url))
+        except Exception:  # noqa: BLE001 - a failing checker means "not live"
+            return False
+    try:  # pragma: no cover - trivial network shim
+        import urllib.request
+
+        request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            return 200 <= resp.status < 400
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def resolve_citation_live(
+    store: SnapshotStore, url: str, http_head: Optional[Any] = None
+) -> Dict[str, Any]:
+    """resolve_citation with the liveness check performed here: live links
+    resolve live; dead links fall back to the archive; dead-and-unsnapshotted
+    stays the flagged uncited state."""
+    return resolve_citation(store, url, live_ok=check_liveness(url, http_head=http_head))
+
+
+def prune_snapshots(
+    store: SnapshotStore,
+    now_ms: int,
+    max_age_ms: Optional[int] = None,
+    keep_latest: bool = True,
+) -> int:
+    """Retention: drop snapshots older than ``max_age_ms``, by default always
+    keeping each URL's latest so a citation never loses its last archive copy.
+    Returns rows deleted. ``max_age_ms=None`` prunes nothing."""
+    if max_age_ms is None:
+        return 0
+    cutoff = now_ms - max_age_ms
+    if keep_latest:
+        result = store._conn.execute(
+            """
+            DELETE FROM url_snapshots
+            WHERE fetched_at < ?
+              AND fetched_at < (
+                  SELECT MAX(s2.fetched_at) FROM url_snapshots s2
+                  WHERE s2.url = url_snapshots.url
+              )
+            """,
+            [cutoff],
+        )
+    else:
+        result = store._conn.execute(
+            "DELETE FROM url_snapshots WHERE fetched_at < ?", [cutoff]
+        )
+    row = result.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0

--- a/tests/unit/ingestion/test_refetch.py
+++ b/tests/unit/ingestion/test_refetch.py
@@ -1,0 +1,104 @@
+"""Unit tests for the staged re-fetch scheduler (#824) — offline."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.corrections import record_revision, revision_history
+from src.ingestion.refetch import DEFAULT_STAGES_MS, due_documents, run_refetch
+from src.ingestion.snapshots import SnapshotStore
+
+_DAY = 24 * 60 * 60 * 1000
+
+
+@pytest.fixture()
+def conn():
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect(":memory:")
+    c.execute("CREATE TABLE documents (document_id TEXT, url TEXT, ingested_at BIGINT)")
+    return c
+
+
+def _add(conn, doc_id, url, ingested_at):
+    conn.execute("INSERT INTO documents VALUES (?, ?, ?)", [doc_id, url, ingested_at])
+
+
+def test_due_after_first_stage(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    _add(conn, "news:2", "https://a.com/y", ingested_at=0)
+    # Half a day in: nothing due yet.
+    assert due_documents(conn, now_ms=_DAY // 2) == []
+    # Two days in: both due for stage 0 (the 1d stage).
+    due = due_documents(conn, now_ms=2 * _DAY)
+    assert [(d["document_id"], d["stage"]) for d in due] == [("news:1", 0), ("news:2", 0)]
+
+
+def test_completed_stage_not_redue(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    record_revision(conn, "news:1", "original body of the article", fetched_at=0)  # rev 0 baseline
+    # A stage-0 re-fetch happened at day 2 (content changed -> revision 1).
+    record_revision(conn, "news:1", "a substantively different article body", fetched_at=2 * _DAY)
+    # Day 3: stage 0 satisfied, stage 1 (7d) not yet reached -> nothing due.
+    assert due_documents(conn, now_ms=3 * _DAY) == []
+    # Day 8: stage 1 is now due.
+    due = due_documents(conn, now_ms=8 * _DAY)
+    assert [(d["document_id"], d["stage"]) for d in due] == [("news:1", 1)]
+
+
+def test_urlless_documents_never_due(conn):
+    _add(conn, "note:1", None, ingested_at=0)
+    assert due_documents(conn, now_ms=10 * _DAY) == []
+
+
+def test_run_refetch_records_changes_and_summary(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    record_revision(conn, "news:1", "The mayor won 60% of the vote in the election.", fetched_at=0)
+    fetched = {"https://a.com/x": "The mayor won 52% of the vote in the election."}
+    summary = run_refetch(conn, lambda url: fetched[url], now_ms=2 * _DAY)
+    assert summary["due"] == 1 and summary["checked"] == 1
+    assert summary["changed"] == 1
+    assert summary["by_class"] == {"silent_substantive": 1}
+    assert len(revision_history(conn, "news:1")) == 2
+
+
+def test_run_refetch_unchanged_content(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    record_revision(conn, "news:1", "Same body.", fetched_at=0)
+    summary = run_refetch(conn, lambda url: "Same body.", now_ms=2 * _DAY)
+    assert summary["changed"] == 0
+    assert summary["by_class"] == {"unchanged": 1}
+
+
+def test_fetch_failure_skips_not_aborts(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    _add(conn, "news:2", "https://b.com/y", ingested_at=0)
+    record_revision(conn, "news:2", "original b body here", fetched_at=0)
+
+    def fetcher(url):
+        if "a.com" in url:
+            raise ConnectionError("down")
+        return "a very different b body entirely now"
+
+    summary = run_refetch(conn, fetcher, now_ms=2 * _DAY)
+    assert summary["skipped"] == 1
+    assert summary["checked"] == 1  # b.com still processed
+
+
+def test_per_domain_cap(conn):
+    for i in range(8):
+        _add(conn, f"news:{i}", f"https://a.com/{i}", ingested_at=0)
+    summary = run_refetch(conn, lambda url: "body", now_ms=2 * _DAY, per_domain=3)
+    assert summary["checked"] == 3
+    assert summary["skipped"] == 5
+
+
+def test_shared_fetch_pass_snapshots(conn):
+    _add(conn, "news:1", "https://a.com/x", ingested_at=0)
+    store = SnapshotStore(conn)
+    run_refetch(conn, lambda url: "<p>fresh body</p>", now_ms=2 * _DAY, snapshot_store=store)
+    snap = store.latest("https://a.com/x")
+    assert snap is not None and snap.text == "fresh body"  # one fetch served both (#825)
+
+
+def test_default_stages_shape():
+    assert DEFAULT_STAGES_MS == (1 * _DAY, 7 * _DAY, 30 * _DAY)

--- a/tests/unit/ingestion/test_snapshot_wiring.py
+++ b/tests/unit/ingestion/test_snapshot_wiring.py
@@ -1,0 +1,89 @@
+"""Unit tests for snapshot wiring: ingest hook, liveness, retention (#825)."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.snapshots import (
+    SnapshotStore,
+    check_liveness,
+    prune_snapshots,
+    resolve_citation_live,
+    snapshot_document,
+)
+
+
+@pytest.fixture()
+def store():
+    duckdb = pytest.importorskip("duckdb")
+    return SnapshotStore(duckdb.connect(":memory:"))
+
+
+def _doc(url="https://ex.com/story"):
+    return Document(
+        document_id="news:1", source_type="news", language="en",
+        ingested_at=100, url=url, title="Story",
+    )
+
+
+def test_snapshot_document_archives_fetched_page(store):
+    out = snapshot_document(store, _doc(), "<p>the article body</p>", fetched_at=100)
+    assert out is not None and out["chars"] > 0
+    snap = store.latest("https://ex.com/story")
+    assert snap.text == "the article body"
+
+
+def test_snapshot_document_noop_without_url(store):
+    doc = Document(document_id="note:1", source_type="note", language="en", ingested_at=1)
+    assert snapshot_document(store, doc, "<p>x</p>", fetched_at=1) is None
+
+
+def test_snapshot_document_accepts_dicts(store):
+    out = snapshot_document(store, {"url": "https://ex.com/d"}, "<p>dict doc</p>", fetched_at=5)
+    assert out is not None
+    assert store.has("https://ex.com/d")
+
+
+def test_check_liveness_injectable():
+    assert check_liveness("https://ex.com", http_head=lambda url: True) is True
+    assert check_liveness("https://ex.com", http_head=lambda url: False) is False
+    # A raising checker counts as dead, never as an error.
+    def boom(url):
+        raise ConnectionError("down")
+    assert check_liveness("https://ex.com", http_head=boom) is False
+
+
+def test_resolve_citation_live_paths(store):
+    store.snapshot("https://ex.com/gone", "<p>archived body</p>", fetched_at=100)
+    live = resolve_citation_live(store, "https://ex.com/gone", http_head=lambda u: True)
+    assert live["source"] == "live" and live["cited"] is True
+    dead = resolve_citation_live(store, "https://ex.com/gone", http_head=lambda u: False)
+    assert dead["source"] == "archive" and dead["cited"] is True
+    assert dead["text"] == "archived body"
+    never = resolve_citation_live(store, "https://ex.com/never", http_head=lambda u: False)
+    assert never["cited"] is False and never["source"] == "none"
+
+
+def test_prune_keeps_each_urls_latest(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=100)
+    store.snapshot("https://ex.com/a", "<p>v2</p>", fetched_at=200)
+    store.snapshot("https://ex.com/b", "<p>only</p>", fetched_at=100)
+    deleted = prune_snapshots(store, now_ms=10_000, max_age_ms=5_000)
+    # Both old rows are past cutoff, but each URL's latest survives.
+    assert deleted == 1
+    assert store.latest("https://ex.com/a").text == "v2"
+    assert store.latest("https://ex.com/b").text == "only"  # last copy never pruned
+
+
+def test_prune_without_policy_is_noop(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=1)
+    assert prune_snapshots(store, now_ms=10_000, max_age_ms=None) == 0
+    assert store.has("https://ex.com/a")
+
+
+def test_prune_keep_latest_false_drops_all_old(store):
+    store.snapshot("https://ex.com/a", "<p>v1</p>", fetched_at=100)
+    deleted = prune_snapshots(store, now_ms=10_000, max_age_ms=5_000, keep_latest=False)
+    assert deleted == 1
+    assert store.latest("https://ex.com/a") is None


### PR DESCRIPTION
## Overview

Closes #824 — the last of the eight hardening/fetch-layer issues. The thing that *feeds* the corrections core (PR #807): a staged re-fetch pass over already-ingested documents.

**Stacked on #847** (snapshot wiring): it uses `snapshot_document` so one fetch serves both corrections diffing and the citation archive. Merge #847 first; this PR's diff then reduces to the refetch commit.

## Changes

- **`src/ingestion/refetch.py`**:
  - `due_documents()` — selects documents whose age crossed a re-fetch stage (default **1d / 7d / 30d** after ingest) with no revision recorded at-or-after that stage; revision 0 (the ingest baseline) never satisfies a stage; one stage per document per run, earliest-ingested first, capped.
  - `run_refetch()` — pulls each due URL via an **injectable fetcher** (a failure skips that document, never aborts the run), records revisions via `record_revision`, honours a **per-domain politeness cap**, and — with a snapshot store supplied — archives the fetched page in the same pass (#825: one fetch serves both). Returns a `{due, checked, skipped, changed, by_class}` summary.
  - `python -m src.ingestion.refetch` runs one pass against the warehouse (urllib fetcher + snapshot store).

## Testing

- 9 tests, offline: stage due/undue timing, **completed-stage-not-redue then next-stage-due**, URL-less exclusion, change recording + summary (`silent_substantive` classified), unchanged no-op, fetch-failure skip, the per-domain cap, and the shared snapshot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_