### PR TITLE
Generalize the adaptive layer to Connector.harvest_run (#896, #897)

### DIFF
--- a/src/ingestion/connectors/base.py
+++ b/src/ingestion/connectors/base.py
@@ -20,11 +20,23 @@ See ``docs/architecture/knowledge-engine-pivot.md``.
 from __future__ import annotations
 
 import abc
+import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
 
 from services.ingest.common.document_model import Document
+
+logger = logging.getLogger(__name__)
+
+
+class PermanentFetchError(Exception):
+    """A fetch failure that will not succeed on retry (404, gone, unauthorized).
+
+    ``harvest_run`` skips a source immediately when ``fetch`` raises this,
+    instead of burning retries. Any other exception is treated as transient
+    and retried with backoff.
+    """
 
 
 @dataclass
@@ -35,6 +47,11 @@ class SourceRef:
     title: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+    @property
+    def source_id(self) -> str:
+        """Stable key for health tracking (explicit ``source_id`` or the locator)."""
+        return str(self.metadata.get("source_id") or self.locator)
+
 
 @dataclass
 class RawDocument:
@@ -44,6 +61,48 @@ class RawDocument:
     content: Union[bytes, str]
     content_type: Optional[str] = None
     fetched_at: int = field(default_factory=lambda: int(time.time() * 1000))
+
+
+@dataclass
+class HarvestSummary:
+    """Outcome of one :meth:`Connector.harvest_run` (#897).
+
+    Source-stage counts satisfy ``discovered >= fetched >= parsed`` (some
+    discovered sources are skipped by scheduling or error before fetch/parse).
+    Store-stage counts satisfy ``inserted + duplicate + invalid == documents``
+    when a store is attached — every produced document lands in exactly one
+    outcome. ``per_source`` breaks the same counts down by ``source_id`` so a
+    single degraded source is visible against a healthy run.
+    """
+
+    discovered: int = 0     # sources enumerated by discover()
+    skipped: int = 0        # sources not due / quarantined (not fetched)
+    fetched: int = 0        # sources fetched successfully
+    fetch_errors: int = 0   # sources that failed to fetch (retries exhausted / permanent)
+    parsed: int = 0         # sources parsed successfully
+    parse_errors: int = 0   # sources that failed to parse
+    documents: int = 0      # Document records produced by parse
+    inserted: int = 0       # documents persisted by the store
+    duplicate: int = 0      # documents dedup-skipped by the store
+    invalid: int = 0        # documents contract-rejected by the store
+    per_source: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+    def _source(self, source_id: str) -> Dict[str, int]:
+        return self.per_source.setdefault(source_id, {
+            "discovered": 0, "skipped": 0, "fetched": 0, "fetch_errors": 0,
+            "parsed": 0, "parse_errors": 0, "documents": 0,
+            "inserted": 0, "duplicate": 0, "invalid": 0,
+        })
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "discovered": self.discovered, "skipped": self.skipped,
+            "fetched": self.fetched, "fetch_errors": self.fetch_errors,
+            "parsed": self.parsed, "parse_errors": self.parse_errors,
+            "documents": self.documents, "inserted": self.inserted,
+            "duplicate": self.duplicate, "invalid": self.invalid,
+            "per_source": self.per_source,
+        }
 
 
 class Connector(abc.ABC):
@@ -88,10 +147,127 @@ class Connector(abc.ABC):
             for document in documents:
                 yield document
 
