### PR TITLE
ci: fix Security Scanning SARIF upload and harden the vuln gate

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -183,7 +183,13 @@ jobs:
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest
-    
+    # SARIF upload to the code-scanning API needs security-events: write; the
+    # repo-default token is read-only, which failed the upload with "Resource
+    # not accessible by integration" and skipped the vuln gate below.
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -200,12 +206,19 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
+        # Best-effort Security-tab reporting: a code-scanning upload hiccup must
+        # never fail CI or skip the vulnerability gate below (which is the real
+        # enforcement). v3 — the v1/v2 CodeQL actions are deprecated.
         if: always()
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy scanner for critical vulnerabilities
+        # Always run the gate — it is authoritative and must not be skipped just
+        # because the best-effort Security-tab upload above had a problem.
+        if: always()
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'
@@ -285,8 +298,9 @@ jobs:
           output: 'trivy-image-${{ matrix.service.name }}.sarif'
 
       - name: Upload image scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
+        continue-on-error: true
         with:
           sarif_file: 'trivy-image-${{ matrix.service.name }}.sarif'
 


### PR DESCRIPTION
## 🎯 Overview

Follow-up to #849. That PR triaged the airflow/mlflow CVEs into `.trivyignore`, but the **Security Scanning** job still failed on `main` — at a *different* step. The SARIF upload errored with:

```
CodeQL Action major versions v1 and v2 have been deprecated
Resource not accessible by integration
```

Two independent problems, and a latent security hole:

1. **Deprecated action** — the upload used `github/codeql-action/upload-sarif@v2` (v1/v2 are EOL).
2. **Missing permission** — the job ran with the repo-default read-only token, which lacks `security-events: write`.
3. **Gate silently bypassed** — because the upload step failed, GitHub's implicit `success()` guard **skipped the actual vulnerability gate** (the exit-code Trivy scan). A cosmetic Security-tab upload hiccup was able to bypass security enforcement entirely.

## 📋 Changes Summary

- **Grant `security-events: write`** (+ `contents: read`) on the `security-scan` job so the SARIF upload is authorized.
- **Bump `upload-sarif` `v2` → `v3`** — both the repo scan and the image scan.
- **`continue-on-error: true`** on the Security-tab uploads — best-effort reporting must never fail CI.
- **`if: always()`** on the vulnerability gate so it is authoritative and can never be skipped by a prior step. With #849's `.trivyignore` in place, the gate now passes on the known, tracked backlog.

## ✅ Testing

- [x] `ci-cd-pipeline.yml` parses (`yaml.safe_load`).
- [x] Root cause confirmed from the failed job log (deprecation + "Resource not accessible by integration"), not inferred.

## Impact

🟢 Low risk — CI config only. Makes the vulnerability gate authoritative and unskippable, fixes the SARIF upload, and turns **Security Scanning** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_