### PR TITLE
Make the analytics readers source-type-agnostic

### DIFF
--- a/src/analytics/anomalies.py
+++ b/src/analytics/anomalies.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 from src.analytics.framework import AnalyticJob, read_results
 from src.analytics.honesty import analytic_envelope, interval
 from src.analytics.stats import mad, median, robust_z_scores
+from src.database.news_articles_compat import corpus_table
 
 RESULT_TABLE = "analytics_anomalies"
 DEFAULT_THRESHOLD = 3.5
@@ -41,12 +42,12 @@ ASSUMPTIONS = [
 def _series_by_topic(conn) -> Dict[str, List[Dict[str, Any]]]:
     """Per-topic daily (date, volume, sentiment) points, ordered by date."""
     rows = conn.execute(
-        """
+        f"""
         SELECT category AS topic,
                CAST(publish_date AS DATE) AS day,
                COUNT(*) AS volume,
                AVG(sentiment_score) AS sentiment
-        FROM news_articles
+        FROM {corpus_table(conn)}
         WHERE category IS NOT NULL AND publish_date IS NOT NULL
         GROUP BY 1, 2
         ORDER BY 1, 2
@@ -74,7 +75,8 @@ def compute_anomalies(
 
     Returns one row per (topic, metric, day) carrying the observed value, its
     robust z-score and an anomaly flag, plus the series' median/MAD so the
-    panel can draw the expected band. Read-only against ``news_articles``.
+    panel can draw the expected band. Read-only against the corpus
+    (``corpus_documents`` when present, else ``news_articles``).
     """
     computed_at = datetime.now(timezone.utc).isoformat()
     out: List[Dict[str, Any]] = []

--- a/src/analytics/drift.py
+++ b/src/analytics/drift.py
@@ -24,6 +24,7 @@ from src.analytics.conformal import calibrated_envelope_fields, conformal_interv
 from src.analytics.honesty import analytic_envelope, interval
 from src.analytics.stats import cosine, holt_forecast
 from src.analytics.text import context_counts, tokenize
+from src.database.news_articles_compat import corpus_table
 
 DRIFT_METHOD = "lexical context-vector cosine drift (embedding fallback)"
 DRIFT_ASSUMPTIONS = [
@@ -43,7 +44,7 @@ FORECAST_ASSUMPTIONS = [
 def _mentions(conn, term: str, days: int) -> List[Dict[str, Any]]:
     cutoff = datetime.now(timezone.utc) - timedelta(days=max(2, days))
     rows = conn.execute(
-        "SELECT title, publish_date FROM news_articles "
+        f"SELECT title, publish_date FROM {corpus_table(conn)} "
         "WHERE title ILIKE ? AND publish_date >= ? ORDER BY publish_date",
         [f"%{term}%", cutoff],
     ).fetchall()
@@ -100,7 +101,7 @@ def _velocity_series(conn, topic: str, days: int) -> List[float]:
     cutoff = datetime.now(timezone.utc) - timedelta(days=max(3, days))
     rows = conn.execute(
         "SELECT CAST(publish_date AS DATE) AS day, COUNT(*) "
-        "FROM news_articles WHERE category = ? AND publish_date >= ? "
+        f"FROM {corpus_table(conn)} WHERE category = ? AND publish_date >= ? "
         "GROUP BY 1 ORDER BY 1",
         [topic, cutoff],
     ).fetchall()

--- a/src/analytics/lead_lag.py
+++ b/src/analytics/lead_lag.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 from src.analytics.framework import AnalyticJob
 from src.analytics.honesty import analytic_envelope
 from src.analytics.stats import cross_correlation_lag
+from src.database.news_articles_compat import corpus_table
 
 RESULT_TABLE = "analytics_lead_lag"
 MAX_LAG = 7
@@ -46,7 +47,7 @@ def _outlet_series(conn, topic: str, outlets: Optional[List[str]]):
     rows = conn.execute(
         f"""
         SELECT source, CAST(publish_date AS DATE) AS day, COUNT(*) AS volume
-        FROM news_articles
+        FROM {corpus_table(conn)}
         WHERE {' AND '.join(clauses)} AND publish_date IS NOT NULL
         GROUP BY 1, 2
         ORDER BY 1, 2
@@ -145,7 +146,7 @@ class LeadLagJob(AnalyticJob):
         topics = [
             r[0]
             for r in conn.execute(
-                "SELECT DISTINCT category FROM news_articles WHERE category IS NOT NULL"
+                f"SELECT DISTINCT category FROM {corpus_table(conn)} WHERE category IS NOT NULL"
             ).fetchall()
         ]
         out: List[Dict[str, Any]] = []

--- a/src/analytics/narratives.py
+++ b/src/analytics/narratives.py
@@ -22,6 +22,7 @@ from src.analytics.framework import AnalyticJob
 from src.analytics.honesty import analytic_envelope
 from src.analytics.stats import cosine
 from src.analytics.text import tf_vector, top_terms
+from src.database.news_articles_compat import corpus_table
 
 RESULT_TABLE = "analytics_narratives"
 SIM_THRESHOLD = 0.18
@@ -50,7 +51,7 @@ def _docs(conn, topic: Optional[str], days: Optional[int]) -> List[Dict[str, Any
     where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
     params.append(MAX_DOCS)
     rows = conn.execute(
-        f"SELECT id, title, category FROM news_articles {where} "
+        f"SELECT id, title, category FROM {corpus_table(conn)} {where} "
         f"ORDER BY publish_date DESC NULLS LAST LIMIT ?",
         params,
     ).fetchall()
@@ -159,7 +160,7 @@ class NarrativeJob(AnalyticJob):
         topics = [
             r[0]
             for r in conn.execute(
-                "SELECT DISTINCT category FROM news_articles WHERE category IS NOT NULL"
+                f"SELECT DISTINCT category FROM {corpus_table(conn)} WHERE category IS NOT NULL"
             ).fetchall()
         ]
         out: List[Dict[str, Any]] = []

--- a/src/database/news_articles_compat.py
+++ b/src/database/news_articles_compat.py
@@ -80,6 +80,24 @@ def _news_articles_is_view(conn) -> bool:
     return bool(row) and str(row[0]).upper() == "VIEW"
 
 
+def corpus_table(conn) -> str:
+    """The corpus table a *source-agnostic* reader should query.
+
+    Prefers the ``corpus_documents`` view (every ``source_type``) so blog, paper,
+    transcript, book and note documents are counted alongside news; falls back to
+    the news-only ``news_articles`` view/table for legacy warehouses and test
+    fixtures that only seed it. Always returns a name — defaulting to
+    ``news_articles`` preserves the prior behaviour when neither view exists.
+    """
+    for name in ("corpus_documents", "news_articles"):
+        row = conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = ?", [name]
+        ).fetchone()
+        if row:
+            return name
+    return "news_articles"
+
+
 def ensure_documents_schema(conn) -> None:
     """Ensure the base tables the view depends on exist."""
     DocumentStore(conn)     # documents (+ content_hash index)

--- a/tests/unit/analytics/test_source_agnostic.py
+++ b/tests/unit/analytics/test_source_agnostic.py
@@ -1,0 +1,76 @@
+"""Source-type-agnostic analytics reads (DS-C).
+
+anomalies / drift / lead_lag / narratives used to read the news-only
+``news_articles`` view, silently dropping blog / paper / transcript / book / note
+documents. They now read through ``corpus_table`` (the source-agnostic
+``corpus_documents`` view when present). These pin that a non-news document is
+counted, and that the resolver falls back to ``news_articles`` for legacy
+fixtures.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.analytics import anomalies, lead_lag, narratives
+from src.database.news_articles_compat import corpus_table, ensure_corpus_documents_view
+from src.ingestion.document_store import DocumentStore
+
+D1 = 1_700_000_000_000
+D2 = D1 + 86_400_000  # +1 day
+
+
+def _doc(doc_id, source_type, source, category, day_ms):
+    return Document(
+        document_id=doc_id, source_type=source_type, language="en",
+        ingested_at=day_ms, created_at=day_ms, url=f"https://ex.com/{doc_id}",
+        title=f"{category} headline", content="body text",
+        source_id=source, metadata={"source": source, "category": category},
+    )
+
+
+@pytest.fixture
+def wh():
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn).upsert([
+        _doc("n1", "news", "Reuters", "Economy", D1),
+        _doc("p1", "paper", "Nature", "Science", D1),   # non-news, unique category
+        _doc("b1", "blog", "Field Notes", "Economy", D2),  # non-news, shared category
+    ])
+    ensure_corpus_documents_view(conn)
+    return conn
+
+
+def test_resolver_prefers_corpus_documents(wh):
+    assert corpus_table(wh) == "corpus_documents"
+
+
+def test_narratives_docs_include_non_news(wh):
+    ids = {d["id"] for d in narratives._docs(wh, topic=None, days=None)}
+    assert {"p1", "b1"} <= ids  # paper + blog surfaced, not just news
+
+
+def test_anomaly_series_includes_a_non_news_only_category(wh):
+    series = anomalies._series_by_topic(wh)
+    # "Science" exists only on the paper document — invisible under news-only.
+    assert "Science" in series
+    assert "Economy" in series
+
+
+def test_lead_lag_outlet_series_includes_a_non_news_source(wh):
+    series = lead_lag._outlet_series(wh, topic="Economy", outlets=None)
+    assert "Field Notes" in series  # the blog outlet
+    assert "Reuters" in series
+
+
+def test_falls_back_to_news_articles_without_the_corpus_view():
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    assert corpus_table(conn) == "news_articles"
+    conn.close()


### PR DESCRIPTION
## Summary

`anomalies`, `drift`, `lead_lag`, and `narratives` resolved their per-topic volume, velocity, outlet, and clustering series by reading the news-only `news_articles` view (`source_type = 'news'`). So blog, paper, transcript, book, and note documents — first-class members of the unified `documents` corpus — were silently dropped from anomaly bands, drift velocity, lead-lag matrices, and narrative clusters.

## Changes

- Add `news_articles_compat.corpus_table(conn)` — returns the source-agnostic `corpus_documents` view (every `source_type`, same legacy column shape) when present, falling back to `news_articles` for legacy warehouses and fixtures that only seed it.
- Repoint the four modules' corpus reads through it (`_series_by_topic`, `_mentions`/`_velocity_series`, `_outlet_series` + job `compute`, `_docs` + job `compute`). Shared column names mean only the table name changes.

## Why it's safe

The resolver falls back to `news_articles`, so the existing analytics suite (127 tests) is unchanged. New tests (`test_source_agnostic.py`) seed mixed-`source_type` documents behind the `corpus_documents` view and pin that a paper/blog document is counted — its category, outlet, and id surface — and that the resolver falls back when the corpus view is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_