### PR TITLE
Harden the OSINT person guard to fail closed (no person identification)

### DIFF
--- a/src/osint/common.py
+++ b/src/osint/common.py
@@ -18,6 +18,98 @@ from typing import Any, Dict, List, Optional, Sequence
 # an unscored source neither helps nor hurts a corroboration tally.
 DEFAULT_CREDIBILITY = 0.5
 
+# Roles in ``document_actors`` that denote a human individual. The guardrail is
+# "never identify a person", so classification is an ANY-overlap test, never a
+# subset test: a person who *also* carries a non-person role (a "president" who
+# is also a "subject") must still be caught. Kept deliberately broad — office and
+# title roles are all held by individuals — because a false "is a person" only
+# costs a refusal, while a false "not a person" would leak a person's location.
+PERSON_ROLES = frozenset({
+    # generic person markers
+    "person", "people", "individual", "human", "man", "woman",
+    # attribution / narrative roles a human carries
+    "speaker", "spokesperson", "spokesman", "spokeswoman", "author",
+    "subject", "witness", "victim", "suspect", "defendant", "plaintiff",
+    "signatory", "interviewee", "quoted",
+    # office / title roles, all held by individuals
+    "president", "vice-president", "vice president", "vp", "minister",
+    "secretary", "senator", "governor", "mayor", "chancellor", "premier",
+    "prime minister", "official", "politician", "lawmaker", "legislator",
+    "representative", "congressman", "congresswoman", "mp", "diplomat",
+    "ambassador", "judge", "justice", "prosecutor", "attorney", "lawyer",
+    "general", "colonel", "admiral", "officer", "commander", "chief",
+    "ceo", "cfo", "cto", "coo", "director", "executive", "chairman",
+    "chairwoman", "chair", "chairperson", "founder", "owner", "leader",
+    "head", "manager", "activist", "protester", "journalist", "reporter",
+    "correspondent", "columnist", "editor", "analyst", "researcher",
+    "scientist", "professor", "economist", "athlete", "player", "actor",
+    "artist", "celebrity",
+})
+
+# Entity types a caller may pass to *positively* assert person-ness or, for the
+# non-person set, to override role inference (an outlet named as a "subject" is
+# not a person). Narrow and explicit; any other type falls through to inference.
+_PERSON_TYPES = frozenset({"person", "people", "individual", "human"})
+_NONPERSON_TYPES = frozenset({
+    "organization", "organisation", "org", "company", "corporation", "corp",
+    "outlet", "publisher", "publication", "agency", "institution", "group",
+    "party", "team", "place", "location", "gpe", "geo", "country", "nation",
+    "state", "city", "region", "facility", "landmark", "product", "work",
+    "event", "law", "norp", "language", "date", "time", "money", "percent",
+    "quantity", "unknown",
+})
+
+
+def is_person(conn, entity, entity_type=None, *, unknown_is_person: bool = True) -> bool:
+    """Fail-closed person classifier backing the de-anonymisation guardrails.
+
+    Returns True when *entity* must be treated as a human individual, so a gated
+    tool refuses to geolocate or profile it. The bias is deliberately toward
+    True: this enforces a "never identify a person" guardrail, so an entity we
+    cannot confidently classify as *non*-human is treated as a person.
+
+    Resolution order:
+
+    * an explicit ``entity_type`` wins — a person-type is a person, a
+      non-person-type (organisation, place, …) is not;
+    * a ``person:`` id prefix is a person;
+    * otherwise the entity's roles in ``document_actors`` decide, by **any**
+      overlap with :data:`PERSON_ROLES` (never a subset test, so a person who
+      also carries a non-person role is still caught);
+    * when nothing classifies the entity — no type, no prefix, no roles, or the
+      lookup errors — ``unknown_is_person`` decides. It defaults to True
+      (fail closed) for an entity being de-anonymised; a caller scanning
+      free text (e.g. a topic substring, which is usually not a name at all)
+      passes ``unknown_is_person=False`` so ordinary topics are not refused.
+    """
+    etype = (entity_type or "").strip().lower()
+    if etype in _PERSON_TYPES:
+        return True
+    if etype in _NONPERSON_TYPES:
+        return False
+    if isinstance(entity, str) and entity.lower().startswith("person:"):
+        return True
+    if not table_exists(conn, "document_actors"):
+        return unknown_is_person
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT lower(role) FROM document_actors "
+            "WHERE actor_name = ? OR entity_id = ?",
+            [entity, entity],
+        ).fetchall()
+    except Exception:
+        # Cannot classify -> fail closed (or per the caller's unknown policy).
+        return unknown_is_person
+    roles = {r[0] for r in rows if r[0]}
+    if not roles:
+        # Entity absent from — or role-less in — the actor layer.
+        return unknown_is_person
+    if roles & PERSON_ROLES:
+        return True
+    # Present with roles, none person-denoting -> a non-person actor (e.g. an
+    # organisation tagged only "organization"/"outlet").
+    return False
+
 
 def table_exists(conn, table: str) -> bool:
     try:

