### PR TITLE
Make argument-mining reads source-type-agnostic (evidence, conflicts, stance, positions, actors)

### DIFF
--- a/src/argument_mining/conflict_graph.py
+++ b/src/argument_mining/conflict_graph.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from src.database.news_articles_compat import corpus_table
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -219,7 +221,7 @@ def compute_claim_conflicts(
                    COALESCE(n.source, c.source_type) AS source_name,
                    n.id AS article_id
             FROM argument_claims c
-            LEFT JOIN news_articles n ON c.document_id = n.id
+            LEFT JOIN {corpus_table(conn)} n ON c.document_id = n.id
             WHERE {" AND ".join(where_parts)}
             ORDER BY c.extracted_at DESC NULLS LAST
             LIMIT ?
@@ -376,8 +378,8 @@ def build_conflict_graph(
                 FROM claim_conflicts cf
                 JOIN argument_claims ca ON cf.claim_id_a = ca.claim_id
                 JOIN argument_claims cb ON cf.claim_id_b = cb.claim_id
-                LEFT JOIN news_articles na ON ca.document_id = na.id
-                LEFT JOIN news_articles nb ON cb.document_id = nb.id
+                LEFT JOIN {corpus_table(conn)} na ON ca.document_id = na.id
+                LEFT JOIN {corpus_table(conn)} nb ON cb.document_id = nb.id
                 {where_clause}
                 ORDER BY cf.similarity_score DESC
                 LIMIT ?

--- a/src/argument_mining/evidence.py
+++ b/src/argument_mining/evidence.py
@@ -25,8 +25,14 @@ from typing import Callable, List, Optional, Tuple
 
 from services.ingest.common.document_model import Document
 from src.argument_mining.models import get_claim_detector
+from src.database.news_articles_compat import corpus_table
 
 logger = logging.getLogger(__name__)
+
+# Cap on the default retrieval corpus. Was a hard-coded 500 (news-only); raised
+# and named so a corpus with papers/books/blogs is not truncated to an
+# unrepresentative slice. Override via NOESIS_EVIDENCE_CORPUS_LIMIT.
+_DEFAULT_CORPUS_LIMIT = 5000
 
 # Minimum cosine similarity to consider a sentence as evidence
 SIMILARITY_THRESHOLD = 0.20
@@ -283,14 +289,25 @@ def run_pipeline(
 
 
 def _default_corpus(conn, exclude_document_id: str) -> List[CorpusEntry]:
-    """Load all content from news_articles as a sentence corpus."""
+    """Load content from the whole corpus as a sentence corpus.
+
+    Reads every source type (via ``corpus_table``), not just news, so evidence
+    matching is representative once the corpus holds papers, books, or blogs.
+    """
+    import os
+
+    try:
+        limit = int(os.getenv("NOESIS_EVIDENCE_CORPUS_LIMIT", _DEFAULT_CORPUS_LIMIT))
+    except (TypeError, ValueError):
+        limit = _DEFAULT_CORPUS_LIMIT
     try:
         rows = conn.execute(
-            "SELECT id, content FROM news_articles WHERE id != ? AND content IS NOT NULL LIMIT 500",
-            [exclude_document_id],
+            f"SELECT id, content FROM {corpus_table(conn)} "
+            "WHERE id != ? AND content IS NOT NULL LIMIT ?",
+            [exclude_document_id, limit],
         ).fetchall()
     except Exception as exc:
-        logger.warning("Could not load corpus from news_articles: %s", exc)
+        logger.warning("Could not load corpus: %s", exc)
         return []
 
     corpus: List[CorpusEntry] = []

--- a/src/argument_mining/metadata.py
+++ b/src/argument_mining/metadata.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Dict, List, Sequence, Tuple
 
+from src.database.news_articles_compat import corpus_table
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -417,20 +419,20 @@ def store_actors(records: List[ActorRecord], conn) -> None:
 
 def run_actor_batch(conn, lock, limit: int = 200) -> dict:
     """
-    Extract actors for news_articles documents not yet in ``document_actors``.
+    Extract actors for corpus documents not yet in ``document_actors``.
 
-    Sweeps ``news_articles`` for documents whose ``id`` is absent from
-    ``document_actors``, extracts actors, and persists them.  Safe to call
-    repeatedly.
+    Sweeps the whole corpus (every source type, via ``corpus_table``) for
+    documents whose ``id`` is absent from ``document_actors``, extracts actors,
+    and persists them.  Safe to call repeatedly.
     """
     from services.ingest.common.document_model import Document  # type: ignore[import]
 
     try:
         with lock:
             rows = conn.execute(
-                """
+                f"""
                 SELECT id, title, content, source, category
-                FROM news_articles
+                FROM {corpus_table(conn)}
                 WHERE id NOT IN (SELECT DISTINCT document_id FROM document_actors)
                 LIMIT ?
                 """,

--- a/src/argument_mining/position_tracker.py
+++ b/src/argument_mining/position_tracker.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import List, Tuple
 
+from src.database.news_articles_compat import corpus_table
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -241,9 +243,9 @@ def run_followthrough_batch(conn, lock, limit: int = 50) -> dict:
 
         with lock:
             articles = conn.execute(
-                """
+                f"""
                 SELECT id, content, publish_date
-                FROM news_articles
+                FROM {corpus_table(conn)}
                 WHERE CAST(publish_date AS VARCHAR) > ?
                 LIMIT 200
                 """,

--- a/src/argument_mining/stance_aggregator.py
+++ b/src/argument_mining/stance_aggregator.py
@@ -11,6 +11,8 @@ import threading
 import time
 from datetime import datetime, timedelta, timezone
 
+from src.database.news_articles_compat import corpus_table
+
 logger = logging.getLogger(__name__)
 
 _WINDOW_DAYS = 7
@@ -40,9 +42,9 @@ def run_stance_aggregation(
 
     with lock:
         rows = conn.execute(
-            """
+            f"""
             SELECT id, title, content, source, category
-            FROM news_articles
+            FROM {corpus_table(conn)}
             WHERE publish_date >= ?
             ORDER BY publish_date DESC
             LIMIT ?

--- a/src/database/news_articles_compat.py
+++ b/src/database/news_articles_compat.py
@@ -89,12 +89,17 @@ def corpus_table(conn) -> str:
     fixtures that only seed it. Always returns a name — defaulting to
     ``news_articles`` preserves the prior behaviour when neither view exists.
     """
-    for name in ("corpus_documents", "news_articles"):
-        row = conn.execute(
-            "SELECT 1 FROM information_schema.tables WHERE table_name = ?", [name]
-        ).fetchone()
-        if row:
-            return name
+    try:
+        for name in ("corpus_documents", "news_articles"):
+            row = conn.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = ?", [name]
+            ).fetchone()
+            if row:
+                return name
+    except Exception:
+        # A connection that cannot introspect (e.g. a white-box test double):
+        # fall back to the legacy name rather than crashing the caller.
+        pass
     return "news_articles"
 
 

--- a/tests/unit/argument_mining/test_conflict_graph_coverage.py
+++ b/tests/unit/argument_mining/test_conflict_graph_coverage.py
@@ -332,9 +332,12 @@ class TestComputeClaimConflicts(unittest.TestCase):
             ("FROM claim_evidence e", []),
         ])
         compute_claim_conflicts(conn, _lock(), limit=50, date_range="2026-01-01")
-        # First executed statement is the claim load; params include date + limit
-        load_sql, load_params = conn.executed[0]
-        self.assertIn("FROM argument_claims c", load_sql)
+        # The claim-load statement (found by content, since the corpus-table
+        # resolver may run introspection queries first); params include date + limit
+        load_sql, load_params = next(
+            e for e in conn.executed if "FROM argument_claims c" in e[0]
+        )
+        self.assertIn("2026-01-01", load_params)
         self.assertIn("2026-01-01", load_params)
         self.assertIn(50, load_params)
 
@@ -424,7 +427,7 @@ class TestBuildConflictGraph(unittest.TestCase):
             topic="Economy", source_type="news",
             date_cutoff="2026-05-01", limit=10,
         )
-        sql, params = conn.executed[0]
+        sql, params = next(e for e in conn.executed if "claim_conflicts cf" in e[0])
         self.assertIn("WHERE", sql)
         self.assertIn("news", params)          # source_type filter (twice)
         self.assertIn("%Economy%", params)     # topic ILIKE

--- a/tests/unit/argument_mining/test_source_agnostic.py
+++ b/tests/unit/argument_mining/test_source_agnostic.py
@@ -1,0 +1,62 @@
+"""Source-type-agnostic argument-mining reads (DS-D).
+
+The evidence corpus loader, conflict/stance/position sweeps, and the actor batch
+resolved documents through the news-only ``news_articles`` view, dropping
+blog / paper / transcript / book / note documents. They now read through
+``corpus_table``. These pin that a non-news document is included, and that the
+resolver falls back to ``news_articles`` for legacy fixtures.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.argument_mining.evidence import _default_corpus
+from src.database.news_articles_compat import corpus_table, ensure_corpus_documents_view
+from src.ingestion.document_store import DocumentStore
+
+_TS = 1_700_000_000_000
+
+
+def _doc(doc_id, source_type, source, content):
+    return Document(
+        document_id=doc_id, source_type=source_type, language="en",
+        ingested_at=_TS, created_at=_TS, url=f"https://ex.com/{doc_id}",
+        title=f"{source_type} headline", content=content,
+        source_id=source, metadata={"source": source, "category": "general"},
+    )
+
+
+@pytest.fixture
+def wh():
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn).upsert([
+        _doc("n1", "news", "Reuters", "The central bank held rates steady this week."),
+        _doc("p1", "paper", "Nature", "The measured warming trend continued through the decade."),
+    ])
+    ensure_corpus_documents_view(conn)
+    return conn
+
+
+def test_resolver_prefers_corpus_documents(wh):
+    assert corpus_table(wh) == "corpus_documents"
+
+
+def test_evidence_corpus_includes_non_news(wh):
+    entries = _default_corpus(wh, exclude_document_id="n1")
+    doc_ids = {e[1] for e in entries}
+    assert "p1" in doc_ids       # the paper document is in the retrieval corpus
+    assert "n1" not in doc_ids   # the excluded document is absent
+
+
+def test_falls_back_to_news_articles_without_corpus_view():
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE news_articles (id VARCHAR, title VARCHAR, url VARCHAR, "
+        "content VARCHAR, publish_date TIMESTAMP, source VARCHAR, category VARCHAR, "
+        "sentiment_score DOUBLE, sentiment_label VARCHAR)"
+    )
+    assert corpus_table(conn) == "news_articles"
+    conn.close()


### PR DESCRIPTION
## Summary

The evidence retrieval corpus, the conflict graph's source/topic resolution, the stance aggregator, the position/follow-through tracker, and the actor-extraction batch all read the news-only `news_articles` view — so blog / paper / transcript / book / note documents were dropped from cross-corpus evidence matching, conflict citations, stance rollups, position tracking, and actor extraction.

## Changes

Repoint the direct reads through `news_articles_compat.corpus_table(conn)` (the source-agnostic `corpus_documents` view when present, else `news_articles`):

- **`evidence._default_corpus`** now loads the whole corpus, and its hard-coded `LIMIT 500` becomes a named `_DEFAULT_CORPUS_LIMIT` (5000, overridable via `NOESIS_EVIDENCE_CORPUS_LIMIT`) so a corpus with papers/books isn't truncated to an unrepresentative slice.
- **`conflict_graph`** (both the claim-load and the `claim_conflicts` join sites), **`stance_aggregator`**, **`position_tracker`**, and **`metadata.run_actor_batch`** resolve document source/category through the same helper.

`corpus_table` is hardened to fall back to `news_articles` if a connection can't introspect (a white-box test double), so it never crashes a caller.

## Tests

- The two conflict-graph coverage tests that asserted on `executed[0]` now select the domain statement by content (the resolver may run introspection queries first).
- New `test_source_agnostic.py` seeds mixed-`source_type` documents and pins that a paper document is in the evidence corpus, and that the resolver falls back to `news_articles` without the corpus view.

The full `tests/unit/argument_mining` suite (366) stays green via the fallback; the outlet-scoring/clustering source unification is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_