### PR TITLE
Make the veracity classifier import-safe; add gated tests/unit/ml coverage

### DIFF
--- a/src/ml/fake_news_detection.py
+++ b/src/ml/fake_news_detection.py
@@ -12,8 +12,9 @@ import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-import torch
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
+# torch / transformers are imported lazily inside the methods that need them, so
+# importing this module (e.g. to reference the class or for collection) does not
+# pull the heavy ML stack. Model construction still loads a model on demand.
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -41,7 +42,7 @@ class FakeNewsDetector:
             config_path: Path to configuration file
         """
         self.model_name = model_name
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = None  # resolved lazily in _initialize_model (needs torch)
 
         # Load configuration
         self.config = self._load_config(config_path)
@@ -82,7 +83,26 @@ class FakeNewsDetector:
         return default_config
 
     def _initialize_model(self):
-        """Initialize the transformer model and tokenizer."""
+        """Initialize the transformer model and tokenizer.
+
+        torch / transformers are imported here (not at module load) so importing
+        the module stays dependency-light; they are required only to build a
+        detector. If they are unavailable, fall through to the rule-based path.
+        """
+        try:
+            import torch
+            from transformers import (
+                AutoModelForSequenceClassification,
+                AutoTokenizer,
+                pipeline,
+            )
+        except Exception as exc:  # torch/transformers not installed
+            logger.warning("ML deps unavailable (%s); using rule-based fallback", exc)
+            self.classifier = None
+            self.model = None
+            return
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         try:
             # Try to use a pipeline first for simplicity
             self.classifier = pipeline(

--- a/tests/unit/ml/test_input_validator.py
+++ b/tests/unit/ml/test_input_validator.py
@@ -1,0 +1,68 @@
+"""Tests for src/ml/validation/input_validator.py.
+
+Dependency-light unit coverage in the gated ``tests/unit/ml`` tree (matches the
+``tests/unit`` convention). The validator is stdlib-only, so it runs in the
+curated CI test environment without the ML stack.
+"""
+
+import os
+import sys
+
+SRC = os.path.join(os.path.dirname(__file__), "..", "..", "..", "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+import pytest  # noqa: E402
+
+from ml.validation.input_validator import (  # noqa: E402
+    InputValidator,
+    ValidatedArticle,
+    ValidationError,
+)
+
+
+def test_validate_accepts_and_normalizes():
+    v = InputValidator()
+    article = v.validate("  Headline  ", "  Some body content here.  ")
+    assert isinstance(article, ValidatedArticle)
+    assert article.title == "Headline"          # edges stripped
+    assert article.content == "Some body content here."
+    assert article.combined() == "Headline. Some body content here."
+
+
+def test_none_inputs_are_rejected():
+    v = InputValidator()
+    with pytest.raises(ValidationError):
+        v.validate(None, "content")
+    with pytest.raises(ValidationError):
+        v.validate("title", None)
+
+
+def test_too_short_title_and_content_rejected():
+    v = InputValidator(min_title_len=3, min_content_len=5)
+    with pytest.raises(ValidationError):
+        v.validate("ab", "long enough content")
+    with pytest.raises(ValidationError):
+        v.validate("title", "abcd")
+
+
+def test_oversized_content_is_truncated_preserving_title():
+    v = InputValidator(min_title_len=1, min_content_len=1, max_total_len=20)
+    article = v.validate("title", "x" * 100)
+    # title (5) preserved; content truncated to fit max_total_len (20)
+    assert article.title == "title"
+    assert len(article.title) + len(article.content) <= 20
+
+
+def test_safe_captures_errors_instead_of_raising():
+    v = InputValidator()
+    article, errors = v.safe("ab", "")   # both too short
+    assert errors                        # at least one error captured
+    assert isinstance(article, ValidatedArticle)  # partial article, no raise
+
+
+def test_safe_returns_no_errors_on_valid_input():
+    v = InputValidator()
+    article, errors = v.safe("Headline", "Some body content.")
+    assert errors == []
+    assert article.title == "Headline"


### PR DESCRIPTION
## Summary

Two loose ends from the ML consolidation:

1. **Import-safety of the veracity classifier.** `src/ml/fake_news_detection.py` imported `torch` and `transformers` at module load and resolved a CUDA device in `__init__`, so merely importing the module (or collecting it) pulled the heavy ML stack and failed where it isn't installed — even though the classifier is only constructed on demand.
2. **`tests/unit/ml` convention gap.** After the mock-stack removal, the gated `tests/unit/ml` tree held only `test_text_cleaner.py`.

## Changes

- Move the `torch` / `transformers` imports into `_initialize_model`, resolve the device there, and fall through to the existing rule-based path when the ML deps are unavailable. The module — and its `models` / `inference` re-exporters — now import with **no ML stack present**; model construction still loads a model on demand, unchanged.
- Add `tests/unit/ml/test_input_validator.py` — dependency-light coverage of the kept `InputValidator`, matching the `tests/unit/*` convention. (The real MLOps stack keeps its own tests under `tests/unit/services` / `tests/unit/mlops`.)

Verified the module imports cleanly in an environment without `torch`, and the gated `tests/unit/ml` suite passes (11 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_