### PR TITLE
Add generic article-extraction fallback cascade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,6 +85,11 @@ duckdb>=1.0.0,<2.0.0
 # host reports itself unavailable when this is missing.
 mcp>=1.28.1
 
+# Article-extraction cascade (#877) — both optional; src/ingestion/extract.py
+# degrades trafilatura -> readability-lxml -> bs4 heuristic without them
+trafilatura>=1.8.0
+readability-lxml>=0.8.1
+
 # Media connector (#523) — all optional; connector degrades gracefully without them
 openai-whisper>=20231117   # local Whisper model inference (pip install openai-whisper)
 faster-whisper>=1.0.0      # faster CTranslate2-based Whisper (GPU/CPU)

--- a/src/ingestion/connectors/blog/readability.py
+++ b/src/ingestion/connectors/blog/readability.py
@@ -1,26 +1,19 @@
 """Full-text article body extraction for blog posts.
 
-Tries readability-lxml if installed; falls back to a bs4 heuristic that finds
-the largest semantic content block (<article> / <main> / biggest <div>) and
-strips navigation, scripts, and boilerplate.
+The extraction itself lives in the shared site-agnostic cascade
+(``src.ingestion.extract``, #877): trafilatura → readability-lxml → bs4
+heuristic, each optional dependency degrading gracefully. This module keeps
+the blog connector's fetch + string-result contract.
 """
 
 from __future__ import annotations
 
-import re
 from urllib.request import Request, urlopen
+
+from src.ingestion.extract import extract_article
 
 _USER_AGENT = "NeuroNewsBot/1.0 (+https://github.com/Ikey168/NeuroNews)"
 _HTTP_TIMEOUT = 15
-
-# Tags whose content is always boilerplate — strip before scoring.
-_NOISE_TAGS = {
-    "script", "style", "nav", "header", "footer", "aside",
-    "form", "iframe", "button", "noscript", "figure", "figcaption",
-}
-
-# Minimum characters for full text to be considered useful.
-_MIN_CHARS = 200
 
 
 def fetch_full_text(url: str, _http_get=None) -> str:
@@ -38,23 +31,8 @@ def fetch_full_text(url: str, _http_get=None) -> str:
     if not html:
         return ""
 
-    # Try readability-lxml first (much better extraction quality).
-    try:
-        from readability import Document as ReadabilityDoc  # type: ignore
-
-        doc = ReadabilityDoc(html if isinstance(html, str) else html.decode("utf-8", errors="replace"))
-        cleaned = doc.summary()
-        text = _strip_tags(cleaned).strip()
-        if len(text) >= _MIN_CHARS:
-            return text
-    except Exception:
-        pass
-
-    # bs4 fallback.
-    try:
-        return _bs4_extract(html if isinstance(html, bytes) else html.encode("utf-8"))
-    except Exception:
-        return ""
+    result = extract_article(html, url=url)
+    return result.text if result is not None else ""
 
 
 def _default_http_get(url: str) -> bytes:
@@ -64,39 +42,3 @@ def _default_http_get(url: str) -> bytes:
     )
     with urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
         return resp.read()
