### PR TITLE
Route the connector harvester through harvest_run + DocumentStore (#907)

### DIFF
--- a/src/provisioning/pipeline_runner.py
+++ b/src/provisioning/pipeline_runner.py
@@ -4,13 +4,20 @@ Track P2 wired ``Provisioner.ingest`` to run bound pipelines through an injected
 ``pipeline_runner`` callable, but left that callable unbound in the serving path
 so ``kg_ingest`` degraded to routing already-ingested documents. This module is
 the real runner: it runs a bound connector through the ingestion connector
-registry (the same connectors ``pipeline_mcp`` exposes), and persists the
-harvested documents into the shared ``news_articles`` corpus so ingest routing
-copies them into the KG namespace. No simulation branch.
+registry (the same connectors ``pipeline_mcp`` exposes).
+
+By default it drives the connector through :meth:`Connector.harvest_run` (#896)
+— so every source gets retry, ``SourceHealthTracker`` drift detection, and
+scheduling — persisting the harvested documents through a :class:`DocumentStore`
+into the unified ``documents`` sink (#894). A :class:`_BridgingStore` mirrors the
+same documents into the legacy ``news_articles`` corpus so ingest routing (which
+still reads ``news_articles``) copies them into the KG namespace and existing
+readers keep working. That bridge is removed once the ``news_articles``
+compatibility view (#909) lands.
 
 Persistence is idempotent by document id, so re-ingesting a connector converges
-rather than duplicating. The harvester is injectable so tests can exercise the
-real persist-and-route path without a live network fetch.
+rather than duplicating. The harvester (legacy records path) is still injectable
+so existing tests exercise the persist-and-route path without a live fetch.
 """
 
 from __future__ import annotations
@@ -134,30 +141,106 @@ def default_harvester(connector_type: str, config: Dict[str, Any]) -> List[Dict[
     return records[:DEFAULT_LIMIT]
 
 
+def _resolve_connector(connector_type: str):
+    """Resolve a registered connector instance, or None if unavailable."""
+    try:
+        import src.ingestion.connectors  # noqa: F401 - trigger registrations
+        from src.ingestion.connectors.registry import get_connector, is_registered
+    except Exception:  # noqa: BLE001
+        return None
+    if not connector_type or not is_registered(connector_type):
+        return None
+    try:
+        return get_connector(connector_type)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class _BridgingStore:
+    """A DocumentStore-compatible sink that also mirrors documents to ``news_articles``.
+
+    ``harvest_run`` persists through the injected ``store`` and hands us the
+    :class:`Document`\\ s per source. We upsert them into the unified
+    ``documents`` sink and, during the transition, mirror them into the legacy
+    ``news_articles`` corpus (idempotent by id) so KG ingest routing and the
+    existing ``news_articles`` readers keep working until the compatibility
+    view (#909) replaces the corpus.
+    """
+
+    def __init__(self, doc_store, conn, source: str):
+        self._docs = doc_store
+        self._conn = conn
+        self._source = source
+        self.bridged = 0
+
+    def upsert(self, documents):
+        summary = self._docs.upsert(documents)
+        records = []
+        for doc in documents:
+            rec = _doc_to_record(doc, getattr(doc, "source_type", "") or "note")
+            rec.setdefault("source", self._source)
+            records.append(rec)
+        self.bridged += persist_records(self._conn, self._source, records)
+        return summary
+
+
 def build_pipeline_runner(
     conn,
     harvester: Optional[Callable[[str, Dict[str, Any]], List[Dict[str, Any]]]] = None,
+    connector_resolver: Optional[Callable[[str], Any]] = None,
 ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
-    """Return the ``pipeline_runner`` callable ``Provisioner`` invokes per bound
-    pipeline: run the connector for real and persist its documents into the
-    corpus so ingest routing picks them up. The harvester defaults to the live
-    connector registry and is injectable for tests."""
-    harvest = harvester or default_harvester
+    """Return the ``pipeline_runner`` callable ``Provisioner`` invokes per bound pipeline.
+
+    Default (no ``harvester``): resolve the connector and run it through
+    ``harvest_run`` into the ``documents`` sink, bridging to ``news_articles``.
+    If a ``harvester`` is injected, the legacy records path is used instead (it
+    persists to ``news_articles`` only) — this preserves existing tests and
+    custom record-shaped harvesters. ``connector_resolver`` is injectable so the
+    live path is testable with a fake connector.
+    """
+    resolve = connector_resolver or _resolve_connector
 
     def runner(spec: Dict[str, Any]) -> Dict[str, Any]:
         connector = spec.get("connector")
         connector_type = spec.get("connector_type") or ""
         config = spec.get("config") or {}
         source = config.get("source") or connector
-        records = harvest(connector_type, config)
-        for rec in records:
-            rec.setdefault("source", source)
-        written = persist_records(conn, source, records)
+        query = config.get("query") if isinstance(config, dict) else None
+
+        # Legacy injected records path — persist to news_articles only.
+        if harvester is not None:
+            records = harvester(connector_type, config) or []
+            for rec in records:
+                rec.setdefault("source", source)
+            written = persist_records(conn, source, records)
+            return {
+                "connector": connector, "source": source,
+                "fetched": len(records), "written": written, "documents": 0,
+            }
+
+        # Default live path — harvest_run into the documents sink + bridge.
+        connector_obj = resolve(connector_type)
+        if connector_obj is None:
+            return {
+                "connector": connector, "source": source,
+                "fetched": 0, "written": 0, "documents": 0,
+            }
+
+        from src.ingestion.document_store import DocumentStore
+        from src.ingestion.source_health import SourceHealthTracker
+
+        health_path = config.get("health_path") if isinstance(config, dict) else None
+        bridge = _BridgingStore(DocumentStore(conn), conn, source)
+        summary = connector_obj.harvest_run(
+            query=query,
+            store=bridge,
+            health=SourceHealthTracker(health_path),
+            respect_schedule=False,
+        )
         return {
-            "connector": connector,
-            "source": source,
-            "fetched": len(records),
-            "written": written,
+            "connector": connector, "source": source,
+            "fetched": summary.documents, "written": bridge.bridged,
+            "documents": summary.inserted,
         }
 
     return runner

--- a/tests/unit/provisioning/test_live_pipeline_runner.py
+++ b/tests/unit/provisioning/test_live_pipeline_runner.py
@@ -85,3 +85,68 @@ def test_ingest_without_runner_degrades_to_routing(conn, seed):
 def test_default_harvester_unknown_connector_is_empty():
     # Best-effort: an unregistered connector type yields nothing, never raises.
     assert default_harvester("not-a-real-connector-type", {"query": None}) == []
+
+
+# --------------------------------------------------------------------------- #
+# Live harvest_run path: documents sink + news_articles bridge (#907)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_connector(docs):
+    from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+    from services.ingest.common.document_model import Document
+
+    class _FakeConnector(Connector):
+        source_type = "news"
+
+        def discover(self, query=None):
+            return [SourceRef("feed", metadata={"source_id": "feed-1"})]
+
+        def fetch(self, ref):
+            return RawDocument(ref=ref, content="raw")
+
+        def parse(self, raw):
+            return [
+                Document(
+                    document_id=d["id"], source_type="news", language="en",
+                    ingested_at=1_700_000_000_000, title=d.get("title"),
+                    content=d.get("content"), url=d.get("url"),
+                )
+                for d in docs
+            ]
+
+    return _FakeConnector()
+
+
+def test_live_path_persists_to_documents_and_bridges_to_news_articles(conn):
+    docs = [
+        {"id": "d1", "title": "One", "content": "Body one.", "url": "https://ex.com/1"},
+        {"id": "d2", "title": "Two", "content": "Body two.", "url": "https://ex.com/2"},
+    ]
+    runner = build_pipeline_runner(conn, connector_resolver=lambda ct: _fake_connector(docs))
+    res = runner({"connector": "grid", "connector_type": "news", "config": {"source": "Feed"}})
+
+    assert res["documents"] == 2       # unified documents sink
+    assert res["written"] == 2         # bridged into news_articles
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT COUNT(*) FROM news_articles WHERE source = 'Feed'"
+    ).fetchone()[0] == 2
+
+
+def test_live_path_is_idempotent(conn):
+    docs = [{"id": "d1", "title": "One", "content": "Body.", "url": "https://ex.com/1"}]
+    runner = build_pipeline_runner(conn, connector_resolver=lambda ct: _fake_connector(docs))
+    spec = {"connector": "grid", "connector_type": "news", "config": {"source": "Feed"}}
+    runner(spec)
+    second = runner(spec)
+    assert second["documents"] == 0    # already ingested -> no new documents
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 1
+
+
+def test_live_path_unknown_connector_returns_zeros(conn):
+    runner = build_pipeline_runner(conn, connector_resolver=lambda ct: None)
+    res = runner({"connector": "x", "connector_type": "nope", "config": {}})
+    assert res == {
+        "connector": "x", "source": "x", "fetched": 0, "written": 0, "documents": 0,
+    }


### PR DESCRIPTION
## Summary

`provisioning/pipeline_runner` is the one registry-iterating harvester, but it did manual `discover`/`fetch`/`parse` and flattened every `Document` — regardless of source type — into the legacy `news_articles` table, bypassing the adaptive layer and never touching the `documents` sink. Closes **#907**.

## What changed

- **Default path → `harvest_run` + `DocumentStore`.** The runner now resolves the connector and drives it through `Connector.harvest_run` (#896) into a `DocumentStore` (#894), so every source gets retry, `SourceHealthTracker` drift detection, and scheduling, and its documents land in the unified `documents` table.
- **`_BridgingStore`.** A `DocumentStore`-compatible sink that forwards to the documents table *and* mirrors the same documents into `news_articles` (idempotent by id), so KG ingest routing — which still reads `news_articles` — and existing readers keep working. This bridge is removed once the `news_articles` compatibility view (#909) lands.
- **Back-compat preserved.** The injected-harvester (legacy records) path still works for existing tests and custom record-shaped harvesters (persists to `news_articles` only). `connector_resolver` is injectable so the live path is testable with a fake connector.

The production `provisioning_mcp` runner (`build_pipeline_runner(con)`, no harvester) now takes the live path, so provisioned ingestion populates `documents` for real.

## Tests

`tests/unit/provisioning/test_live_pipeline_runner.py` — new live-path tests: persists to `documents` and bridges to `news_articles`, idempotent re-run adds nothing, unknown connector returns zeros. The existing injected-harvester, `persist_records`, and degrade-to-routing tests are unchanged.

Full `tests/unit/provisioning` dir: **58 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_