### PR TITLE
Add URL canonicalization + content-hash dedup helpers

### DIFF
--- a/src/ingestion/canonical.py
+++ b/src/ingestion/canonical.py
@@ -1,0 +1,91 @@
+"""
+URL canonicalization and content hashing for ingest-time dedup (#895).
+
+The news path dedups by *exact* URL, so tracking-param and fragment variants of
+the same page look like new documents, and the same body syndicated under
+different URLs is only merged downstream. These pure helpers give the document
+sink (#894) two stable dedup keys:
+
+- :func:`canonicalize_url` — a URL stripped of tracking noise and normalized,
+  so ``…/story?utm_source=x#top`` and ``…/story`` collapse.
+- :func:`content_hash` — a SHA-256 over normalized text, so the same article
+  under two URLs hashes identically (URL-independent near-dup collapse).
+
+Dependency-free (stdlib only), so it is import-safe in the CI gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+# Query parameters that never identify content — always dropped.
+_TRACKING_PARAMS = frozenset({
+    "fbclid", "gclid", "gclsrc", "dclid", "msclkid", "yclid", "mc_cid",
+    "mc_eid", "igshid", "ref", "ref_src", "ref_url", "cmpid", "cid", "spm",
+    "_hsenc", "_hsmi", "vero_id", "wt_mc", "s_kwcid", "ncid", "at_medium",
+    "at_campaign",
+})
+# Prefixes whose whole family is tracking (utm_source, utm_medium, …).
+_TRACKING_PREFIXES = ("utm_", "pk_", "piwik_", "matomo_", "hsa_")
+
+_DEFAULT_PORTS = {"http": "80", "https": "443"}
+
+
+def canonicalize_url(url: str) -> str:
+    """Return a canonical form of ``url`` for dedup.
+
+    Lowercases scheme/host, drops the default port, removes tracking query
+    params and the fragment, sorts the remaining query keys, and trims a
+    trailing slash on non-root paths. Returns the input unchanged if it does
+    not parse as an absolute URL.
+    """
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url.strip())
+    except ValueError:
+        return url
+    if not parts.scheme or not parts.netloc:
+        return url
+
+    scheme = parts.scheme.lower()
+
+    host = parts.hostname or ""
+    host = host.lower()
+    port = parts.port
+    netloc = host
+    if port is not None and str(port) != _DEFAULT_PORTS.get(scheme):
+        netloc = f"{host}:{port}"
+    if parts.username:
+        cred = parts.username + (f":{parts.password}" if parts.password else "")
+        netloc = f"{cred}@{netloc}"
+
+    path = parts.path
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+
+    kept = [
+        (k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if not _is_tracking(k)
+    ]
+    query = urlencode(sorted(kept))
+
+    return urlunsplit((scheme, netloc, path, query, ""))  # fragment dropped
+
+
+def _is_tracking(key: str) -> bool:
+    k = key.lower()
+    return k in _TRACKING_PARAMS or any(k.startswith(p) for p in _TRACKING_PREFIXES)
+
+
+def content_hash(text: str) -> str:
+    """Stable SHA-256 over normalized text for URL-independent dedup.
+
+    Normalization lowercases and collapses all whitespace so trivial
+    formatting differences (re-wrapping, extra spaces) do not defeat the
+    duplicate check. Empty/whitespace-only input hashes the empty string.
+    """
+    normalized = re.sub(r"\s+", " ", (text or "")).strip().lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()

--- a/tests/unit/ingestion/test_canonical.py
+++ b/tests/unit/ingestion/test_canonical.py
@@ -1,0 +1,92 @@
+"""Unit tests for ingest-time URL canonicalization + content hashing (#895)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.canonical import canonicalize_url, content_hash
+
+
+# --------------------------------------------------------------------------- #
+# canonicalize_url
+# --------------------------------------------------------------------------- #
+
+
+def test_strips_tracking_params_and_fragment():
+    a = canonicalize_url("https://ex.com/story?utm_source=nl&utm_medium=email#top")
+    b = canonicalize_url("https://ex.com/story")
+    assert a == b == "https://ex.com/story"
+
+
+def test_strips_assorted_click_ids():
+    for noisy in [
+        "https://ex.com/p?fbclid=abc",
+        "https://ex.com/p?gclid=xyz",
+        "https://ex.com/p?mc_cid=1&mc_eid=2",
+        "https://ex.com/p?ref=twitter",
+    ]:
+        assert canonicalize_url(noisy) == "https://ex.com/p"
+
+
+def test_keeps_meaningful_query_and_sorts_keys():
+    a = canonicalize_url("https://ex.com/s?b=2&a=1&utm_source=x")
+    assert a == "https://ex.com/s?a=1&b=2"
+
+
+def test_lowercases_host_and_scheme_keeps_path_case():
+    u = canonicalize_url("HTTPS://Example.COM/Story/Path")
+    assert u == "https://example.com/Story/Path"
+
+
+def test_drops_default_port_keeps_custom():
+    assert canonicalize_url("https://ex.com:443/p") == "https://ex.com/p"
+    assert canonicalize_url("http://ex.com:80/p") == "http://ex.com/p"
+    assert canonicalize_url("https://ex.com:8443/p") == "https://ex.com:8443/p"
+
+
+def test_trailing_slash_normalized_but_root_kept():
+    assert canonicalize_url("https://ex.com/a/b/") == "https://ex.com/a/b"
+    assert canonicalize_url("https://ex.com/") == "https://ex.com/"
+
+
+def test_distinct_urls_stay_distinct():
+    assert canonicalize_url("https://ex.com/a") != canonicalize_url("https://ex.com/b")
+    assert canonicalize_url("https://a.com/x") != canonicalize_url("https://b.com/x")
+
+
+def test_non_url_returned_unchanged():
+    assert canonicalize_url("") == ""
+    assert canonicalize_url("not a url") == "not a url"
+    assert canonicalize_url("file:///local") == "file:///local"  # no netloc
+
+
+# --------------------------------------------------------------------------- #
+# content_hash
+# --------------------------------------------------------------------------- #
+
+
+def test_same_body_hashes_equal_regardless_of_whitespace_case():
+    assert content_hash("The Budget  Passed.\n") == content_hash("the budget passed.")
+
+
+def test_different_body_hashes_differ():
+    assert content_hash("A bill passed") != content_hash("A bill failed")
+
+
+def test_empty_and_none_hash_stably():
+    assert content_hash("") == content_hash("   \n ")
+    assert content_hash(None) == content_hash("")  # type: ignore[arg-type]
+
+
+def test_hash_is_hex_sha256():
+    h = content_hash("x")
+    assert len(h) == 64 and all(c in "0123456789abcdef" for c in h)
+
+
+def test_syndicated_article_dedup_scenario():
+    """Same story under two outlets' URLs -> same content hash, different canon URL."""
+    body = "Parliament approved the budget after a marathon debate."
+    u1 = canonicalize_url("https://bbc.com/news/budget?utm_source=rss")
+    u2 = canonicalize_url("https://guardian.com/uk/budget#comments")
+    assert u1 != u2
+    assert content_hash(body) == content_hash(body + "  ")


### PR DESCRIPTION
## Overview

First of the ingestion-hardening series. Ingest-time dedup foundation consumed by the unified document sink (#894).

## Changes — `src/ingestion/canonical.py`

- `canonicalize_url(url)` — strips tracking params (`utm_*`, `fbclid`, `gclid`, `mc_cid`, `pk_*`, …) and fragments, lowercases scheme/host, drops default ports, sorts remaining query keys, trims trailing slashes on non-root paths. Non-URLs pass through unchanged.
- `content_hash(text)` — stable SHA-256 over whitespace/case-normalized text, so the same body syndicated under two URLs hashes identically.

Pure stdlib → import-safe in the CI gate.

## Testing

13 offline tests: tracking-param + fragment stripping, click-id families, meaningful-query preservation + key sorting, host/scheme casing, default-port handling, trailing-slash normalization, distinctness, and the syndicated-article scenario. **All pass.**

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_