-
-
-def _bs4_extract(html: bytes) -> str:
-    from bs4 import BeautifulSoup
-
-    soup = BeautifulSoup(html, "html.parser")
-
-    # Remove noise elements in-place.
-    for tag in soup.find_all(_NOISE_TAGS):
-        tag.decompose()
-
-    # Prefer semantic content containers.
-    for selector in ("article", "main", '[role="main"]', ".post-content", ".entry-content", ".article-body"):
-        el = soup.select_one(selector)
-        if el:
-            text = _normalize(el.get_text(separator=" "))
-            if len(text) >= _MIN_CHARS:
-                return text
-
-    # Fall back to the largest <div> by text length (heuristic).
-    best_text = ""
-    for div in soup.find_all("div"):
-        t = _normalize(div.get_text(separator=" "))
-        if len(t) > len(best_text):
-            best_text = t
-
-    return best_text if len(best_text) >= _MIN_CHARS else ""
-
-
-def _strip_tags(html: str) -> str:
-    """Remove HTML tags from a string."""
-    return re.sub(r"<[^>]+>", " ", html)
-
-
-def _normalize(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()

--- a/src/ingestion/extract.py
+++ b/src/ingestion/extract.py
@@ -1,0 +1,162 @@
+"""
+Generic article-content extraction cascade (#877).
+
+Per-site CSS selectors are brittle: a site redesign silently breaks them and
+articles vanish with no error. This module is the safety net — a site-agnostic
+extraction cascade callers run when (or before) selector-based extraction
+fails, so a layout change degrades to "generic extraction, lower confidence"
+instead of silent loss.
+
+Stages, best first, each optional dependency degrading gracefully:
+
+1. ``trafilatura``     — state-of-the-art article extraction (optional)
+2. ``readability-lxml``— classic readability algorithm (optional)
+3. bs4 heuristic       — largest semantic block; always available
+
+Each stage must clear ``MIN_CHARS`` of extracted text or the cascade falls
+through; ``None`` is returned only when every stage fails. Results carry the
+``method`` and a coarse ``confidence`` so downstream consumers can distinguish
+selector-extracted from generic-extracted content.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Minimum characters for extracted text to be considered a real article body.
+MIN_CHARS = 200
+
+# Tags whose content is always boilerplate — stripped before heuristic scoring.
+_NOISE_TAGS = {
+    "script", "style", "nav", "header", "footer", "aside",
+    "form", "iframe", "button", "noscript", "figure", "figcaption",
+}
+
+# Semantic containers tried (in order) before the largest-<div> fallback.
+_SEMANTIC_SELECTORS = (
+    "article", "main", '[role="main"]',
+    ".post-content", ".entry-content", ".article-body",
+)
+
+# Coarse confidence per extraction method: selector-based extraction elsewhere
+# in the pipeline is implicitly 1.0; these are the degraded tiers below it.
+_CONFIDENCE = {"trafilatura": 0.9, "readability": 0.7, "bs4-heuristic": 0.5}
+
+
+@dataclass(frozen=True)
+class ExtractResult:
+    """Outcome of a successful cascade stage."""
+
+    text: str
+    method: str            # trafilatura | readability | bs4-heuristic
+    confidence: float      # coarse tier, see _CONFIDENCE
+    title: Optional[str] = None
+
+
+def extract_article(html, url: Optional[str] = None) -> Optional[ExtractResult]:
+    """Extract the main article text from raw HTML, site-agnostically.
+
+    ``html`` may be ``str`` or ``bytes``. Returns ``None`` only when every
+    stage fails to produce ``MIN_CHARS`` of text — callers treat that as a
+    genuine empty/non-article page.
+    """
+    if not html:
+        return None
+    text_html = html.decode("utf-8", errors="replace") if isinstance(html, bytes) else html
+
+    result = _try_trafilatura(text_html, url)
+    if result is not None:
+        return result
+
+    result = _try_readability(text_html)
+    if result is not None:
+        return result
+
+    return _try_bs4_heuristic(text_html)
+
+
+def _try_trafilatura(html: str, url: Optional[str]) -> Optional[ExtractResult]:
+    try:
+        import trafilatura  # type: ignore
+    except ImportError:
+        return None
+    try:
+        text = trafilatura.extract(html, url=url, include_comments=False)
+    except Exception:  # noqa: BLE001 - a stage failure falls through, never raises
+        return None
+    text = _normalize(text or "")
+    if len(text) < MIN_CHARS:
+        return None
+    title = None
+    try:
+        meta = trafilatura.extract_metadata(html)
+        title = getattr(meta, "title", None) or None
+    except Exception:  # noqa: BLE001
+        pass
+    return ExtractResult(text=text, method="trafilatura",
+                         confidence=_CONFIDENCE["trafilatura"], title=title)
+
+
+def _try_readability(html: str) -> Optional[ExtractResult]:
+    try:
+        from readability import Document  # type: ignore
+    except ImportError:
+        return None
+    try:
+        doc = Document(html)
+        text = _normalize(_strip_tags(doc.summary()))
+        title = (doc.short_title() or "").strip() or None
+    except Exception:  # noqa: BLE001
+        return None
+    if len(text) < MIN_CHARS:
+        return None
+    return ExtractResult(text=text, method="readability",
+                         confidence=_CONFIDENCE["readability"], title=title)
+
+
+def _try_bs4_heuristic(html: str) -> Optional[ExtractResult]:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:  # pragma: no cover - bs4 is a hard dep of the scrapers
+        return None
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception:  # noqa: BLE001
+        return None
+
+    for tag in soup.find_all(_NOISE_TAGS):
+        tag.decompose()
+
+    title = None
+    h1 = soup.find("h1")
+    if h1 is not None:
+        title = _normalize(h1.get_text(separator=" ")) or None
+
+    for selector in _SEMANTIC_SELECTORS:
+        el = soup.select_one(selector)
+        if el:
+            text = _normalize(el.get_text(separator=" "))
+            if len(text) >= MIN_CHARS:
+                return ExtractResult(text=text, method="bs4-heuristic",
+                                     confidence=_CONFIDENCE["bs4-heuristic"], title=title)
+
+    # Largest <div> by text length — last resort.
+    best = ""
+    for div in soup.find_all("div"):
+        t = _normalize(div.get_text(separator=" "))
+        if len(t) > len(best):
+            best = t
+    if len(best) >= MIN_CHARS:
+        return ExtractResult(text=best, method="bs4-heuristic",
+                             confidence=_CONFIDENCE["bs4-heuristic"], title=title)
+    return None
+
+
+def _strip_tags(html: str) -> str:
+    return re.sub(r"<[^>]+>", " ", html)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()

--- a/tests/unit/ingestion/test_extract.py
+++ b/tests/unit/ingestion/test_extract.py
@@ -1,0 +1,113 @@
+"""Unit tests for the generic article-extraction cascade (#877) — offline.
+
+The CI gate installs neither trafilatura nor readability-lxml, so these tests
+exercise the always-available bs4 stage plus the cascade's fall-through and
+degradation contracts. When the optional libraries ARE installed locally, the
+same assertions still hold (the cascade just answers from an earlier stage
+with higher confidence).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("bs4")
+
+from src.ingestion.extract import MIN_CHARS, ExtractResult, extract_article
+
+_BODY = "Parliament voted on the budget today. " * 12  # comfortably > MIN_CHARS
+
+
+def _page(body_html: str) -> str:
+    return f"""
+    <html><head><title>t</title><script>var x = 1;</script></head>
+    <body>
+      <nav>Home News Sport Weather More Links Nav Nav Nav</nav>
+      {body_html}
+      <footer>Copyright Notice And A Lot Of Boilerplate Text Here</footer>
+    </body></html>
+    """
+
+
+def test_extracts_article_tag():
+    html = _page(f"<article><h2>Budget vote</h2><p>{_BODY}</p></article>")
+    result = extract_article(html)
+    assert result is not None
+    assert "Parliament voted" in result.text
+    assert result.confidence > 0
+    assert result.method in {"trafilatura", "readability", "bs4-heuristic"}
+
+
+def test_boilerplate_excluded_from_bs4_stage():
+    html = _page(f"<main><p>{_BODY}</p></main>")
+    result = extract_article(html)
+    assert result is not None
+    assert "Copyright Notice" not in result.text
+    assert "Home News Sport" not in result.text
+
+
+def test_h1_reported_as_title():
+    html = _page(f"<h1>Budget approved</h1><article><p>{_BODY}</p></article>")
+    result = extract_article(html)
+    assert result is not None
+    if result.method == "bs4-heuristic":  # optional libs may title differently
+        assert result.title == "Budget approved"
+    else:
+        assert result.title  # some title extracted
+
+
+def test_largest_div_fallback_without_semantic_tags():
+    html = _page(f"<div class='x'>short</div><div class='y'><p>{_BODY}</p></div>")
+    result = extract_article(html)
+    assert result is not None
+    assert "Parliament voted" in result.text
+
+
+def test_short_content_returns_none():
+    assert extract_article(_page("<article><p>too short</p></article>")) is None
+
+
+def test_empty_input_returns_none():
+    assert extract_article("") is None
+    assert extract_article(b"") is None
+    assert extract_article(None) is None
+
+
+def test_bytes_input_accepted():
+    html = _page(f"<article><p>{_BODY}</p></article>").encode("utf-8")
+    result = extract_article(html)
+    assert result is not None and "Parliament voted" in result.text
+
+
+def test_confidence_tiers_are_ordered():
+    # The contract downstream consumers rely on: generic methods rank below
+    # selector extraction (1.0) and are ordered by expected quality.
+    html = _page(f"<article><p>{_BODY}</p></article>")
+    result = extract_article(html)
+    assert result is not None
+    assert 0 < result.confidence < 1.0
+
+
+def test_result_is_frozen_dataclass():
+    r = ExtractResult(text="x", method="bs4-heuristic", confidence=0.5)
+    with pytest.raises(AttributeError):
+        r.text = "y"  # type: ignore[misc]
+
+
+def test_min_chars_constant_sane():
+    assert 50 <= MIN_CHARS <= 1000
+
+
+def test_blog_readability_delegates_to_cascade():
+    """The blog connector's fetch_full_text now answers via the shared cascade."""
+    from src.ingestion.connectors.blog.readability import fetch_full_text
+
+    html = _page(f"<article><p>{_BODY}</p></article>").encode("utf-8")
+    text = fetch_full_text("https://example.com/post", _http_get=lambda url: html)
+    assert "Parliament voted" in text
+
+    # Network failure still degrades to empty string, never raises.
+    def boom(url):
+        raise ConnectionError("down")
+
+    assert fetch_full_text("https://example.com/post", _http_get=boom) == ""


### PR DESCRIPTION
## Overview

First of the scraper-adaptivity series. Per-site CSS selectors break silently on redesigns — this adds the safety net the rest of the series builds on.

## Changes

- **`src/ingestion/extract.py`** — shared, site-agnostic extraction cascade: **trafilatura → readability-lxml → bs4 heuristic** (largest semantic block). Each optional dependency degrades gracefully; the bs4 stage is always available. Each stage must clear `MIN_CHARS` or falls through; `None` only when all fail. Results carry `method` + coarse `confidence` (0.9/0.7/0.5) so consumers can distinguish selector-extracted content (implicit 1.0) from the degraded generic tiers.
- **`blog/readability.py`** — now delegates to the cascade instead of carrying its own readability+bs4 copy; fetch + empty-string-on-failure contract unchanged.
- **`requirements.txt`** — `trafilatura` + `readability-lxml` added as optional extras (cascade works without them).

## Testing

- 11 new offline tests in `tests/unit/ingestion/test_extract.py` (gate-covered): stage fall-through, boilerplate exclusion, bytes input, short-content rejection, frozen result, blog delegation incl. failure path — **all pass**.
- Existing blog connector tests (21) pass unchanged.
- Gate installs neither optional lib, so CI exercises the pure-bs4 degradation path by construction.

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_