### PR TITLE
Harden the live ingestion path: retry, UA rotation, full-text, health wiring

### DIFF
--- a/src/ingestion/scrapy_integration.py
+++ b/src/ingestion/scrapy_integration.py
@@ -21,12 +21,17 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import itertools
 import logging
+import os
+import random
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import List, Optional, Sequence, Tuple
+from typing import Callable, List, Optional, Sequence, Tuple
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 import xml.etree.ElementTree as ET
 
@@ -39,6 +44,24 @@ logger = logging.getLogger(__name__)
 USER_AGENT = "NeuroNewsBot/1.0 (+https://github.com/Ikey168/NeuroNews)"
 HTTP_TIMEOUT = 15
 _ATOM = "{http://www.w3.org/2005/Atom}"
+
+# Hardening (#880): rotating realistic UAs + retry policy for the live path.
+_USER_AGENTS = (
+    USER_AGENT,
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0",
+)
+_UA_POOL = itertools.cycle(_USER_AGENTS)
+_RETRY_STATUSES = {429, 500, 502, 503, 504}
+_RETRIES = 3
+_RETRY_BASE_DELAY = 0.5  # seconds; exponential with jitter
+
+# Optional full-text bodies (#880): opt-in via env or fetch_articles(full_text=).
+FULL_TEXT_ENV = "NOESIS_INGEST_FULL_TEXT"
+FULL_TEXT_CAP = 20  # max page fetches per feed per run (politeness)
 
 
 @dataclass(frozen=True)
@@ -181,10 +204,38 @@ def score_sentiment(text: str) -> Tuple[float, str]:
 # --------------------------------------------------------------------------- #
 
 
-def _http_get(url: str) -> bytes:
-    req = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/rss+xml, application/xml, text/xml, */*"})
-    with urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return resp.read()
+def _http_get(
+    url: str,
+    retries: int = _RETRIES,
+    _urlopen: Optional[Callable] = None,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> bytes:
+    """GET with rotating User-Agent and retry on transient failures (#880).
+
+    Retries 429/5xx/network errors with exponential backoff + jitter;
+    permanent HTTP errors (403/404/...) raise immediately.
+    """
+    opener = _urlopen or urlopen  # resolved at call time (patchable)
+    last_exc: Exception = RuntimeError("unreachable")
+    for attempt in range(retries):
+        req = Request(url, headers={
+            "User-Agent": next(_UA_POOL),
+            "Accept": "application/rss+xml, application/xml, text/xml, "
+                      "text/html, */*",
+        })
+        try:
+            with opener(req, timeout=HTTP_TIMEOUT) as resp:
+                return resp.read()
+        except HTTPError as exc:
+            if exc.code not in _RETRY_STATUSES:
+                raise  # permanent — do not hammer the server
+            last_exc = exc
+        except (URLError, TimeoutError, OSError) as exc:
+            last_exc = exc
+        if attempt < retries - 1:
+            delay = _RETRY_BASE_DELAY * (2 ** attempt)
+            _sleep(delay + random.uniform(0, delay / 4))
+    raise last_exc
 
 
 def _strip_html(text: Optional[str]) -> str:
@@ -278,21 +329,89 @@ def _build_article(
     )
 
 
+def _full_text_enabled(full_text: Optional[bool]) -> bool:
+    if full_text is not None:
+        return full_text
+    return os.environ.get(FULL_TEXT_ENV, "").lower() in ("1", "true", "yes")
+
+
+def _upgrade_to_full_text(
+    articles: List[Article], http_get: Callable[[str], bytes], cap: int
+) -> int:
+    """Replace RSS-summary bodies with extracted page text where possible (#880).
+
+    Best-effort: any per-article failure keeps the summary. Returns the number
+    of upgraded articles. Capped per run for politeness.
+    """
+    from src.ingestion.extract import extract_article
+
+    upgraded = 0
+    for article in articles[:cap]:
+        try:
+            result = extract_article(http_get(article.url), url=article.url)
+        except Exception:  # noqa: BLE001 - degrade to the summary, never abort
+            continue
+        if result is not None and len(result.text) > len(article.content):
+            article.content = result.text
+            article.sentiment_score, article.sentiment_label = score_sentiment(
+                "{0}. {1}".format(article.title, result.text)
+            )
+            upgraded += 1
+    return upgraded
+
+
 def fetch_articles(
-    feeds: Optional[Sequence[Feed]] = None, limit_per_feed: int = 25
+    feeds: Optional[Sequence[Feed]] = None,
+    limit_per_feed: int = 25,
+    full_text: Optional[bool] = None,
+    full_text_cap: int = FULL_TEXT_CAP,
+    http_get: Optional[Callable[[str], bytes]] = None,
+    health=None,
+    now_ms: Optional[int] = None,
 ) -> List[Article]:
