### PR TITLE
Add per-source extraction-health tracking, drift detection, and adaptive scheduling

### DIFF
--- a/src/ingestion/source_health.py
+++ b/src/ingestion/source_health.py
@@ -1,0 +1,277 @@
+"""
+Per-source extraction-health tracking, drift detection, and adaptive
+scheduling (#878, #879).
+
+The scrapers' blind spot: a site redesign breaks a selector, the page still
+returns 200, extraction yields nothing, and the source silently goes dark —
+indistinguishable from "no news today". All existing failure telemetry fires
+on fetch/HTTP errors, never on "200 OK but zero articles extracted".
+
+``SourceHealthTracker`` closes that gap with deterministic, threshold-based
+rules over a rolling per-source window:
+
+- ``record_run()`` after every harvest/scrape pass (articles extracted,
+  per-field fill rates, fetch errors).
+- A source is ``unknown`` until ``MIN_RUNS`` runs, then ``healthy`` /
+  ``degraded`` / ``quarantined``:
+
+  * **degraded** — recent yield or field-fill collapsed against the source's
+    own baseline (median of prior runs): every recent run yielded zero while
+    the baseline is >= 1; or recent mean yield fell below
+    ``DEGRADED_YIELD_RATIO`` of a solid baseline; or a field that used to
+    fill >= ``FILL_BASELINE_OK`` now fills < ``FILL_DEGRADED``.
+  * **quarantined** — degradation persisted for ``QUARANTINE_AFTER``
+    consecutive bad runs. Any healthy run fully recovers the source.
+
+- Adaptive scheduling (#879): ``due()`` / ``next_due_ms()`` back a harvest
+  loop — consecutive empty runs back the recrawl interval off exponentially
+  (bounded), productive runs snap it back to the base interval, and
+  quarantined sources are probed only at the max interval so they can
+  self-recover without hammering a broken or blocking site.
+
+State is in-memory with optional JSON persistence; the clock is injectable
+(``now_ms``) so everything is offline-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections import deque
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Drift thresholds (#878) — deterministic and documented ----------------
+MIN_RUNS = 5                 # runs before a source can be judged at all
+EVAL_WINDOW = 3              # most-recent runs evaluated against the baseline
+HISTORY = 30                 # rolling window of retained runs per source
+DEGRADED_YIELD_RATIO = 0.25  # recent mean yield below this fraction of baseline
+SOLID_BASELINE = 4           # ratio rule only applies to baselines >= this
+FILL_BASELINE_OK = 0.9       # a field is "reliably filled" at/above this rate
+FILL_DEGRADED = 0.5          # ... and "collapsed" below this rate
+QUARANTINE_AFTER = 5         # consecutive bad runs before quarantine
+
+# --- Scheduling defaults (#879) --------------------------------------------
+DEFAULT_BASE_INTERVAL_MS = 30 * 60 * 1000        # 30 min between fetches
+DEFAULT_MAX_INTERVAL_MS = 24 * 60 * 60 * 1000    # never back off past 1 day
+
+STATUSES = ("unknown", "healthy", "degraded", "quarantined")
+
+
+def field_fill_rates(
+    articles: Iterable[Dict[str, Any]],
+    fields: Iterable[str] = ("title", "content"),
+) -> Dict[str, float]:
+    """Fraction of articles with a non-empty value per field (1.0 when empty run)."""
+    items = list(articles)
+    if not items:
+        return {f: 1.0 for f in fields}
+    return {
+        f: sum(1 for a in items if str(a.get(f) or "").strip()) / len(items)
+        for f in fields
+    }
+
+
+class SourceHealthTracker:
+    """Rolling extraction-health state for scraped/harvested sources."""
+
+    def __init__(self, path: Optional[str] = None):
+        self._path = path
+        # source_id -> {"runs": deque[dict], "bad_streak": int, "empty_streak": int,
+        #               "last_run_ms": int|None}
+        self._sources: Dict[str, Dict[str, Any]] = {}
+        if path and os.path.exists(path):
+            self._load()
+
+    # ------------------------------------------------------------------ #
+    # Recording
+    # ------------------------------------------------------------------ #
+
+    def record_run(
+        self,
+        source_id: str,
+        articles: int,
+        field_fill: Optional[Dict[str, float]] = None,
+        fetch_errors: int = 0,
+        now_ms: Optional[int] = None,
+    ) -> str:
+        """Record one harvest/scrape pass; returns the post-run status."""
+        now_ms = self._now(now_ms)
+        state = self._sources.setdefault(
+            source_id,
+            {"runs": deque(maxlen=HISTORY), "bad_streak": 0, "empty_streak": 0,
+             "last_run_ms": None},
+        )
+        state["runs"].append({
+            "at_ms": now_ms,
+            "articles": int(articles),
+            "fill": dict(field_fill or {}),
+            "fetch_errors": int(fetch_errors),
+        })
+        state["last_run_ms"] = now_ms
+        state["empty_streak"] = 0 if articles > 0 else state["empty_streak"] + 1
+
+        if self._run_is_bad(source_id):
+            state["bad_streak"] += 1
+        else:
+            state["bad_streak"] = 0  # any healthy run fully recovers
+
+        if self._path:
+            self._save()
+
+        status = self.status(source_id)
+        if status in ("degraded", "quarantined"):
+            logger.warning(
+                "source-health: %s is %s (yield baseline=%s, bad_streak=%d)",
+                source_id, status,
+                (self.baseline(source_id) or {}).get("yield"),
+                state["bad_streak"],
+            )
+        return status
+
+    # ------------------------------------------------------------------ #
+    # Drift assessment (#878)
+    # ------------------------------------------------------------------ #
+
+    def baseline(self, source_id: str) -> Optional[Dict[str, Any]]:
+        """Median yield and per-field fill over runs preceding the eval window."""
+        runs = list(self._sources.get(source_id, {}).get("runs", ()))
+        history = runs[:-EVAL_WINDOW] if len(runs) > EVAL_WINDOW else []
+        if len(history) < MIN_RUNS - EVAL_WINDOW or not history:
+            return None
+        fill_fields = {f for r in history for f in r["fill"]}
+        return {
+            "yield": median(r["articles"] for r in history),
+            "fill": {
+                f: median(r["fill"].get(f, 1.0) for r in history)
+                for f in fill_fields
+            },
+            "runs": len(history),
+        }
+
+    def status(self, source_id: str) -> str:
+        state = self._sources.get(source_id)
+        if state is None or len(state["runs"]) < MIN_RUNS:
+            return "unknown"
+        if not self._run_is_bad(source_id):
+            return "healthy"
+        if state["bad_streak"] >= QUARANTINE_AFTER:
+            return "quarantined"
+        return "degraded"
+
+    def is_quarantined(self, source_id: str) -> bool:
+        return self.status(source_id) == "quarantined"
+
+    def _run_is_bad(self, source_id: str) -> bool:
+        """True when the recent window has collapsed against the baseline."""
+        base = self.baseline(source_id)
+        if base is None:
+            return False
+        recent = list(self._sources[source_id]["runs"])[-EVAL_WINDOW:]
+
+        yields = [r["articles"] for r in recent]
+        if base["yield"] >= 1 and all(y == 0 for y in yields):
+            return True
+        if base["yield"] >= SOLID_BASELINE and mean(yields) < DEGRADED_YIELD_RATIO * base["yield"]:
+            return True
+        for field, base_fill in base["fill"].items():
+            if base_fill >= FILL_BASELINE_OK:
+                recent_fill = mean(r["fill"].get(field, 1.0) for r in recent)
+                if recent_fill < FILL_DEGRADED:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Adaptive scheduling (#879)
+    # ------------------------------------------------------------------ #
+
+    def next_due_ms(
+        self,
+        source_id: str,
+        base_interval_ms: int = DEFAULT_BASE_INTERVAL_MS,
+        max_interval_ms: int = DEFAULT_MAX_INTERVAL_MS,
+    ) -> Optional[int]:
+        """Timestamp after which the source should be fetched again.
+
+        None (always due) for sources with no recorded runs. Empty runs back
+        the interval off exponentially (bounded); a productive run resets it
+        to the base. Quarantined sources are probed at the max interval only.
+        """
+        state = self._sources.get(source_id)
+        if state is None or state["last_run_ms"] is None:
+            return None
+        if self.is_quarantined(source_id):
+            interval = max_interval_ms
+        else:
+            interval = min(
+                base_interval_ms * (2 ** min(state["empty_streak"], 16)),
+                max_interval_ms,
+            )
+        return state["last_run_ms"] + interval
+
+    def due(
+        self,
+        source_id: str,
+        now_ms: Optional[int] = None,
+        base_interval_ms: int = DEFAULT_BASE_INTERVAL_MS,
+        max_interval_ms: int = DEFAULT_MAX_INTERVAL_MS,
+    ) -> bool:
+        """Whether a harvest loop should fetch this source now."""
+        next_at = self.next_due_ms(source_id, base_interval_ms, max_interval_ms)
+        return True if next_at is None else self._now(now_ms) >= next_at
+
+    # ------------------------------------------------------------------ #
+    # Reporting / persistence
+    # ------------------------------------------------------------------ #
+
+    def report(self) -> List[Dict[str, Any]]:
+        """Per-source health summary for monitoring/MCP surfaces."""
+        out = []
+        for source_id, state in sorted(self._sources.items()):
+            runs = list(state["runs"])
+            out.append({
+                "source_id": source_id,
+                "status": self.status(source_id),
+                "runs": len(runs),
+                "last_articles": runs[-1]["articles"] if runs else None,
+                "baseline": self.baseline(source_id),
+                "bad_streak": state["bad_streak"],
+                "empty_streak": state["empty_streak"],
+                "last_run_ms": state["last_run_ms"],
+            })
+        return out
+
+    def _save(self) -> None:
+        try:
+            payload = {
+                sid: {**state, "runs": list(state["runs"])}
+                for sid, state in self._sources.items()
+            }
+            os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
+            with open(self._path, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh)
+        except OSError as exc:  # persistence is best-effort, never fatal
+            logger.warning("source-health: could not persist state: %s", exc)
+
+    def _load(self) -> None:
+        try:
+            with open(self._path, encoding="utf-8") as fh:
+                payload = json.load(fh)
+            for sid, state in payload.items():
+                self._sources[sid] = {
+                    "runs": deque(state.get("runs", []), maxlen=HISTORY),
+                    "bad_streak": int(state.get("bad_streak", 0)),
+                    "empty_streak": int(state.get("empty_streak", 0)),
+                    "last_run_ms": state.get("last_run_ms"),
+                }
+        except (OSError, ValueError) as exc:
+            logger.warning("source-health: could not load state (%s); starting fresh", exc)
+            self._sources = {}
+
+    @staticmethod
+    def _now(now_ms: Optional[int]) -> int:
+        return int(time.time() * 1000) if now_ms is None else int(now_ms)

--- a/tests/unit/ingestion/test_source_health.py
+++ b/tests/unit/ingestion/test_source_health.py
@@ -1,0 +1,193 @@
+"""Unit tests for source extraction-health tracking (#878, #879) — offline."""
+
+from __future__ import annotations
+
+from src.ingestion.source_health import (
+    DEFAULT_BASE_INTERVAL_MS,
+    DEFAULT_MAX_INTERVAL_MS,
+    MIN_RUNS,
+    QUARANTINE_AFTER,
+    SourceHealthTracker,
+    field_fill_rates,
+)
+
+_GOOD_FILL = {"title": 1.0, "content": 1.0}
+_MIN = 60 * 1000
+
+
+def _seed_healthy(tracker, source="bbc", runs=10, articles=10, start_ms=0):
+    """Record a healthy history; returns the timestamp after the last run."""
+    t = start_ms
+    for _ in range(runs):
+        tracker.record_run(source, articles, _GOOD_FILL, now_ms=t)
+        t += 30 * _MIN
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# Drift detection (#878)
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_until_min_runs():
+    tracker = SourceHealthTracker()
+    for i in range(MIN_RUNS - 1):
+        assert tracker.record_run("bbc", 10, _GOOD_FILL, now_ms=i) == "unknown"
+    assert tracker.record_run("bbc", 10, _GOOD_FILL, now_ms=99) == "healthy"
+
+
+def test_healthy_source_stays_healthy():
+    tracker = SourceHealthTracker()
+    _seed_healthy(tracker)
+    assert tracker.status("bbc") == "healthy"
+    base = tracker.baseline("bbc")
+    assert base is not None and base["yield"] == 10
+
+
+def test_zero_yield_runs_flag_degraded_not_no_news():
+    """The core blind spot: 200-OK-but-zero-extracted becomes a distinct signal."""
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker)
+    # Selector breaks: fetches keep "succeeding" with zero articles.
+    for i in range(3):
+        status = tracker.record_run("bbc", 0, now_ms=t + i * 30 * _MIN)
+    assert status == "degraded"
+
+
+def test_low_new_content_is_not_degraded():
+    """A quiet news day (some yield) must NOT look like breakage."""
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker, articles=10)
+    for i in range(3):
+        status = tracker.record_run("bbc", 4, _GOOD_FILL, now_ms=t + i * 30 * _MIN)
+    assert status == "healthy"  # 40% of baseline is above the 25% collapse line
+
+
+def test_field_fill_collapse_flags_degraded():
+    """Yield intact but the title selector broke -> fill-rate drift fires."""
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker)
+    status = "healthy"
+    for i in range(3):
+        status = tracker.record_run(
+            "bbc", 10, {"title": 0.1, "content": 1.0}, now_ms=t + i * 30 * _MIN
+        )
+    assert status == "degraded"
+
+
+def test_quarantine_after_persistent_degradation_and_recovery():
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker)
+    status = "healthy"
+    runs_needed = 0
+    while status != "quarantined":
+        status = tracker.record_run("bbc", 0, now_ms=t)
+        t += 30 * _MIN
+        runs_needed += 1
+        assert runs_needed < 20, "never quarantined"
+    assert tracker.is_quarantined("bbc")
+    # One healthy run fully recovers the source.
+    assert tracker.record_run("bbc", 10, _GOOD_FILL, now_ms=t) == "healthy"
+
+
+def test_sources_tracked_independently():
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker, "bbc")
+    _seed_healthy(tracker, "cnn")
+    for i in range(3):
+        tracker.record_run("bbc", 0, now_ms=t + i)
+    assert tracker.status("bbc") == "degraded"
+    assert tracker.status("cnn") == "healthy"
+
+
+def test_field_fill_rates_helper():
+    articles = [
+        {"title": "a", "content": "x"},
+        {"title": "", "content": "y"},
+        {"title": "c", "content": ""},
+    ]
+    rates = field_fill_rates(articles)
+    assert abs(rates["title"] - 2 / 3) < 1e-9
+    assert abs(rates["content"] - 2 / 3) < 1e-9
+    # An empty run reports full fill so zero-yield runs don't fake fill drift.
+    assert field_fill_rates([]) == {"title": 1.0, "content": 1.0}
+
+
+# --------------------------------------------------------------------------- #
+# Adaptive scheduling (#879)
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_source_always_due():
+    tracker = SourceHealthTracker()
+    assert tracker.due("new-source", now_ms=0)
+
+
+def test_productive_source_uses_base_interval():
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker)  # last run at t - 30min
+    last = t - 30 * _MIN
+    assert not tracker.due("bbc", now_ms=last + DEFAULT_BASE_INTERVAL_MS - 1)
+    assert tracker.due("bbc", now_ms=last + DEFAULT_BASE_INTERVAL_MS)
+
+
+def test_empty_runs_back_off_exponentially_bounded():
+    tracker = SourceHealthTracker()
+    tracker.record_run("quiet", 0, now_ms=0)     # empty_streak=1 -> 2x base
+    next_at = tracker.next_due_ms("quiet")
+    assert next_at == 2 * DEFAULT_BASE_INTERVAL_MS
+    tracker.record_run("quiet", 0, now_ms=next_at)  # streak=2 -> 4x
+    assert tracker.next_due_ms("quiet") == next_at + 4 * DEFAULT_BASE_INTERVAL_MS
+    # Bounded: a long streak never exceeds the max interval.
+    for i in range(12):
+        tracker.record_run("quiet", 0, now_ms=1_000_000 + i)
+    assert (
+        tracker.next_due_ms("quiet") - 1_000_011
+    ) <= DEFAULT_MAX_INTERVAL_MS
+
+
+def test_productive_run_resets_backoff():
+    tracker = SourceHealthTracker()
+    for i in range(4):
+        tracker.record_run("s", 0, now_ms=i)
+    tracker.record_run("s", 7, _GOOD_FILL, now_ms=100)
+    assert tracker.next_due_ms("s") == 100 + DEFAULT_BASE_INTERVAL_MS
+
+
+def test_quarantined_source_probes_at_max_interval():
+    tracker = SourceHealthTracker()
+    t = _seed_healthy(tracker)
+    for i in range(QUARANTINE_AFTER + 3):
+        tracker.record_run("bbc", 0, now_ms=t + i)
+    assert tracker.is_quarantined("bbc")
+    last = t + QUARANTINE_AFTER + 2
+    assert tracker.next_due_ms("bbc") == last + DEFAULT_MAX_INTERVAL_MS
+    # Never permanently starved: due again once the probe interval elapses.
+    assert tracker.due("bbc", now_ms=last + DEFAULT_MAX_INTERVAL_MS)
+
+
+# --------------------------------------------------------------------------- #
+# Persistence + reporting
+# --------------------------------------------------------------------------- #
+
+
+def test_persistence_roundtrip(tmp_path):
+    path = str(tmp_path / "health.json")
+    tracker = SourceHealthTracker(path=path)
+    t = _seed_healthy(tracker)
+    for i in range(3):
+        tracker.record_run("bbc", 0, now_ms=t + i)
+
+    reloaded = SourceHealthTracker(path=path)
+    assert reloaded.status("bbc") == "degraded"
+    assert reloaded.baseline("bbc")["yield"] == 10
+
+
+def test_report_shape():
+    tracker = SourceHealthTracker()
+    _seed_healthy(tracker)
+    (entry,) = tracker.report()
+    assert entry["source_id"] == "bbc"
+    assert entry["status"] == "healthy"
+    assert entry["runs"] == 10
+    assert entry["baseline"]["yield"] == 10


