### PR TITLE
ci: fix nlp/scraper image builds (mkdir as non-root user)

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -247,6 +247,9 @@ jobs:
     timeout-minutes: 30
     
     strategy:
+      # Validation builds are independent — one failing image shouldn't cancel
+      # the others, so every leg's result is visible in a single run.
+      fail-fast: false
       matrix:
         service:
           - name: api

--- a/docker/nlp.Dockerfile
+++ b/docker/nlp.Dockerfile
@@ -72,7 +72,10 @@ USER neuronews
 COPY --chown=neuronews:neuronews . .
 
 # Create data and logs directories
-RUN mkdir -p /app/data /app/logs /app/models
+USER root
+RUN mkdir -p /app/data /app/logs /app/models \
+    && chown -R neuronews:neuronews /app/data /app/logs /app/models
+USER neuronews
 
 # Health check
 HEALTHCHECK --interval=60s --timeout=30s --start-period=120s --retries=3 \
@@ -93,7 +96,10 @@ COPY --chown=neuronews:neuronews config/ ./config/
 COPY --chown=neuronews:neuronews requirements.txt ./
 
 # Create directories
-RUN mkdir -p /app/data /app/logs /app/models
+USER root
+RUN mkdir -p /app/data /app/logs /app/models \
+    && chown -R neuronews:neuronews /app/data /app/logs /app/models
+USER neuronews
 
 # Health check
 HEALTHCHECK --interval=60s --timeout=30s --start-period=120s --retries=3 \

--- a/docker/scraper.Dockerfile
+++ b/docker/scraper.Dockerfile
@@ -69,7 +69,10 @@ USER neuronews
 COPY --chown=neuronews:neuronews . .
 
 # Create data directory
-RUN mkdir -p /app/data /app/logs
+USER root
+RUN mkdir -p /app/data /app/logs \
+    && chown -R neuronews:neuronews /app/data /app/logs
+USER neuronews
 
 # Health check
 HEALTHCHECK --interval=60s --timeout=30s --start-period=60s --retries=3 \
@@ -90,7 +93,10 @@ COPY --chown=neuronews:neuronews config/ ./config/
 COPY --chown=neuronews:neuronews requirements.txt ./
 
 # Create directories
-RUN mkdir -p /app/data /app/logs
+USER root
+RUN mkdir -p /app/data /app/logs \
+    && chown -R neuronews:neuronews /app/data /app/logs
+USER neuronews
 
 # Health check
 HEALTHCHECK --interval=60s --timeout=30s --start-period=60s --retries=3 \


### PR DESCRIPTION
## 🎯 Overview

The `Build Images (validation)` job (from #872) confirmed the heavy image builds actually work — the nlp build ran through torch, spaCy, and NLTK downloads — then failed on a genuine Dockerfile bug.

## 🐛 Root cause

```
#19 [production 4/4] RUN mkdir -p /app/data /app/logs /app/models
mkdir: cannot create directory '/app/data': Permission denied
```

The `production` (and `development`) stages run `mkdir /app/...` **after** `USER neuronews`, but `WORKDIR /app` is root-owned, so the non-root user can't create subdirectories. `scraper.Dockerfile` had the identical bug (hidden by matrix fail-fast cancelling it); `fastapi.Dockerfile` is unaffected.

## 📋 Changes

- **`docker/nlp.Dockerfile` / `docker/scraper.Dockerfile`**: create the runtime dirs as `root` and `chown` them to `neuronews` (both the production and development stages).
- **`ci-cd-pipeline.yml`**: set `fail-fast: false` on the validation matrix so one failing image no longer cancels the others — every leg's result shows in a single run.

## ✅ Verification

- [x] Confirmed from the failed build log (exact `mkdir … Permission denied` at `nlp.Dockerfile:96`).
- [x] The prior run also confirmed the framework works: `Test & Quality` + `Security Scanning` green, and `Deploy to Staging/Production` + `Update GitOps` correctly **skipped** (ENABLE_DEPLOY gating).
- [x] YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_