### PR TITLE
Add a persisted enrichment sink keyed by document_id (#908)

### DIFF
--- a/src/ingestion/enrichment_store.py
+++ b/src/ingestion/enrichment_store.py
@@ -1,0 +1,106 @@
+"""
+Persisted enrichment sink, keyed by ``document_id`` (#908).
+
+Enrichments were deliberately split out of the core document record —
+``DocumentEnrichments`` (sentiment, topics) in
+:mod:`services.ingest.common.document_model` *extracts* them, but nothing
+persisted them: the ``documents`` table has no sentiment/topic columns, and no
+enrichment table existed. So sentiment/topic signals lived only on the legacy
+``news_articles`` corpus, and would vanish the moment consumers moved off it.
+
+``EnrichmentStore`` is that missing sink. It keeps the core ``documents`` record
+enrichment-free — enrichments remain one analyzer's output among many — while
+giving downstream analyzers a place to write and readers/joins a place to pull
+sentiment and topics back by ``document_id``. The DuckDB connection is injected,
+so it is offline-testable against an in-memory database, and ``upsert`` is
+idempotent (last write wins per document).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS document_enrichments (
+    document_id     TEXT PRIMARY KEY,
+    sentiment_score DOUBLE,
+    sentiment_label TEXT,
+    topics          TEXT,   -- JSON array
+    updated_at      BIGINT
+)
+"""
+
+
+class EnrichmentStore:
+    """Idempotent per-document store for sentiment/topic enrichments."""
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        self.conn.execute(_SCHEMA)
+
+    def upsert(
+        self,
+        document_id: str,
+        *,
+        sentiment_score: Optional[float] = None,
+        sentiment_label: Optional[str] = None,
+        topics: Optional[List[str]] = None,
+        updated_at: Optional[int] = None,
+    ) -> None:
+        """Insert or replace the enrichments for ``document_id`` (last write wins)."""
+        self.conn.execute(
+            """
+            INSERT INTO document_enrichments
+                (document_id, sentiment_score, sentiment_label, topics, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (document_id) DO UPDATE SET
+                sentiment_score = excluded.sentiment_score,
+                sentiment_label = excluded.sentiment_label,
+                topics          = excluded.topics,
+                updated_at      = excluded.updated_at
+            """,
+            [
+                document_id,
+                sentiment_score,
+                sentiment_label,
+                json.dumps(list(topics)) if topics is not None else None,
+                updated_at,
+            ],
+        )
+
+    def upsert_enrichments(
+        self, document_id: str, enrichments: Dict[str, Any], updated_at: Optional[int] = None
+    ) -> None:
+        """Upsert from a ``DocumentEnrichments``-style dict (sentiment_score/topics)."""
+        self.upsert(
+            document_id,
+            sentiment_score=enrichments.get("sentiment_score"),
+            sentiment_label=enrichments.get("sentiment_label"),
+            topics=enrichments.get("topics"),
+            updated_at=updated_at,
+        )
+
+    def get(self, document_id: str) -> Optional[Dict[str, Any]]:
+        """Return the enrichments for ``document_id``, or None if absent."""
+        row = self.conn.execute(
+            "SELECT sentiment_score, sentiment_label, topics, updated_at "
+            "FROM document_enrichments WHERE document_id = ?",
+            [document_id],
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "sentiment_score": row[0],
+            "sentiment_label": row[1],
+            "topics": json.loads(row[2]) if row[2] else [],
+            "updated_at": row[3],
+        }
+
+    def count(self) -> int:
+        return self.conn.execute(
+            "SELECT COUNT(*) FROM document_enrichments"
+        ).fetchone()[0]

--- a/tests/unit/ingestion/test_enrichment_store.py
+++ b/tests/unit/ingestion/test_enrichment_store.py
@@ -1,0 +1,72 @@
+"""Unit tests for the persisted enrichment sink (#908). Offline, in-memory DuckDB."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from src.ingestion.enrichment_store import EnrichmentStore
+
+
+@pytest.fixture
+def store() -> EnrichmentStore:
+    return EnrichmentStore(duckdb.connect(":memory:"))
+
+
+def test_ensure_schema_is_idempotent():
+    conn = duckdb.connect(":memory:")
+    EnrichmentStore(conn)
+    EnrichmentStore(conn)  # second construction must not raise
+    assert conn.execute("SELECT COUNT(*) FROM document_enrichments").fetchone()[0] == 0
+
+
+def test_upsert_and_get_roundtrip(store: EnrichmentStore):
+    store.upsert(
+        "d1", sentiment_score=0.8, sentiment_label="positive",
+        topics=["energy", "policy"], updated_at=1_700_000_000_000,
+    )
+    rec = store.get("d1")
+    assert rec == {
+        "sentiment_score": 0.8,
+        "sentiment_label": "positive",
+        "topics": ["energy", "policy"],
+        "updated_at": 1_700_000_000_000,
+    }
+
+
+def test_get_missing_returns_none(store: EnrichmentStore):
+    assert store.get("nope") is None
+
+
+def test_upsert_is_idempotent_last_write_wins(store: EnrichmentStore):
+    store.upsert("d1", sentiment_score=0.1, sentiment_label="negative", topics=["a"])
+    store.upsert("d1", sentiment_score=0.9, sentiment_label="positive", topics=["b", "c"])
+    rec = store.get("d1")
+    assert rec["sentiment_score"] == 0.9
+    assert rec["sentiment_label"] == "positive"
+    assert rec["topics"] == ["b", "c"]
+    assert store.count() == 1  # replaced, not duplicated
+
+
+def test_partial_enrichment_stores_nulls(store: EnrichmentStore):
+    store.upsert("d1", sentiment_score=0.5)  # no label, no topics
+    rec = store.get("d1")
+    assert rec["sentiment_score"] == 0.5
+    assert rec["sentiment_label"] is None
+    assert rec["topics"] == []
+
+
+def test_upsert_enrichments_from_dict(store: EnrichmentStore):
+    store.upsert_enrichments("d1", {"sentiment_score": -0.3, "topics": ["climate"]})
+    rec = store.get("d1")
+    assert rec["sentiment_score"] == -0.3
+    assert rec["topics"] == ["climate"]
+    assert rec["sentiment_label"] is None
+
+
+def test_multiple_documents_are_independent(store: EnrichmentStore):
+    store.upsert("d1", sentiment_label="positive")
+    store.upsert("d2", sentiment_label="negative")
+    assert store.get("d1")["sentiment_label"] == "positive"
+    assert store.get("d2")["sentiment_label"] == "negative"
+    assert store.count() == 2


### PR DESCRIPTION
## Summary

Enrichments were deliberately split out of the core document record — `DocumentEnrichments` (sentiment, topics) *extracts* them, but nothing persisted them: the `documents` table has no sentiment/topic columns and no enrichment table existed. So those signals lived only on the legacy `news_articles` corpus and would vanish the moment consumers moved off it (blocking the sentiment/topic readers in the reader-migration work). Closes **#908**.

## What changed

`src/ingestion/enrichment_store.py` — `EnrichmentStore(conn)`:
- a `document_enrichments` table: `document_id` (PK), `sentiment_score`, `sentiment_label`, `topics` (JSON array), `updated_at`;
- an **idempotent** `upsert` (`ON CONFLICT DO UPDATE`, last write wins);
- `upsert_enrichments(document_id, enrichments)` for `DocumentEnrichments`-style dicts;
- `get(document_id)` / `count()`.

The connection is injected (offline-testable), mirroring `DocumentStore`. The core `documents` record stays enrichment-free — enrichments remain one analyzer's output among many, joined by `document_id` (the seam the compatibility view will use).

## Tests

`tests/unit/ingestion/test_enrichment_store.py` — 7 tests: schema idempotency, upsert/get round-trip, last-write-wins, partial enrichments (nulls), dict upsert, per-document independence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_