### PR DESCRIPTION
## Overview

Closes the scrapers' key blind spot: a layout change breaks a selector → fetches keep returning 200 with **zero extracted articles** → indistinguishable from "no news today" and invisible to all fetch-error telemetry. This gives that state a name and a schedule.

## Changes — `src/ingestion/source_health.py`

**Drift detection (#878):**
- `record_run(source_id, articles, field_fill, fetch_errors)` per harvest pass over a rolling window (optional JSON persistence, injectable clock).
- Deterministic rules against the source's **own baseline** (median yield/fill of prior runs): repeated zero-yield vs a nonzero baseline, mean yield collapsing below 25% of a solid baseline, or a reliably-filled field (≥0.9) dropping under 0.5 fill → **degraded**; persistent degradation → **quarantined**; any healthy run fully recovers.
- Crucially: a quiet news day (reduced but nonzero yield) stays **healthy** — tested.

**Adaptive scheduling (#879):**
- `due()` / `next_due_ms()` for harvest loops: exponential backoff on consecutive empty runs (bounded at a max interval), instant reset on a productive run, quarantined sources probed only at the max interval — so broken sources stop wasting fetches but can always self-recover.

Plus `field_fill_rates()` helper and `report()` for monitoring/MCP surfaces.

## Testing

15 offline unit tests in gate-covered `tests/unit/ingestion/test_source_health.py` — unknown→healthy transition, the zero-yield-vs-quiet-day distinction, fill-collapse drift, quarantine + recovery, per-source isolation, backoff/reset/probe scheduling, persistence roundtrip. **All pass.**

Closes #878
Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_