--- a/src/osint/dossier.py
+++ b/src/osint/dossier.py
@@ -11,7 +11,10 @@ Person-entity guardrail (enforced here, not just documented): a person entity
 must have at least one ingested public document, and only document-sourced
 facts are surfaced. A person with no ingested documents is refused rather than
 described from inference, so the tool never emits an unsourced claim about an
-individual.
+individual. Person-ness is classified fail-closed by
+:func:`src.osint.common.is_person`: an entity that cannot be confidently
+classified as non-human (no explicit ``entity_type``, no roles) is treated as a
+person, so the guardrail errs toward refusal.
 
 Stdlib-only; the connection is injected read-only.
 """
@@ -21,29 +24,6 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from src.osint import common, evidence
-
-# Roles that denote a human individual, used to infer person-ness when the
-# caller does not pass an explicit entity_type.
-_PERSON_ROLES = {"speaker", "author", "subject", "person", "spokesperson"}
-
-
-def _is_person(conn, entity: str, entity_type: Optional[str]) -> bool:
-    if entity_type and entity_type.strip().lower() in ("person", "people", "individual"):
-        return True
-    if isinstance(entity, str) and entity.lower().startswith("person:"):
-        return True
-    if not common.table_exists(conn, "document_actors"):
-        return False
-    try:
-        rows = conn.execute(
-            "SELECT DISTINCT lower(role) FROM document_actors "
-            "WHERE actor_name = ? OR entity_id = ?",
-            [entity, entity],
-        ).fetchall()
-    except Exception:
-        return False
-    roles = {r[0] for r in rows if r[0]}
-    return bool(roles) and roles.issubset(_PERSON_ROLES)
 
 
 def _mentions(conn, entity: str) -> List[Dict[str, Any]]:
@@ -129,7 +109,7 @@ def entity_dossier(conn, entity: str, entity_type: Optional[str] = None) -> Dict
     if not common.table_exists(conn, "document_actors"):
         return {"error": "no entity-mention layer available", "entity": entity}
 
-    is_person = _is_person(conn, entity, entity_type)
+    is_person = common.is_person(conn, entity, entity_type)
     mentions = _mentions(conn, entity)
 
     if is_person and not mentions:

--- a/src/osint/gated.py
+++ b/src/osint/gated.py
@@ -47,9 +47,6 @@ _PLACE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Roles that denote a human individual; geolocation of these is refused.
-_PERSON_ROLES = {"speaker", "author", "subject", "person", "spokesperson"}
-
 # Words dropped before comparing claim text for narrative-coordination overlap.
 _STOP = frozenset(
     """a an and are as at be by for from has have in into is it its of on or that
