### PR TITLE
Move the OSINT imagery review queue off the read-write warehouse (least privilege)

### DIFF
--- a/src/config/env.py
+++ b/src/config/env.py
@@ -60,6 +60,25 @@ def warehouse_path(default: Optional[str] = None) -> Optional[str]:
     return str(Path(__file__).resolve().parents[2] / "data" / "neuronews.duckdb")
 
 
+def imagery_queue_path(default: Optional[str] = None) -> Optional[str]:
+    """The dedicated OSINT imagery review-queue store path
+    (``NOESIS_IMAGERY_QUEUE_PATH`` / ``NEURONEWS_IMAGERY_QUEUE_PATH``).
+
+    The gated imagery tier reads corpus assets from the warehouse *read-only* but
+    must write review-queue suggestions somewhere; per least privilege those
+    writes go to this separate DuckDB file (holding only the review queue), never
+    to the read-write corpus warehouse. Falls back to
+    ``<repo>/data/osint_imagery_queue.duckdb`` when neither var nor ``default``
+    is set.
+    """
+    resolved = resolve_env("IMAGERY_QUEUE_PATH")
+    if resolved is not None:
+        return resolved
+    if default is not None:
+        return default
+    return str(Path(__file__).resolve().parents[2] / "data" / "osint_imagery_queue.duckdb")
+
+
 def enabled_packs(default: str = "") -> str:
     """The enabled domain packs, comma-separated
     (``NOESIS_ENABLED_PACKS`` / ``NEURONEWS_ENABLED_PACKS``)."""

--- a/src/osint/imagery_gated.py
+++ b/src/osint/imagery_gated.py
@@ -17,6 +17,12 @@ the enforcement, not just the docs:
   becomes citable only when an operator confirms it via :func:`confirm_suggestion`.
 * **No default provider.** ``reverse_image_search`` needs an injected provider;
   with none configured the tier is inert (``no_provider_configured``).
+* **Least privilege for the queue.** The corpus asset is read from a *read-only*
+  warehouse connection; the review-queue write goes to a separate ``queue_conn``
+  (a dedicated store) so the gated imagery tier never holds write access to the
+  corpus warehouse. ``queue_conn`` defaults to ``conn`` for single-store callers
+  (e.g. tests); the served tools pass a read-only corpus conn and a distinct
+  read-write queue conn.
 
 See ``docs/architecture/OSINT_IMAGERY_PLAN.md`` §3.3.
 """
@@ -104,12 +110,16 @@ def reverse_image_search(
     sha256: str,
     provider: Optional[ReverseSearchProvider] = None,
     now_ms: Optional[int] = None,
+    queue_conn=None,
 ) -> Dict[str, Any]:
     """Queue reverse-image-search *suggestions* for a corpus asset.
 
     No default provider ships; with none configured the tier is inert. Results
-    are queued uncited — evidence only after operator confirmation.
+    are queued uncited — evidence only after operator confirmation. The corpus
+    asset is read from ``conn`` (read-only); the queue write goes to
+    ``queue_conn`` (defaults to ``conn``).
     """
+    queue_conn = conn if queue_conn is None else queue_conn
     if provider is None:
         return {"status": "no_provider_configured", "sha256": sha256,
                 "note": "reverse image search has no default provider; supply one to enable"}
@@ -124,7 +134,7 @@ def reverse_image_search(
     queued = []
     for hit in hits:
         suggestion = {"url": hit.get("url"), "title": hit.get("title"), "cited": False}
-        sid = _queue_suggestion(conn, "reverse_image_search", sha256, suggestion, now_ms)
+        sid = _queue_suggestion(queue_conn, "reverse_image_search", sha256, suggestion, now_ms)
         queued.append({"suggestion_id": sid, **suggestion})
     return {
         "status": "queued",
@@ -140,12 +150,16 @@ def geolocate_image(
     sha256: str,
     vlm: Optional[GeoVLM] = None,
     now_ms: Optional[int] = None,
+    queue_conn=None,
 ) -> Dict[str, Any]:
     """Queue visible-landmark geolocation *hypotheses* for a corpus asset.
 
     Suggestion-grade, never auto-cited. Reasons about the place in the scene,
