### PR TITLE
Unify the OSINT gated set in the agent runtime and honor both env prefixes

### DIFF
--- a/src/agent/runtime.py
+++ b/src/agent/runtime.py
@@ -13,8 +13,10 @@ the R4 tool-loop discipline (a per-server allowlist plus a call budget), it:
 
 * refuses any tool not on its plane's allowlist,
 * refuses a **gated** OSINT tool while the review gate is off, so an agent can
-  never invoke ``geolocate_claims`` / ``narrative_coordination`` unless a human
-  has opened the gate (M10.3 / the R11 review gate),
+  never invoke any tool in the canonical gated set
+  (:data:`src.osint.investigations.GATED_TOOLS` — ``geolocate_claims``,
+  ``narrative_coordination`` and the imagery tier) unless a human has opened the
+  gate (M10.3 / the R11 review gate),
 * enforces a step budget (total, and optionally per plane), so a runaway agent
   is bounded, and
 * records every call to a transcript and an optional audit sink, so the whole
@@ -26,9 +28,10 @@ the agents inject a dispatcher. Stdlib-only.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
+
+from src.config.env import resolve_env
 
 PLANE_PROVISIONING = "provisioning"
 PLANE_OSINT = "osint"
@@ -47,22 +50,35 @@ _OSINT_TOOLS = frozenset({
     "corroborate", "source_reliability", "contradiction_scan", "entity_dossier",
     "relationship_path", "timeline_reconstruct", "trace_artifact", "investigation_audit",
 })
-# The review-gated OSINT tools: allowlisted only when the gate is open.
-_OSINT_GATED_TOOLS = frozenset({"geolocate_claims", "narrative_coordination"})
+
+
+def _osint_gated_tools() -> frozenset:
+    """The review-gated OSINT tools, from the single canonical list
+    (:data:`src.osint.investigations.GATED_TOOLS`) so the runtime gate and the
+    served surface can never drift — the imagery tier is gated here too.
+
+    Imported lazily to keep this module's import stdlib-light (the ``src.osint``
+    package pulls the analytics stack); ``default_planes`` resolves it at
+    agent-setup time, not at import."""
+    from src.osint.investigations import GATED_TOOLS
+
+    return frozenset(GATED_TOOLS)
 
 
 def gated_tools_enabled() -> bool:
-    """Whether the OSINT review gate is open (``NOESIS_OSINT_GATED_TOOLS``)."""
-    return os.getenv("NOESIS_OSINT_GATED_TOOLS", "off").lower() in ("on", "1", "true")
+    """Whether the OSINT review gate is open
+    (``NOESIS_OSINT_GATED_TOOLS`` / legacy ``NEURONEWS_OSINT_GATED_TOOLS``)."""
+    return (resolve_env("OSINT_GATED_TOOLS", "off") or "off").lower() in ("on", "1", "true")
 
 
 def default_planes() -> Dict[str, Dict[str, Any]]:
     """The planes, with per-plane server and tool allowlist. The OSINT
     plane admits the gated tools only while the review gate is open."""
-    osint_tools = _OSINT_TOOLS | (_OSINT_GATED_TOOLS if gated_tools_enabled() else frozenset())
+    gated = _osint_gated_tools()
+    osint_tools = _OSINT_TOOLS | (gated if gated_tools_enabled() else frozenset())
     return {
         PLANE_PROVISIONING: {"server": _PLANE_SERVERS[PLANE_PROVISIONING], "tools": _PROVISIONING_TOOLS},
-        PLANE_OSINT: {"server": _PLANE_SERVERS[PLANE_OSINT], "tools": osint_tools, "gated": _OSINT_GATED_TOOLS},
+        PLANE_OSINT: {"server": _PLANE_SERVERS[PLANE_OSINT], "tools": osint_tools, "gated": gated},
     }
 
 

--- a/tests/unit/agent/test_agent_runtime.py
+++ b/tests/unit/agent/test_agent_runtime.py
@@ -116,7 +116,37 @@ def test_every_call_reaches_the_audit_sink():
 
 
 def test_gated_tools_enabled_reads_the_env(monkeypatch):
+    monkeypatch.delenv("NEURONEWS_OSINT_GATED_TOOLS", raising=False)
     monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "on")
     assert runtime.gated_tools_enabled() is True
     monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "off")
     assert runtime.gated_tools_enabled() is False
