### PR TITLE
Make news_articles a view over the documents sink (#909, #910)

### DIFF
--- a/src/api/routes/privacy_routes.py
+++ b/src/api/routes/privacy_routes.py
@@ -26,10 +26,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/user", tags=["privacy"])
 
 # Tables that contain user-generated or curated data that can be erased.
-# (news_articles, source_stances, and argument_claims as stated in the issue;
-#  plus the derived/linked tables that reference them.)
+# (the documents corpus, source_stances, and argument_claims as stated in the
+#  issue; plus the derived/linked tables that reference them.) news_articles is
+#  now a view over documents (#909), so the base tables documents +
+#  document_enrichments are erased instead.
 _ERASABLE_TABLES = [
-    "news_articles",
+    "documents",
+    "document_enrichments",
     "argument_claims",
     "claim_evidence",
     "source_stances",

--- a/src/database/local_warehouse_seed.py
+++ b/src/database/local_warehouse_seed.py
@@ -20,18 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 _SCHEMA = """
-CREATE TABLE IF NOT EXISTS news_articles (
-    id            VARCHAR,
-    title         VARCHAR,
-    url           VARCHAR,
-    content       VARCHAR,
-    publish_date  TIMESTAMP,
-    source        VARCHAR,
-    category      VARCHAR,
-    sentiment_score DOUBLE,
-    sentiment_label VARCHAR
-);
-
 CREATE TABLE IF NOT EXISTS document_frames (
     document_id   VARCHAR,
     source_type   VARCHAR,
@@ -304,28 +292,33 @@ def _migrate_attribution_columns(conn: duckdb.DuckDBPyConnection) -> None:
 
 
 def ensure_schema(conn: duckdb.DuckDBPyConnection) -> None:
-    """Create the news_articles table if it does not exist."""
+    """Create the analytics tables and the ``news_articles`` compatibility view.
+
+    ``news_articles`` is now a view over the unified ``documents`` sink (#909);
+    the analysis tables (frames, claims, stances, …) remain base tables.
+    """
     conn.execute(_SCHEMA)
     _migrate_factcheck_columns(conn)
     _migrate_attribution_columns(conn)
+    # Base tables (documents, document_enrichments) + the news_articles view.
+    from src.database.news_articles_compat import ensure_news_articles_view
+    ensure_news_articles_view(conn)
 
 
 def seed_if_empty(conn: duckdb.DuckDBPyConnection) -> None:
-    """Seed sample articles only when the table has no rows."""
+    """Seed sample news documents only when the corpus is empty."""
+    from src.database.news_articles_compat import (
+        NEWS_ARTICLES_COLUMNS,
+        write_news_articles,
+    )
+
     count = conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0]
     if count and count > 0:
         return
 
     rows = _build_rows(datetime.now())
-    conn.executemany(
-        """
-        INSERT INTO news_articles
-            (id, title, url, content, publish_date, source, category,
-             sentiment_score, sentiment_label)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        rows,
-    )
+    dict_rows = [dict(zip(NEWS_ARTICLES_COLUMNS, row)) for row in rows]
+    write_news_articles(conn, dict_rows)
     logger.info("Seeded local warehouse with %d sample articles", len(rows))
 
 

--- a/src/database/news_articles_compat.py
+++ b/src/database/news_articles_compat.py
@@ -1,0 +1,156 @@
+"""
+``news_articles`` as a compatibility view over the unified ``documents`` sink (#909).
+
+The knowledge-engine pivot made ``documents`` (document-ingest-v1) the canonical
+corpus, but ~40 consumers still read ``FROM news_articles``. Rather than rewrite
+every query, ``news_articles`` becomes a **view** projecting the news documents
+(``source_type='news'``) back into the legacy column shape, joined to the
+``document_enrichments`` sink for sentiment. Readers are unchanged; the base of
+truth is ``documents`` (+ ``document_enrichments``).
+
+Because a view is not writable, the few paths that used to ``INSERT INTO
+news_articles`` write through :func:`write_news_articles`, which maps the legacy
+columns onto ``documents`` + ``document_enrichments`` (the inverse of the view).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, Optional
+
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.enrichment_store import EnrichmentStore
+
+# Legacy news_articles columns, in order.
+NEWS_ARTICLES_COLUMNS = (
+    "id", "title", "url", "content", "publish_date",
+    "source", "category", "sentiment_score", "sentiment_label",
+)
+
+# news_articles projected from documents (+ enrichments). created_at is epoch ms;
+# source/category live in metadata; sentiment comes from the enrichment sink.
+_VIEW_SQL = """
+CREATE VIEW news_articles AS
+SELECT
+    d.document_id AS id,
+    d.title       AS title,
+    d.url         AS url,
+    d.content     AS content,
+    CASE WHEN d.created_at IS NULL THEN NULL
+         ELSE CAST(to_timestamp(d.created_at / 1000) AS TIMESTAMP) END AS publish_date,
+    COALESCE(d.source_id, json_extract_string(d.metadata, '$.source')) AS source,
+    json_extract_string(d.metadata, '$.category') AS category,
+    e.sentiment_score AS sentiment_score,
+    e.sentiment_label AS sentiment_label
+FROM documents d
+LEFT JOIN document_enrichments e ON e.document_id = d.document_id
+WHERE d.source_type = 'news'
+"""
+
+
+def _news_articles_is_view(conn) -> bool:
+    row = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'news_articles'"
+    ).fetchone()
+    return bool(row) and str(row[0]).upper() == "VIEW"
+
+
+def ensure_documents_schema(conn) -> None:
+    """Ensure the base tables the view depends on exist."""
+    DocumentStore(conn)     # documents (+ content_hash index)
+    EnrichmentStore(conn)   # document_enrichments
+
+
+def ensure_news_articles_view(conn) -> None:
+    """Create the ``news_articles`` view over ``documents`` if it is not present.
+
+    A no-op if ``news_articles`` already exists as a view. If it exists as a base
+    table (a legacy warehouse, or a test that created its own), it is left alone
+    — callers that want the view over a legacy table must migrate it first (see
+    :func:`migrate_news_articles_to_view`).
+    """
+    ensure_documents_schema(conn)
+    exists = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'news_articles'"
+    ).fetchone()
+    if exists is None:
+        conn.execute(_VIEW_SQL)
+
+
+def write_news_articles(conn, rows: Iterable[Dict[str, Any]]) -> int:
+    """Write legacy ``news_articles``-shaped rows through to ``documents``.
+
+    Each row is a dict with any subset of :data:`NEWS_ARTICLES_COLUMNS` (``id``
+    required). ``source``/``category`` fold into ``documents.metadata``,
+    ``publish_date`` into ``created_at`` (epoch ms), and sentiment into
+    ``document_enrichments``. Idempotent by ``document_id``. Returns the number
+    of documents written.
+    """
+    ensure_documents_schema(conn)
+    written = 0
+    for row in rows:
+        doc_id = row.get("id")
+        if not doc_id:
+            continue
+        metadata: Dict[str, Any] = {}
+        if row.get("source") is not None:
+            metadata["source"] = row["source"]
+        if row.get("category") is not None:
+            metadata["category"] = row["category"]
+        pub = row.get("publish_date")
+        conn.execute(
+            """
+            INSERT INTO documents
+                (document_id, source_type, language, ingested_at, created_at,
+                 source_id, url, title, content, metadata)
+            VALUES (?, 'news', 'en', ?,
+                    CASE WHEN ? IS NULL THEN NULL ELSE epoch_ms(CAST(? AS TIMESTAMP)) END,
+                    ?, ?, ?, ?, ?)
+            ON CONFLICT (document_id) DO NOTHING
+            """,
+            [
+                doc_id, int(row.get("ingested_at") or 0),
+                pub, pub,
+                row.get("source"), row.get("url"),
+                row.get("title"), row.get("content"),
+                json.dumps(metadata),
+            ],
+        )
+        if row.get("sentiment_score") is not None or row.get("sentiment_label") is not None:
+            EnrichmentStore(conn).upsert(
+                doc_id,
+                sentiment_score=row.get("sentiment_score"),
+                sentiment_label=row.get("sentiment_label"),
+            )
+        written += 1
+    return written
+
+
+def migrate_news_articles_to_view(conn) -> int:
+    """Migrate a legacy ``news_articles`` base table into ``documents`` + the view.
+
+    Copies every existing ``news_articles`` row into ``documents`` (+
+    ``document_enrichments``) via :func:`write_news_articles`, drops the base
+    table, and creates the view. Idempotent: when ``news_articles`` is already
+    the view (or absent), this only ensures the view exists and returns 0.
+    Returns the number of migrated rows.
+    """
+    row = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'news_articles'"
+    ).fetchone()
+    migrated = 0
+    if row is not None and str(row[0]).upper() in ("BASE TABLE", "LOCAL TEMPORARY"):
+        colnames = [
+            c[0] for c in conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'news_articles'"
+            ).fetchall()
+        ]
+        legacy = conn.execute(
+            f"SELECT {', '.join(colnames)} FROM news_articles"
+        ).fetchall()
+        dict_rows = [dict(zip(colnames, r)) for r in legacy]
+        conn.execute("DROP TABLE news_articles")
+        migrated = write_news_articles(conn, dict_rows)
+    ensure_news_articles_view(conn)
+    return migrated

--- a/src/ingestion/scrapy_integration.py
+++ b/src/ingestion/scrapy_integration.py
@@ -429,28 +429,28 @@ def store_articles(articles: Sequence[Article], replace: bool = False) -> int:
     """
     from src.database.local_analytics_connector import get_shared_connection
     from src.database.local_warehouse_seed import ensure_schema
+    from src.database.news_articles_compat import (
+        NEWS_ARTICLES_COLUMNS,
+        write_news_articles,
+    )
 
     conn = get_shared_connection()
-    ensure_schema(conn)
+    ensure_schema(conn)  # documents + document_enrichments + news_articles view
 
+    # news_articles is a view over documents (#909); write through to the base.
     if replace:
-        conn.execute("DELETE FROM news_articles")
+        conn.execute("DELETE FROM documents WHERE source_type = 'news'")
     else:
         # Remove the synthetic sample seed so real news isn't mixed with it.
-        conn.execute("DELETE FROM news_articles WHERE id LIKE 'art-%'")
+        conn.execute("DELETE FROM documents WHERE document_id LIKE 'art-%'")
 
-    existing = {row[0] for row in conn.execute("SELECT id FROM news_articles").fetchall()}
+    existing = {
+        row[0] for row in conn.execute(
+            "SELECT document_id FROM documents WHERE source_type = 'news'"
+        ).fetchall()
+    }
     new_rows = [a.as_row() for a in articles if a.id not in existing]
-    if new_rows:
-        conn.executemany(
-            """
-            INSERT INTO news_articles
-                (id, title, url, content, publish_date, source, category,
-                 sentiment_score, sentiment_label)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            new_rows,
-        )
+    write_news_articles(conn, [dict(zip(NEWS_ARTICLES_COLUMNS, r)) for r in new_rows])
     return len(new_rows)
 
 

--- a/src/provisioning/pipeline_runner.py
+++ b/src/provisioning/pipeline_runner.py
@@ -9,11 +9,9 @@ registry (the same connectors ``pipeline_mcp`` exposes).
 By default it drives the connector through :meth:`Connector.harvest_run` (#896)
 — so every source gets retry, ``SourceHealthTracker`` drift detection, and
 scheduling — persisting the harvested documents through a :class:`DocumentStore`
-into the unified ``documents`` sink (#894). A :class:`_BridgingStore` mirrors the
-same documents into the legacy ``news_articles`` corpus so ingest routing (which
-still reads ``news_articles``) copies them into the KG namespace and existing
-readers keep working. That bridge is removed once the ``news_articles``
-compatibility view (#909) lands.
+into the unified ``documents`` sink (#894). ``news_articles`` is now a view over
+``documents`` (#909), so KG ingest routing (which reads ``news_articles``) sees
+the harvested documents without a separate mirror.
 
 Persistence is idempotent by document id, so re-ingesting a connector converges
 rather than duplicating. The harvester (legacy records path) is still injectable
@@ -156,34 +154,6 @@ def _resolve_connector(connector_type: str):
         return None
 
 
-class _BridgingStore:
-    """A DocumentStore-compatible sink that also mirrors documents to ``news_articles``.
-
-    ``harvest_run`` persists through the injected ``store`` and hands us the
-    :class:`Document`\\ s per source. We upsert them into the unified
-    ``documents`` sink and, during the transition, mirror them into the legacy
-    ``news_articles`` corpus (idempotent by id) so KG ingest routing and the
-    existing ``news_articles`` readers keep working until the compatibility
-    view (#909) replaces the corpus.
-    """
-
-    def __init__(self, doc_store, conn, source: str):
-        self._docs = doc_store
-        self._conn = conn
-        self._source = source
-        self.bridged = 0
-
-    def upsert(self, documents):
-        summary = self._docs.upsert(documents)
-        records = []
-        for doc in documents:
-            rec = _doc_to_record(doc, getattr(doc, "source_type", "") or "note")
-            rec.setdefault("source", self._source)
-            records.append(rec)
-        self.bridged += persist_records(self._conn, self._source, records)
-        return summary
-
-
 def build_pipeline_runner(
     conn,
     harvester: Optional[Callable[[str, Dict[str, Any]], List[Dict[str, Any]]]] = None,
@@ -218,7 +188,7 @@ def build_pipeline_runner(
                 "fetched": len(records), "written": written, "documents": 0,
             }
 
-        # Default live path — harvest_run into the documents sink + bridge.
+        # Default live path — harvest_run into the unified documents sink.
         connector_obj = resolve(connector_type)
         if connector_obj is None:
             return {
@@ -226,20 +196,24 @@ def build_pipeline_runner(
                 "fetched": 0, "written": 0, "documents": 0,
             }
 
+        from src.database.news_articles_compat import ensure_news_articles_view
         from src.ingestion.document_store import DocumentStore
         from src.ingestion.source_health import SourceHealthTracker
 
+        # documents(+enrichments) + the news_articles view, so KG ingest routing
+        # (which reads news_articles) sees the harvested documents (#909).
+        ensure_news_articles_view(conn)
         health_path = config.get("health_path") if isinstance(config, dict) else None
-        bridge = _BridgingStore(DocumentStore(conn), conn, source)
+        store = DocumentStore(conn)
         summary = connector_obj.harvest_run(
             query=query,
-            store=bridge,
+            store=store,
             health=SourceHealthTracker(health_path),
             respect_schedule=False,
         )
         return {
             "connector": connector, "source": source,
-            "fetched": summary.documents, "written": bridge.bridged,
+            "fetched": summary.documents, "written": summary.inserted,
             "documents": summary.inserted,
         }
 

--- a/tests/unit/ingestion/test_news_articles_compat.py
+++ b/tests/unit/ingestion/test_news_articles_compat.py
@@ -1,0 +1,139 @@
+"""Unit tests for news_articles as a compatibility view over documents (#909).
+
+Offline, in-memory DuckDB. Covers the view projection, the inverse writer, and
+migrating a legacy news_articles base table into the view.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from src.database.news_articles_compat import (
+    ensure_news_articles_view,
+    migrate_news_articles_to_view,
+    write_news_articles,
+)
+
+
+@pytest.fixture
+def conn():
+    return duckdb.connect(":memory:")
+
+
+def _is_view(conn) -> bool:
+    row = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'news_articles'"
+    ).fetchone()
+    return bool(row) and str(row[0]).upper() == "VIEW"
+
+
+# --------------------------------------------------------------------------- #
+# View + writer
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_view_creates_a_view_and_is_idempotent(conn):
+    ensure_news_articles_view(conn)
+    ensure_news_articles_view(conn)  # second call is a no-op
+    assert _is_view(conn)
+    assert conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 0
+
+
+def test_write_maps_legacy_columns_through_the_view(conn):
+    ensure_news_articles_view(conn)
+    written = write_news_articles(conn, [{
+        "id": "a1", "title": "Fed holds", "url": "http://x/1", "content": "Body.",
+        "publish_date": "2026-05-20", "source": "Reuters", "category": "Economy",
+        "sentiment_score": 0.3, "sentiment_label": "positive",
+    }])
+    assert written == 1
+    row = conn.execute(
+        "SELECT id, title, url, content, publish_date, source, category, "
+        "sentiment_score, sentiment_label FROM news_articles"
+    ).fetchone()
+    assert row[0] == "a1"
+    assert row[1] == "Fed holds"
+    assert str(row[4]).startswith("2026-05-20")  # publish_date round-trips
+    assert row[5] == "Reuters"
+    assert row[6] == "Economy"
+    assert row[7] == 0.3
+    assert row[8] == "positive"
+
+
+def test_write_handles_partial_rows(conn):
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [{"id": "a1", "title": "Just a title", "source": "BBC"}])
+    row = conn.execute(
+        "SELECT id, title, source, category, publish_date, sentiment_score FROM news_articles"
+    ).fetchone()
+    assert row == ("a1", "Just a title", "BBC", None, None, None)
+
+
+def test_write_is_idempotent_by_id(conn):
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [{"id": "a1", "title": "First", "source": "s"}])
+    write_news_articles(conn, [{"id": "a1", "title": "Second", "source": "s"}])
+    assert conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 1
+
+
+def test_view_only_exposes_news_source_type(conn):
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [{"id": "n1", "title": "News", "source": "s"}])
+    # A non-news document must not surface through the news_articles view.
+    conn.execute(
+        "INSERT INTO documents (document_id, source_type, language, ingested_at, title) "
+        "VALUES ('p1', 'paper', 'en', 0, 'A paper')"
+    )
+    ids = {r[0] for r in conn.execute("SELECT id FROM news_articles").fetchall()}
+    assert ids == {"n1"}
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
+
+
+def test_analytics_style_aggregation_works_over_the_view(conn):
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [
+        {"id": "a1", "title": "T", "source": "Reuters", "category": "Economy",
+         "publish_date": "2026-05-20", "sentiment_score": 0.2},
+        {"id": "a2", "title": "T", "source": "Reuters", "category": "Economy",
+         "publish_date": "2026-05-21", "sentiment_score": 0.4},
+    ])
+    row = conn.execute(
+        "SELECT source, DATE_TRUNC('month', publish_date), AVG(sentiment_score) "
+        "FROM news_articles GROUP BY 1, 2"
+    ).fetchone()
+    assert row[0] == "Reuters"
+    assert abs(row[2] - 0.3) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Migration
+# --------------------------------------------------------------------------- #
+
+
+def test_migrate_legacy_table_to_view(conn):
+    # A legacy warehouse with news_articles as a base table.
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    conn.execute(
+        "INSERT INTO news_articles VALUES "
+        "('art-1', 'Legacy', 'http://x', 'Body', TIMESTAMP '2026-05-20', 'Reuters', "
+        "'Economy', 0.5, 'positive')"
+    )
+    migrated = migrate_news_articles_to_view(conn)
+    assert migrated == 1
+    assert _is_view(conn)
+    row = conn.execute(
+        "SELECT id, source, sentiment_label FROM news_articles"
+    ).fetchone()
+    assert row == ("art-1", "Reuters", "positive")
+    assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 1
+
+
+def test_migrate_is_idempotent(conn):
+    ensure_news_articles_view(conn)  # already a view
+    assert migrate_news_articles_to_view(conn) == 0
+    assert _is_view(conn)