-    """Fetch and parse all feeds, skipping any that fail."""
+    """Fetch and parse all feeds, skipping any that fail.
+
+    ``full_text`` (default: the ``NOESIS_INGEST_FULL_TEXT`` env flag) upgrades
+    article bodies from the RSS summary to extracted page text via the generic
+    cascade (#877), capped per feed. Passing a ``SourceHealthTracker`` as
+    ``health`` records every pass (drift detection, #878) and skips feeds that
+    are not yet due or quarantined (adaptive scheduling, #879). Both are
+    opt-in; default behavior is unchanged.
+    """
     feeds = list(feeds) if feeds is not None else DEFAULT_FEEDS
+    getter = http_get or _http_get
+    want_full_text = _full_text_enabled(full_text)
     articles: List[Article] = []
     for feed in feeds:
+        if health is not None and not health.due(feed.name, now_ms=now_ms):
+            logger.info("Skipping %s (not due / quarantined)", feed.name)
+            continue
+        fetch_errors = 0
+        parsed: List[Article] = []
         try:
             logger.info("Fetching %s (%s)", feed.name, feed.url)
-            raw = _http_get(feed.url)
+            raw = getter(feed.url)
             parsed = parse_feed(raw, feed, limit=limit_per_feed)
+            if want_full_text and parsed:
+                upgraded = _upgrade_to_full_text(parsed, getter, full_text_cap)
+                logger.info("  upgraded %d/%d bodies to full text", upgraded, len(parsed))
             logger.info("  %d articles from %s", len(parsed), feed.name)
             articles.extend(parsed)
         except Exception as exc:
+            fetch_errors = 1
             logger.warning("Failed to fetch %s: %s", feed.name, exc)
+        if health is not None:
+            from src.ingestion.source_health import field_fill_rates
+
+            health.record_run(
+                feed.name,
+                len(parsed),
+                field_fill_rates(
+                    [{"title": a.title, "content": a.content} for a in parsed]
+                ),
+                fetch_errors=fetch_errors,
+                now_ms=now_ms,
+            )
     return articles
 
 
@@ -339,11 +458,15 @@ def ingest(
     feeds: Optional[Sequence[Feed]] = None,
     limit_per_feed: int = 25,
     replace: bool = False,
+    full_text: Optional[bool] = None,
+    health=None,
 ) -> dict:
     """Fetch real news and store it. Returns summary stats."""
     from src.database.local_analytics_connector import get_shared_connection
 
-    articles = fetch_articles(feeds, limit_per_feed=limit_per_feed)
+    articles = fetch_articles(
+        feeds, limit_per_feed=limit_per_feed, full_text=full_text, health=health
+    )
     inserted = store_articles(articles, replace=replace)
     total = get_shared_connection().execute(
         "SELECT COUNT(*) FROM news_articles"
@@ -357,11 +480,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--replace", action="store_true", help="Wipe the table before inserting"
     )