-    never the subject (no person identification).
+    never the subject (no person identification). The corpus asset is read from
+    ``conn`` (read-only); the queue write goes to ``queue_conn`` (defaults to
+    ``conn``).
     """
+    queue_conn = conn if queue_conn is None else queue_conn
     if vlm is None:
         return {"status": "no_backend_configured", "sha256": sha256,
                 "note": "geolocation assist needs a vision backend"}
@@ -165,7 +179,7 @@ def geolocate_image(
             "grade": "suggestion",
             "cited": False,
         }
-        sid = _queue_suggestion(conn, "geolocate_image", sha256, suggestion, now_ms)
+        sid = _queue_suggestion(queue_conn, "geolocate_image", sha256, suggestion, now_ms)
         queued.append({"suggestion_id": sid, **suggestion})
     return {
         "status": "queued",

--- a/tests/unit/config/test_env.py
+++ b/tests/unit/config/test_env.py
@@ -6,7 +6,12 @@ identically, alias-first (NOESIS_* canonical, NEURONEWS_* fallback).
 
 import pytest
 
-from src.config.env import enabled_packs, resolve_env, warehouse_path
+from src.config.env import (
+    enabled_packs,
+    imagery_queue_path,
+    resolve_env,
+    warehouse_path,
+)
 
 
 def test_canonical_prefix_wins(monkeypatch):
@@ -68,6 +73,23 @@ def test_warehouse_path_default_keeps_legacy_filename(monkeypatch):
     monkeypatch.delenv("NEURONEWS_DB_PATH", raising=False)
     assert warehouse_path().endswith("data/neuronews.duckdb")
     assert warehouse_path("/override.db") == "/override.db"
+
+
+def test_imagery_queue_path_prefers_env_then_default(monkeypatch):
+    monkeypatch.delenv("NOESIS_IMAGERY_QUEUE_PATH", raising=False)
+    monkeypatch.setenv("NEURONEWS_IMAGERY_QUEUE_PATH", "/data/q.db")
+    assert imagery_queue_path() == "/data/q.db"
+    monkeypatch.setenv("NOESIS_IMAGERY_QUEUE_PATH", "/data/noesis-q.db")
+    assert imagery_queue_path() == "/data/noesis-q.db"
+
+
+def test_imagery_queue_path_defaults_to_a_separate_store(monkeypatch):
+    monkeypatch.delenv("NOESIS_IMAGERY_QUEUE_PATH", raising=False)
+    monkeypatch.delenv("NEURONEWS_IMAGERY_QUEUE_PATH", raising=False)
+    # A dedicated file, distinct from the corpus warehouse (least privilege).
+    assert imagery_queue_path().endswith("data/osint_imagery_queue.duckdb")
+    assert imagery_queue_path() != warehouse_path()
+    assert imagery_queue_path("/override-q.db") == "/override-q.db"
 
 
 def test_enabled_packs_helper(monkeypatch):

--- a/tests/unit/osint/test_imagery_gated.py
+++ b/tests/unit/osint/test_imagery_gated.py
@@ -60,6 +60,45 @@ def test_reverse_search_queues_uncited_suggestions(conn_with_asset):
     assert queue["count"] == 1
 
 
+def test_queue_writes_go_to_a_separate_store(conn_with_asset, tmp_path):
+    # Least privilege: the corpus asset is read from `conn`, but the review-queue
+    # write lands in a *separate* queue store — the corpus connection is never
+    # written to (no queue table appears there).
+    duckdb = pytest.importorskip("duckdb")
+    corpus, sha = conn_with_asset
+    queue = duckdb.connect(str(tmp_path / "queue.duckdb"))
+    provider = lambda b: [{"url": "https://other.example/story", "title": "Elsewhere"}]
+    res = reverse_image_search(corpus, sha, provider=provider, now_ms=10, queue_conn=queue)
+    assert res["status"] == "queued"
+    # The suggestion is in the dedicated queue store...
+    assert list_review_queue(queue, cited=False)["count"] == 1
+    # ...and the corpus connection holds no review queue at all.
+    corpus_tables = {
+        r[0] for r in corpus.execute(
+            "SELECT table_name FROM information_schema.tables"
+        ).fetchall()
+    }
+    assert "imagery_review_queue" not in corpus_tables
+    queue.close()
+
+
+def test_geolocate_queue_write_goes_to_separate_store(conn_with_asset, tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    corpus, sha = conn_with_asset
+    queue = duckdb.connect(str(tmp_path / "queue.duckdb"))
+    vlm = lambda b: [{"landmark": "a bridge", "place": "somewhere", "confidence": 0.4}]
+    res = geolocate_image(corpus, sha, vlm=vlm, now_ms=5, queue_conn=queue)
+    assert res["status"] == "queued"
+    assert list_review_queue(queue)["count"] == 1
+    corpus_tables = {
+        r[0] for r in corpus.execute(
+            "SELECT table_name FROM information_schema.tables"
+        ).fetchall()
+    }
+    assert "imagery_review_queue" not in corpus_tables
+    queue.close()
+
+
 def test_geolocate_image_no_backend(conn_with_asset):
     conn, sha = conn_with_asset
     assert geolocate_image(conn, sha, vlm=None)["status"] == "no_backend_configured"

--- a/tools/osint_mcp/server.py
+++ b/tools/osint_mcp/server.py
@@ -396,12 +396,14 @@ if _gated_enabled():
             con.close()
 
     # -- Track C / C4: imagery external tier (review-queued, no default provider)
-    def _warehouse_rw():
+    # Least privilege: corpus assets are read from the read-only warehouse; the
+    # review-queue write goes to a *separate* store, so the gated imagery tier
+    # never holds write access to the corpus warehouse.
+    def _imagery_queue_rw():
         import duckdb
 
-        from src.config.env import warehouse_path
-        path = warehouse_path(str(REPO_ROOT / "data" / "neuronews.duckdb"))
-        return duckdb.connect(path)
+        from src.config.env import imagery_queue_path
+        return duckdb.connect(imagery_queue_path())
 
     @mcp.tool
     def reverse_image_search(sha256: str) -> dict:
@@ -413,17 +415,19 @@ if _gated_enabled():
             sha256: a corpus image asset hash (never an operator-supplied photo).
         """
         try:
-            con = _warehouse_rw()
+            con = _warehouse_ro()
+            queue = _imagery_queue_rw()
         except Exception as exc:
             return {"error": str(exc)}
         try:
             from src.osint.imagery_gated import reverse_image_search as _ris
 
-            return _ris(con, sha256, provider=None)  # no default provider
+            return _ris(con, sha256, provider=None, queue_conn=queue)  # no default provider
         except Exception as exc:
             return {"error": str(exc)}
         finally:
             con.close()
+            queue.close()
 
     @mcp.tool
     def geolocate_image(sha256: str) -> dict:
@@ -435,17 +439,19 @@ if _gated_enabled():
             sha256: a corpus image asset hash.
         """
         try:
-            con = _warehouse_rw()
+            con = _warehouse_ro()
+            queue = _imagery_queue_rw()
         except Exception as exc:
             return {"error": str(exc)}
         try:
             from src.osint.imagery_gated import geolocate_image as _geo
 
-            return _geo(con, sha256, vlm=None)  # no default backend
+            return _geo(con, sha256, vlm=None, queue_conn=queue)  # no default backend
         except Exception as exc:
             return {"error": str(exc)}
         finally:
             con.close()
+            queue.close()
 
 
 @mcp.tool(


### PR DESCRIPTION
## Summary

The two gated imagery tools — `reverse_image_search` and `geolocate_image` — opened a read-**write** connection to the *entire* corpus warehouse (`_warehouse_rw`) solely to append a row to `imagery_review_queue`. Every other OSINT tool opens the warehouse read-only. Granting the imagery tier write access to the whole warehouse — where a bug or abuse could mutate `documents`, `argument_claims`, `outlet_scores`, … — just to record a review-queue suggestion violates least privilege.

## Changes

- **Corpus reads stay read-only.** The corpus asset is now read via `_warehouse_ro()`; `_warehouse_rw()` is removed from the server.
- **Queue writes go to a dedicated store.** New `config.env.imagery_queue_path` (`NOESIS_IMAGERY_QUEUE_PATH` / `NEURONEWS_IMAGERY_QUEUE_PATH`, default `data/osint_imagery_queue.duckdb`) resolves a separate DuckDB file that holds only the review queue. The gated imagery tier no longer holds write access to the corpus warehouse.
- **`queue_conn` parameter.** `reverse_image_search`/`geolocate_image` gain a `queue_conn` that defaults to `conn`, so single-store callers (tests, embedded use) are unaffected; the served tools pass a read-only corpus conn and a distinct read-write queue conn.

## Tests

- `test_imagery_gated.py`: two new tests assert the queue write lands in a separate store and the corpus connection is never written to (no `imagery_review_queue` table appears on it).
- `test_env.py`: the new `imagery_queue_path` resolver — env precedence and a default that is distinct from the corpus warehouse path.

No change to the served surface: the imagery tools remain behind `NOESIS_OSINT_GATED_TOOLS` (off by default), and the corpus-images-only / no-person-identification / uncited-until-confirmed guarantees are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_