### PR TITLE
Add a health-aware harvest scheduler + lightweight entrypoint (#920, #921)

### DIFF
--- a/src/ingestion/scheduler.py
+++ b/src/ingestion/scheduler.py
@@ -1,0 +1,136 @@
+"""
+Health-aware harvest scheduler (orchestration reintegration).
+
+The adaptive layer (``SourceHealthTracker.due()`` / quarantine back-off, #879)
+was consulted *inside* ``Connector.harvest_run`` but nothing drove repeated,
+health-aware harvests — the only scheduled orchestration (the ``news_pipeline``
+Airflow DAG) ran mock data. This is the missing driver: a small, dependency-light
+loop that runs every registered connector through ``harvest_run`` with a shared,
+persistent health tracker, so each :meth:`HarvestScheduler.run_once` lets the
+adaptive scheduling decide what actually fetches.
+
+Because ``harvest_run(respect_schedule=True)`` already skips sources that are not
+:meth:`~src.ingestion.source_health.SourceHealthTracker.due` (backed off or
+quarantined), invoking ``run_once`` from cron / a loop / a scheduled Routine
+gives adaptive cadence — healthy sources at their base interval, empty ones
+backing off, quarantined ones probed rarely — without a heavy orchestrator.
+
+The store and health tracker are injected, so the scheduler is offline-testable.
+:func:`main` wires it to the local warehouse for a real (or looped) run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_KEYS = (
+    "discovered", "skipped", "fetched", "fetch_errors", "parsed",
+    "parse_errors", "documents", "inserted", "duplicate", "invalid",
+)
+
+
+class HarvestScheduler:
+    """Runs registered connectors through ``harvest_run`` with shared health."""
+
+    def __init__(self, store, health, connectors: Optional[Sequence[Tuple[str, Any]]] = None):
+        """``connectors`` is an explicit ``[(name, Connector), …]`` (tests); when
+        omitted, the registered connectors are resolved from the registry."""
+        self.store = store
+        self.health = health
+        self._connectors = list(connectors) if connectors is not None else None
+
+    def _iter_connectors(self) -> List[Tuple[str, Any]]:
+        if self._connectors is not None:
+            return self._connectors
+        import src.ingestion.connectors  # noqa: F401 - trigger registrations
+        from src.ingestion.connectors.registry import available_source_types, get_connector
+
+        return [(name, get_connector(name)) for name in available_source_types()]
+
+    def run_once(self, query: Optional[Any] = None, now_ms: Optional[int] = None) -> Dict[str, Any]:
+        """Run every connector once (health-aware); return a per-connector + total summary.
+
+        Each connector runs with ``respect_schedule=True``, so sources that are
+        not due (backed off / quarantined) are skipped this pass. A connector
+        that raises is recorded and does not abort the others.
+        """
+        per_connector: Dict[str, Any] = {}
+        totals: Dict[str, int] = {k: 0 for k in _SUMMARY_KEYS}
+
+        for name, connector in self._iter_connectors():
+            try:
+                summary = connector.harvest_run(
+                    query=query, store=self.store, health=self.health,
+                    respect_schedule=True, now_ms=now_ms,
+                )
+            except Exception as exc:  # noqa: BLE001 - one connector never aborts the run
+                logger.warning("harvest-scheduler: connector %s failed: %s", name, exc)
+                per_connector[name] = {"error": str(exc)}
+                continue
+            d = summary.as_dict()
+            per_connector[name] = d
+            for k in _SUMMARY_KEYS:
+                totals[k] += int(d.get(k, 0))
+
+        logger.info(
+            "harvest-scheduler: ran %d connectors — inserted=%d duplicate=%d "
+            "invalid=%d skipped=%d",
+            len(per_connector), totals["inserted"], totals["duplicate"],
+            totals["invalid"], totals["skipped"],
+        )
+        return {"connectors": per_connector, "totals": totals}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the harvest scheduler against the local warehouse (once or on a loop).
+
+    A lightweight alternative to a full orchestrator: cron, a scheduled Routine,
+    or ``--loop`` drives adaptive, health-aware harvesting into the ``documents``
+    corpus, with per-source back-off persisted at ``--health-path``.
+    """
+    import argparse
+    import json
+    import time
+
+    parser = argparse.ArgumentParser(description="Run the health-aware harvest scheduler")
+    parser.add_argument("--health-path", default=None,
+                        help="JSON file for persistent per-source health/scheduling state")
+    parser.add_argument("--loop", action="store_true",
+                        help="Keep running, sleeping --interval seconds between passes")
+    parser.add_argument("--interval", type=float, default=1800.0,
+                        help="Seconds between passes when --loop (default 30 min)")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.ingestion.document_store import DocumentStore
+    from src.ingestion.source_health import SourceHealthTracker
+
+    store = DocumentStore(get_shared_connection())
+    health = SourceHealthTracker(args.health_path)
+    scheduler = HarvestScheduler(store, health)
+
+    def _pass() -> None:
+        result = scheduler.run_once()
+        print(json.dumps(result["totals"]))
+
+    if not args.loop:
+        _pass()
+        return 0
+
+    logger.info("harvest-scheduler: looping every %.0fs (Ctrl-C to stop)", args.interval)
+    try:
+        while True:
+            _pass()
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        logger.info("harvest-scheduler: stopped")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/ingestion/test_scheduler.py
+++ b/tests/unit/ingestion/test_scheduler.py
@@ -1,0 +1,108 @@
+"""Unit tests for the health-aware harvest scheduler (orchestration). Offline."""
+
+from __future__ import annotations
+
+from typing import List
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.connectors.base import Connector, RawDocument, SourceRef
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.scheduler import HarvestScheduler
+from src.ingestion.source_health import SourceHealthTracker
+
+
+class _FakeConnector(Connector):
+    source_type = "news"
+
+    def __init__(self, source_id: str, docs: List[Document], raises: bool = False):
+        self._source_id = source_id
+        self._docs = docs
+        self._raises = raises
+
+    def discover(self, query=None):
+        return [SourceRef(self._source_id, metadata={"source_id": self._source_id})]
+
+    def fetch(self, ref):
+        if self._raises:
+            raise RuntimeError("boom")
+        return RawDocument(ref=ref, content="raw")
+
+    def parse(self, raw):
+        return list(self._docs)
+
+
+def _doc(doc_id, content="Body.", source_type="news"):
+    return Document(document_id=doc_id, source_type=source_type, language="en",
+                    ingested_at=1_700_000_000_000, url=f"https://ex.com/{doc_id}",
+                    content=content)
+
+
+@pytest.fixture
+def store():
+    return DocumentStore(duckdb.connect(":memory:"))
+
+
+def test_run_once_harvests_all_connectors_and_aggregates(store):
+    connectors = [
+        ("news", _FakeConnector("s1", [_doc("a1"), _doc("a2", content="Two.")])),
+        ("blog", _FakeConnector("s2", [_doc("b1", content="Blog.", source_type="blog")])),
+    ]
+    sched = HarvestScheduler(store, SourceHealthTracker(), connectors=connectors)
+    result = sched.run_once(now_ms=1000)
+
+    assert result["totals"]["documents"] == 3
+    assert result["totals"]["inserted"] == 3
+    assert store.count() == 3
+    # per-connector detail is present
+    assert result["connectors"]["news"]["inserted"] == 2
+    assert result["connectors"]["blog"]["inserted"] == 1
+
+
+def test_totals_reconcile_with_per_connector(store):
+    connectors = [
+        ("news", _FakeConnector("s1", [_doc("a1")])),
+        ("blog", _FakeConnector("s2", [_doc("b1", source_type="blog")])),
+    ]
+    result = HarvestScheduler(store, SourceHealthTracker(), connectors=connectors).run_once(now_ms=1)
+    for key in ("inserted", "documents", "duplicate", "invalid"):
+        assert result["totals"][key] == sum(
+            c[key] for c in result["connectors"].values() if "error" not in c
+        )
+
+
+def test_health_aware_second_pass_skips_not_due_sources(store):
+    health = SourceHealthTracker()
+    conn = [("news", _FakeConnector("s1", [_doc("a1")]))]
+    sched = HarvestScheduler(store, health, connectors=conn)
+
+    first = sched.run_once(now_ms=1000)
+    assert first["totals"]["inserted"] == 1
+
+    # Same instant: the source was just harvested, so it is not due -> skipped.
+    second = sched.run_once(now_ms=1000)
+    assert second["totals"]["skipped"] == 1
+    assert second["totals"]["inserted"] == 0
+    assert store.count() == 1
+
+
+def test_a_failing_connector_does_not_abort_the_run(store):
+    connectors = [
+        ("news", _FakeConnector("s1", [_doc("a1")])),
+        ("broken", _FakeConnector("s2", [], raises=True)),
+    ]
+    result = HarvestScheduler(store, SourceHealthTracker(), connectors=connectors).run_once(now_ms=1)
+    # The healthy connector still harvested; the broken one is recorded, not raised.
+    assert result["connectors"]["news"]["inserted"] == 1
+    # broken's fetch error is caught inside harvest_run -> a summary with fetch_errors,
+    # not a scheduler-level error entry.
+    assert result["connectors"]["broken"]["fetch_errors"] == 1
+    assert store.count() == 1
+
+
+def test_no_connectors_yields_zero_totals(store):
+    result = HarvestScheduler(store, SourceHealthTracker(), connectors=[]).run_once()
+    assert result["connectors"] == {}
+    assert result["totals"]["inserted"] == 0


### PR DESCRIPTION
## Summary

The adaptive layer (`SourceHealthTracker.due()` / quarantine back-off) was consulted *inside* `harvest_run` but **nothing drove repeated, health-aware harvests** — the only scheduled orchestration (the `news_pipeline` DAG) ran mock data, and the real `documents`-populating paths were all manual. So drift-detection and adaptive scheduling were dead capability. Closes **#920** (scheduler) and **#921** (entrypoint).

## What changed

`src/ingestion/scheduler.py` — `HarvestScheduler(store, health, connectors=None)`:
- **`run_once()`** runs every registered connector through `harvest_run(respect_schedule=True)` with a shared, persistent `SourceHealthTracker`, aggregating a per-connector + total summary;
- because `harvest_run(respect_schedule=True)` already skips not-`due()`/quarantined sources, each pass lets the **adaptive scheduling decide what actually fetches** — healthy sources at cadence, empty ones backing off, quarantined ones probed rarely;
- a failing connector is recorded, never aborts the pass.

**`main()`** is the lightweight, right-sized alternative to a full orchestrator: cron, a scheduled Routine, or `--loop --interval` drives adaptive harvesting into the warehouse `documents` corpus, with per-source back-off persisted at `--health-path`. No Airflow required.

## Tests

`tests/unit/ingestion/test_scheduler.py` — 5 gate-covered tests with fake connectors: aggregation, totals reconcile with per-connector detail, **adaptive second-pass skip** of a just-harvested (not-due) source, a failing connector isolated, empty-connectors. Full `tests/unit/ingestion`: 438 passed.

_Part of reintegrating the orchestration layer; the DAG wiring (#922) follows._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_