### PR TITLE
Reintegrate the Kafka ingest consumer to document-ingest-v1 + a DocumentStore sink (#916)

### DIFF
--- a/services/ingest/consumer.py
+++ b/services/ingest/consumer.py
@@ -21,14 +21,19 @@ from datetime import datetime
 from typing import Any, Dict, Optional, List, Callable
 from dataclasses import dataclass, asdict
 
-from confluent_kafka import Consumer, Producer, KafkaException
-from confluent_kafka.serialization import SerializationContext, MessageField
-from confluent_kafka.schema_registry import SchemaRegistryClient
-from confluent_kafka.schema_registry.avro import AvroDeserializer
+try:  # confluent_kafka is only needed to actually consume, not to import this module.
+    from confluent_kafka import Consumer, Producer, KafkaException
+    from confluent_kafka.serialization import SerializationContext, MessageField
+    from confluent_kafka.schema_registry import SchemaRegistryClient
+    from confluent_kafka.schema_registry.avro import AvroDeserializer
+except ImportError:  # pragma: no cover - optional dependency
+    Consumer = Producer = KafkaException = None
+    SerializationContext = MessageField = None
+    SchemaRegistryClient = AvroDeserializer = None
 
 from services.ingest.common.contracts import (
-    ArticleIngestValidator, 
-    DataContractViolation, 
+    ArticleIngestValidator,
+    DataContractViolation,
     ContractValidationMetrics
 )
 
@@ -212,10 +217,14 @@ class ArticleIngestConsumer:
             self.metrics.increment_failure()
             return False
     
+    def _dlq_key(self, payload: Dict[str, Any]) -> str:
+        """Kafka key for a DLQ message (overridden by the document consumer)."""
+        return payload.get('article_id', 'unknown')
+
     def _send_to_dlq(
-        self, 
-        original_payload: Dict[str, Any], 
-        error_message: str, 
+        self,
+        original_payload: Dict[str, Any],
+        error_message: str,
         error_type: str,
         message
     ):
@@ -238,7 +247,7 @@ class ArticleIngestConsumer:
             self.dlq_producer.produce(
                 topic=self.dlq_topic,
                 value=dlq_payload.encode('utf-8'),
-                key=str(original_payload.get('article_id', 'unknown')).encode('utf-8'),
+                key=str(self._dlq_key(original_payload)).encode('utf-8'),
                 headers={
                     'error_type': error_type,
                     'schema_version': self.schema_version,
@@ -460,6 +469,93 @@ def create_default_consumer(
         topic=topic,
         dlq_topic=dlq_topic,
         consumer_group=consumer_group
+    )
+
+
+class DocumentIngestConsumer(ArticleIngestConsumer):
+    """Kafka consumer that validates ``document-ingest-v1`` and persists to a DocumentStore.
+
+    Reuses the base consumer's Kafka + DLQ machinery, but validates and sinks
+    through :class:`~services.ingest.document_sink.DocumentSink` (which upserts
+    into the unified ``documents`` corpus), bridges legacy ``article-ingest-v1``
+    messages to documents, and keys the DLQ by ``document_id``.
+    """
+
+    def __init__(
+        self,
+        kafka_config: Dict[str, Any],
+        store,
+        topic: str = "document_ingest",
+        dlq_topic: str = "document_ingest_dlq",
+        consumer_group: str = "document-ingest-consumer",
+        schema_registry_url: Optional[str] = None,
+        schema_version: str = "v1",
+        max_retries: int = 3,
+    ):
+        # Validation + persistence happen in the sink, not the article validator.
+        super().__init__(
+            kafka_config=kafka_config, topic=topic, dlq_topic=dlq_topic,
+            consumer_group=consumer_group, schema_registry_url=schema_registry_url,
+            schema_version=schema_version, max_retries=max_retries,
+            enable_validation=False,
+        )
+        from services.ingest.document_sink import DocumentSink
+        self._sink = DocumentSink(store)
+
+    def _dlq_key(self, payload: Dict[str, Any]) -> str:
+        from services.ingest.document_sink import to_document_payload
+        return to_document_payload(payload).get("document_id", "unknown")
+
+    def process_message(
+        self, message, callback: Optional[Callable[[Dict[str, Any]], None]] = None
+    ) -> bool:
+        """Deserialize, validate-and-persist through the sink, DLQ on failure."""
+        from services.ingest.document_sink import to_document_payload
+
+        try:
+            payload = self._deserialize_message(message)
+        except ConsumerValidationError as e:
+            raw_payload = {"raw_value": message.value().decode("utf-8", errors="ignore")}
+            self._send_to_dlq(raw_payload, str(e), "PROCESSING_ERROR", message)
+            return False
+
+        result = self._sink(payload)
+        if result["outcome"] == "invalid":
+            self.metrics.increment_failure()
+            self._send_to_dlq(
+                to_document_payload(payload),
+                result.get("error", "Schema validation failed"),
+                "VALIDATION_ERROR",
+                message,
+            )
+            return False
+
+        self.processed_count += 1
+        self.metrics.increment_success()
+        if callback:
+            callback(to_document_payload(payload))
+        return True
+
+    def get_metrics(self) -> Dict[str, int]:
+        return {**super().get_metrics(), **self._sink.metrics()}
+
+
+def create_document_consumer(
+    store,
+    bootstrap_servers: str = "localhost:9092",
+    topic: str = "document_ingest",
+    dlq_topic: str = "document_ingest_dlq",
+    consumer_group: str = "document-ingest-consumer",
+) -> "DocumentIngestConsumer":
+    """Create a document consumer sinking to ``store`` (a DocumentStore)."""
+    kafka_config = {
+        'bootstrap.servers': bootstrap_servers,
+        'auto.offset.reset': 'earliest',
+        'enable.auto.commit': False,
+    }
+    return DocumentIngestConsumer(
+        kafka_config=kafka_config, store=store, topic=topic,
+        dlq_topic=dlq_topic, consumer_group=consumer_group,
     )
 
 

--- a/services/ingest/document_sink.py
+++ b/services/ingest/document_sink.py
@@ -1,0 +1,72 @@
+"""
+Document sink for the Kafka ingest consumer (#916).
+
+The Kafka ingest consumer historically validated ``article-ingest-v1`` and had
+no sink — valid messages were validated and dropped. This module is the sink:
+a small, Kafka-free core that normalizes an incoming payload to
+``document-ingest-v1`` (bridging legacy ``article-ingest-v1`` messages) and
+persists it through a :class:`~src.ingestion.document_store.DocumentStore`.
+
+Kept import-free of ``confluent_kafka`` so it is offline-testable and importable
+in the CI gate; the Kafka wiring lives in :mod:`services.ingest.consumer`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from services.ingest.common.document_model import article_to_document
+
+
+def to_document_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize an incoming payload to a ``document-ingest-v1`` dict.
+
+    A payload that already has a ``document_id`` is passed through. A legacy
+    ``article-ingest-v1`` payload (``article_id``) is bridged via
+    :func:`article_to_document`. Anything else is returned unchanged so
+    downstream validation rejects it (rather than raising here).
+    """
+    if "document_id" in payload:
+        return payload
+    if "article_id" in payload:
+        try:
+            return article_to_document(payload)
+        except Exception:  # noqa: BLE001 - malformed article -> let validation reject
+            return payload
+    return payload
+
+
+class DocumentSink:
+    """Validate-and-persist sink: one payload -> ``documents`` (or dead-letter).
+
+    Wraps a :class:`DocumentStore`; ``__call__`` normalizes, validates (via the
+    store's ``document-ingest-v1`` validation), and upserts, returning a small
+    outcome dict (``stored`` / ``duplicate`` / ``invalid``). Never raises on a
+    bad payload — an invalid document is reported, not thrown, so the caller can
+    route it to a DLQ. Running counters (``stored``/``duplicate``/``invalid``)
+    are kept for metrics.
+    """
+
+    def __init__(self, store, validate: bool = True):
+        self.store = store
+        self.validate = validate
+        self.stored = 0
+        self.duplicate = 0
+        self.invalid = 0
+
+    def __call__(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        doc = to_document_payload(payload)
+        summary = self.store.upsert([doc], validate=self.validate)
+        document_id = doc.get("document_id")
+        if summary.invalid:
+            self.invalid += 1
+            error = summary.dead_letter[0]["error"] if summary.dead_letter else "invalid document"
+            return {"outcome": "invalid", "document_id": document_id, "error": error}
+        if summary.inserted:
+            self.stored += 1
+            return {"outcome": "stored", "document_id": document_id}
+        self.duplicate += 1
+        return {"outcome": "duplicate", "document_id": document_id}
+
+    def metrics(self) -> Dict[str, int]:
+        return {"stored": self.stored, "duplicate": self.duplicate, "invalid": self.invalid}

--- a/tests/unit/ingestion/test_document_consumer.py
+++ b/tests/unit/ingestion/test_document_consumer.py
@@ -1,0 +1,104 @@
+"""Routing tests for DocumentIngestConsumer.process_message (#916).
+
+Offline: the consumer is built without __init__ (so no Kafka client is needed),
+with a fake message and a fake DLQ producer, to exercise the deserialize ->
+sink -> DLQ routing.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from services.ingest.consumer import DocumentIngestConsumer
+from services.ingest.document_sink import DocumentSink
+from src.ingestion.document_store import DocumentStore
+
+
+class _FakeMessage:
+    def __init__(self, payload: dict):
+        self._value = json.dumps(payload).encode("utf-8")
+
+    def value(self):
+        return self._value
+
+    def topic(self):
+        return "document_ingest"
+
+    def partition(self):
+        return 0
+
+    def offset(self):
+        return 1
+
+    def timestamp(self):
+        return (0, 1_700_000_000_000)
+
+
+def _consumer():
+    """A DocumentIngestConsumer wired to a real in-memory sink but no Kafka."""
+    c = DocumentIngestConsumer.__new__(DocumentIngestConsumer)
+    c._sink = DocumentSink(DocumentStore(duckdb.connect(":memory:")))
+    c.avro_deserializer = None
+    c.processed_count = 0
+    c.dlq_count = 0
+    c.dlq_topic = "document_ingest_dlq"
+    c.schema_version = "v1"
+    c.consumer_group = "document-ingest-consumer"
+    c.metrics = MagicMock()
+    c.dlq_producer = MagicMock()
+    return c
+
+
+def _doc(doc_id="d1", source_type="news"):
+    return {
+        "document_id": doc_id, "source_type": source_type, "language": "en",
+        "ingested_at": 1_700_000_000_000, "url": f"https://ex.com/{doc_id}",
+        "content": "Body.",
+    }
+
+
+def test_valid_message_is_stored_and_callback_fires():
+    c = _consumer()
+    seen = []
+    ok = c.process_message(_FakeMessage(_doc("d1")), callback=seen.append)
+    assert ok is True
+    assert c._sink.store.count() == 1
+    assert seen and seen[0]["document_id"] == "d1"
+    c.dlq_producer.produce.assert_not_called()
+
+
+def test_invalid_message_goes_to_dlq_keyed_by_document_id():
+    c = _consumer()
+    bad = _doc("d1", source_type="not-a-type")
+    ok = c.process_message(_FakeMessage(bad))
+    assert ok is False
+    assert c._sink.store.count() == 0
+    c.dlq_producer.produce.assert_called_once()
+    # DLQ key is the document_id, not article_id.
+    assert c.dlq_producer.produce.call_args.kwargs["key"] == b"d1"
+
+
+def test_article_message_is_bridged_and_stored():
+    c = _consumer()
+    article = {
+        "article_id": "a1", "language": "en", "ingested_at": 1_700_000_000_000,
+        "url": "https://ex.com/a1", "title": "H", "body": "Body.",
+        "source_id": "reuters", "published_at": 1_699_000_000_000,
+    }
+    ok = c.process_message(_FakeMessage(article))
+    assert ok is True
+    stored = c._sink.store.get("a1")
+    assert stored is not None and stored["source_type"] == "news"
+
+
+def test_duplicate_message_is_not_dlqd():
+    c = _consumer()
+    c.process_message(_FakeMessage(_doc("d1")))
+    ok = c.process_message(_FakeMessage(_doc("d1")))
+    assert ok is True  # duplicate is a success, not a DLQ
+    c.dlq_producer.produce.assert_not_called()
+    assert c._sink.store.count() == 1

--- a/tests/unit/ingestion/test_document_sink.py
+++ b/tests/unit/ingestion/test_document_sink.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Kafka consumer's document sink core (#916). Offline."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.document_sink import DocumentSink, to_document_payload
+from src.ingestion.document_store import DocumentStore
+
+
+@pytest.fixture
+def sink() -> DocumentSink:
+    return DocumentSink(DocumentStore(duckdb.connect(":memory:")))
+
+
+def _doc_payload(doc_id="d1", source_type="news", content="Body."):
+    return {
+        "document_id": doc_id,
+        "source_type": source_type,
+        "language": "en",
+        "ingested_at": 1_700_000_000_000,
+        "url": f"https://ex.com/{doc_id}",
+        "content": content,
+    }
+
+
+def _article_payload(article_id="a1"):
+    return {
+        "article_id": article_id,
+        "language": "en",
+        "ingested_at": 1_700_000_000_000,
+        "url": f"https://ex.com/{article_id}",
+        "title": "Headline",
+        "body": "Article body.",
+        "source_id": "reuters",
+        "published_at": 1_699_000_000_000,
+        "country": "US",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# to_document_payload
+# --------------------------------------------------------------------------- #
+
+
+def test_document_payload_passes_through():
+    p = _doc_payload()
+    assert to_document_payload(p) is p
+
+
+def test_article_payload_is_bridged_to_document():
+    doc = to_document_payload(_article_payload("a1"))
+    assert doc["document_id"] == "a1"
+    assert doc["source_type"] == "news"
+    assert doc["content"] == "Article body."
+    assert doc["metadata"].get("country") == "US"
+
+
+def test_malformed_article_returned_unchanged_for_rejection():
+    # Missing required article fields -> not bridgeable -> returned as-is.
+    p = {"article_id": "a1"}
+    assert to_document_payload(p) == p
+
+
+# --------------------------------------------------------------------------- #
+# DocumentSink
+# --------------------------------------------------------------------------- #
+
+
+def test_valid_document_is_stored(sink: DocumentSink):
+    res = sink(_doc_payload("d1"))
+    assert res == {"outcome": "stored", "document_id": "d1"}
+    assert sink.store.count() == 1
+
+
+def test_duplicate_document_is_reported(sink: DocumentSink):
+    sink(_doc_payload("d1"))
+    res = sink(_doc_payload("d1"))
+    assert res["outcome"] == "duplicate"
+    assert sink.store.count() == 1
+
+
+def test_invalid_document_is_dead_lettered_not_raised(sink: DocumentSink):
+    bad = _doc_payload("d1")
+    bad["source_type"] = "not-a-type"
+    res = sink(bad)
+    assert res["outcome"] == "invalid"
+    assert res["document_id"] == "d1"
+    assert "error" in res
+    assert sink.store.count() == 0
+
+
+def test_missing_required_field_is_invalid(sink: DocumentSink):
+    bad = _doc_payload("d1")
+    del bad["language"]
+    assert sink(bad)["outcome"] == "invalid"
+
+
+def test_article_payload_is_bridged_and_stored(sink: DocumentSink):
+    res = sink(_article_payload("a1"))
+    assert res == {"outcome": "stored", "document_id": "a1"}
+    stored = sink.store.get("a1")
+    assert stored["source_type"] == "news"
+
+
+def test_metrics_track_outcomes(sink: DocumentSink):
+    sink(_doc_payload("d1"))
+    sink(_doc_payload("d1"))  # duplicate
+    bad = _doc_payload("d2"); bad["source_type"] = "x"
+    sink(bad)  # invalid
+    assert sink.metrics() == {"stored": 1, "duplicate": 1, "invalid": 1}


### PR DESCRIPTION
## Summary

`services/ingest/consumer.py` (`ArticleIngestConsumer`) validated the legacy `article-ingest-v1` and **had no sink** — valid messages were validated and dropped, so the Kafka ingest path was disconnected from the unified `documents` corpus. It also imported `confluent_kafka` at module top, so it couldn't be imported or unit-tested without the Kafka client. First step of reintegrating the streaming stack; closes **#916**.

## What changed

- **`services/ingest/document_sink.py`** (new, Kafka-free): `to_document_payload()` normalizes a payload to `document-ingest-v1` — bridging legacy `article-ingest-v1` messages via `article_to_document`, passing documents through, returning anything else unchanged so validation rejects it. `DocumentSink` validates + upserts through a `DocumentStore`, returning a `stored`/`duplicate`/`invalid` outcome (**never raising** on a bad payload, so the caller can DLQ it) with running metrics.
- **`consumer.py`**: the `confluent_kafka` import is **guarded** (the module now imports without it); a `_dlq_key()` hook is extracted from `_send_to_dlq`; `DocumentIngestConsumer` validates + persists through `DocumentSink`, bridges article messages, and keys the DLQ by `document_id`, reusing the base Kafka/DLQ machinery. `ArticleIngestConsumer` behaviour is unchanged (its `_dlq_key` still returns `article_id`).

## Tests (gate-covered)

- `tests/unit/ingestion/test_document_sink.py` — bridge/pass-through, stored/duplicate/invalid outcomes, article bridging, metrics.
- `tests/unit/ingestion/test_document_consumer.py` — `process_message` deserialize → sink → DLQ routing (DLQ keyed by `document_id`, article bridging, duplicate-is-not-DLQ), via a Kafka-free constructed consumer.

Full `tests/unit/ingestion`: 433 passed, 5 skipped.

_Part of reintegrating the streaming stack. Follow-ups: de-dupe the drifted Spark trees, migrate the Spark jobs to `document-ingest-v1`, and repoint topics/Debezium._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_