@@ -58,21 +55,14 @@ _STOP = frozenset(
 _TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'\-]+")
 
 
-def _is_person(conn, entity: str) -> bool:
-    if isinstance(entity, str) and entity.lower().startswith("person:"):
-        return True
-    if not common.table_exists(conn, "document_actors"):
-        return False
-    try:
-        rows = conn.execute(
-            "SELECT DISTINCT lower(role) FROM document_actors "
-            "WHERE actor_name = ? OR entity_id = ?",
-            [entity, entity],
-        ).fetchall()
-    except Exception:
-        return False
-    roles = {r[0] for r in rows if r[0]}
-    return bool(roles) and roles.issubset(_PERSON_ROLES)
+def _person_refusal(who: str) -> Dict[str, Any]:
+    return {
+        "error": (
+            f"refused: {who!r} is a person; geolocate_claims resolves only "
+            f"event geography, never a person's location"
+        ),
+        "code": "person_geolocation_refused",
+    }
 
 
 def geolocate_claims(
@@ -86,14 +76,15 @@ def geolocate_claims(
         entity: optional entity filter (an actor in the corpus). A person
             entity is refused; this tool never locates individuals.
     """
-    if entity is not None and _is_person(conn, entity):
-        return {
-            "error": (
-                f"refused: {entity!r} is a person; geolocate_claims resolves only "
-                f"event geography, never a person's location"
-            ),
-            "code": "person_geolocation_refused",
-        }
+    # Fail-closed person guard on the entity filter: an entity we cannot
+    # confidently classify as non-human is treated as a person and refused.
+    if entity is not None and common.is_person(conn, entity):
+        return _person_refusal(entity)
+    # The same guard on the topic path: a topic that positively names a known
+    # person is refused too (unknown_is_person=False so ordinary topics — which
+    # are not names — still resolve event geography).
+    if topic and common.is_person(conn, topic, unknown_is_person=False):
+        return _person_refusal(topic)
     if not common.table_exists(conn, "argument_claims"):
         return {"locations": [], "count": 0, "note": "no claim layer available"}
 

--- a/tests/unit/osint/test_common_is_person.py
+++ b/tests/unit/osint/test_common_is_person.py
@@ -1,0 +1,85 @@
+"""Direct tests for the fail-closed person classifier (OS-A safety hardening).
+
+``common.is_person`` backs the "never identify a person" guardrail on the gated
+geolocation tool and the entity dossier. These pin the branches that used to
+fail *open* (subset test + a 5-word role vocabulary) now failing *closed*.
+"""
+
+from src.osint import common
+
+
+def _actors(conn, rows):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS document_actors ("
+        "document_id VARCHAR, source_type VARCHAR, actor_name VARCHAR, "
+        "entity_id VARCHAR, role VARCHAR, confidence DOUBLE, extracted_at VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO document_actors (document_id, actor_name, entity_id, role) "
+        "VALUES (?, ?, ?, ?)",
+        rows,
+    )
+
+
+# --- explicit type wins ------------------------------------------------------
+
+
+def test_person_type_is_person(conn):
+    assert common.is_person(conn, "Anyone", entity_type="person") is True
+
+
+def test_nonperson_type_overrides_role_inference(conn):
+    # An outlet tagged with a person-ish role, but the caller asserts it is an
+    # organisation: the explicit non-person type wins.
+    _actors(conn, [("d1", "Wire Co", "org:w", "author")])
+    assert common.is_person(conn, "Wire Co", entity_type="organization") is False
+
+
+def test_person_id_prefix_is_person(conn):
+    assert common.is_person(conn, "person:jr") is True
+
+
+# --- ANY-match, not subset (the core fail-open fix) --------------------------
+
+
+def test_office_role_is_person_any_match(conn):
+    # "president" is not in the old 5-word whitelist; under a subset test it
+    # slipped the guard. ANY overlap with a person role now classifies it.
+    _actors(conn, [("d1", "Sam Cole", "person:sc", "president")])
+    assert common.is_person(conn, "Sam Cole") is True
+
+
+def test_mixed_roles_including_a_person_role_is_person(conn):
+    # A person tagged both "subject" and "official" — subset test would fail
+    # (official was absent); ANY-match catches it.
+    _actors(conn, [
+        ("d1", "Pat Lane", "person:pl", "official"),
+        ("d2", "Pat Lane", "person:pl", "subject"),
+    ])
+    assert common.is_person(conn, "Pat Lane") is True
+
+
+def test_org_only_roles_is_not_person(conn):
+    _actors(conn, [("d1", "Grid Authority", "org:ga", "organization")])
+    assert common.is_person(conn, "Grid Authority") is False
+
+
+# --- unknown handling: fail-closed by default, positive-only for free text ---
+
+
+def test_unknown_entity_defaults_to_person(conn):
+    _actors(conn, [("d1", "Someone", "person:s", "speaker")])
+    # A name absent from the actor layer cannot be classified -> fail closed.
+    assert common.is_person(conn, "Absent Name") is True
+
+
+def test_unknown_entity_is_not_person_for_free_text_scan(conn):
+    _actors(conn, [("d1", "Someone", "person:s", "speaker")])
+    # A topic substring that names nobody must not be refused as a person.
+    assert common.is_person(conn, "flooding", unknown_is_person=False) is False
+
+
+def test_no_actor_layer_falls_back_to_unknown_policy(conn):
+    # No document_actors table at all.
+    assert common.is_person(conn, "Anyone") is True
+    assert common.is_person(conn, "Anyone", unknown_is_person=False) is False

--- a/tests/unit/osint/test_dossier.py
+++ b/tests/unit/osint/test_dossier.py
@@ -48,12 +48,25 @@ def test_person_with_no_document_is_refused(seed):
     assert "mentions" not in out  # no inference-only facts surfaced
 
 
-def test_person_inferred_from_role_is_guardrailed(seed):
+def test_unknown_entity_defaults_to_person_and_is_refused(seed):
     _corpus(seed)
-    # A person known only by a person-role but with no documents of their own.
+    # An entity absent from the corpus with no explicit non-person type is
+    # treated as a person (fail-closed): rather than describe an individual from
+    # nothing, the guardrail refuses instead of returning an empty brief.
     out = entity_dossier(seed.conn, "Nonexistent Speaker")
-    # Not a person (no rows -> not classified person) so returns not-found, not a crash.
-    assert out["found"] is False
+    assert out.get("code") == "person_requires_documents"
+    assert out["is_person"] is True
+
+
+def test_person_with_office_role_is_classified_person(seed):
+    _corpus(seed)
+    # Only role is "president" — under the old subset test this slipped the guard
+    # (not a subset of the 5-word person vocabulary). ANY person-denoting role
+    # now classifies the entity as a person.
+    seed.actors([("d1", "Sam Cole", "person:sc", "president")])
+    out = entity_dossier(seed.conn, "Sam Cole")
+    assert out["is_person"] is True
+    assert out["found"] is True
 
 
 def test_non_person_with_no_documents_is_allowed_empty(seed):

--- a/tests/unit/osint/test_gated.py
+++ b/tests/unit/osint/test_gated.py
@@ -44,6 +44,33 @@ def test_geolocate_refuses_a_person(seed):
     assert "locations" not in out  # emits nothing for a person
 
 
+def test_geolocate_refuses_person_with_office_role(seed):
+    _corpus(seed)
+    # Only role is "president" — under the old subset test this slipped the guard
+    # (president is not one of the 5 whitelisted person roles). ANY person-
+    # denoting role now classifies the entity as a person and refuses.
+    seed.actors([("d2", "Sam Cole", "person:sc", "president")])
+    out = geolocate_claims(seed.conn, entity="Sam Cole")
+    assert out.get("code") == "person_geolocation_refused"
+
+
+def test_geolocate_refuses_person_named_as_topic(seed):
+    _corpus(seed)
+    # The guard covers the topic path, not just the entity filter: a topic that
+    # positively names a known person is refused.
+    out = geolocate_claims(seed.conn, topic="Jordan Rivera")
+    assert out.get("code") == "person_geolocation_refused"
+
+
+def test_geolocate_allows_ordinary_topic_not_a_person(seed):
+    _corpus(seed)
+    # An ordinary topic (not a name) still resolves event geography — the topic
+    # guard is positive-only, so it does not over-refuse free text.
+    out = geolocate_claims(seed.conn, topic="flooding")
+    assert "code" not in out
+    assert out["locations"]
+
+
 def test_geolocate_never_labels_a_person_location(seed):
     _corpus(seed)
     out = geolocate_claims(seed.conn)  # unscoped


### PR DESCRIPTION
## Summary

The person guard behind the review-gated geolocation tool (`geolocate_claims`) and the entity dossier (`entity_dossier`) failed **open**. It classified an entity as a person only when its `document_actors` roles were a **subset** of a 5-word vocabulary (`{speaker, author, subject, person, spokesperson}`). Consequences:

- A person tagged with **any** other role — `president`, `official`, `minister`, `witness` — was not a subset, so the guard let the tools geolocate/profile them.
- An entity with **no roles** was treated as not-a-person.
- The geolocation **topic path** skipped the person check entirely.

Since the guardrail is *"never identify a person"*, the correct default when a classification is uncertain is to **refuse**, not to proceed.

## Changes

- **New `common.is_person(conn, entity, entity_type=None, *, unknown_is_person=True)`** — one fail-closed classifier, replacing the two duplicated `_is_person` implementations in `gated.py` and `dossier.py`:
  - **ANY** overlap with the person-role set classifies the entity as a person (never a subset test), so a person who also carries a non-person role is still caught;
  - the role vocabulary is broadened to the office/title/attribution roles an individual carries;
  - an explicit `entity_type` wins (person-type → person; organisation/place/… → not a person) — a precise escape hatch for legitimate non-person queries;
  - anything unclassifiable (no type, no prefix, no roles, or a lookup error) is treated as a person by default — **fail closed** — while free-text scans (the topic string) pass `unknown_is_person=False` so ordinary topics are not over-refused.
- **`geolocate_claims`** now also refuses a **topic** that positively names a known person, closing the topic-path gap.
- **`entity_dossier`** refuses an unclassifiable entity rather than describing an individual from nothing.

## Tests

- `tests/unit/osint/test_common_is_person.py` (new) pins each branch: explicit-type wins, `person:` prefix, ANY-match office/mixed roles, org-only → not person, unknown → fail closed, free-text scan → not person, missing actor layer → unknown policy.
- `test_gated.py`: office-role refusal, person-named-as-topic refusal, ordinary-topic still resolves geography.
- `test_dossier.py`: unknown entity defaults to person and is refused; office-role entity is classified a person. (The old `test_person_inferred_from_role_is_guardrailed`, which asserted the fail-*open* behaviour, is replaced.)

No behavioural change for the served surface: the gated tools remain behind the `NOESIS_OSINT_GATED_TOOLS` flag (off by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_