--- a/tests/unit/ingestion/test_scrapy_integration_coverage.py
+++ b/tests/unit/ingestion/test_scrapy_integration_coverage.py
@@ -301,24 +301,46 @@ def _make_article(id_="rss-1", url="http://a"):
     )
 
 
+def _install_real_warehouse(monkeypatch, conn):
+    """Point store_articles' shared connection at a real in-memory DuckDB."""
+    monkeypatch.setattr(
+        "src.database.local_analytics_connector.get_shared_connection", lambda: conn
+    )
+
+
 def test_store_articles_inserts_only_new(monkeypatch):
-    conn = _FakeConn()
-    conn._existing_ids = ["rss-existing"]
-    _install_fake_warehouse(monkeypatch, conn)
+    import duckdb
+
+    from src.database.news_articles_compat import ensure_news_articles_view, write_news_articles
+
+    conn = duckdb.connect(":memory:")
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [{"id": "rss-existing", "title": "t", "source": "s"}])
+    _install_real_warehouse(monkeypatch, conn)
+
     arts = [_make_article("rss-existing"), _make_article("rss-new", "http://b")]
     n = si.store_articles(arts, replace=False)
     assert n == 1  # only rss-new inserted
-    assert len(conn.inserted) == 1
-    # Non-replace path deletes the synthetic seed.
-    assert any("art-%" in d for d in conn.deleted)
+    # news_articles is a view over documents; both survive.
+    ids = {r[0] for r in conn.execute("SELECT id FROM news_articles").fetchall()}
+    assert ids == {"rss-existing", "rss-new"}
 
 
 def test_store_articles_replace_clears_table(monkeypatch):