+
+
+def test_gated_tools_enabled_honors_the_legacy_alias(monkeypatch):
+    # The gate honors both env prefixes (alias-first, per src.config.env).
+    monkeypatch.delenv("NOESIS_OSINT_GATED_TOOLS", raising=False)
+    monkeypatch.setenv("NEURONEWS_OSINT_GATED_TOOLS", "on")
+    assert runtime.gated_tools_enabled() is True
+
+
+def test_runtime_gated_set_matches_the_canonical_list(monkeypatch):
+    # The runtime's gated set is the single canonical GATED_TOOLS — no drift
+    # from the served surface, so the imagery tier is gate-enforced here too.
+    from src.osint.investigations import GATED_TOOLS
+
+    monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "on")
+    planes = default_planes()
+    assert planes[PLANE_OSINT]["gated"] == frozenset(GATED_TOOLS)
+    assert {"reverse_image_search", "geolocate_image"} <= planes[PLANE_OSINT]["gated"]
+    # With the gate open every canonical gated tool is admitted to the plane.
+    assert frozenset(GATED_TOOLS) <= planes[PLANE_OSINT]["tools"]
+
+
+def test_imagery_gated_tool_is_refused_while_gate_closed(monkeypatch):
+    monkeypatch.delenv("NEURONEWS_OSINT_GATED_TOOLS", raising=False)
+    monkeypatch.setenv("NOESIS_OSINT_GATED_TOOLS", "off")
+    rt = AgentRuntime(_fake_caller(), planes=default_planes())
+    with pytest.raises(NotAllowed):
+        rt.call(PLANE_OSINT, "reverse_image_search", {"sha256": "0" * 64})
+    assert rt.steps_used == 0

--- a/tests/unit/osint/test_investigations.py
+++ b/tests/unit/osint/test_investigations.py
@@ -74,13 +74,17 @@ def test_osint_telemetry_empty_without_activity(seed):
     assert osint_telemetry(seed.conn) == {}
 
 
-def test_gated_tools_are_absent_from_the_server():
-    """Enforcement of the review gate: the two gated tools must not be exposed
-    by the OSINT MCP server until the gate passes."""
+def test_gated_tools_are_absent_from_the_server(monkeypatch):
+    """Enforcement of the review gate: the gated tools must not be exposed by the
+    OSINT MCP server until the gate passes."""
     import importlib.util
     import sys
     from pathlib import Path
 
+    # Hermetic: the gate reads either env prefix, so clear both to assert the
+    # default-closed state regardless of the ambient environment.
+    monkeypatch.delenv("NOESIS_OSINT_GATED_TOOLS", raising=False)
+    monkeypatch.delenv("NEURONEWS_OSINT_GATED_TOOLS", raising=False)
     repo = Path(__file__).resolve().parents[3]
     path = repo / "tools/osint_mcp/server.py"
     spec = importlib.util.spec_from_file_location("osint_gate_check", path)
@@ -108,6 +112,10 @@ def _served_tool_names(monkeypatch, flag):
     import sys
     from pathlib import Path
 
+    # Hermetic: the gate reads either env prefix. Always clear the legacy prefix,
+    # and drive only the canonical one, so an ambient NEURONEWS_ value cannot
+    # flip the gate under the test.
+    monkeypatch.delenv("NEURONEWS_OSINT_GATED_TOOLS", raising=False)
     if flag is None:
         monkeypatch.delenv("NOESIS_OSINT_GATED_TOOLS", raising=False)
     else:


### PR DESCRIPTION
## Summary

The agent runtime carried its own `_OSINT_GATED_TOOLS = {geolocate_claims, narrative_coordination}` — only **two** of the **four** tools behind the review gate. It had drifted from the canonical `src.osint.investigations.GATED_TOOLS`, which also lists the imagery tier (`reverse_image_search`, `geolocate_image`), so the runtime's notion of "gated" disagreed with the served surface. It also read the gate flag with `os.getenv("NOESIS_OSINT_GATED_TOOLS")`, ignoring the legacy `NEURONEWS_` alias that the rest of the config surface — and the MCP server's own gate — honor via `src.config.env.resolve_env`.

## Changes

- **Single source of truth for the gated set.** The runtime gated set is now resolved from the canonical `GATED_TOOLS`, imported **lazily** inside `default_planes` so the module stays stdlib-light at import (the `src.osint` package pulls the analytics stack). The two sets can no longer drift, and the imagery tier is gate-enforced in the agent runtime too.
- **Both env prefixes.** `gated_tools_enabled()` now uses `resolve_env("OSINT_GATED_TOOLS", "off")`, so the gate honors both `NOESIS_` and the legacy `NEURONEWS_` prefix — matching the server's `_gated_enabled`.

## Tests

- **Hermetic gate tests.** The two server-gate tests asserted the default-closed gate but cleared only the `NOESIS_` prefix, so an ambient `NEURONEWS_OSINT_GATED_TOOLS` value could flip the gate under the test. Both now clear **both** prefixes.
- **New runtime tests** pin that the runtime gated set equals the canonical list (imagery included), that the legacy alias opens the gate, and that an imagery gated tool is refused while the gate is closed.

No change to default behaviour: the gate stays closed by default and the served surface is unchanged. Verified that importing `src.agent.runtime` still pulls no `src.osint`/`src.analytics` at import time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_