### PR TITLE
Wire the news_pipeline DAG to the real engine (#922)

### DIFF
--- a/airflow/dags/news_pipeline.py
+++ b/airflow/dags/news_pipeline.py
@@ -1,15 +1,19 @@
 """
-NeuroNews Data Pipeline DAG (Issue #189)
+Noesis daily data pipeline DAG.
 
-A minimal, reviewable DAG that demonstrates the complete NeuroNews data pipeline
-from scraping to publishing, with proper OpenLineage tracking for data lineage.
+Runs the real ingestion engine on a schedule (was a mock demo, #922):
 
-This DAG shows:
-- TaskFlow API usage for clean, maintainable code
-- Deterministic dataset paths for lineage tracking
-- Four-stage data processing: Raw → Bronze → Silver → Gold
-- Proper error handling and retries
-- Daily scheduling with European timezone
+- **scrape** → the health-aware :class:`HarvestScheduler` harvests every
+  registered connector through ``harvest_run`` into the unified ``documents``
+  corpus (retry + drift detection + adaptive back-off);
+- **clean** → a corpus checkpoint (validation/dedup already happen at write time
+  in ``DocumentStore``);
+- **nlp** → :func:`src.ingestion.enrich.enrich_documents` writes sentiment/topics
+  into ``document_enrichments``;
+- **publish** → an analytics summary over the real corpus.
+
+Task bodies import the engine lazily, so the DAG imports (for dag-check) without
+the `src` package on the path; the tasks need it at execution time.
 """
 
 from datetime import datetime, timedelta
@@ -75,412 +79,91 @@ def news_pipeline():
     """
     
     @task
-    def scrape(**context) -> Dict[str, str]:
+    def scrape(**context) -> Dict[str, Any]:
+        """Harvest real documents into the warehouse via the health-aware scheduler.
+
+        Runs every registered connector through ``harvest_run`` (retry + drift
+        detection + adaptive scheduling) into the unified ``documents`` corpus.
+        Replaces the former mock article generator.
         """
-        Scrape news articles from various sources.
-        
-        Returns:
-            Dict with paths to created files
-        """
-        from datetime import datetime
         import os
-        
-        # Use LineageHelper for standardized dataset URIs (Issue #193)
-        lineage_helper = LineageHelper()
-        ds = context['ds']
-        
-        # Generate standardized dataset URIs using naming convention
-        articles_uri = lineage_helper.create_dataset_uri(
-            layer="raw",
-            entity="news_articles", 
-            partition_date=ds,
-            sequence="001",
-            file_format="json"
+
+        from src.database.local_analytics_connector import get_shared_connection
+        from src.ingestion.document_store import DocumentStore
+        from src.ingestion.scheduler import HarvestScheduler
+        from src.ingestion.source_health import SourceHealthTracker
+
+        conn = get_shared_connection()
+        health_path = os.getenv(
+            "NEURONEWS_HEALTH_PATH", "/opt/airflow/data/source_health.json"
         )
-        
-        metadata_uri = lineage_helper.create_dataset_uri(
-            layer="raw",
-            entity="scraping_metadata",
-            partition_date=ds, 
-            sequence="001",
-            file_format="json"
-        )
-        
-        # Convert URIs to local file paths
-        articles_path = articles_uri.replace('file://', '')
-        metadata_path = metadata_uri.replace('file://', '')
-        
-        # Ensure directories exist
-        os.makedirs(os.path.dirname(articles_path), exist_ok=True)
-        os.makedirs(os.path.dirname(metadata_path), exist_ok=True)
-        
-        # Mock scraped data - in production this would call real scrapers
-        mock_articles = [
-            {
-                "id": f"article_{i}",
-                "title": f"Sample News Article {i}",
-                "content": f"This is the content of news article {i}. It contains important information about current events.",
-                "url": f"https://example.com/article-{i}",
-                "source": "example.com",
-                "publish_date": ds,
-                "scraped_at": datetime.now().isoformat(),
-                "language": "en"
-            }
-            for i in range(1, 11)  # 10 sample articles
-        ]
-        
-        # Write articles to JSON
-        with open(articles_path, 'w') as f:
-            json.dump(mock_articles, f, indent=2)
-        
-        # Write scraping metadata
-        metadata = {
-            "scraping_date": ds,
-            "total_articles": len(mock_articles),
-            "sources": ["example.com"],
-            "scraping_duration_seconds": 30,
-            "success": True
-        }
-        
-        with open(metadata_path, 'w') as f:
-            json.dump(metadata, f, indent=2)
-        
-        print(f"✅ Scraped {len(mock_articles)} articles")
-        print(f"📄 Articles saved to: {articles_path}")
-        print(f"📊 Metadata saved to: {metadata_path}")
-        print(f"🔗 Articles URI: {articles_uri}")
-        print(f"🔗 Metadata URI: {metadata_uri}")
-        
-        return {
-            "articles_path": articles_path,
-            "metadata_path": metadata_path,
-            "articles_uri": articles_uri,
-            "metadata_uri": metadata_uri,
-            "article_count": len(mock_articles)
-        }
-    
+        scheduler = HarvestScheduler(DocumentStore(conn), SourceHealthTracker(health_path))
+        result = scheduler.run_once()
+        totals = result["totals"]
+        print(f"✅ Harvested: inserted={totals['inserted']} "
+              f"duplicate={totals['duplicate']} skipped={totals['skipped']}")
+        return {"totals": totals}
+
     @task
-    def clean(scrape_result: Dict[str, str], **context) -> Dict[str, str]:
+    def clean(scrape_result: Dict[str, Any], **context) -> Dict[str, Any]:
+        """Validation/dedup is done at write time by DocumentStore.
+
+        SLA: 15 minutes (Issue #190). This is a corpus checkpoint — it reports the
+        number of documents in the warehouse after the harvest.
         """
-        Clean and standardize scraped articles.
-        
-        SLA: 15 minutes (Issue #190)
-        This task should complete within 15 minutes of its scheduled time.
-        
-        Args:
-            scrape_result: Output from scrape task
-            
-        Returns:
-            Dict with paths to cleaned data files
-        """
-        import os
-        import pandas as pd
-        from datetime import datetime
-        
-        # Use LineageHelper for standardized dataset URIs (Issue #193)
-        lineage_helper = LineageHelper()
-        ds = context['ds']
-        
-        # Input path from scrape task
-        articles_path = scrape_result["articles_path"]
-        
-        # Generate standardized output URIs using naming convention
-        clean_articles_uri = lineage_helper.create_dataset_uri(
-            layer="bronze",
-            entity="clean_articles",
-            partition_date=ds,
-            sequence="001", 
-            file_format="parquet"
-        )
-        
-        metadata_uri = lineage_helper.create_dataset_uri(
-            layer="bronze",
-            entity="article_metadata",
-            partition_date=ds,
-            sequence="001",
-            file_format="parquet"
-        )
-        
-        # Convert URIs to local file paths
-        clean_articles_path = clean_articles_uri.replace('file://', '')
-        metadata_path = metadata_uri.replace('file://', '')
-        
-        # Ensure directories exist
-        os.makedirs(os.path.dirname(clean_articles_path), exist_ok=True)
-        os.makedirs(os.path.dirname(metadata_path), exist_ok=True)
-        
-        # Load raw articles
-        with open(articles_path, 'r') as f:
-            raw_articles = json.load(f)
-        
-        # Clean and standardize data
-        cleaned_articles = []
-        for article in raw_articles:
-            cleaned = {
-                "article_id": article["id"],
-                "title": article["title"].strip(),
-                "content": article["content"].strip(),
-                "url": article["url"],
-                "source": article["source"],
-                "publish_date": article["publish_date"],
-                "scraped_at": article["scraped_at"],
-                "language": article["language"],
-                "word_count": len(article["content"].split()),
-                "title_length": len(article["title"]),
-                "cleaned_at": datetime.now().isoformat(),
-                "is_valid": len(article["content"]) > 50  # Basic validation
-            }
-            cleaned_articles.append(cleaned)
-        
-        # Convert to DataFrame and save as Parquet
-        df_articles = pd.DataFrame(cleaned_articles)
-        df_articles.to_parquet(clean_articles_path, index=False)
-        
-        # Create metadata summary
-        metadata = {
-            "processing_date": ds,
-            "total_articles": len(cleaned_articles),
-            "valid_articles": sum(1 for a in cleaned_articles if a["is_valid"]),
-            "invalid_articles": sum(1 for a in cleaned_articles if not a["is_valid"]),
-            "avg_word_count": df_articles["word_count"].mean(),
-            "sources": df_articles["source"].unique().tolist(),
-            "languages": df_articles["language"].unique().tolist()
-        }
-        
-        df_metadata = pd.DataFrame([metadata])
-        df_metadata.to_parquet(metadata_path, index=False)
-        
-        print(f"✅ Cleaned {len(cleaned_articles)} articles")
-        print(f"📄 Clean articles saved to: {clean_articles_path}")
-        print(f"📊 Metadata saved to: {metadata_path}")
-        print(f"📈 Valid articles: {metadata['valid_articles']}/{metadata['total_articles']}")
-        print(f"🔗 Clean articles URI: {clean_articles_uri}")
-        print(f"🔗 Metadata URI: {metadata_uri}")
-        
-        return {
-            "clean_articles_path": clean_articles_path,
-            "metadata_path": metadata_path,
-            "clean_articles_uri": clean_articles_uri,
-            "metadata_uri": metadata_uri,
-            "valid_article_count": metadata['valid_articles']
-        }
-    
+        from src.database.local_analytics_connector import get_shared_connection
+
+        conn = get_shared_connection()
+        total = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        print(f"✅ Documents in warehouse: {total} "
+              f"(inserted this run: {scrape_result['totals']['inserted']})")
+        return {"documents_in_warehouse": total}
+
     @task
-    def nlp(clean_result: Dict[str, str], **context) -> Dict[str, str]:
+    def nlp(clean_result: Dict[str, Any], **context) -> Dict[str, Any]:
+        """Enrich un-enriched documents (sentiment + topics) into document_enrichments.
+
+        Replaces the former mock NLP; delegates to the gate-tested
+        ``src.ingestion.enrich`` pass (pluggable analyzer, lexicon default).
         """
-        Perform NLP processing on cleaned articles.
-        
-        Args:
-            clean_result: Output from clean task
-            
-        Returns:
-            Dict with paths to NLP processed files
-        """
-        import os
-        import pandas as pd
-        from datetime import datetime
-        import re
-        
-        # Load IO paths configuration
-        io_paths = load_io_paths()
-        ds = context['ds']
-        
-        # Input and output paths
-        clean_articles_path = clean_result["clean_articles_path"]
-        nlp_processed_path = io_paths['silver']['nlp_processed'].replace('{{ ds }}', ds)
-        sentiment_path = io_paths['silver']['sentiment_scores'].replace('{{ ds }}', ds)
-        entities_path = io_paths['silver']['named_entities'].replace('{{ ds }}', ds)
-        keywords_path = io_paths['silver']['keywords'].replace('{{ ds }}', ds)
-        
-        # Ensure directories exist
-        os.makedirs(os.path.dirname(nlp_processed_path), exist_ok=True)
-        
-        # Load cleaned articles
-        df_articles = pd.read_parquet(clean_articles_path)
-        
-        # Mock NLP processing - in production this would use real NLP models
-        nlp_results = []
-        sentiment_results = []
-        entity_results = []
-        keyword_results = []
-        
-        for _, article in df_articles.iterrows():
-            if not article["is_valid"]:
-                continue
-                
-            article_id = article["article_id"]
-            content = article["content"]
-            
-            # Mock sentiment analysis
-            sentiment_score = 0.1  # Slightly positive sentiment
-            sentiment = "positive" if sentiment_score > 0 else "negative" if sentiment_score < 0 else "neutral"
-            
-            sentiment_results.append({
-                "article_id": article_id,
-                "sentiment": sentiment,
-                "sentiment_score": sentiment_score,
-                "confidence": 0.85
-            })
-            
-            # Mock named entity extraction
-            # Simple regex to find capitalized words as mock entities
-            entities = re.findall(r'\b[A-Z][a-z]+\b', content)
-            for entity in set(entities[:5]):  # Top 5 unique entities
-                entity_results.append({
-                    "article_id": article_id,
-                    "entity": entity,
-                    "entity_type": "PERSON",  # Mock type
-                    "confidence": 0.9
-                })
-            
-            # Mock keyword extraction
-            words = content.lower().split()
-            word_freq = {}
-            for word in words:
-                if len(word) > 4:  # Only consider longer words
-                    word_freq[word] = word_freq.get(word, 0) + 1
-            
-            # Top 5 keywords by frequency
-            top_keywords = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:5]
-            for keyword, frequency in top_keywords:
-                keyword_results.append({
-                    "article_id": article_id,
-                    "keyword": keyword,
-                    "frequency": frequency,
-                    "relevance_score": frequency / len(words)
-                })
-            
-            # Comprehensive NLP result
-            nlp_results.append({
-                "article_id": article_id,
-                "processed_at": datetime.now().isoformat(),
-                "sentiment": sentiment,
-                "sentiment_score": sentiment_score,
-                "entity_count": len(set(entities)),
-                "keyword_count": len(top_keywords),
-                "readability_score": 7.5,  # Mock readability score
-                "language_detected": article["language"],
-                "processing_time_ms": 150  # Mock processing time
-            })
-        
-        # Save all NLP results as Parquet files
-        pd.DataFrame(nlp_results).to_parquet(nlp_processed_path, index=False)
-        pd.DataFrame(sentiment_results).to_parquet(sentiment_path, index=False)
-        pd.DataFrame(entity_results).to_parquet(entities_path, index=False)
-        pd.DataFrame(keyword_results).to_parquet(keywords_path, index=False)
-        
-        print(f"✅ Processed {len(nlp_results)} articles with NLP")
-        print(f"📄 NLP results saved to: {nlp_processed_path}")
-        print(f"💭 Sentiment scores saved to: {sentiment_path}")
-        print(f"🏷️  Named entities saved to: {entities_path}")
-        print(f"🔑 Keywords saved to: {keywords_path}")
-        
-        return {
-            "nlp_processed_path": nlp_processed_path,
-            "sentiment_path": sentiment_path,
-            "entities_path": entities_path,
-            "keywords_path": keywords_path,
-            "processed_article_count": len(nlp_results)
-        }
-    
+        from src.database.local_analytics_connector import get_shared_connection
+        from src.ingestion.enrich import enrich_documents
+
+        conn = get_shared_connection()
+        enriched = enrich_documents(conn)
+        print(f"✅ Enriched {enriched} documents into document_enrichments")
+        return {"enriched": enriched}
+
     @task
-    def publish(nlp_result: Dict[str, str], **context) -> Dict[str, str]:
+    def publish(nlp_result: Dict[str, Any], **context) -> Dict[str, Any]:
+        """Business-ready analytics summary over the real corpus.
+
+        Aggregates counts by source_type and the sentiment distribution from
+        the documents + document_enrichments tables.
         """
-        Create business-ready datasets for analytics.
-        
-        Args:
-            nlp_result: Output from nlp task
-            
-        Returns:
-            Dict with paths to published datasets
-        """
-        import os
-        import pandas as pd
-        from datetime import datetime
-        
-        # Load IO paths configuration
-        io_paths = load_io_paths()
-        ds = context['ds']
-        
-        # Input paths
-        nlp_processed_path = nlp_result["nlp_processed_path"]
-        sentiment_path = nlp_result["sentiment_path"]
-        entities_path = nlp_result["entities_path"]
-        keywords_path = nlp_result["keywords_path"]
-        
-        # Output paths
-        daily_summary_path = io_paths['gold']['daily_summary'].replace('{{ ds }}', ds)
-        trending_topics_path = io_paths['gold']['trending_topics'].replace('{{ ds }}', ds)
-        sentiment_trends_path = io_paths['gold']['sentiment_trends'].replace('{{ ds }}', ds)
-        
-        # Ensure directories exist
-        os.makedirs(os.path.dirname(daily_summary_path), exist_ok=True)
-        
-        # Load processed data
-        df_nlp = pd.read_parquet(nlp_processed_path)
-        df_sentiment = pd.read_parquet(sentiment_path)
-        df_entities = pd.read_parquet(entities_path)
-        df_keywords = pd.read_parquet(keywords_path)
-        
-        # Create daily summary
-        sentiment_counts = df_sentiment['sentiment'].value_counts()
-        daily_summary = {
-            "date": ds,
-            "total_articles": len(df_nlp),
-            "avg_sentiment_score": df_sentiment['sentiment_score'].mean(),
-            "positive_articles": sentiment_counts.get('positive', 0),
-            "negative_articles": sentiment_counts.get('negative', 0),
-            "neutral_articles": sentiment_counts.get('neutral', 0),
-            "total_entities": len(df_entities),
-            "unique_entities": df_entities['entity'].nunique(),
-            "total_keywords": len(df_keywords),
-            "unique_keywords": df_keywords['keyword'].nunique(),
-            "avg_readability": df_nlp['readability_score'].mean(),
-            "created_at": datetime.now().isoformat()
+        from src.database.local_analytics_connector import get_shared_connection
+
+        conn = get_shared_connection()
+        by_source_type = dict(
+            conn.execute(
+                "SELECT source_type, COUNT(*) FROM documents GROUP BY 1 ORDER BY 1"
+            ).fetchall()
+        )
+        by_sentiment = dict(
+            conn.execute(
+                "SELECT COALESCE(sentiment_label, 'unenriched'), COUNT(*) "
+                "FROM document_enrichments GROUP BY 1 ORDER BY 1"
+            ).fetchall()
+        )
+        summary = {
+            "date": context.get("ds"),
+            "documents_by_source_type": by_source_type,
+            "documents_by_sentiment": by_sentiment,
+            "enriched_this_run": nlp_result["enriched"],
         }
-        
-        pd.DataFrame([daily_summary]).to_csv(daily_summary_path, index=False)
-        
-        # Create trending topics (top entities by frequency)
-        trending_entities = (df_entities.groupby('entity')
-                           .agg({
-                               'article_id': 'count',
-                               'confidence': 'mean'
-                           })
-                           .rename(columns={'article_id': 'mention_count'})
-                           .sort_values('mention_count', ascending=False)
-                           .head(10)
-                           .reset_index())
-        
-        trending_entities['date'] = ds
-        trending_entities['rank'] = range(1, len(trending_entities) + 1)
-        trending_entities.to_csv(trending_topics_path, index=False)
-        
-        # Create sentiment trends
-        sentiment_trends = df_sentiment.groupby('sentiment').agg({
-            'sentiment_score': ['count', 'mean', 'std'],
-            'confidence': 'mean'
-        }).round(3)
-        
-        sentiment_trends.columns = ['article_count', 'avg_score', 'score_std', 'avg_confidence']
-        sentiment_trends = sentiment_trends.reset_index()
-        sentiment_trends['date'] = ds
-        sentiment_trends.to_csv(sentiment_trends_path, index=False)
-        
-        print(f"✅ Published analytics datasets for {ds}")
-        print(f"📊 Daily summary: {daily_summary_path}")
-        print(f"📈 Trending topics: {trending_topics_path}")
-        print(f"💭 Sentiment trends: {sentiment_trends_path}")
-        print(f"📋 Summary: {daily_summary['total_articles']} articles, "
-              f"{daily_summary['avg_sentiment_score']:.3f} avg sentiment")
-        
-        return {
-            "daily_summary_path": daily_summary_path,
-            "trending_topics_path": trending_topics_path,
-            "sentiment_trends_path": sentiment_trends_path,
-            "summary": daily_summary
-        }
-    
+        print(f"📊 Published corpus summary: {summary}")
+        return summary
+
     # Define task dependencies using TaskFlow API
     scrape_result = scrape()
     clean_result = clean(scrape_result)

--- a/src/ingestion/enrich.py
+++ b/src/ingestion/enrich.py
@@ -1,0 +1,118 @@
+"""
+Document enrichment pass (orchestration reintegration, #922).
+
+The scheduled pipeline used to fake NLP (hardcoded sentiment, regex "entities").
+This is the real enrichment step: read documents that have no enrichment yet,
+run a pluggable analyzer, and persist sentiment/topics into the
+``document_enrichments`` sink (#908) keyed by ``document_id`` — the ``nlp`` stage
+the ``news_pipeline`` DAG now delegates to.
+
+The default analyzer is a dependency-free lexicon sentiment + keyword topics, so
+the enrichment pass runs (and is gate-tested) offline; a heavier model can be
+injected via the ``analyzer`` parameter without touching the wiring.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.enrichment_store import EnrichmentStore
+
+Analyzer = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+# Small, transparent sentiment lexicons (news/finance-leaning).
+_POSITIVE = frozenset({
+    "good", "great", "gain", "gains", "gained", "rise", "rises", "rose", "up",
+    "boost", "boosts", "strong", "win", "wins", "won", "success", "approve",
+    "approved", "growth", "grow", "record", "surge", "surges", "beat", "beats",
+    "improve", "improved", "recovery", "optimistic", "positive",
+})
+_NEGATIVE = frozenset({
+    "bad", "loss", "losses", "lost", "fall", "falls", "fell", "down", "weak",
+    "fail", "fails", "failed", "crisis", "decline", "declines", "cut", "cuts",
+    "drop", "drops", "plunge", "plunges", "recession", "concern", "concerns",
+    "fear", "fears", "warning", "slump", "negative", "risk", "risks",
+})
+_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with",
+    "at", "by", "from", "as", "is", "are", "was", "were", "be", "been", "it",
+    "its", "this", "that", "these", "those", "has", "have", "had", "will",
+    "would", "could", "should", "after", "over", "into", "about", "than", "then",
+})
+
+
+def _tokens(text: str) -> List[str]:
+    return re.findall(r"[a-z']+", (text or "").lower())
+
+
+def lexicon_sentiment(text: str) -> Dict[str, Any]:
+    """Deterministic lexicon sentiment: score in [-1, 1] + a label."""
+    words = _tokens(text)
+    pos = sum(w in _POSITIVE for w in words)
+    neg = sum(w in _NEGATIVE for w in words)
+    total = pos + neg
+    if total == 0:
+        return {"sentiment_score": 0.0, "sentiment_label": "neutral"}
+    score = round((pos - neg) / total, 3)
+    label = "positive" if score > 0.1 else "negative" if score < -0.1 else "neutral"
+    return {"sentiment_score": score, "sentiment_label": label}
+
+
+def keyword_topics(text: str, top_n: int = 5) -> List[str]:
+    """Top-N frequent, non-trivial keywords as lightweight topics."""
+    freq: Dict[str, int] = {}
+    for w in _tokens(text):
+        if len(w) > 4 and w not in _STOPWORDS:
+            freq[w] = freq.get(w, 0) + 1
+    ranked = sorted(freq.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [w for w, _ in ranked[:top_n]]
+
+
+def default_analyzer(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Lexicon sentiment + keyword topics over the document's title + content."""
+    text = f"{doc.get('title') or ''} {doc.get('content') or ''}"
+    result = lexicon_sentiment(text)
+    result["topics"] = keyword_topics(text)
+    return result
+
+
+def enrich_documents(
+    conn,
+    analyzer: Optional[Analyzer] = None,
+    limit: Optional[int] = None,
+) -> int:
+    """Enrich documents that have no enrichment yet; return how many were enriched.
+
+    Reads ``documents`` LEFT JOIN ``document_enrichments`` for the un-enriched
+    rows, runs ``analyzer`` (default: lexicon sentiment + keyword topics), and
+    upserts the result into ``document_enrichments``. Idempotent: an already-
+    enriched document is skipped, so re-running only fills the gaps.
+    """
+    analyzer = analyzer or default_analyzer
+    DocumentStore(conn)          # ensure documents table
+    store = EnrichmentStore(conn)  # ensure document_enrichments table
+
+    query = (
+        "SELECT d.document_id, d.title, d.content FROM documents d "
+        "LEFT JOIN document_enrichments e ON e.document_id = d.document_id "
+        "WHERE e.document_id IS NULL ORDER BY d.ingested_at DESC"
+    )
+    params: List[Any] = []
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+
+    rows = conn.execute(query, params).fetchall()
+    enriched = 0
+    for document_id, title, content in rows:
+        result = analyzer({"document_id": document_id, "title": title, "content": content})
+        store.upsert(
+            document_id,
+            sentiment_score=result.get("sentiment_score"),
+            sentiment_label=result.get("sentiment_label"),
+            topics=result.get("topics"),
+        )
+        enriched += 1
+    return enriched

--- a/tests/unit/ingestion/test_enrich.py
+++ b/tests/unit/ingestion/test_enrich.py
@@ -1,0 +1,110 @@
+"""Unit tests for the document enrichment pass (#922). Offline, in-memory DuckDB."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.enrich import (
+    default_analyzer,
+    enrich_documents,
+    keyword_topics,
+    lexicon_sentiment,
+)
+from src.ingestion.enrichment_store import EnrichmentStore
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    DocumentStore(c)
+    EnrichmentStore(c)
+    return c
+
+
+def _add(store, doc_id, content, title=""):
+    store.upsert([Document(document_id=doc_id, source_type="news", language="en",
+                           ingested_at=1_700_000_000_000, title=title,
+                           content=content, url=f"https://ex.com/{doc_id}")])
+
+
+# --------------------------------------------------------------------------- #
+# analyzer
+# --------------------------------------------------------------------------- #
+
+
+def test_lexicon_sentiment_polarity():
+    assert lexicon_sentiment("Markets surge as profits gain and growth beats")["sentiment_label"] == "positive"
+    assert lexicon_sentiment("Losses mount as the crisis deepens and stocks plunge")["sentiment_label"] == "negative"
+    assert lexicon_sentiment("The committee met on Tuesday")["sentiment_label"] == "neutral"
+
+
+def test_lexicon_sentiment_score_range():
+    s = lexicon_sentiment("gain gain loss")["sentiment_score"]
+    assert -1.0 <= s <= 1.0
+
+
+def test_keyword_topics_extracts_frequent_terms():
+    topics = keyword_topics("budget budget parliament parliament parliament economy the a an")
+    assert topics[0] == "parliament"  # most frequent, >4 chars, non-stopword
+    assert "budget" in topics
+    assert "the" not in topics  # stopword excluded
+
+
+def test_default_analyzer_shape():
+    r = default_analyzer({"title": "Growth surges", "content": "profits gain"})
+    assert set(r) == {"sentiment_score", "sentiment_label", "topics"}
+    assert isinstance(r["topics"], list)
+
+
+# --------------------------------------------------------------------------- #
+# enrich_documents
+# --------------------------------------------------------------------------- #
+
+
+def test_enriches_documents_and_persists(conn):
+    store = DocumentStore(conn)
+    _add(store, "d1", "Markets surge as profits gain", title="Boom")
+    _add(store, "d2", "Losses mount amid the crisis", title="Bust")
+
+    n = enrich_documents(conn)
+    assert n == 2
+    enr = EnrichmentStore(conn)
+    assert enr.get("d1")["sentiment_label"] == "positive"
+    assert enr.get("d2")["sentiment_label"] == "negative"
+    assert isinstance(enr.get("d1")["topics"], list)
+
+
+def test_is_idempotent_only_fills_gaps(conn):
+    store = DocumentStore(conn)
+    _add(store, "d1", "Markets surge")
+    assert enrich_documents(conn) == 1
+    # Re-running enriches nothing new (d1 already has an enrichment).
+    assert enrich_documents(conn) == 0
+    # A newly-added document is picked up on the next pass.
+    _add(store, "d2", "Crisis deepens")
+    assert enrich_documents(conn) == 1
+
+
+def test_limit_caps_the_batch(conn):
+    store = DocumentStore(conn)
+    for i in range(5):
+        _add(store, f"d{i}", f"content {i} gain")
+    assert enrich_documents(conn, limit=2) == 2
+    assert EnrichmentStore(conn).count() == 2
+
+
+def test_pluggable_analyzer_is_used(conn):
+    store = DocumentStore(conn)
+    _add(store, "d1", "anything")
+
+    def _fixed(_doc):
+        return {"sentiment_score": 0.42, "sentiment_label": "custom", "topics": ["x"]}
+
+    enrich_documents(conn, analyzer=_fixed)
+    rec = EnrichmentStore(conn).get("d1")
+    assert rec["sentiment_score"] == 0.42
+    assert rec["sentiment_label"] == "custom"
+    assert rec["topics"] == ["x"]


### PR DESCRIPTION
## Summary

`airflow/dags/news_pipeline.py` was entirely **mock**: `scrape()` returned 10 hardcoded fake articles, `nlp()` faked sentiment/entities/keywords, and the stages wrote JSON→Parquet→CSV file layers — never calling the real scrapers/connectors, never writing DuckDB, never running real NLP. Final step of the orchestration reintegration; closes **#922**.

## What changed

The four tasks are now thin wrappers over gate-tested helpers:
- **scrape** → `HarvestScheduler.run_once()` harvests every registered connector through `harvest_run` into the `documents` corpus (health-aware, adaptive back-off);
- **clean** → a corpus checkpoint (`DocumentStore` already validates/dedups at write time);
- **nlp** → `src.ingestion.enrich.enrich_documents` writes sentiment/topics into `document_enrichments`;
- **publish** → an analytics summary over `documents` + `document_enrichments`.

**`src/ingestion/enrich.py`** (new): `enrich_documents(conn, analyzer=, limit=)` reads un-enriched documents (`documents` LEFT JOIN `document_enrichments`), runs a **pluggable analyzer** (default: a dependency-free lexicon sentiment + keyword topics), and upserts to `document_enrichments`. Idempotent — fills gaps only.

## dag-check safety

Task bodies import the engine **lazily** (inside `@task`), so the DAG still imports for `dag-check` without `src` on the path — only at execution time. The DAG compiles and no mock/file-layer plumbing remains.

## Tests

`tests/unit/ingestion/test_enrich.py` — 8 gate-covered tests: sentiment polarity, keyword topics (stopword exclusion), enrich-and-persist, idempotent gap-filling, `limit`, and pluggable-analyzer override. (The scrape helper is covered by the scheduler's tests from #923.)

_Completes the orchestration reintegration: the scheduled DAG now runs the real engine, driven by the health-aware scheduler (#920/#921)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_