### PR TITLE
Make OSINT source-type-agnostic and project enrichment topics

### DIFF
--- a/src/database/news_articles_compat.py
+++ b/src/database/news_articles_compat.py
@@ -48,6 +48,31 @@ WHERE d.source_type = 'news'
 """
 
 
+# The source-type-agnostic companion of the news_articles view: the same legacy
+# column shape over *every* document (no source_type filter), plus source_type
+# and the enrichment topics. OSINT resolves citations from this so a blog, paper
+# or filing resolves to its source exactly like a news article does, instead of
+# being mis-flagged uncited by the news-only view.
+_CORPUS_VIEW_SQL = """
+CREATE VIEW corpus_documents AS
+SELECT
+    d.document_id AS id,
+    d.title       AS title,
+    d.url         AS url,
+    d.content     AS content,
+    CASE WHEN d.created_at IS NULL THEN NULL
+         ELSE CAST(to_timestamp(d.created_at / 1000) AS TIMESTAMP) END AS publish_date,
+    COALESCE(d.source_id, json_extract_string(d.metadata, '$.source')) AS source,
+    json_extract_string(d.metadata, '$.category') AS category,
+    d.source_type     AS source_type,
+    e.sentiment_score AS sentiment_score,
+    e.sentiment_label AS sentiment_label,
+    e.topics          AS topics
+FROM documents d
+LEFT JOIN document_enrichments e ON e.document_id = d.document_id
+"""
+
+
 def _news_articles_is_view(conn) -> bool:
     row = conn.execute(
         "SELECT table_type FROM information_schema.tables WHERE table_name = 'news_articles'"
@@ -61,6 +86,23 @@ def ensure_documents_schema(conn) -> None:
     EnrichmentStore(conn)   # document_enrichments
 
 
+def ensure_corpus_documents_view(conn) -> None:
+    """Create the source-type-agnostic ``corpus_documents`` view if absent.
+
+    Unlike ``news_articles`` (news-only), this projects every document into the
+    legacy column shape, so OSINT and other source-agnostic readers resolve a
+    document's source/citation regardless of its ``source_type``. A no-op if it
+    already exists. ``corpus_documents`` is a new name, so it never collides with
+    a legacy ``news_articles`` base table.
+    """
+    ensure_documents_schema(conn)
+    exists = conn.execute(
+        "SELECT table_type FROM information_schema.tables WHERE table_name = 'corpus_documents'"
+    ).fetchone()
+    if exists is None:
+        conn.execute(_CORPUS_VIEW_SQL)
+
+
 def ensure_news_articles_view(conn) -> None:
     """Create the ``news_articles`` view over ``documents`` if it is not present.
 
@@ -68,6 +110,9 @@ def ensure_news_articles_view(conn) -> None:
     table (a legacy warehouse, or a test that created its own), it is left alone
     — callers that want the view over a legacy table must migrate it first (see
     :func:`migrate_news_articles_to_view`).
+
+    The source-agnostic ``corpus_documents`` view is ensured alongside, so every
+    warehouse-setup path that builds the news view also gets the corpus view.
     """
     ensure_documents_schema(conn)
     exists = conn.execute(
@@ -75,6 +120,7 @@ def ensure_news_articles_view(conn) -> None:
     ).fetchone()
     if exists is None:
         conn.execute(_VIEW_SQL)
+    ensure_corpus_documents_view(conn)
 
 
 def write_news_articles(conn, rows: Iterable[Dict[str, Any]]) -> int:

--- a/src/osint/common.py
+++ b/src/osint/common.py
@@ -122,22 +122,38 @@ def table_exists(conn, table: str) -> bool:
         return False
 
 
+def citation_table(conn) -> Optional[str]:
+    """The table OSINT resolves a document's citation (source/url/title/date)
+    from, source-type-agnostic when available.
+
+    Prefers the source-agnostic ``corpus_documents`` view (every ``source_type``)
+    so a blog, paper or filing resolves to its source exactly like a news
+    article; falls back to the news-only ``news_articles`` view/table for legacy
+    warehouses and test fixtures that only seed it. ``None`` when neither exists.
+    """
+    if table_exists(conn, "corpus_documents"):
+        return "corpus_documents"
+    if table_exists(conn, "news_articles"):
+        return "news_articles"
+    return None
+
+
 def claim_sources(conn, claim_ids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
     """Map each claim_id to its carrying source: ``{source, source_type, url,
-    document_id}``. Resolves the outlet name via ``news_articles`` when the
-    claim's document is a news article, else falls back to the claim's
-    ``source_type`` as the source label."""
+    document_id}``. Resolves the outlet name via the source-agnostic citation
+    table (:func:`citation_table`) for a document of any ``source_type``, else
+    falls back to the claim's ``source_type`` as the source label."""
     if not claim_ids or not table_exists(conn, "argument_claims"):
         return {}
     ph = ", ".join("?" for _ in claim_ids)
