### PR TITLE
ci: make legacy whole-tree test job advisory

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -79,6 +79,11 @@ jobs:
           safety check --output json > safety-report.json || true
 
       - name: Run unit tests
+        # ADVISORY (de-scoped): this legacy whole-tree gate + 90%-coverage bar is
+        # systemically red pending docs/development/TEST_SUITE_REPAIR_PLAN.md. The
+        # authoritative PR gate is the curated .github/workflows/unit-tests.yml
+        # (#818); this step reports but must not fail the build.
+        continue-on-error: true
         run: |
           # Tests run ONE FILE PER PROCESS, in parallel. Many suites mock shared
           # globals (psycopg2/asyncpg via sys.modules, boto3 default sessions,
@@ -157,6 +162,9 @@ jobs:
           LOCAL_CLOUD_CONNECT_TIMEOUT: "3"
 
       - name: Run integration tests
+        # ADVISORY (de-scoped): see the unit-tests note above; the curated
+        # unit-tests.yml (#818) is the authoritative gate.
+        continue-on-error: true
         run: |
           pytest tests/integration/ -v --tb=short
         env:


### PR DESCRIPTION
## 🎯 Overview

Follow-up to #849/#870. Removing the dead `codegen.py` step (#849) unmasked a pre-existing, systemic failure in the **legacy "Test & Quality Checks"** job: it runs the entire `tests/` tree one-file-per-process with a **90%-coverage** bar, and dozens of files fail at collection (missing optional deps across `scraper/`, `security/`, `services/`, `services/rag/`, `vector_backends/`, …) on top of the coverage shortfall. The dead step had been failing the job in ~6s before any test ran, hiding this.

Per maintainer decision, **de-scope** this legacy job rather than silently delete it or weaken the real gate.

## 📋 Changes Summary

- Mark the **whole-tree unit test** step and the **integration test** step `continue-on-error: true`, so the legacy job reports without failing the build.
- Document *why* inline: full-suite repair is tracked in `docs/development/TEST_SUITE_REPAIR_PLAN.md`, and the **authoritative PR gate is the curated `unit-tests.yml` (#818)**, which is green.

## ✅ Testing

- [x] `ci-cd-pipeline.yml` parses (`yaml.safe_load`).
- [x] Root cause confirmed from the failed job log (dozens of failing files listed + coverage gate), not inferred.

## Impact

🟢 Low risk — CI config only. Turns the legacy job green without deleting it or masking the real gate. Does **not** touch `unit-tests.yml` (#818), which remains the enforcing PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_