-    conn = _FakeConn()
-    _install_fake_warehouse(monkeypatch, conn)
+    import duckdb
+
+    from src.database.news_articles_compat import ensure_news_articles_view, write_news_articles
+
+    conn = duckdb.connect(":memory:")
+    ensure_news_articles_view(conn)
+    write_news_articles(conn, [{"id": "rss-old", "title": "old", "source": "s"}])
+    _install_real_warehouse(monkeypatch, conn)
+
     n = si.store_articles([_make_article()], replace=True)
     assert n == 1
-    assert any(d == "DELETE FROM news_articles" for d in conn.deleted)
+    # replace wiped the prior news documents.
+    ids = {r[0] for r in conn.execute("SELECT id FROM news_articles").fetchall()}
+    assert ids == {"rss-1"}
 
 
 def test_ingest_returns_summary(monkeypatch):

--- a/tests/unit/provisioning/test_live_pipeline_runner.py
+++ b/tests/unit/provisioning/test_live_pipeline_runner.py
@@ -118,7 +118,7 @@ def _fake_connector(docs):
     return _FakeConnector()
 
 
-def test_live_path_persists_to_documents_and_bridges_to_news_articles(conn):
+def test_live_path_persists_to_documents_and_view_reflects_them(conn):
     docs = [
         {"id": "d1", "title": "One", "content": "Body one.", "url": "https://ex.com/1"},
         {"id": "d2", "title": "Two", "content": "Body two.", "url": "https://ex.com/2"},
@@ -127,11 +127,9 @@ def test_live_path_persists_to_documents_and_bridges_to_news_articles(conn):
     res = runner({"connector": "grid", "connector_type": "news", "config": {"source": "Feed"}})
 
     assert res["documents"] == 2       # unified documents sink
-    assert res["written"] == 2         # bridged into news_articles
     assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
-    assert conn.execute(
-        "SELECT COUNT(*) FROM news_articles WHERE source = 'Feed'"
-    ).fetchone()[0] == 2
+    # news_articles is a view over documents, so KG routing sees the harvest.
+    assert conn.execute("SELECT COUNT(*) FROM news_articles").fetchone()[0] == 2
 
 
 def test_live_path_is_idempotent(conn):


### PR DESCRIPTION
## Summary

The knowledge-engine pivot made `documents` (document-ingest-v1) the canonical corpus, but ~40 consumers still read `FROM news_articles`. Rather than rewrite every query, **`news_articles` becomes a view** that projects the news documents (`source_type='news'`) back into the legacy column shape, LEFT JOINed to the `document_enrichments` sink (#908) for sentiment. Readers are unchanged; the base of truth is `documents` (+ `document_enrichments`).

This is a single atomic PR closing **#909** and **#910** — a view and its writers can't land separately (a view isn't writable, so the gate can't be green in between).

## `src/database/news_articles_compat.py`
- `ensure_news_articles_view()` — creates the `documents`/`document_enrichments` base tables and the `news_articles` view;
- `write_news_articles()` — the inverse-of-view writer: maps the legacy columns onto `documents` (+ enrichments) so paths that used to `INSERT INTO news_articles` keep working;
- `migrate_news_articles_to_view()` — copies a legacy `news_articles` base table into `documents` + the view, idempotently.

## Repointed DuckDB serving-warehouse writers → base tables
- **seed** (`local_warehouse_seed`) seeds `documents` (+ view) instead of a `news_articles` table;
- **`scrapy_integration.store_articles`** writes through `write_news_articles` and dedups/deletes on `documents`;
- **provisioning live path** drops the R3 `news_articles` bridge (now redundant) and writes only `DocumentStore`, ensuring the view so KG ingest routing still sees the harvest;
- **privacy purge** erases the `documents` + `document_enrichments` base tables.

## Scope

The remaining `news_articles` writers target **other backends** and are out of scope: `sentiment_pipeline` / `ner_article_processor` / `kubernetes/*` use psycopg2/Snowflake, `keyword_topic_database` updates Snowflake, and `osint/gated_calibration` uses its own in-memory table. None touch the DuckDB serving warehouse.

The blast radius turned out narrow: the 31 test files that write `news_articles` create their **own** table in their **own** connection (self-contained, unaffected). Only the shared-warehouse writers above needed repointing — empirically verified by running the full gate.

## Tests

- `tests/unit/ingestion/test_news_articles_compat.py` (new, 8 tests) — view projection, `publish_date` round-trip, partial rows, idempotent writer, news-only filtering, analytics-style aggregation over the view, and legacy-table migration.
- `scrapy` store tests rewritten behaviour-based over a real in-memory warehouse; the provisioning live-path test now asserts the view reflects `documents`.

**Full local gate: 1322 passed, 32 skipped**, with 4 pre-existing env-only failures (argument_mining/evidence + osint gated-tools) that are unrelated to this change and green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_