### PR TITLE
Decouple the ingest write path from the DuckDB single-writer lock (#898)

### DIFF
--- a/src/ingestion/staging.py
+++ b/src/ingestion/staging.py
@@ -1,0 +1,119 @@
+"""
+Staging-and-merge write path, decoupled from the DuckDB single-writer lock (#898).
+
+DuckDB allows a single writer, so ingestion historically required stopping the
+API server before a harvest (``scrapy_integration.main()``: *"stop the API
+server first — DuckDB allows a single writer"*). That blocks continuous or
+scheduled ingestion while the API is serving reads.
+
+This module breaks the coupling:
+
+- :func:`open_staging` gives the harvest its **own** DuckDB file (a
+  :class:`~src.ingestion.document_store.DocumentStore` over it), so a long
+  harvest writes without ever touching the serving warehouse's writer lock;
+- :func:`merge_staging` attaches that staging file to the main warehouse and
+  ``INSERT``\\s only the rows not already present, in one short-lived writer
+  window (a maintenance tick), so the serving process holds the lock for
+  milliseconds instead of the whole harvest.
+
+The merge is **idempotent**: it dedups by ``document_id`` and by
+``(content_hash, source_type)`` against the main warehouse, so re-merging the
+same staging adds nothing new — the same semantics :class:`DocumentStore`
+applies within a single database, now applied across the staging boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from src.ingestion.document_store import DocumentStore
+
+logger = logging.getLogger(__name__)
+
+# Columns of the documents table, in schema order (mirrors DocumentStore._SCHEMA).
+_COLUMNS = (
+    "document_id", "source_type", "language", "ingested_at", "created_at",
+    "source_id", "url", "canonical_url", "content_hash", "title", "content",
+    "content_ref", "authors", "metadata",
+)
+
+
+@dataclass
+class MergeSummary:
+    """Outcome of one :func:`merge_staging` call."""
+
+    staged: int = 0    # rows present in the staging warehouse
+    merged: int = 0    # rows inserted into the main warehouse
+    skipped: int = 0   # staged rows already present (deduped)
+
+    def as_dict(self) -> dict:
+        return {"staged": self.staged, "merged": self.merged, "skipped": self.skipped}
+
+
+def open_staging(path: str) -> DocumentStore:
+    """Open (creating if needed) a staging DuckDB at ``path`` as a DocumentStore.
+
+    The returned store is an ordinary :class:`DocumentStore` — validated,
+    deduped, idempotent — but backed by a standalone file, so writing to it
+    never contends with the serving warehouse. Close its ``.conn`` before
+    merging so the file can be attached read-only.
+    """
+    import duckdb
+
+    return DocumentStore(duckdb.connect(path))
+
+
+def merge_staging(
+    main_conn: Any,
+    staging_path: str,
+    *,
+    attach_name: str = "staging_merge",
+) -> MergeSummary:
+    """Merge the ``documents`` rows from a staging DuckDB file into the main warehouse.
+
+    Attaches ``staging_path`` read-only, inserts only the rows whose
+    ``document_id`` is absent *and* whose ``(content_hash, source_type)`` is not
+    already present, then detaches. Runs in a single short writer window on
+    ``main_conn``. Idempotent: re-merging the same staging inserts nothing.
+
+    Returns a :class:`MergeSummary`. The staging file's connection must be
+    closed before calling (DuckDB cannot attach a file held open elsewhere).
+    """
+    # Guarantee the main warehouse has the documents table before merging into it.
+    DocumentStore(main_conn)
+
+    main_conn.execute(f"ATTACH '{staging_path}' AS {attach_name} (READ_ONLY)")
+    try:
+        staged = main_conn.execute(
+            f"SELECT COUNT(*) FROM {attach_name}.documents"
+        ).fetchone()[0]
+
+        cols = ", ".join(_COLUMNS)
+        before = main_conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        main_conn.execute(
+            f"""
+            INSERT INTO documents ({cols})
+            SELECT {', '.join('s.' + c for c in _COLUMNS)}
+            FROM {attach_name}.documents s
+            WHERE s.document_id NOT IN (SELECT document_id FROM documents)
+              AND NOT EXISTS (
+                  SELECT 1 FROM documents m
+                  WHERE m.content_hash IS NOT NULL
+                    AND m.content_hash = s.content_hash
+                    AND m.source_type = s.source_type
+              )
+            """
+        )
+        after = main_conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+    finally:
+        main_conn.execute(f"DETACH {attach_name}")
+
+    merged = after - before
+    summary = MergeSummary(staged=staged, merged=merged, skipped=staged - merged)
+    logger.info(
+        "staging-merge: staged=%d merged=%d skipped=%d (from %s)",
+        summary.staged, summary.merged, summary.skipped, staging_path,
+    )
+    return summary

--- a/tests/unit/ingestion/test_staging.py
+++ b/tests/unit/ingestion/test_staging.py
@@ -1,0 +1,179 @@
+"""Unit tests for the staging + merge write path (#898).
+
+Offline: two temp DuckDB files (a serving warehouse and a staging warehouse).
+Proves a harvest can write to staging while a reader holds the main DB, and
+that merging staging into main is idempotent and content-deduped.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.staging import MergeSummary, merge_staging, open_staging
+
+
+def _doc(doc_id: str, *, content: str = "Body text.", source_type: str = "news",
+         url: str | None = None) -> Document:
+    return Document(
+        document_id=doc_id,
+        source_type=source_type,
+        language="en",
+        ingested_at=1_700_000_000_000,
+        url=url or f"https://ex.com/{doc_id}",
+        content=content,
+    )
+
+
+def _paths(tmp_path):
+    return str(tmp_path / "main.duckdb"), str(tmp_path / "staging.duckdb")
+
+
+# --------------------------------------------------------------------------- #
+# Decoupling: write to staging while a reader holds main
+# --------------------------------------------------------------------------- #
+
+
+def test_harvest_writes_to_staging_while_reader_holds_main(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+
+    # A reader holds the main warehouse open (as the serving API would).
+    main = duckdb.connect(main_path)
+    DocumentStore(main)
+    assert main.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+
+    # The harvest writes to a *separate* staging file — no lock contention.
+    staging = open_staging(stg_path)
+    summary = staging.upsert([_doc("d1"), _doc("d2", content="Other.")])
+    assert summary.inserted == 2
+    assert staging.count() == 2
+    staging.conn.close()
+
+    # The reader is unaffected and still sees an empty main warehouse.
+    assert main.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Merge
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_moves_staged_rows_into_main(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    main = duckdb.connect(main_path)
+
+    staging = open_staging(stg_path)
+    staging.upsert([_doc("d1"), _doc("d2", content="Second.")])
+    staging.conn.close()
+
+    summary = merge_staging(main, stg_path)
+    assert summary.staged == 2
+    assert summary.merged == 2
+    assert summary.skipped == 0
+    assert main.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
+    # The actual documents made it across, not just the count.
+    ids = {r[0] for r in main.execute("SELECT document_id FROM documents").fetchall()}
+    assert ids == {"d1", "d2"}
+
+
+def test_merge_into_fresh_main_autocreates_schema(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    staging = open_staging(stg_path)
+    staging.upsert([_doc("d1")])
+    staging.conn.close()
+
+    # main has never had the documents table — merge must create it.
+    main = duckdb.connect(main_path)
+    summary = merge_staging(main, stg_path)
+    assert summary.merged == 1
+
+
+def test_merge_is_idempotent(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    main = duckdb.connect(main_path)
+
+    staging = open_staging(stg_path)
+    staging.upsert([_doc("d1"), _doc("d2", content="Second.")])
+    staging.conn.close()
+
+    first = merge_staging(main, stg_path)
+    second = merge_staging(main, stg_path)
+    assert first.merged == 2
+    assert second.merged == 0
+    assert second.skipped == 2
+    assert main.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
+
+
+def test_merge_skips_content_duplicates_already_in_main(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    main = duckdb.connect(main_path)
+
+    body = "Parliament approved the budget after a marathon debate."
+    # A row already sits in main with this body.
+    DocumentStore(main).upsert([_doc("main-1", content=body, url="https://a.com/x")])
+
+    # Staging has the same body under a *different* id and URL (syndicated).
+    staging = open_staging(stg_path)
+    staging.upsert([
+        _doc("stg-dup", content=body, url="https://b.com/y"),
+        _doc("stg-new", content="A genuinely new story."),
+    ])
+    staging.conn.close()
+
+    summary = merge_staging(main, stg_path)
+    assert summary.staged == 2
+    assert summary.merged == 1   # only the new story crosses over
+    assert summary.skipped == 1
+    ids = {r[0] for r in main.execute("SELECT document_id FROM documents").fetchall()}
+    assert ids == {"main-1", "stg-new"}
+
+
+def test_merge_accumulates_across_multiple_staging_files(tmp_path):
+    main_path = str(tmp_path / "main.duckdb")
+    main = duckdb.connect(main_path)
+
+    for n in range(3):
+        stg_path = str(tmp_path / f"staging-{n}.duckdb")
+        staging = open_staging(stg_path)
+        staging.upsert([_doc(f"batch{n}-a", content=f"A{n}"),
+                        _doc(f"batch{n}-b", content=f"B{n}")])
+        staging.conn.close()
+        merge_staging(main, stg_path)
+
+    assert main.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 6
+
+
+def test_merge_empty_staging_is_a_noop(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    main = duckdb.connect(main_path)
+    staging = open_staging(stg_path)  # created, never written
+    staging.conn.close()
+
+    summary = merge_staging(main, stg_path)
+    assert summary.as_dict() == {"staged": 0, "merged": 0, "skipped": 0}
+
+
+def test_merge_summary_counts_reconcile(tmp_path):
+    main_path, stg_path = _paths(tmp_path)
+    main = duckdb.connect(main_path)
+    DocumentStore(main).upsert([_doc("shared", content="Shared body.")])
+
+    staging = open_staging(stg_path)
+    staging.upsert([
+        _doc("shared", content="Shared body."),   # dup id + content
+        _doc("fresh1", content="Fresh one."),
+        _doc("fresh2", content="Fresh two."),
+    ])
+    staging.conn.close()
+
+    summary = merge_staging(main, stg_path)
+    d = summary.as_dict()
+    assert d["staged"] == d["merged"] + d["skipped"]
+    assert d == {"staged": 3, "merged": 2, "skipped": 1}
+
+
+def test_merge_summary_dataclass_defaults():
+    s = MergeSummary()
+    assert s.as_dict() == {"staged": 0, "merged": 0, "skipped": 0}


### PR DESCRIPTION
## Summary

DuckDB allows a single writer, so ingestion historically required stopping the API server before a harvest (`scrapy_integration.main()`: *"stop the API server first — DuckDB allows a single writer"*). That blocks continuous or scheduled ingestion while the API is serving reads — a real operational scaling limit.

`src/ingestion/staging.py` breaks the coupling, closing **#898**.

## What it does

- **`open_staging(path)`** gives a harvest its **own** DuckDB file (an ordinary `DocumentStore` over it — validated, deduped, idempotent), so a long harvest writes without ever touching the serving warehouse's writer lock.
- **`merge_staging(main_conn, staging_path)`** attaches the staging file **read-only** and `INSERT`s only the rows not already present into the main warehouse, then detaches — one short-lived writer window (a maintenance tick) instead of holding the lock for the whole harvest.

The merge is **idempotent**: it dedups by `document_id` *and* by `(content_hash, source_type)` against main, so re-merging the same staging adds nothing new — the same semantics `DocumentStore` (#894) applies within a single database, now applied across the staging boundary. It returns a `MergeSummary {staged, merged, skipped}` where `staged == merged + skipped`.

It's a small, composable utility the harvest/ingest entrypoints can opt into — the connection is injected, so it's offline-testable.

## Tests

`tests/unit/ingestion/test_staging.py` — 9 tests with two temp DuckDB files, all passing:
- harvest writes to staging while a reader holds the main DB (no lock error);
- merge moves the staged rows (and the actual documents) into main;
- merge into a fresh main auto-creates the schema;
- **idempotent** re-merge inserts nothing;
- cross-boundary content dedup (a body already in main, syndicated under a new id/URL in staging, is skipped);
- accumulation across multiple staging files;
- empty-staging no-op and summary reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_