-    has_articles = table_exists(conn, "news_articles")
-    if has_articles:
+    citation_tbl = citation_table(conn)
+    if citation_tbl:
         rows = conn.execute(
             f"""
             SELECT c.claim_id, c.source_type, c.document_id,
                    a.source, a.url
             FROM argument_claims c
-            LEFT JOIN news_articles a ON c.document_id = a.id
+            LEFT JOIN {citation_tbl} a ON c.document_id = a.id
             WHERE c.claim_id IN ({ph})
             """,
             list(claim_ids),

--- a/src/osint/corroboration.py
+++ b/src/osint/corroboration.py
@@ -46,14 +46,14 @@ def _support_contradict_from_evidence(
     whose source and credibility we resolve."""
     if not common.table_exists(conn, "claim_evidence"):
         return []
-    has_articles = common.table_exists(conn, "news_articles")
-    if has_articles:
+    citation_tbl = common.citation_table(conn)
+    if citation_tbl:
         rows = conn.execute(
-            """
+            f"""
             SELECT e.relation, e.evidence_source_type, e.similarity_score,
                    a.source
             FROM claim_evidence e
-            LEFT JOIN news_articles a ON e.evidence_document_id = a.id
+            LEFT JOIN {citation_tbl} a ON e.evidence_document_id = a.id
             WHERE e.claim_id = ?
               AND lower(e.relation) IN ('supports', 'contradicts')
             """,

--- a/src/osint/dossier.py
+++ b/src/osint/dossier.py
@@ -55,11 +55,12 @@ def _mentions(conn, entity: str) -> List[Dict[str, Any]]:
 
 
 def _first_last_seen(conn, document_ids: List[str]) -> Dict[str, Optional[str]]:
-    if not document_ids or not common.table_exists(conn, "news_articles"):
+    citation_tbl = common.citation_table(conn)
+    if not document_ids or not citation_tbl:
         return {"first_seen": None, "last_seen": None}
     ph = ", ".join("?" for _ in document_ids)
     row = conn.execute(
-        f"SELECT MIN(publish_date), MAX(publish_date) FROM news_articles WHERE id IN ({ph})",
+        f"SELECT MIN(publish_date), MAX(publish_date) FROM {citation_tbl} WHERE id IN ({ph})",
         document_ids,
     ).fetchone()
     return {

--- a/src/osint/evidence.py
+++ b/src/osint/evidence.py
@@ -59,19 +59,27 @@ def render_state(independent_sources: int) -> str:
 
 
 def document_citations(conn, document_ids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
-    """Resolve document ids to citations via ``news_articles``. A document id
-    with no matching article yields a citation with ``cited=False`` so the gap
-    is visible."""
+    """Resolve document ids to citations via the source-agnostic citation table
+    (:func:`common.citation_table`), so a document of any ``source_type``
+    resolves. A document id with no matching row yields a citation with
+    ``cited=False`` so the gap is visible. When the source-agnostic
+    ``corpus_documents`` view is in use, a resolved citation also carries the
+    enrichment ``topics``."""
+    import json
+
     uniq = [d for d in dict.fromkeys(document_ids) if d]
     out: Dict[str, Dict[str, Any]] = {}
     resolved: Dict[str, Any] = {}
-    if uniq and common.table_exists(conn, "news_articles"):
+    citation_tbl = common.citation_table(conn)
+    if uniq and citation_tbl:
         ph = ", ".join("?" for _ in uniq)
+        # Only corpus_documents carries topics; news_articles has no such column.
+        topics_expr = "topics" if citation_tbl == "corpus_documents" else "NULL"
         for r in conn.execute(
-            f"SELECT id, source, url, title FROM news_articles WHERE id IN ({ph})",
+            f"SELECT id, source, url, title, {topics_expr} FROM {citation_tbl} WHERE id IN ({ph})",
             uniq,
         ).fetchall():
-            resolved[r[0]] = {"source": r[1], "url": r[2], "title": r[3]}
+            resolved[r[0]] = {"source": r[1], "url": r[2], "title": r[3], "topics": r[4]}
     for d in uniq:
         info = resolved.get(d)
         out[d] = citation(
@@ -82,6 +90,12 @@ def document_citations(conn, document_ids: Sequence[str]) -> Dict[str, Dict[str,
         )
         if info is not None:
             out[d]["title"] = info.get("title")
+            raw_topics = info.get("topics")
+            if raw_topics is not None:
+                try:
+                    out[d]["topics"] = json.loads(raw_topics) if isinstance(raw_topics, str) else list(raw_topics)
+                except (ValueError, TypeError):
+                    out[d]["topics"] = []
     return out
 
 

--- a/src/osint/gated.py
+++ b/src/osint/gated.py
@@ -106,8 +106,9 @@ def geolocate_claims(
         where.append("c.document_id IN (" + ", ".join("?" for _ in doc_ids) + ")")
         params.extend(doc_ids)
 
-    has_articles = common.table_exists(conn, "news_articles")
-    join = "LEFT JOIN news_articles a ON c.document_id = a.id" if has_articles else ""
+    citation_tbl = common.citation_table(conn)
+    has_articles = citation_tbl is not None
+    join = f"LEFT JOIN {citation_tbl} a ON c.document_id = a.id" if has_articles else ""
     src = "a.source" if has_articles else "NULL"
     url = "a.url" if has_articles else "NULL"
     clause = ("WHERE " + " AND ".join(where)) if where else ""
@@ -158,7 +159,8 @@ def narrative_coordination(
         topic: optional topic filter (claim-text substring).
         min_similarity: Jaccard threshold for two claims to count as echoing.
     """
-    if not (common.table_exists(conn, "argument_claims") and common.table_exists(conn, "news_articles")):
+    citation_tbl = common.citation_table(conn)
+    if not (common.table_exists(conn, "argument_claims") and citation_tbl):
         return {"cohorts": [], "count": 0, "note": "claim and source layers required"}
 
     where = ["a.source IS NOT NULL"]
@@ -168,8 +170,8 @@ def narrative_coordination(
         params.append(f"%{topic}%")
     params.append(int(limit))
     rows = conn.execute(
-        "SELECT c.claim_id, c.claim_text, a.source FROM argument_claims c "
-        "JOIN news_articles a ON c.document_id = a.id "
+        f"SELECT c.claim_id, c.claim_text, a.source FROM argument_claims c "
+        f"JOIN {citation_tbl} a ON c.document_id = a.id "
         f"WHERE {' AND '.join(where)} LIMIT ?",
         params,
     ).fetchall()

--- a/src/osint/provenance.py
+++ b/src/osint/provenance.py
@@ -25,11 +25,12 @@ from src.osint import common, evidence
 
 
 def _document_row(conn, document_id: str) -> Optional[Dict[str, Any]]:
-    if not common.table_exists(conn, "news_articles"):
+    citation_tbl = common.citation_table(conn)
+    if not citation_tbl:
         return None
     row = conn.execute(
-        "SELECT id, title, source, url, publish_date, category "
-        "FROM news_articles WHERE id = ?",
+        f"SELECT id, title, source, url, publish_date, category "
+        f"FROM {citation_tbl} WHERE id = ?",
         [document_id],
     ).fetchone()
     if row is None:

--- a/src/osint/reliability.py
+++ b/src/osint/reliability.py
@@ -39,10 +39,11 @@ ASSUMPTIONS = [
 
 
 def _track_record(conn, source: str) -> Dict[str, Any]:
-    if not common.table_exists(conn, "news_articles"):
+    citation_tbl = common.citation_table(conn)
+    if not citation_tbl:
         return {"documents": 0, "last_seen": None}
     row = conn.execute(
-        "SELECT COUNT(*), MAX(publish_date) FROM news_articles WHERE source = ?",
+        f"SELECT COUNT(*), MAX(publish_date) FROM {citation_tbl} WHERE source = ?",
         [source],
     ).fetchone()
     return {
@@ -53,16 +54,14 @@ def _track_record(conn, source: str) -> Dict[str, Any]:
 
 def _claim_record(conn, source: str) -> Dict[str, Any]:
     """Corroboration hit-rate and disputed-rate over the source's claims."""
-    if not (
-        common.table_exists(conn, "argument_claims")
-        and common.table_exists(conn, "news_articles")
-    ):
+    citation_tbl = common.citation_table(conn)
+    if not (common.table_exists(conn, "argument_claims") and citation_tbl):
         return {"claims": 0, "corroborated": 0, "disputed": 0}
     claim_rows = conn.execute(
-        """
+        f"""
         SELECT c.claim_id, COALESCE(c.factcheck_verdict, '')
         FROM argument_claims c
-        JOIN news_articles a ON c.document_id = a.id
+        JOIN {citation_tbl} a ON c.document_id = a.id
         WHERE a.source = ?
         """,
         [source],

--- a/src/osint/timeline.py
+++ b/src/osint/timeline.py
@@ -55,9 +55,10 @@ def timeline_reconstruct(
         where.append("c.document_id IN (" + ", ".join("?" for _ in doc_ids) + ")")
         params.extend(doc_ids)
 
-    has_articles = common.table_exists(conn, "news_articles")
+    citation_tbl = common.citation_table(conn)
+    has_articles = citation_tbl is not None
     date_expr = "a.publish_date" if has_articles else "CAST(NULL AS TIMESTAMP)"
-    join = "LEFT JOIN news_articles a ON c.document_id = a.id" if has_articles else ""
+    join = f"LEFT JOIN {citation_tbl} a ON c.document_id = a.id" if has_articles else ""
     clause = ("WHERE " + " AND ".join(where)) if where else ""
     params.append(int(limit))
 

--- a/tests/unit/osint/test_source_agnostic.py
+++ b/tests/unit/osint/test_source_agnostic.py
@@ -1,0 +1,104 @@
+"""Source-type-agnostic citation resolution for OSINT (OS-C).
+
+Before OS-C the OSINT tools resolved citations only through the news-only
+``news_articles`` view, so a blog / paper / filing document was mis-flagged
+uncited even though it is a first-class corpus document. These pin the
+source-agnostic ``corpus_documents`` resolution and the projected enrichment
+topics.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.database.news_articles_compat import ensure_corpus_documents_view
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.enrichment_store import EnrichmentStore
+from src.osint import common, evidence
+
+
+def _doc(doc_id: str, source_type: str, source: str) -> Document:
+    return Document(
+        document_id=doc_id,
+        source_type=source_type,
+        language="en",
+        ingested_at=1_700_000_000_000,
+        created_at=1_700_000_000_000,
+        url=f"https://ex.com/{doc_id}",
+        title=f"{source_type} document",
+        content="Body.",
+        source_id=source,
+        metadata={"source": source, "category": "general"},
+    )
+
+
+@pytest.fixture
+def wh():
+    conn = duckdb.connect(":memory:")
+    store = DocumentStore(conn)
+    enr = EnrichmentStore(conn)
+    store.upsert([
+        _doc("n1", "news", "Reuters"),
+        _doc("p1", "paper", "Nature"),
+        _doc("b1", "blog", "Field Notes"),
+    ])
+    enr.upsert("p1", sentiment_score=0.2, sentiment_label="positive",
+               topics=["physics", "energy"])
+    conn.execute(
+        "CREATE TABLE argument_claims (claim_id VARCHAR, claim_text VARCHAR, "
+        "document_id VARCHAR, source_type VARCHAR, confidence DOUBLE, factcheck_verdict VARCHAR)"
+    )
+    conn.executemany(
+        "INSERT INTO argument_claims (claim_id, claim_text, document_id, source_type) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            ("kn", "A news claim.", "n1", "news"),
+            ("kp", "A paper claim.", "p1", "paper"),
+            ("kb", "A blog claim.", "b1", "blog"),
+        ],
+    )
+    ensure_corpus_documents_view(conn)
+    return conn
+
+
+def test_citation_table_prefers_the_source_agnostic_view(wh):
+    assert common.citation_table(wh) == "corpus_documents"
+
+
+def test_non_news_claim_resolves_to_its_source(wh):
+    # The paper and blog claims resolve to their outlet — not mis-flagged uncited.
+    srcs = common.claim_sources(wh, ["kn", "kp", "kb"])
+    assert srcs["kp"]["source"] == "Nature" and srcs["kp"]["resolved"] is True
+    assert srcs["kb"]["source"] == "Field Notes" and srcs["kb"]["resolved"] is True
+    assert srcs["kn"]["source"] == "Reuters" and srcs["kn"]["resolved"] is True
+
+
+def test_document_citations_project_enrichment_topics(wh):
+    cites = evidence.document_citations(wh, ["p1", "n1"])
+    assert cites["p1"]["cited"] is True
+    assert cites["p1"]["topics"] == ["physics", "energy"]
+    # A document without enrichment topics simply carries none.
+    assert "topics" not in cites["n1"] or cites["n1"].get("topics") in (None, [])
+
+
+def test_reliability_track_record_counts_non_news_sources(wh):
+    from src.osint import source_reliability
+
+    out = source_reliability(wh, "Nature")
+    # Nature is a paper source; its track record is visible source-agnostically.
+    assert out["track_record"]["documents"] == 1
+    assert out["found"] is True
+
+
+def test_fallback_to_news_articles_when_no_corpus_view():
+    # A legacy fixture that only seeds news_articles still resolves (fallback).
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    assert common.citation_table(conn) == "news_articles"
+    conn.close()


### PR DESCRIPTION
## Summary

Every OSINT tool resolved a document's citation (source / url / title / publish_date) by joining `news_articles`, which since #909 is a view filtered to `source_type = 'news'`. So a blog, paper, transcript or filing — first-class corpus documents — could not resolve to their source and were **mis-flagged uncited**, and dropped from reliability track records, timelines, coordination cohorts, and dossier dates.

## Changes

- **`corpus_documents` view** (new, in `news_articles_compat`): projects *every* document into the same legacy column shape as `news_articles`, minus the news-only filter, plus `source_type` and the enrichment `topics`. The news-only `news_articles` view is **left untouched** for its ~40 legacy consumers. `ensure_news_articles_view` now also ensures `corpus_documents`, so every warehouse-setup path builds both.
- **`common.citation_table(conn)`**: resolves the table OSINT reads from — the source-agnostic `corpus_documents` when present, else the legacy `news_articles` (so fixtures/warehouses that only seed the news view keep working unchanged). All eight OSINT readers — corroboration, reliability, timeline, dossier, provenance, evidence, and both gated tools — resolve citations through it. Shared column names mean the join SQL is unchanged; only the table name is.
- **Topics projection**: `evidence.document_citations` now projects the enrichment `topics` onto a resolved citation when reading through `corpus_documents`.

## Why it's safe

The resolver falls back to `news_articles`, so existing behaviour — and the entire OSINT test suite — is unchanged. The new view is purely additive (a new name; never collides with a legacy `news_articles` base table) and reversible.

## Tests

`tests/unit/osint/test_source_agnostic.py` (new): seeds mixed-`source_type` documents behind the `corpus_documents` view and pins that a paper/blog claim resolves to its source (not mis-flagged uncited), that reliability track records count non-news sources, that enrichment topics are projected onto citations, and that the resolver falls back to `news_articles` when the corpus view is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_