### PR TITLE
Make config_async.json the single source of truth for async sources

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,6 +75,7 @@ jobs:
             tests/unit/osint \
             tests/unit/provisioning \
             tests/unit/reports \
+            tests/unit/scraper_adaptive \
             tests/unit/services_api \
             tests/unit/tools \
             --ignore=tests/unit/argument_mining/test_frames_by_source.py \

--- a/src/scraper/async_scraper_engine.py
+++ b/src/scraper/async_scraper_engine.py
@@ -915,8 +915,28 @@ class AsyncNewsScraperEngine:
         return self.monitor.get_stats()
 
 
-# Pre-configured news sources
-ASYNC_NEWS_SOURCES = [
+# Pre-configured news sources — built from config_async.json, the single
+# source of truth (#881). The former in-code literal duplicated the JSON and
+# the two drifted; a minimal fallback remains only for a missing/broken file.
+def load_async_sources(path=None) -> List[NewsSource]:
+    """Build NewsSource objects from the canonical sources config (#881)."""
+    from .sources_config import enabled_sources
+
+    return [
+        NewsSource(
+            name=entry["name"],
+            base_url=entry["base_url"],
+            article_selectors=dict(entry["article_selectors"]),
+            link_patterns=list(entry.get("link_patterns", [])),
+            requires_js=bool(entry.get("requires_js", False)),
+            rate_limit=float(entry.get("rate_limit", 1.0)),
+            timeout=int(entry.get("timeout", 30)),
+        )
+        for entry in enabled_sources(path)
+    ]
+
+
+_FALLBACK_SOURCES = [
     NewsSource(
         name="BBC",
         base_url="https://www.bbc.com/news",
@@ -930,56 +950,12 @@ ASYNC_NEWS_SOURCES = [
         requires_js=False,
         rate_limit=1.0,
     ),
-    NewsSource(
-        name="CNN",
-        base_url="https://www.cnn.com",
-        article_selectors={
-            "title": "h1.headline__text, h1",
-            "content": ".zn-body__paragraph, article p",
-            "author": ".byline__name",
-            "date": ".update-time",
-        },
-        link_patterns=[r"/2024/.*", r"/2025/.*"],
-        requires_js=False,
-        rate_limit=1.0,
-    ),
-    NewsSource(
-        name="TechCrunch",
-        base_url="https://techcrunch.com",
-        article_selectors={
-            "title": "h1.article__title, h1",
-            "content": ".article-content p",
-            "author": ".article__byline a",
-            "date": "time[datetime]",
-        },
-        link_patterns=[r"/2024/.*", r"/2025/.*"],
-        requires_js=False,
-        rate_limit=2.0,
-    ),
-    NewsSource(
-        name="The Verge",
-        base_url="https://www.theverge.com",
-        article_selectors={
-            "title": "h1.c-page-title, h1",
-            "content": ".c-entry-content p",
-            "author": ".c-byline__author-name",
-            "date": "time[datetime]",
-        },
-        link_patterns=[r"/2024/.*", r"/2025/.*"],
-        requires_js=True,
-        rate_limit=1.0,
-    ),
-    NewsSource(
-        name="Wired",
-        base_url="https://www.wired.com",
-        article_selectors={
-            "title": "h1[data-testid='ContentHeaderHed'], h1",
-            "content": "div[data-testid='ArticleBodyWrapper'] p",
-            "author": "a[data-testid='ContentHeaderAuthorLink']",
-            "date": "time[data-testid='ContentHeaderPublishDate']",
-        },
-        link_patterns=[r"/story/.*"],
-        requires_js=True,
-        rate_limit=1.0,
-    ),
 ]
+
+try:
+    ASYNC_NEWS_SOURCES = load_async_sources()
+except Exception as _exc:  # config missing/broken: stay importable, log loudly
+    logging.getLogger(__name__).error(
+        "sources config unusable (%s); using minimal fallback source list", _exc
+    )
+    ASYNC_NEWS_SOURCES = _FALLBACK_SOURCES

--- a/src/scraper/sources_config.py
+++ b/src/scraper/sources_config.py
@@ -1,0 +1,82 @@
+"""
+Canonical async-scraper source configuration loader (#881).
+
+The async engine's sources were defined twice — ``config_async.json`` and the
+``ASYNC_NEWS_SOURCES`` literal in ``async_scraper_engine.py`` — and the copies
+drifted. This stdlib-only module makes the JSON file the single source of
+truth: the engine builds its ``NewsSource`` list through :func:`load_sources`,
+and adaptivity features that read or patch selectors (drift detection #878,
+selector repair #882) have one canonical place to work with.
+
+Import-safe by design (no aiohttp/playwright), so it is unit-testable in the
+curated CI gate. Malformed config fails loudly with a path to the offending
+entry — never a silent partial load.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+CONFIG_PATH = Path(__file__).parent / "config_async.json"
+
+_REQUIRED = ("name", "base_url", "article_selectors")
+_SELECTOR_FIELDS = ("title", "content")  # selectors an entry must at least define
+
+
+class SourcesConfigError(ValueError):
+    """Raised when the sources config is missing, unparsable, or invalid."""
+
+
+def load_sources(path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Load and validate the ``sources[]`` list from the async config JSON.
+
+    Returns every entry (including disabled ones) as validated dicts; use
+    :func:`enabled_sources` for the fetchable subset. Raises
+    :class:`SourcesConfigError` with a precise message on any problem.
+    """
+    cfg_path = Path(path) if path else CONFIG_PATH
+    try:
+        raw = cfg_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SourcesConfigError(f"cannot read sources config {cfg_path}: {exc}") from exc
+    try:
+        config = json.loads(raw)
+    except ValueError as exc:
+        raise SourcesConfigError(f"sources config {cfg_path} is not valid JSON: {exc}") from exc
+
+    sources = config.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise SourcesConfigError(f"{cfg_path}: expected a non-empty 'sources' list")
+
+    for i, entry in enumerate(sources):
+        _validate_entry(entry, f"{cfg_path} sources[{i}]")
+    return sources
+
+
+def enabled_sources(path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """The subset of :func:`load_sources` entries with ``enabled`` != false."""
+    return [s for s in load_sources(path) if s.get("enabled", True)]
+
+
+def _validate_entry(entry: Any, where: str) -> None:
+    if not isinstance(entry, dict):
+        raise SourcesConfigError(f"{where}: entry must be an object")
+    for field in _REQUIRED:
+        if not entry.get(field):
+            raise SourcesConfigError(f"{where}: missing required field '{field}'")
+    selectors = entry["article_selectors"]
+    if not isinstance(selectors, dict):
+        raise SourcesConfigError(f"{where}: 'article_selectors' must be an object")
+    for field in _SELECTOR_FIELDS:
+        if not isinstance(selectors.get(field), str) or not selectors[field].strip():
+            raise SourcesConfigError(
+                f"{where}: article_selectors must define a non-empty '{field}' selector"
+            )
+    if "rate_limit" in entry and not isinstance(entry["rate_limit"], (int, float)):
+        raise SourcesConfigError(f"{where}: 'rate_limit' must be a number")
+    if "requires_js" in entry and not isinstance(entry["requires_js"], bool):
+        raise SourcesConfigError(f"{where}: 'requires_js' must be a boolean")
+    if "link_patterns" in entry and not isinstance(entry["link_patterns"], list):
+        raise SourcesConfigError(f"{where}: 'link_patterns' must be a list")

--- a/tests/unit/scraper_adaptive/test_sources_config.py
+++ b/tests/unit/scraper_adaptive/test_sources_config.py
@@ -1,0 +1,107 @@
+"""Unit tests for the canonical async-sources config loader (#881) — offline.
+
+Deliberately does NOT import the async engine (aiohttp/playwright); the loader
+is stdlib-only so this file runs in the curated CI gate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.scraper.sources_config import (
+    CONFIG_PATH,
+    SourcesConfigError,
+    enabled_sources,
+    load_sources,
+)
+
+
+def _write(tmp_path, payload) -> str:
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return str(p)
+
+
+def _entry(**overrides):
+    base = {
+        "name": "Example",
+        "base_url": "https://example.com",
+        "article_selectors": {"title": "h1", "content": "article p"},
+        "link_patterns": ["/news/.*"],
+        "requires_js": False,
+        "rate_limit": 1.5,
+        "enabled": True,
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# The repo's real config is the single source of truth — it must always load.
+# --------------------------------------------------------------------------- #
+
+
+def test_repo_config_loads_and_validates():
+    sources = load_sources()
+    assert CONFIG_PATH.exists()
+    assert len(sources) >= 5
+    names = {s["name"] for s in sources}
+    assert "BBC" in names
+    for s in sources:
+        assert s["article_selectors"]["title"]
+        assert s["article_selectors"]["content"]
+
+
+def test_enabled_sources_filters_disabled(tmp_path):
+    path = _write(tmp_path, {"sources": [
+        _entry(name="On"),
+        _entry(name="Off", enabled=False),
+        _entry(name="Implicit"),
+    ]})
+    assert [s["name"] for s in load_sources(path)] == ["On", "Off", "Implicit"]
+    assert [s["name"] for s in enabled_sources(path)] == ["On", "Implicit"]
+
+
+# --------------------------------------------------------------------------- #
+# Malformed config fails loudly, pointing at the offending entry.
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_file_raises():
+    with pytest.raises(SourcesConfigError, match="cannot read"):
+        load_sources("/nonexistent/config.json")
+
+
+def test_invalid_json_raises(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(SourcesConfigError, match="not valid JSON"):
+        load_sources(str(p))
+
+
+def test_missing_sources_list_raises(tmp_path):
+    with pytest.raises(SourcesConfigError, match="non-empty 'sources'"):
+        load_sources(_write(tmp_path, {"sources": []}))
+
+
+@pytest.mark.parametrize("break_it, message", [
+    (lambda e: e.pop("name"), "missing required field 'name'"),
+    (lambda e: e.pop("article_selectors"), "missing required field 'article_selectors'"),
+    (lambda e: e.__setitem__("article_selectors", "h1"), "must be an object"),
+    (lambda e: e["article_selectors"].pop("content"), "non-empty 'content' selector"),
+    (lambda e: e.__setitem__("rate_limit", "fast"), "'rate_limit' must be a number"),
+    (lambda e: e.__setitem__("requires_js", "yes"), "'requires_js' must be a boolean"),
+    (lambda e: e.__setitem__("link_patterns", "/news/"), "'link_patterns' must be a list"),
+])
+def test_invalid_entry_raises_with_location(tmp_path, break_it, message):
+    entry = _entry()
+    break_it(entry)
+    path = _write(tmp_path, {"sources": [_entry(name="fine"), entry]})
+    with pytest.raises(SourcesConfigError, match="sources\\[1\\]"):
+        try:
+            load_sources(path)
+        except SourcesConfigError as exc:
+            assert message in str(exc)
+            raise


### PR DESCRIPTION
## Overview

The async engine's source definitions existed **twice** — `config_async.json` and the `ASYNC_NEWS_SOURCES` literal in `async_scraper_engine.py` — and the copies had already drifted (different selectors, rate limits, source sets). Every adaptivity feature that reads or patches selectors (#878 drift detection, #882 selector repair) needs one canonical place.

## Changes

- **`src/scraper/sources_config.py`** — stdlib-only loader/validator: `load_sources()` returns validated entries or raises `SourcesConfigError` pointing at the offending `sources[i]` (never a silent partial load); `enabled_sources()` filters the fetchable subset. Import-safe (no aiohttp/playwright) → gate-testable.
- **`async_scraper_engine.py`** — `ASYNC_NEWS_SOURCES` is now built from the JSON via `load_async_sources()`; the ~70-line in-code literal shrinks to a one-source fallback used only when the file is missing/broken (logged loudly, module stays importable).
- **New gate-covered test dir `tests/unit/scraper_adaptive/`** (added to `unit-tests.yml`) — home for the scraper-adaptivity series' offline tests.

## Testing

12 offline tests: the repo's **real** config loads and validates (BBC present, all entries carry title/content selectors), enabled-filtering, and 7 parametrized failure modes (missing file, bad JSON, empty list, missing fields, wrong types) each raising with the exact entry location. **All pass.** Engine compiles; its package `__init__` is a bare docstring so the loader import path is heavy-dep-free.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_