### PR TITLE
Add unified, validated, deduped DocumentStore sink (#894, #893)

### DIFF
--- a/src/ingestion/document_store.py
+++ b/src/ingestion/document_store.py
@@ -1,0 +1,219 @@
+"""
+Unified, validated, deduped document sink (#894, #893, #897).
+
+Persistence used to be fragmented — ``news_articles`` (exact-URL dedup),
+``dataset_observations`` (vintage upsert), ``assets`` (sha256), per-connector
+``ingest_to_kg`` — with **no** ``documents`` table and no single place that
+validates against the contract, dedups, or makes ingestion idempotent.
+
+``DocumentStore`` is that place. ``upsert(documents)``:
+
+- validates each document against ``document-ingest-v1`` (#893) — invalid ones
+  are dead-lettered (returned + logged), never written;
+- canonicalizes the URL and computes a content hash (#895) — skipping exact
+  re-inserts (``document_id``) and content duplicates (``content_hash`` +
+  ``source_type``, so the same story syndicated under two URLs collapses);
+- inserts the survivors idempotently;
+
+and returns an :class:`UpsertSummary` (#897). The DuckDB connection is injected,
+so the store is offline-testable against an in-memory database.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+from services.ingest.common.document_model import Document
+
+logger = logging.getLogger(__name__)
+
+# A validator raises on an invalid payload; the default uses document-ingest-v1.
+Validator = Callable[[Dict[str, Any]], None]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS documents (
+    document_id   TEXT PRIMARY KEY,
+    source_type   TEXT NOT NULL,
+    language      TEXT,
+    ingested_at   BIGINT,
+    created_at    BIGINT,
+    source_id     TEXT,
+    url           TEXT,
+    canonical_url TEXT,
+    content_hash  TEXT,
+    title         TEXT,
+    content       TEXT,
+    content_ref   TEXT,
+    authors       TEXT,   -- JSON array
+    metadata      TEXT    -- JSON object
+)
+"""
+
+
+@dataclass
+class UpsertSummary:
+    """Outcome of one :meth:`DocumentStore.upsert` call (#897)."""
+
+    received: int = 0
+    inserted: int = 0
+    duplicate: int = 0
+    invalid: int = 0
+    dead_letter: List[Dict[str, Any]] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "received": self.received,
+            "inserted": self.inserted,
+            "duplicate": self.duplicate,
+            "invalid": self.invalid,
+        }
+
+
+def _default_validator(payload: Dict[str, Any]) -> None:
+    # Imported lazily so the module stays import-safe when validation is off.
+    from services.ingest.common.document_contracts import validate_document
+
+    validate_document(payload)
+
+
+class DocumentStore:
+    """Idempotent, contract-validated, deduped sink for ``Document`` records."""
+
+    def __init__(self, conn, validator: Optional[Validator] = None):
+        self.conn = conn
+        self._validator = validator or _default_validator
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        self.conn.execute(_SCHEMA)
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_documents_content_hash "
+            "ON documents (content_hash, source_type)"
+        )
+
+    def upsert(
+        self,
+        documents: Iterable[Union[Document, Dict[str, Any]]],
+        validate: bool = True,
+    ) -> UpsertSummary:
+        """Validate, dedup, and insert ``documents``; return a summary.
+
+        A validation failure dead-letters that one document (the rest of the
+        batch still stores). Duplicates — same ``document_id``, or same
+        ``(content_hash, source_type)`` — are skipped. Re-running an
+        already-ingested batch inserts nothing.
+        """
+        from src.ingestion.canonical import canonicalize_url, content_hash
+
+        summary = UpsertSummary()
+        seen_ids, seen_hashes = self._load_existing()
+        rows: List[Tuple] = []
+
+        for item in documents:
+            summary.received += 1
+
+            # Normalize to a payload dict *without* constructing a Document yet:
+            # Document.__post_init__ rejects out-of-contract source_types, and a
+            # bad payload must dead-letter rather than abort the whole batch.
+            payload = item.to_dict() if isinstance(item, Document) else dict(item)
+            doc_id = payload.get("document_id", "unknown")
+
+            if validate:
+                try:
+                    self._validator(payload)
+                except Exception as exc:  # noqa: BLE001 - one bad doc never aborts
+                    summary.invalid += 1
+                    summary.dead_letter.append({"document_id": doc_id, "error": str(exc)})
+                    logger.warning("document-store: dead-letter %s (%s)", doc_id, exc)
+                    continue
+
+            # Safe now: a validated payload has a contract-valid source_type. With
+            # validation off, a malformed payload still dead-letters here.
+            try:
+                doc = item if isinstance(item, Document) else Document.from_dict(payload)
+            except Exception as exc:  # noqa: BLE001
+                summary.invalid += 1
+                summary.dead_letter.append({"document_id": doc_id, "error": str(exc)})
+                logger.warning("document-store: dead-letter %s (%s)", doc_id, exc)
+                continue
+
+            chash = content_hash(doc.content or "")
+            hkey = (chash, doc.source_type)
+            if doc.document_id in seen_ids or hkey in seen_hashes:
+                summary.duplicate += 1
+                continue
+
+            seen_ids.add(doc.document_id)
+            seen_hashes.add(hkey)
+            rows.append(self._to_row(doc, canonicalize_url(doc.url) if doc.url else None, chash))
+
+        if rows:
+            self.conn.executemany(
+                """
+                INSERT INTO documents
+                    (document_id, source_type, language, ingested_at, created_at,
+                     source_id, url, canonical_url, content_hash, title, content,
+                     content_ref, authors, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+            summary.inserted = len(rows)
+        return summary
+
+    def count(self) -> int:
+        return self.conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+
+    def get(self, document_id: str) -> Optional[Dict[str, Any]]:
+        cols = [
+            "document_id", "source_type", "language", "ingested_at", "created_at",
+            "source_id", "url", "canonical_url", "content_hash", "title",
+            "content", "content_ref", "authors", "metadata",
+        ]
+        row = self.conn.execute(
+            f"SELECT {', '.join(cols)} FROM documents WHERE document_id = ?",
+            [document_id],
+        ).fetchone()
+        if row is None:
+            return None
+        rec = dict(zip(cols, row))
+        rec["authors"] = json.loads(rec["authors"]) if rec["authors"] else []
+        rec["metadata"] = json.loads(rec["metadata"]) if rec["metadata"] else {}
+        return rec
+
+    # ------------------------------------------------------------------ #
+
+    def _load_existing(self):
+        ids = {
+            r[0] for r in self.conn.execute("SELECT document_id FROM documents").fetchall()
+        }
+        hashes = {
+            (r[0], r[1])
+            for r in self.conn.execute(
+                "SELECT content_hash, source_type FROM documents "
+                "WHERE content_hash IS NOT NULL"
+            ).fetchall()
+        }
+        return ids, hashes
+
+    @staticmethod
+    def _to_row(doc: Document, canonical_url: Optional[str], chash: str) -> Tuple:
+        return (
+            doc.document_id,
+            doc.source_type,
+            doc.language,
+            doc.ingested_at,
+            doc.created_at,
+            doc.source_id,
+            doc.url,
+            canonical_url,
+            chash,
+            doc.title,
+            doc.content,
+            doc.content_ref,
+            json.dumps(doc.authors or []),
+            json.dumps(doc.metadata or {}),
+        )

--- a/tests/unit/ingestion/test_document_store.py
+++ b/tests/unit/ingestion/test_document_store.py
@@ -1,0 +1,266 @@
+"""Unit tests for the unified DocumentStore sink (#894, #893, #897).
+
+Offline: an in-memory DuckDB connection is injected, so nothing touches disk or
+the network. Covers idempotency, exact- and content-dedup, partial-batch
+resilience (one invalid doc never aborts the batch), and summary bookkeeping.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.document_store import DocumentStore, UpsertSummary
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def store() -> DocumentStore:
+    """A DocumentStore over a fresh in-memory DuckDB, using the real validator."""
+    return DocumentStore(duckdb.connect(":memory:"))
+
+
+def _doc(doc_id: str, *, content: str = "Body text.", url: str | None = None,
+         source_type: str = "news", language: str = "en") -> Document:
+    return Document(
+        document_id=doc_id,
+        source_type=source_type,
+        language=language,
+        ingested_at=1_700_000_000_000,
+        url=url,
+        content=content,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Schema / lifecycle
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_schema_is_idempotent():
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn)
+    DocumentStore(conn)  # second construction must not raise on existing table
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+
+
+def test_empty_batch_returns_zeroed_summary(store: DocumentStore):
+    summary = store.upsert([])
+    assert summary.as_dict() == {
+        "received": 0, "inserted": 0, "duplicate": 0, "invalid": 0
+    }
+    assert store.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Insertion + idempotency
+# --------------------------------------------------------------------------- #
+
+
+def test_inserts_distinct_documents(store: DocumentStore):
+    summary = store.upsert([
+        _doc("d1", content="First story.", url="https://ex.com/1"),
+        _doc("d2", content="Second story.", url="https://ex.com/2"),
+    ])
+    assert summary.inserted == 2
+    assert summary.duplicate == 0
+    assert store.count() == 2
+
+
+def test_rerunning_same_batch_inserts_nothing(store: DocumentStore):
+    batch = [
+        _doc("d1", content="First story.", url="https://ex.com/1"),
+        _doc("d2", content="Second story.", url="https://ex.com/2"),
+    ]
+    store.upsert(batch)
+    second = store.upsert(batch)
+    assert second.received == 2
+    assert second.inserted == 0
+    assert second.duplicate == 2
+    assert store.count() == 2
+
+
+def test_same_document_id_is_not_reinserted(store: DocumentStore):
+    store.upsert([_doc("d1", content="Original.", url="https://ex.com/1")])
+    # Same id, *different* body — the id guard still collapses it.
+    summary = store.upsert([_doc("d1", content="Rewritten.", url="https://ex.com/1")])
+    assert summary.inserted == 0
+    assert summary.duplicate == 1
+    assert store.count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# Content dedup (URL-independent)
+# --------------------------------------------------------------------------- #
+
+
+def test_syndicated_content_collapses_across_urls(store: DocumentStore):
+    body = "Parliament approved the budget after a marathon debate."
+    summary = store.upsert([
+        _doc("bbc-1", content=body, url="https://bbc.com/news/budget"),
+        _doc("guardian-1", content=body, url="https://guardian.com/uk/budget"),
+    ])
+    # Same content, different ids/URLs -> second is a content duplicate.
+    assert summary.inserted == 1
+    assert summary.duplicate == 1
+    assert store.count() == 1
+
+
+def test_content_dedup_ignores_whitespace_and_case(store: DocumentStore):
+    store.upsert([_doc("d1", content="The Budget Passed.", url="https://ex.com/1")])
+    summary = store.upsert([_doc("d2", content="the   budget\npassed.", url="https://ex.com/2")])
+    assert summary.inserted == 0
+    assert summary.duplicate == 1
+
+
+def test_same_body_different_source_type_are_both_kept(store: DocumentStore):
+    body = "Identical body across a news article and a blog post."
+    summary = store.upsert([
+        _doc("news-1", content=body, url="https://ex.com/n", source_type="news"),
+        _doc("blog-1", content=body, url="https://ex.com/b", source_type="blog"),
+    ])
+    # Content hash keyed by (hash, source_type), so these do not collide.
+    assert summary.inserted == 2
+    assert store.count() == 2
+
+
+def test_within_batch_content_duplicates_collapse(store: DocumentStore):
+    body = "One story submitted twice in a single batch."
+    summary = store.upsert([
+        _doc("a", content=body, url="https://ex.com/a"),
+        _doc("b", content=body, url="https://ex.com/b"),
+        _doc("c", content=body, url="https://ex.com/c"),
+    ])
+    assert summary.received == 3
+    assert summary.inserted == 1
+    assert summary.duplicate == 2
+
+
+# --------------------------------------------------------------------------- #
+# Validation / dead-lettering (partial-batch resilience)
+# --------------------------------------------------------------------------- #
+
+
+def test_invalid_document_is_dead_lettered_and_batch_survives(store: DocumentStore):
+    good = _doc("good-1", content="Valid body.", url="https://ex.com/good")
+    # Bypass Document.__post_init__ (which would reject a bad source_type) by
+    # feeding a raw payload with an out-of-contract source_type.
+    bad_payload = good.to_dict()
+    bad_payload["document_id"] = "bad-1"
+    bad_payload["source_type"] = "not-a-real-type"
+
+    summary = store.upsert([bad_payload, good])
+    assert summary.received == 2
+    assert summary.invalid == 1
+    assert summary.inserted == 1
+    assert len(summary.dead_letter) == 1
+    assert summary.dead_letter[0]["document_id"] == "bad-1"
+    assert store.count() == 1
+    assert store.get("good-1") is not None
+    assert store.get("bad-1") is None
+
+
+def test_missing_required_field_is_dead_lettered(store: DocumentStore):
+    payload = _doc("d1", url="https://ex.com/1").to_dict()
+    del payload["language"]  # required by document-ingest-v1
+    summary = store.upsert([payload])
+    assert summary.invalid == 1
+    assert summary.inserted == 0
+    assert store.count() == 0
+
+
+def test_validate_false_skips_validation(store: DocumentStore):
+    # An injected validator that would fail must not be consulted when off.
+    def _boom(_payload):
+        raise AssertionError("validator should not run when validate=False")
+
+    s = DocumentStore(duckdb.connect(":memory:"), validator=_boom)
+    summary = s.upsert([_doc("d1", url="https://ex.com/1")], validate=False)
+    assert summary.inserted == 1
+    assert summary.invalid == 0
+
+
+def test_injected_validator_is_used(store: DocumentStore):
+    seen = []
+
+    def _rejecting(payload):
+        seen.append(payload["document_id"])
+        raise ValueError("nope")
+
+    s = DocumentStore(duckdb.connect(":memory:"), validator=_rejecting)
+    summary = s.upsert([_doc("d1", url="https://ex.com/1")])
+    assert seen == ["d1"]
+    assert summary.invalid == 1
+    assert summary.inserted == 0
+
+
+# --------------------------------------------------------------------------- #
+# Persistence details
+# --------------------------------------------------------------------------- #
+
+
+def test_stored_url_is_canonicalized(store: DocumentStore):
+    store.upsert([_doc("d1", url="https://ex.com/story?utm_source=nl#top")])
+    rec = store.get("d1")
+    assert rec["canonical_url"] == "https://ex.com/story"
+    assert rec["url"] == "https://ex.com/story?utm_source=nl#top"  # raw URL preserved
+
+
+def test_get_roundtrips_authors_and_metadata():
+    store = DocumentStore(duckdb.connect(":memory:"))
+    doc = Document(
+        document_id="d1",
+        source_type="paper",
+        language="en",
+        ingested_at=1_700_000_000_000,
+        authors=["Ada Lovelace", "Alan Turing"],
+        metadata={"venue": "arXiv", "year": 2026},
+        content="Abstract.",
+    )
+    store.upsert([doc])
+    rec = store.get("d1")
+    assert rec["authors"] == ["Ada Lovelace", "Alan Turing"]
+    assert rec["metadata"] == {"venue": "arXiv", "year": 2026}
+
+
+def test_get_missing_returns_none(store: DocumentStore):
+    assert store.get("nope") is None
+
+
+def test_accepts_dict_payloads_not_only_documents(store: DocumentStore):
+    payload = _doc("d1", url="https://ex.com/1").to_dict()
+    summary = store.upsert([payload])
+    assert summary.inserted == 1
+    assert store.get("d1") is not None
+
+
+# --------------------------------------------------------------------------- #
+# Summary bookkeeping
+# --------------------------------------------------------------------------- #
+
+
+def test_summary_counts_reconcile(store: DocumentStore):
+    body = "Repeated body."
+    good = _doc("g1", content="Unique.", url="https://ex.com/g")
+    dup_a = _doc("da", content=body, url="https://ex.com/a")
+    dup_b = _doc("db", content=body, url="https://ex.com/b")  # content dup of dup_a
+    bad = good.to_dict()
+    bad["document_id"] = "bad"
+    bad["source_type"] = "bogus"
+
+    summary = store.upsert([good, dup_a, dup_b, bad])
+    d = summary.as_dict()
+    # received == inserted + duplicate + invalid, always.
+    assert d["received"] == d["inserted"] + d["duplicate"] + d["invalid"]
+    assert d == {"received": 4, "inserted": 2, "duplicate": 1, "invalid": 1}
+
+
+def test_upsert_summary_dataclass_defaults():
+    s = UpsertSummary()
+    assert s.as_dict() == {"received": 0, "inserted": 0, "duplicate": 0, "invalid": 0}
+    assert s.dead_letter == []


### PR DESCRIPTION
## Summary

Ingestion persistence was fragmented — `news_articles` (exact-URL dedup), `dataset_observations` (vintage upsert), `assets` (sha256), per-connector `ingest_to_kg` — with **no** `documents` table and no single place that validates against the contract, dedups, or makes ingestion idempotent.

`DocumentStore` is that place. It closes **#894** (unified document sink) and **#893** (contract validation at the sink), and builds on the canonicalization helpers from #895/#900.

## What `upsert(documents)` does

- **Validates** each document against `document-ingest-v1` (#893). Invalid ones are **dead-lettered** — returned in the summary and logged, never written — and one bad document never aborts the rest of the batch (partial-batch resilience).
- **Dedups** using the #895 helpers: canonicalizes the URL and computes a content hash, skipping exact re-inserts (`document_id`) and content duplicates keyed by `(content_hash, source_type)` — so the same story syndicated under two URLs collapses, while identical bodies under different source types are both kept.
- **Inserts** the survivors idempotently and returns an `UpsertSummary(received, inserted, duplicate, invalid, dead_letter)` where `received == inserted + duplicate + invalid` always holds.

The DuckDB connection is **injected**, so the store is offline-testable against an in-memory database, and the validator is injectable (defaulting to the fastavro `document-ingest-v1` validator).

## Design note

Payloads are normalized to a dict and validated *before* a `Document` is constructed. `Document.__post_init__` rejects out-of-contract `source_type`s, so constructing first would crash the batch on a bad payload instead of dead-lettering it — validating the raw payload first preserves partial-batch resilience.

## Tests

`tests/unit/ingestion/test_document_store.py` — 19 tests, all passing, covering:
- idempotent re-run inserts zero;
- content dedup across different URLs, whitespace/case-insensitive, and within a single batch;
- same body under different `source_type`s both kept;
- invalid / missing-required-field documents dead-lettered while valid ones store;
- injected-validator and `validate=False` paths;
- URL canonicalization on write, authors/metadata JSON round-trip, summary reconciliation.

Full `tests/unit/ingestion/` suite: 441 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_