-    def _on_error(self, stage: str, ref: SourceRef) -> None:
-        import logging
+    def harvest_run(
+        self,
+        query: Optional[Any] = None,
+        *,
+        store: Optional[Any] = None,
+        health: Optional[Any] = None,
+        retries: int = 2,
+        backoff_base: float = 0.5,
+        sleep: Callable[[float], None] = time.sleep,
+        now_ms: Optional[int] = None,
+        respect_schedule: bool = True,
+    ) -> HarvestSummary:
+        """Adaptive, observable harvest: retry, health tracking, scheduling (#896, #897).
 
-        logging.getLogger(self.__class__.__module__).warning(
+        Unlike :meth:`harvest` (a bare generator), this drives the same
+        discover -> fetch -> parse chain with the resilience the live RSS path
+        already had, generalized to every connector:
+
+        - transient ``fetch`` failures are retried with exponential backoff;
+          a :class:`PermanentFetchError` skips the source immediately;
+        - each source's yield and field-fill are recorded into ``health`` (a
+          :class:`~src.ingestion.source_health.SourceHealthTracker`), so a
+          source that silently stops yielding is flagged ``degraded``;
+        - when ``respect_schedule`` and ``health`` are set, a source that is
+          not :meth:`~src.ingestion.source_health.SourceHealthTracker.due`
+          (backed off or quarantined) is skipped without fetching;
+        - when a ``store`` (:class:`~src.ingestion.document_store.DocumentStore`)
+          is passed, parsed documents are validated/deduped/persisted and the
+          store outcome folds into the returned :class:`HarvestSummary`.
+
+        ``health`` and ``store`` are duck-typed (only the methods used are
+        required), so the run is offline-testable with fakes.
+        """
+        summary = HarvestSummary()
+
+        for ref in self.discover(query):
+            summary.discovered += 1
+            sid = ref.source_id
+            ps = summary._source(sid)
+            ps["discovered"] += 1
+
+            if (
+                health is not None
+                and respect_schedule
+                and not health.due(sid, now_ms=now_ms)
+            ):
+                summary.skipped += 1
+                ps["skipped"] += 1
+                continue
+
+            raw = self._fetch_with_retry(ref, retries, backoff_base, sleep, summary, ps)
+            if raw is None:
+                self._record_health(health, sid, 0, [], fetch_errors=1, now_ms=now_ms)
+                continue
+            summary.fetched += 1
+            ps["fetched"] += 1
+
+            try:
+                documents = self.parse(raw)
+            except Exception:  # noqa: BLE001 - resilience: skip unparseable sources
+                self._on_error("parse", ref)
+                summary.parse_errors += 1
+                ps["parse_errors"] += 1
+                self._record_health(health, sid, 0, [], fetch_errors=0, now_ms=now_ms)
+                continue
+            summary.parsed += 1
+            ps["parsed"] += 1
+            summary.documents += len(documents)
+            ps["documents"] += len(documents)
+
+            self._record_health(health, sid, len(documents), documents,
+                                 fetch_errors=0, now_ms=now_ms)
+
+            if store is not None and documents:
+                up = store.upsert(documents)
+                summary.inserted += up.inserted
+                summary.duplicate += up.duplicate
+                summary.invalid += up.invalid
+                ps["inserted"] += up.inserted
+                ps["duplicate"] += up.duplicate
+                ps["invalid"] += up.invalid
+
+        return summary
+
+    def _fetch_with_retry(self, ref, retries, backoff_base, sleep, summary, ps):
+        """Fetch ``ref``, retrying transient errors; return the raw doc or None."""
+        attempt = 0
+        while True:
+            try:
+                return self.fetch(ref)
+            except PermanentFetchError:
+                self._on_error("fetch", ref)
+                summary.fetch_errors += 1
+                ps["fetch_errors"] += 1
+                return None
+            except Exception:  # noqa: BLE001 - transient: retry with backoff
+                attempt += 1
+                if attempt > retries:
+                    self._on_error("fetch", ref)
+                    summary.fetch_errors += 1
+                    ps["fetch_errors"] += 1
+                    return None
+                sleep(backoff_base * (2 ** (attempt - 1)))
+
+    @staticmethod
+    def _record_health(health, source_id, articles, documents, *, fetch_errors, now_ms):
+        """Record one source's outcome into a SourceHealthTracker, if provided."""
+        if health is None:
+            return
+        from src.ingestion.source_health import field_fill_rates
+
+        fill = field_fill_rates(
+            [{"title": d.title, "content": d.content} for d in documents]
+        )
+        health.record_run(
+            source_id, articles, field_fill=fill,
+            fetch_errors=fetch_errors, now_ms=now_ms,
+        )
+
+    def _on_error(self, stage: str, ref: SourceRef) -> None:
+        logger.warning(
             "%s: %s stage failed for %s", self.__class__.__name__, stage, ref.locator,
             exc_info=True,
         )