+    parser.add_argument(
+        "--full-text", action="store_true",
+        help="Upgrade bodies from RSS summaries to extracted page text (#880)",
+    )
+    parser.add_argument(
+        "--adaptive", action="store_true",
+        help="Track source health and skip feeds not due / quarantined (#878/#879)",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    health = None
+    if args.adaptive:
+        from src.ingestion.source_health import SourceHealthTracker
+
+        health = SourceHealthTracker(path=os.path.join("data", "source_health.json"))
     try:
-        stats = ingest(limit_per_feed=args.limit, replace=args.replace)
+        stats = ingest(
+            limit_per_feed=args.limit,
+            replace=args.replace,
+            full_text=True if args.full_text else None,
+            health=health,
+        )
     except Exception as exc:  # most commonly the DuckDB single-writer lock
         logger.error("Ingestion failed: %s", exc)
         logger.error(

--- a/tests/unit/ingestion/test_ingestion_hardening.py
+++ b/tests/unit/ingestion/test_ingestion_hardening.py
@@ -1,0 +1,196 @@
+"""Unit tests for the hardened live ingestion path (#880) — offline.
+
+Covers retry/backoff behavior of _http_get, the opt-in full-text upgrade via
+the extraction cascade (#877), and the SourceHealthTracker wiring (#878/#879).
+"""
+
+from __future__ import annotations
+
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+import src.ingestion.scrapy_integration as si
+from src.ingestion.source_health import SourceHealthTracker
+
+_RSS = b"""<?xml version="1.0"?>
+<rss version="2.0"><channel><title>t</title>
+<item><title>Budget vote passes</title><link>https://ex.com/a1</link>
+<description>Short summary.</description>
+<pubDate>Mon, 06 Jul 2026 10:00:00 GMT</pubDate></item>
+</channel></rss>"""
+
+_FEED = si.Feed("Example", "https://ex.com/rss", "World")
+
+_PAGE = (
+    "<html><body><article><p>"
+    + "The parliament approved the annual budget after a long debate. " * 10
+    + "</p></article></body></html>"
+).encode("utf-8")
+
+
+class _Resp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+# --------------------------------------------------------------------------- #
+# _http_get retry behavior
+# --------------------------------------------------------------------------- #
+
+
+def test_http_get_retries_transient_then_succeeds():
+    calls = {"n": 0}
+    sleeps = []
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise HTTPError(req.full_url, 503, "unavailable", None, None)
+        return _Resp(b"ok")
+
+    out = si._http_get("https://ex.com", _urlopen=opener, _sleep=sleeps.append)
+    assert out == b"ok"
+    assert calls["n"] == 3
+    assert len(sleeps) == 2 and sleeps[1] > sleeps[0]  # exponential backoff
+
+
+def test_http_get_permanent_error_raises_immediately():
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        raise HTTPError(req.full_url, 404, "not found", None, None)
+
+    with pytest.raises(HTTPError):
+        si._http_get("https://ex.com", _urlopen=opener, _sleep=lambda s: None)
+    assert calls["n"] == 1  # no hammering on permanent errors
+
+
+def test_http_get_exhausts_retries_and_raises_last_error():
+    def opener(req, timeout=None):
+        raise URLError("connection refused")
+
+    with pytest.raises(URLError):
+        si._http_get("https://ex.com", retries=2, _urlopen=opener, _sleep=lambda s: None)
+
+
+def test_http_get_rotates_user_agent():
+    uas = []
+
+    def opener(req, timeout=None):
+        uas.append(req.get_header("User-agent"))
+        raise URLError("down")
+
+    with pytest.raises(URLError):
+        si._http_get("https://ex.com", retries=3, _urlopen=opener, _sleep=lambda s: None)
+    assert len(set(uas)) > 1  # different attempts wear different UAs
+
+
+# --------------------------------------------------------------------------- #
+# Full-text upgrade (#880 via #877)
+# --------------------------------------------------------------------------- #
+
+
+def _getter(url: str) -> bytes:
+    return _RSS if url.endswith("rss") else _PAGE
+
+
+def test_full_text_upgrade_replaces_summary():
+    articles = si.fetch_articles([_FEED], full_text=True, http_get=_getter)
+    (a,) = articles
+    assert "parliament approved the annual budget" in a.content
+    assert len(a.content) > len("Short summary.")
+
+
+def test_full_text_off_by_default():
+    articles = si.fetch_articles([_FEED], http_get=_getter)
+    (a,) = articles
+    assert a.content == "Short summary."
+
+
+def test_full_text_failure_keeps_summary():
+    def getter(url: str) -> bytes:
+        if url.endswith("rss"):
+            return _RSS
+        raise ConnectionError("article page down")
+
+    articles = si.fetch_articles([_FEED], full_text=True, http_get=getter)
+    (a,) = articles
+    assert a.content == "Short summary."  # degraded, not dropped
+
+
+def test_full_text_cap_limits_page_fetches():
+    page_fetches = {"n": 0}
+
+    def getter(url: str) -> bytes:
+        if url.endswith("rss"):
+            return _RSS
+        page_fetches["n"] += 1
+        return _PAGE
+
+    si.fetch_articles([_FEED], full_text=True, full_text_cap=0, http_get=getter)
+    assert page_fetches["n"] == 0
+
+
+def test_full_text_env_flag(monkeypatch):
+    monkeypatch.setenv(si.FULL_TEXT_ENV, "1")
+    articles = si.fetch_articles([_FEED], http_get=_getter)
+    assert "parliament approved" in articles[0].content
+
+
+# --------------------------------------------------------------------------- #
+# Health-tracker wiring (#878/#879)
+# --------------------------------------------------------------------------- #
+
+
+def test_health_records_every_pass():
+    tracker = SourceHealthTracker()
+    si.fetch_articles([_FEED], http_get=_getter, health=tracker, now_ms=0)
+    (entry,) = tracker.report()
+    assert entry["source_id"] == "Example"
+    assert entry["last_articles"] == 1
+
+
+def test_health_records_fetch_failure_as_zero_yield():
+    def getter(url: str) -> bytes:
+        raise ConnectionError("feed down")
+
+    tracker = SourceHealthTracker()
+    si.fetch_articles([_FEED], http_get=getter, health=tracker, now_ms=0)
+    (entry,) = tracker.report()
+    assert entry["last_articles"] == 0
+
+
+def test_health_skips_feed_not_due():
+    tracker = SourceHealthTracker()
+    tracker.record_run("Example", 5, now_ms=0)  # just fetched
+    fetches = {"n": 0}
+
+    def getter(url: str) -> bytes:
+        fetches["n"] += 1
+        return _RSS
+
+    # One minute later: not due yet -> skipped entirely.
+    out = si.fetch_articles([_FEED], http_get=getter, health=tracker, now_ms=60_000)
+    assert out == [] and fetches["n"] == 0
+
+    # After the base interval: due again.
+    out = si.fetch_articles(
+        [_FEED], http_get=getter, health=tracker,
+        now_ms=60_000 + 30 * 60 * 1000,
+    )
+    assert len(out) == 1 and fetches["n"] == 1
+
+
+def test_no_health_tracker_means_no_behavior_change():
+    assert len(si.fetch_articles([_FEED], http_get=_getter)) == 1

--- a/tests/unit/ingestion/test_scrapy_integration_coverage.py
+++ b/tests/unit/ingestion/test_scrapy_integration_coverage.py
@@ -133,7 +133,8 @@ def test_http_get_reads_response(monkeypatch):
     out = si._http_get("http://example.com/feed")
     assert out == b"<rss>data</rss>"
     assert captured["timeout"] == si.HTTP_TIMEOUT
-    assert "NeuroNewsBot" in captured["ua"]
+    # UA now rotates through a realistic pool (#880).
+    assert captured["ua"] in si._USER_AGENTS
 
 
 # --------------------------------------------------------------------------- #
@@ -324,7 +325,7 @@ def test_ingest_returns_summary(monkeypatch):
     conn = _FakeConn()
     conn._count = 7
     _install_fake_warehouse(monkeypatch, conn)
-    monkeypatch.setattr(si, "fetch_articles", lambda feeds, limit_per_feed: [_make_article()])
+    monkeypatch.setattr(si, "fetch_articles", lambda feeds, limit_per_feed, **kw: [_make_article()])
     stats = si.ingest(limit_per_feed=3, replace=False)
     assert stats["fetched"] == 1
     assert stats["inserted"] == 1
@@ -334,7 +335,7 @@ def test_ingest_returns_summary(monkeypatch):
 def test_main_success(monkeypatch):
     monkeypatch.setattr(
         si, "ingest",
-        lambda limit_per_feed, replace: {
+        lambda limit_per_feed, replace, **kw: {
             "fetched": 2, "inserted": 2, "total_in_warehouse": 2,
         },
     )
@@ -344,7 +345,7 @@ def test_main_success(monkeypatch):
 def test_main_replace_flag_passed(monkeypatch):
     captured = {}
 
-    def _fake_ingest(limit_per_feed, replace):
+    def _fake_ingest(limit_per_feed, replace, **kw):
         captured["limit"] = limit_per_feed
         captured["replace"] = replace
         return {"fetched": 0, "inserted": 0, "total_in_warehouse": 0}
@@ -356,7 +357,7 @@ def test_main_replace_flag_passed(monkeypatch):
 
 
 def test_main_handles_failure(monkeypatch):
-    def _boom(limit_per_feed, replace):
+    def _boom(limit_per_feed, replace, **kw):
         raise RuntimeError("db locked")
 
     monkeypatch.setattr(si, "ingest", _boom)


### PR DESCRIPTION
## Overview

The path that actually feeds the warehouse (`scrapy_integration.py` + connectors) had none of the scraper stack's robustness: bare `urlopen`, no retry, and article "bodies" that were just the RSS `<description>`. This activates the adaptivity series on the production path.

## Changes

- **Retry + UA rotation** — `_http_get` rotates realistic User-Agents per attempt and retries transient failures (429/5xx/network) with exponential backoff + jitter; permanent HTTP errors (403/404/…) still raise immediately so we never hammer a server. `urlopen` resolved at call time (existing monkeypatch tests keep working).
- **Opt-in full-text bodies** — `--full-text` / `NOESIS_INGEST_FULL_TEXT`: summaries upgraded to extracted page text via the generic cascade (#877), sentiment rescored, capped per feed for politeness; any per-article failure degrades back to the summary.
- **Opt-in adaptive harvesting** — `--adaptive`: every pass recorded into a `SourceHealthTracker` (#878); feeds not due or quarantined are skipped (#879). Fetch failures record as zero-yield runs so drift detection sees them.
- **Default behavior unchanged** when neither option is enabled (tested).

## Testing

- 13 new offline tests (`test_ingestion_hardening.py`): retry-then-succeed with growing backoff, permanent-error fast-fail, retry exhaustion, UA rotation, full-text upgrade/off-by-default/failure-degrades/cap/env-flag, health recording (incl. failure-as-zero-yield), due-skip + re-due, and no-tracker-no-change.
- Existing `scrapy_integration` test stubs updated for the grown signatures (`**kwargs`-tolerant) and rotating-UA assertion.
- **Full gated `tests/unit/ingestion` dir: 424 passed.**

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_