### PR TITLE
Register the orphaned EDGAR filings connector; key the registry by name (#906)

### DIFF
--- a/src/ingestion/connectors/__init__.py
+++ b/src/ingestion/connectors/__init__.py
@@ -22,6 +22,7 @@ from src.ingestion.connectors import upload  # noqa: E402,F401
 from src.ingestion.connectors import media  # noqa: E402,F401
 from src.ingestion.connectors import book  # noqa: E402,F401
 from src.ingestion.connectors import blog  # noqa: E402,F401
+from src.ingestion.connectors import filings_connector  # noqa: E402,F401
 
 __all__ = [
     "Connector",

--- a/src/ingestion/connectors/base.py
+++ b/src/ingestion/connectors/base.py
@@ -115,6 +115,12 @@ class Connector(abc.ABC):
     #: document-ingest-v1 source_type this connector produces.
     source_type: str = ""
 
+    #: Registry key for this connector. Defaults to ``source_type`` when unset,
+    #: so a connector may declare a distinct ``name`` to coexist with another
+    #: that emits the same ``source_type`` (e.g. ``upload`` and ``filings`` both
+    #: produce ``source_type="note"``).
+    name: str = ""
+
     @abc.abstractmethod
     def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
         """Enumerate the sources to ingest (optionally narrowed by ``query``)."""

--- a/src/ingestion/connectors/filings_connector.py
+++ b/src/ingestion/connectors/filings_connector.py
@@ -1,0 +1,98 @@
+"""
+Filings connector — SEC EDGAR filings as document-ingest-v1 records (#906).
+
+The ``edgar`` fetch layer and the ``filings`` mapper existed as libraries but
+were never assembled into a registered :class:`Connector`, so no harvester
+could reach them. This is that assembly: a connector that discovers filers,
+fetches each as a normalized :class:`~src.ingestion.connectors.filings.Filing`
+via EDGAR, and parses it into a ``source_type="note"`` ``Document``.
+
+It registers under the name ``"filings"`` (distinct from its ``source_type``,
+which is ``"note"`` — shared with the ``upload`` connector), and follows the
+adaptive-layer discipline: with no ``NOESIS_EDGAR_USER_AGENT`` configured, or
+for an unresolvable filer, ``fetch`` raises :class:`PermanentFetchError` so the
+source is skipped rather than retried.
+
+Filers are discovered from the ``query`` argument (an iterable of tickers/CIKs),
+the connector's constructor, or the ``NOESIS_EDGAR_FILERS`` env var
+(comma-separated). The HTTP getter is injectable via a supplied
+:class:`~src.ingestion.connectors.edgar.EdgarClient`, so the connector is fully
+offline-testable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from typing import Any, Iterable, List, Optional
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import (
+    Connector,
+    PermanentFetchError,
+    RawDocument,
+    SourceRef,
+)
+from src.ingestion.connectors.edgar import EdgarClient, harvest_filing
+from src.ingestion.connectors.filings import Filing, FilingFact, filing_to_document
+from src.ingestion.connectors.registry import register_connector
+
+FILERS_ENV = "NOESIS_EDGAR_FILERS"
+
+
+def _env_filers() -> List[str]:
+    raw = os.getenv(FILERS_ENV, "")
+    return [tok.strip() for tok in raw.split(",") if tok.strip()]
+
+
+@register_connector
+class FilingsConnector(Connector):
+    """SEC EDGAR filings connector (registry name ``"filings"``)."""
+
+    name = "filings"
+    source_type = "note"
+
+    def __init__(
+        self,
+        client: Optional[EdgarClient] = None,
+        filers: Optional[Iterable[str]] = None,
+    ):
+        self._client = client
+        self._filers = list(filers) if filers is not None else None
+
+    def _get_client(self) -> EdgarClient:
+        return self._client if self._client is not None else EdgarClient()
+
+    def discover(self, query: Optional[Any] = None) -> Iterable[SourceRef]:
+        filers = (
+            list(query) if query is not None
+            else self._filers if self._filers is not None
+            else _env_filers()
+        )
+        for filer in filers:
+            ident = str(filer).strip()
+            if ident:
+                yield SourceRef(locator=ident, metadata={"source_id": f"edgar:{ident}"})
+
+    def fetch(self, ref: SourceRef) -> RawDocument:
+        client = self._get_client()
+        if not client.configured:
+            raise PermanentFetchError(
+                f"{FILERS_ENV.replace('FILERS', 'USER_AGENT')} not configured; skipping EDGAR"
+            )
+        filing = harvest_filing(ref.locator, client=client)
+        if filing is None:
+            raise PermanentFetchError(f"no EDGAR filing resolved for {ref.locator!r}")
+        # Carry the normalized Filing to parse() as JSON (dataclass round-trip).
+        return RawDocument(
+            ref=ref,
+            content=json.dumps(dataclasses.asdict(filing)),
+            content_type="application/json",
+        )
+
+    def parse(self, raw: RawDocument) -> List[Document]:
+        payload = json.loads(raw.content)
+        facts = [FilingFact(**f) for f in payload.pop("facts", [])]
+        filing = Filing(facts=facts, **payload)
+        return [filing_to_document(filing, ingested_at=raw.fetched_at)]

--- a/src/ingestion/connectors/registry.py
+++ b/src/ingestion/connectors/registry.py
@@ -37,8 +37,9 @@ def register_connector(
         source_type = getattr(cls, "source_type", "")
         if not source_type:
             raise ValueError(f"{cls.__name__} must set a non-empty source_type to register")
-        _REGISTRY[source_type] = cls
-        _INSTANCES.pop(source_type, None)  # drop any stale cached instance
+        key = getattr(cls, "name", "") or source_type
+        _REGISTRY[key] = cls
+        _INSTANCES.pop(key, None)  # drop any stale cached instance
         return cls
 
     if connector_cls is not None:
@@ -46,22 +47,36 @@ def register_connector(
     return _do_register
 
 
-def get_connector(source_type: str) -> Connector:
-    """Return a (cached) connector instance for ``source_type``."""
-    if source_type not in _REGISTRY:
+def get_connector(name: str) -> Connector:
+    """Return a (cached) connector instance by registry ``name``.
+
+    The registry key is the connector's ``name`` (defaulting to its
+    ``source_type``), so for the built-in connectors this is still the source
+    type (``"news"``, ``"paper"``, …), while a connector that sets a distinct
+    ``name`` (e.g. ``"filings"``) is resolved by that name.
+    """
+    if name not in _REGISTRY:
         raise KeyError(
-            f"No connector registered for source_type {source_type!r}; "
-            f"available: {available_source_types()}"
+            f"No connector registered as {name!r}; available: {available_source_types()}"
         )
-    if source_type not in _INSTANCES:
-        _INSTANCES[source_type] = _REGISTRY[source_type]()
-    return _INSTANCES[source_type]
+    if name not in _INSTANCES:
+        _INSTANCES[name] = _REGISTRY[name]()
+    return _INSTANCES[name]
 
 
 def available_source_types() -> List[str]:
-    """List the source types that currently have a registered connector."""
+    """List the registry keys (connector names) that resolve via ``get_connector``.
+
+    For the built-in connectors these equal their ``source_type``; a connector
+    with a distinct ``name`` appears under that name.
+    """
     return sorted(_REGISTRY)
 
 
-def is_registered(source_type: str) -> bool:
-    return source_type in _REGISTRY
+def is_registered(name: str) -> bool:
+    return name in _REGISTRY
+
+
+def source_types() -> List[str]:
+    """List the distinct document source types the registered connectors emit."""
+    return sorted({getattr(cls, "source_type", "") for cls in _REGISTRY.values()})

--- a/tests/unit/ingestion/connectors/test_filings_connector.py
+++ b/tests/unit/ingestion/connectors/test_filings_connector.py
@@ -1,0 +1,185 @@
+"""Unit tests for the EDGAR filings connector + registry name-keying (#906).
+
+Offline: EDGAR HTTP is a fake injected getter, and harvest_run persists to an
+in-memory DuckDB DocumentStore.
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from src.ingestion.connectors.base import Connector, PermanentFetchError
+from src.ingestion.connectors.edgar import EdgarClient
+from src.ingestion.connectors.filings_connector import FilingsConnector
+from src.ingestion.connectors.registry import (
+    get_connector,
+    is_registered,
+    register_connector,
+    source_types,
+)
+from src.ingestion.document_store import DocumentStore
+
+# Import the package to trigger registration of the built-in connectors.
+import src.ingestion.connectors  # noqa: F401
+
+
+COMPANY_FACTS = {
+    "entityName": "Acme Corp",
+    "facts": {
+        "us-gaap": {
+            "Revenues": {
+                "units": {
+                    "USD": [
+                        {"fy": 2022, "fp": "FY", "form": "10-K", "val": 17.0e9, "filed": "2023-02-01"},
+                        {"fy": 2023, "fp": "FY", "form": "10-K", "val": 18.0e9, "filed": "2024-02-01"},
+                    ]
+                }
+            },
+        }
+    },
+}
+SUBMISSIONS = {"name": "Acme Corp", "sicDescription": "Widgets"}
+
+
+def _client(user_agent="noesis test@example.com"):
+    def fake_get(url, ua):
+        if "companyfacts" in url:
+            return json.dumps(COMPANY_FACTS)
+        if "submissions" in url:
+            return json.dumps(SUBMISSIONS)
+        raise AssertionError(f"unexpected url {url}")
+
+    return EdgarClient(user_agent=user_agent, http_get=fake_get)
+
+
+# --------------------------------------------------------------------------- #
+# Registry name-keying
+# --------------------------------------------------------------------------- #
+
+
+def test_filings_and_upload_coexist_under_distinct_keys():
+    # Both emit source_type="note"; the registry keys them by name.
+    assert is_registered("filings")
+    assert is_registered("note")
+    assert type(get_connector("filings")).__name__ == "FilingsConnector"
+    assert type(get_connector("note")).__name__ == "UploadConnector"
+    # The distinct source type still resolves once.
+    assert "note" in source_types()
+
+
+def test_name_defaults_to_source_type():
+    from src.ingestion.connectors.registry import _REGISTRY
+
+    class _TmpConnector(Connector):
+        source_type = "xtest_type"  # unique, no explicit name
+
+        def discover(self, query=None):
+            return []
+
+        def fetch(self, ref):
+            raise NotImplementedError
+
+        def parse(self, raw):
+            return []
+
+    try:
+        register_connector(_TmpConnector)
+        assert "xtest_type" in _REGISTRY  # keyed by source_type
+        assert isinstance(get_connector("xtest_type"), _TmpConnector)
+    finally:
+        _REGISTRY.pop("xtest_type", None)
+
+
+def test_explicit_name_keys_registry_without_clobbering_source_type():
+    from src.ingestion.connectors.registry import _REGISTRY
+
+    class _TmpNamed(Connector):
+        source_type = "note"      # shared with upload/filings
+        name = "xtest_named"      # but keyed by this
+
+        def discover(self, query=None):
+            return []
+
+        def fetch(self, ref):
+            raise NotImplementedError
+
+        def parse(self, raw):
+            return []
+
+    try:
+        register_connector(_TmpNamed)
+        assert "xtest_named" in _REGISTRY
+        # Did not overwrite the "note"-keyed upload connector.
+        assert type(get_connector("note")).__name__ == "UploadConnector"
+    finally:
+        _REGISTRY.pop("xtest_named", None)
+
+
+# --------------------------------------------------------------------------- #
+# discover / fetch / parse
+# --------------------------------------------------------------------------- #
+
+
+def test_discover_from_query_constructor_and_env(monkeypatch):
+    conn = FilingsConnector(filers=["from-ctor"])
+    assert [r.locator for r in conn.discover()] == ["from-ctor"]
+    # query overrides the constructor list.
+    assert [r.locator for r in conn.discover(["a", "b"])] == ["a", "b"]
+
+    monkeypatch.setenv("NOESIS_EDGAR_FILERS", "ENV1, ENV2 ,")
+    assert [r.locator for r in FilingsConnector().discover()] == ["ENV1", "ENV2"]
+
+
+def test_fetch_parse_produces_a_note_document():
+    conn = FilingsConnector(client=_client(), filers=["320193"])
+    docs = list(conn.harvest())
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.source_type == "note"
+    assert doc.document_id == "filing:edgar-0000320193"
+    assert doc.title == "Filing: Acme Corp"
+    assert "Widgets" in (doc.content or "")
+
+
+def test_unconfigured_client_skips_the_source():
+    conn = FilingsConnector(
+        client=EdgarClient(user_agent="", http_get=lambda u, a: "{}"),
+        filers=["320193"],
+    )
+    with pytest.raises(PermanentFetchError):
+        conn.fetch(next(iter(conn.discover())))
+    # harvest() swallows it -> no documents.
+    assert list(conn.harvest()) == []
+
+
+def test_unresolvable_filer_skips_the_source():
+    def fake_get(url, ua):
+        if "company_tickers" in url:
+            return json.dumps({})  # ticker table with no match
+        raise AssertionError(url)
+
+    conn = FilingsConnector(
+        client=EdgarClient(user_agent="noesis test@example.com", http_get=fake_get),
+        filers=["NOPE"],
+    )
+    with pytest.raises(PermanentFetchError):
+        conn.fetch(next(iter(conn.discover())))
+
+
+# --------------------------------------------------------------------------- #
+# harvest_run integration
+# --------------------------------------------------------------------------- #
+
+
+def test_harvest_run_persists_filings_to_document_store():
+    conn = FilingsConnector(client=_client(), filers=["320193"])
+    store = DocumentStore(duckdb.connect(":memory:"))
+    summary = conn.harvest_run(store=store)
+    assert summary.documents == 1
+    assert summary.inserted == 1
+    assert store.count() == 1
+    stored = store.get("filing:edgar-0000320193")
+    assert stored is not None and stored["source_type"] == "note"


### PR DESCRIPTION
## Summary

The `edgar` fetch layer and the `filings` mapper existed as libraries but were never assembled into a registered `Connector`, so no harvester could reach them. This wires them up and fixes the registry limitation that blocked it. Closes **#906**.

## What changed

- **`src/ingestion/connectors/filings_connector.py`** — a `FilingsConnector` that discovers filers (from the `query` arg, its constructor, or `NOESIS_EDGAR_FILERS`), fetches each via EDGAR, and parses it into a `source_type="note"` `Document`. It follows the adaptive-layer discipline established in #907's `harvest_run`: an unconfigured (`NOESIS_EDGAR_USER_AGENT` absent) or unresolvable filer raises `PermanentFetchError`, so the source is skipped rather than retried.
- **Registry keyed by connector *name*.** A filing is a `note` — the same `source_type` the `upload` connector emits — and the registry was keyed by `source_type`, so the two could not both register. `Connector.name` (defaulting to `source_type`) is now the registry key, so distinct connectors may share a `source_type`: `filings` registers as `"filings"`, `upload` stays `"note"`, and both resolve via `get_connector`. Added `registry.source_types()` for the distinct emitted document types.

## Deliberately not a connector

`legislative.py` is left as-is. It is a **vote-record evidence store + position-claim checker** (its own `record_vote` / `check_position` API), not a discover→fetch→parse source of `Document`s, so it does not belong in the connector registry. It isn't dead — it's a different kind of component (like the dataset `ObservationStore`).

## Tests

`tests/unit/ingestion/connectors/test_filings_connector.py` — 8 tests:
- registry name-keying: `filings` and `upload` coexist under distinct keys; `name` defaults to `source_type`; an explicit `name` doesn't clobber the `source_type` key;
- `FilingsConnector` discover (query/constructor/env), fetch→parse into a `note` document with an injected EDGAR client;
- skip-on-unconfigured and skip-on-unresolvable (`PermanentFetchError`);
- `harvest_run` persistence into a `DocumentStore`.

Full `tests/unit/ingestion/connectors` dir: 190 passed, 2 skipped. Registry consumers (`tests/unit/provisioning`, `tests/unit/tools`) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_