--- a/tests/unit/ingestion/test_connector_harvest_run.py
+++ b/tests/unit/ingestion/test_connector_harvest_run.py
@@ -1,0 +1,303 @@
+"""Unit tests for adaptive, observable Connector.harvest_run (#896, #897).
+
+Offline: a fake connector drives discover -> fetch -> parse with scripted
+outcomes, a real in-memory ``DocumentStore`` and ``SourceHealthTracker`` verify
+the store/health integration, and ``sleep`` is a no-op so retries don't wait.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Callable, Dict, List, Optional
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import (
+    Connector,
+    HarvestSummary,
+    PermanentFetchError,
+    RawDocument,
+    SourceRef,
+)
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.source_health import SourceHealthTracker
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+def _doc(doc_id: str, *, content: str = "Body text.", title: str = "T") -> Document:
+    return Document(
+        document_id=doc_id,
+        source_type="news",
+        language="en",
+        ingested_at=1_700_000_000_000,
+        url=f"https://ex.com/{doc_id}",
+        title=title,
+        content=content,
+    )
+
+
+class FakeConnector(Connector):
+    """A connector with scripted fetch/parse outcomes for one or more sources."""
+
+    source_type = "news"
+
+    def __init__(
+        self,
+        refs: List[SourceRef],
+        docs: Dict[str, List[Document]],
+        fetch_behaviors: Optional[Dict[str, Callable[[int], None]]] = None,
+        parse_raises: Optional[set] = None,
+    ):
+        self._refs = refs
+        self.docs = docs
+        self._fetch_behaviors = fetch_behaviors or {}
+        self._parse_raises = parse_raises or set()
+        self.fetch_calls: Dict[str, int] = defaultdict(int)
+
+    def discover(self, query=None):
+        return self._refs
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        self.fetch_calls[ref.locator] += 1
+        behavior = self._fetch_behaviors.get(ref.locator)
+        if behavior is not None:
+            behavior(self.fetch_calls[ref.locator])  # may raise
+        return RawDocument(ref=ref, content="raw")
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        if raw.ref.locator in self._parse_raises:
+            raise ValueError("unparseable")
+        return list(self.docs.get(raw.ref.locator, []))
+
+
+def _noop_sleep(_seconds: float) -> None:
+    pass
+
+
+# --------------------------------------------------------------------------- #
+# Retry semantics (#896)
+# --------------------------------------------------------------------------- #
+
+
+def test_transient_fetch_error_is_retried_then_succeeds():
+    ref = SourceRef("feed-a")
+
+    def flaky(attempt: int):
+        if attempt < 3:  # fail attempts 1 and 2, succeed on 3
+            raise RuntimeError("transient network blip")
+
+    conn = FakeConnector([ref], {"feed-a": [_doc("a1")]}, {"feed-a": flaky})
+    summary = conn.harvest_run(retries=2, sleep=_noop_sleep)
+
+    assert conn.fetch_calls["feed-a"] == 3
+    assert summary.fetched == 1
+    assert summary.fetch_errors == 0
+    assert summary.documents == 1
+
+
+def test_permanent_fetch_error_fast_fails_without_retry():
+    ref = SourceRef("feed-a")
+
+    def gone(_attempt: int):
+        raise PermanentFetchError("404 gone")
+
+    conn = FakeConnector([ref], {"feed-a": [_doc("a1")]}, {"feed-a": gone})
+    summary = conn.harvest_run(retries=5, sleep=_noop_sleep)
+
+    assert conn.fetch_calls["feed-a"] == 1  # no retries burned
+    assert summary.fetched == 0
+    assert summary.fetch_errors == 1
+    assert summary.documents == 0
+
+
+def test_transient_error_exhausts_retries():
+    ref = SourceRef("feed-a")
+
+    def always(_attempt: int):
+        raise RuntimeError("still down")
+
+    conn = FakeConnector([ref], {"feed-a": [_doc("a1")]}, {"feed-a": always})
+    summary = conn.harvest_run(retries=2, sleep=_noop_sleep)
+
+    assert conn.fetch_calls["feed-a"] == 3  # initial + 2 retries
+    assert summary.fetch_errors == 1
+    assert summary.fetched == 0
+
+
+def test_parse_error_is_isolated_per_source():
+    refs = [SourceRef("good"), SourceRef("bad")]
+    conn = FakeConnector(
+        refs,
+        {"good": [_doc("g1")], "bad": [_doc("b1")]},
+        parse_raises={"bad"},
+    )
+    summary = conn.harvest_run(sleep=_noop_sleep)
+
+    assert summary.fetched == 2       # both fetched fine
+    assert summary.parsed == 1        # only "good" parsed
+    assert summary.parse_errors == 1
+    assert summary.documents == 1
+
+
+# --------------------------------------------------------------------------- #
+# Health integration + drift detection (#896)
+# --------------------------------------------------------------------------- #
+
+
+def test_source_that_stops_yielding_is_flagged_degraded():
+    ref = SourceRef("feed", metadata={"source_id": "ex"})
+    conn = FakeConnector([ref], {"feed": [_doc("d1"), _doc("d2")]})
+    health = SourceHealthTracker()
+
+    # Five productive runs establish a healthy baseline (yield 2).
+    for _ in range(5):
+        conn.harvest_run(health=health, respect_schedule=False, sleep=_noop_sleep)
+    assert health.status("ex") in ("unknown", "healthy")
+
+    # The source goes dark: 200 OK but zero documents extracted.
+    conn.docs["feed"] = []
+    for _ in range(3):
+        conn.harvest_run(health=health, respect_schedule=False, sleep=_noop_sleep)
+
+    assert health.status("ex") == "degraded"
+
+
+def test_healthy_source_is_not_flagged():
+    ref = SourceRef("feed", metadata={"source_id": "ex"})
+    conn = FakeConnector([ref], {"feed": [_doc("d1"), _doc("d2")]})
+    health = SourceHealthTracker()
+    for _ in range(8):
+        conn.harvest_run(health=health, respect_schedule=False, sleep=_noop_sleep)
+    assert health.status("ex") == "healthy"
+
+
+# --------------------------------------------------------------------------- #
+# Adaptive scheduling / quarantine back-off (#896)
+# --------------------------------------------------------------------------- #
+
+
+def test_quarantined_source_is_skipped_when_respecting_schedule():
+    # Drive a source into quarantine directly, then prove harvest_run backs off.
+    health = SourceHealthTracker()
+    for _ in range(5):
+        health.record_run("ex", articles=3, now_ms=1000)
+    for _ in range(7):
+        health.record_run("ex", articles=0, now_ms=1000)
+    assert health.is_quarantined("ex")
+
+    ref = SourceRef("feed", metadata={"source_id": "ex"})
+    conn = FakeConnector([ref], {"feed": [_doc("d1")]})
+    summary = conn.harvest_run(
+        health=health, respect_schedule=True, now_ms=1000, sleep=_noop_sleep
+    )
+
+    assert summary.skipped == 1
+    assert summary.fetched == 0
+    assert conn.fetch_calls["feed"] == 0  # never touched the source
+
+
+def test_schedule_ignored_when_respect_schedule_false():
+    health = SourceHealthTracker()
+    for _ in range(12):
+        health.record_run("ex", articles=0, now_ms=1000)  # quarantined
+
+    ref = SourceRef("feed", metadata={"source_id": "ex"})
+    conn = FakeConnector([ref], {"feed": [_doc("d1")]})
+    summary = conn.harvest_run(
+        health=health, respect_schedule=False, now_ms=1000, sleep=_noop_sleep
+    )
+    assert summary.skipped == 0
+    assert summary.fetched == 1  # forced fetch despite quarantine
+
+
+# --------------------------------------------------------------------------- #
+# Store integration + summary reconciliation (#897)
+# --------------------------------------------------------------------------- #
+
+
+def test_store_integration_folds_upsert_outcome_into_summary():
+    ref = SourceRef("feed")
+    docs = [
+        _doc("d1", content="Unique story."),
+        _doc("d2", content="Shared body."),
+        _doc("d3", content="Shared body."),  # content duplicate of d2
+    ]
+    conn = FakeConnector([ref], {"feed": docs})
+    store = DocumentStore(duckdb.connect(":memory:"))
+
+    summary = conn.harvest_run(store=store, sleep=_noop_sleep)
+
+    assert summary.documents == 3
+    assert summary.inserted == 2
+    assert summary.duplicate == 1
+    assert summary.invalid == 0
+    # Every produced document lands in exactly one store outcome.
+    assert summary.inserted + summary.duplicate + summary.invalid == summary.documents
+    assert store.count() == 2
+
+
+def test_summary_source_stage_counts_reconcile():
+    refs = [SourceRef("a"), SourceRef("b"), SourceRef("c")]
+    conn = FakeConnector(
+        refs,
+        {"a": [_doc("a1")], "b": [_doc("b1")], "c": [_doc("c1")]},
+        fetch_behaviors={"b": lambda _a: (_ for _ in ()).throw(PermanentFetchError("x"))},
+        parse_raises={"c"},
+    )
+    summary = conn.harvest_run(sleep=_noop_sleep)
+
+    # a: fetched+parsed; b: fetch error; c: fetched but parse error.
+    assert summary.discovered == 3
+    assert summary.fetched == 2      # a, c
+    assert summary.parsed == 1       # a
+    assert summary.fetch_errors == 1
+    assert summary.parse_errors == 1
+    # Stage counts are monotonically non-increasing.
+    assert summary.discovered >= summary.fetched >= summary.parsed
+
+
+def test_per_source_breakdown_isolates_a_degraded_source():
+    refs = [SourceRef("healthy"), SourceRef("broken")]
+    conn = FakeConnector(
+        refs,
+        {"healthy": [_doc("h1"), _doc("h2")], "broken": []},
+        fetch_behaviors={},
+    )
+    summary = conn.harvest_run(sleep=_noop_sleep)
+
+    assert summary.per_source["healthy"]["documents"] == 2
+    assert summary.per_source["broken"]["documents"] == 0
+    assert summary.per_source["broken"]["fetched"] == 1
+
+
+def test_harvest_run_without_health_or_store_just_counts():
+    ref = SourceRef("feed")
+    conn = FakeConnector([ref], {"feed": [_doc("d1"), _doc("d2")]})
+    summary = conn.harvest_run(sleep=_noop_sleep)
+    assert summary.as_dict()["documents"] == 2
+    assert summary.inserted == 0  # no store attached
+
+
+# --------------------------------------------------------------------------- #
+# Back-compat: harvest() generator unchanged
+# --------------------------------------------------------------------------- #
+
+
+def test_harvest_generator_still_yields_documents():
+    ref = SourceRef("feed")
+    conn = FakeConnector([ref], {"feed": [_doc("d1"), _doc("d2")]})
+    out = list(conn.harvest())
+    assert [d.document_id for d in out] == ["d1", "d2"]
+
+
+def test_harvest_summary_dataclass_defaults():
+    s = HarvestSummary()
+    d = s.as_dict()
+    assert d["discovered"] == 0 and d["documents"] == 0
+    assert d["per_source"] == {}


### PR DESCRIPTION
## Summary

The adaptive layer (retry, `SourceHealthTracker` drift detection, adaptive scheduling) only protected the live RSS path (`scrapy_integration.fetch_articles`). Every other connector — blog, paper, book, media, dataset, EDGAR, legislative, upload — still did `try/except → _on_error → continue`, so a source that silently stopped yielding produced only a `logging.warning`: exactly the blind spot `source_health.py` was built to close.

This adds an **opt-in** `Connector.harvest_run()` alongside the unchanged `harvest()` generator, closing **#896** (generalize the adaptive layer) and **#897** (per-connector run summaries and observability).

## `harvest_run()` behaviour

- **Retry**: transient `fetch` failures are retried with exponential backoff; a `PermanentFetchError` skips the source immediately without burning retries.
- **Health**: each source's yield and field-fill are recorded into a `SourceHealthTracker`, so a source that goes dark (200 OK, zero documents) is flagged `degraded` by the existing drift rules.
- **Scheduling**: with `respect_schedule=True` (default), a source that is not `due()` — backed off or quarantined — is skipped without fetching, so broken/blocked sources aren't hammered. `respect_schedule=False` forces a fetch (used to build health history in tests / backfills).
- **Store**: an attached `DocumentStore` (#894) validates/dedups/persists the parsed documents, and its `UpsertSummary` folds into the run result.

`health` and `store` are **duck-typed** (only the methods used are required), so the run is fully offline-testable with fakes. `harvest()` is untouched for back-compat.

## `HarvestSummary` (#897)

Returns `{discovered, skipped, fetched, fetch_errors, parsed, parse_errors, documents, inserted, duplicate, invalid, per_source}` with reconciling invariants:
- **source stages**: `discovered ≥ fetched ≥ parsed`;
- **store stages**: `inserted + duplicate + invalid == documents` (every produced document lands in exactly one outcome);
- **per_source** breaks the same counts down by `source_id`, so one degraded source is visible against an otherwise healthy run — ready for the monitoring/MCP surface.

## Tests

`tests/unit/ingestion/test_connector_harvest_run.py` — 14 tests, all passing:
- retry-then-succeed, permanent-fast-fail (no retries), retry exhaustion;
- per-source parse-error isolation;
- drift-to-`degraded` after a source stops yielding; healthy source stays healthy;
- quarantined source skipped when respecting the schedule (and forced when not);
- `DocumentStore` integration folds upsert counts in and reconciles;
- source-stage and per-source reconciliation;
- `harvest()` generator unchanged.

Full `tests/unit/ingestion/` + `tests/unit/scraper_adaptive/`: 499 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_