### PR TITLE
Add semantic search over the document corpus (embeddings sink + MCP tools)

### DIFF
--- a/services/embeddings/backends/hashing.py
+++ b/services/embeddings/backends/hashing.py
@@ -1,0 +1,55 @@
+"""
+Deterministic hashing embedding backend (offline, dependency-light).
+
+Embeds text via the hashing trick: tokens are hashed into a fixed-dimensional,
+signed bag-of-words vector and L2-normalised. No model download, no network, and
+fully reproducible — this is the default backend for tests and for environments
+without sentence-transformers, and the fallback when the heavy stack is absent.
+
+It captures *lexical* similarity (documents that share vocabulary get similar
+vectors), which is enough for offline semantic-search smoke tests and a usable,
+model-free baseline. Swap in the ``local`` (sentence-transformers) or ``openai``
+backend for semantic (meaning-level) similarity in production.
+"""
+
+import re
+import zlib
+from typing import List
+
+import numpy as np
+
+from ..provider import EmbeddingBackend
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+class HashingBackend(EmbeddingBackend):
+    """Deterministic feature-hashing embeddings; no heavy dependencies."""
+
+    def __init__(self, dim: int = 256, model_name: str = "hashing"):
+        self._dim = int(dim)
+        self._model_name = model_name
+
+    def _embed_one(self, text: str) -> np.ndarray:
+        vec = np.zeros(self._dim, dtype=np.float64)
+        for tok in _TOKEN_RE.findall((text or "").lower()):
+            # crc32 is a stable, non-cryptographic hash (deterministic across
+            # runs, unlike the builtin hash()); the low bit gives a sign so
+            # colliding tokens can cancel rather than always reinforce.
+            h = zlib.crc32(tok.encode("utf-8"))
+            vec[h % self._dim] += 1.0 if (h >> 8) & 1 == 0 else -1.0
+        norm = np.linalg.norm(vec)
+        if norm > 0.0:
+            vec /= norm
+        return vec
+
+    def embed_texts(self, texts: List[str]) -> np.ndarray:
+        if not texts:
+            return np.empty((0, self._dim))
+        return np.vstack([self._embed_one(t) for t in texts])
+
+    def dim(self) -> int:
+        return self._dim
+
+    def name(self) -> str:
+        return self._model_name

--- a/services/embeddings/provider.py
+++ b/services/embeddings/provider.py
@@ -100,6 +100,11 @@ class EmbeddingProvider:
                 model_name=model_name or "text-embedding-ada-002",
                 **kwargs
             )
+        elif provider == "hashing":
+            # Deterministic, dependency-light backend: offline default for tests
+            # and the fallback where sentence-transformers is unavailable.
+            from .backends.hashing import HashingBackend
+            return HashingBackend(**kwargs)
         else:
             raise ValueError(f"Unknown provider: {provider}")
     

--- a/src/analytics/semantic_search.py
+++ b/src/analytics/semantic_search.py
@@ -1,0 +1,206 @@
+"""
+Semantic search over the document embedding sink.
+
+Brute-force cosine similarity over the vectors in ``document_embeddings``
+(written by :func:`src.ingestion.embed.embed_documents`), joined back to the
+corpus for citation metadata. No vector-index extension required — for a modest
+corpus a numpy matrix-multiply is ample, mirroring the style of the existing
+analytics (e.g. image-reuse union-find).
+
+Three entry points:
+
+* :func:`semantic_search` - documents most similar to a free-text query,
+* :func:`similar_documents` - documents most similar to a given document,
+* :func:`near_duplicates` - clusters of near-identical documents.
+
+Query and corpus vectors must live in the same embedding space; pass the same
+``provider``/``model`` used to index. Read-only: these functions never create or
+write tables (the sink is read directly, guarded), so they run against a
+read-only warehouse connection. Stdlib + numpy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from src.database.news_articles_compat import corpus_table
+
+
+def _has_embeddings(conn) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'document_embeddings'"
+        ).fetchone())
+    except Exception:
+        return False
+
+
+def _normalise(mat: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return mat / norms
+
+
+def _load_matrix(conn, model: Optional[str]):
+    if model is not None:
+        rows = conn.execute(
+            "SELECT document_id, vector FROM document_embeddings WHERE model = ?", [model]
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT document_id, vector FROM document_embeddings"
+        ).fetchall()
+    ids = [r[0] for r in rows]
+    if not ids:
+        return ids, np.empty((0, 0))
+    return ids, np.asarray([json.loads(r[1]) for r in rows], dtype=np.float64)
+
+
+def _get_vector(conn, document_id: str):
+    row = conn.execute(
+        "SELECT model, vector FROM document_embeddings WHERE document_id = ?", [document_id]
+    ).fetchone()
+    if row is None:
+        return None, None
+    return row[0], np.asarray(json.loads(row[1]), dtype=np.float64)
+
+
+def _metadata(conn, ids: List[str]) -> Dict[str, Dict[str, Any]]:
+    if not ids:
+        return {}
+    tbl = corpus_table(conn)
+    ph = ", ".join("?" for _ in ids)
+    rows = conn.execute(
+        f"SELECT id, title, source, url FROM {tbl} WHERE id IN ({ph})", ids
+    ).fetchall()
+    return {r[0]: {"title": r[1], "source": r[2], "url": r[3]} for r in rows}
+
+
+def _hits(conn, ids, sims, order, top_k, exclude=None):
+    take = [ids[i] for i in order[: top_k + (1 if exclude else 0)]]
+    meta = _metadata(conn, take)
+    out = []
+    for i in order:
+        doc_id = ids[i]
+        if exclude is not None and doc_id == exclude:
+            continue
+        m = meta.get(doc_id, {})
+        out.append({
+            "document_id": doc_id,
+            "score": round(float(sims[i]), 4),
+            "title": m.get("title"),
+            "source": m.get("source") or "unknown",
+            "url": m.get("url"),
+        })
+        if len(out) >= top_k:
+            break
+    return out
+
+
+def semantic_search(
+    conn, query: str, top_k: int = 10, provider: Optional[Any] = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Documents most semantically similar to ``query``.
+
+    Embeds ``query`` with ``provider`` (default: env-configured) and ranks the
+    stored document vectors by cosine similarity. ``model`` filters the sink to
+    one embedding space (recommended when several were indexed)."""
+    if not _has_embeddings(conn):
+        return {"results": [], "count": 0, "query": query,
+                "note": "no embeddings indexed; run embed_documents first"}
+    ids, mat = _load_matrix(conn, model)
+    if not ids:
+        return {"results": [], "count": 0, "query": query,
+                "note": "no embeddings indexed; run embed_documents first"}
+
+    if provider is None:
+        from services.embeddings.provider import get_embedding_provider
+
+        provider = get_embedding_provider()
+    qvec = np.asarray(provider.embed_texts([query])[0], dtype=np.float64)
+    if qvec.shape[0] != mat.shape[1]:
+        return {"error": "query/corpus embedding dimensions differ; index and "
+                         "query with the same model", "code": "dim_mismatch",
+                "query_dim": int(qvec.shape[0]), "corpus_dim": int(mat.shape[1])}
+
+    sims = _normalise(mat) @ (qvec / (np.linalg.norm(qvec) or 1.0))
+    order = np.argsort(-sims)
+    return {"results": _hits(conn, ids, sims, order, top_k), "count": min(top_k, len(ids)),
+            "query": query, "model": model, "method": "cosine over document embeddings"}
+
+
+def similar_documents(
+    conn, document_id: str, top_k: int = 10, model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Documents most similar to ``document_id`` (excludes the document itself)."""
+    if not _has_embeddings(conn):
+        return {"error": f"document {document_id!r} has no embedding", "code": "not_indexed",
+                "document_id": document_id}
+    doc_model, qvec = _get_vector(conn, document_id)
+    if qvec is None:
+        return {"error": f"document {document_id!r} has no embedding", "code": "not_indexed",
+                "document_id": document_id}
+    ids, mat = _load_matrix(conn, model or doc_model)
+    sims = _normalise(mat) @ (qvec / (np.linalg.norm(qvec) or 1.0))
+    order = np.argsort(-sims)
+    return {"results": _hits(conn, ids, sims, order, top_k, exclude=document_id),
+            "count": top_k, "document_id": document_id,
+            "method": "cosine over document embeddings"}
+
+
+def near_duplicates(
+    conn, threshold: float = 0.9, model: Optional[str] = None, max_docs: int = 2000,
+) -> Dict[str, Any]:
+    """Clusters of near-identical documents (cosine >= ``threshold``).
+
+    Pairwise cosine over the (capped) embedding set, connected components as
+    clusters. ``threshold`` near 1.0 finds near-exact reuse; lower values find
+    looser echoes. Note the ``max_docs`` cap keeps the O(n^2) scan bounded."""
+    if not _has_embeddings(conn):
+        return {"clusters": [], "count": 0, "note": "no embeddings indexed"}
+    ids, mat = _load_matrix(conn, model)
+    if len(ids) < 2:
+        return {"clusters": [], "count": 0, "note": "fewer than two embedded documents"}
+    truncated = len(ids) > max_docs
+    if truncated:
+        ids, mat = ids[:max_docs], mat[:max_docs]
+
+    norm = _normalise(mat)
+    sims = norm @ norm.T
+    parent = list(range(len(ids)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            if sims[i, j] >= threshold:
+                parent[find(i)] = find(j)
+
+    groups: Dict[int, List[int]] = {}
+    for i in range(len(ids)):
+        groups.setdefault(find(i), []).append(i)
+
+    meta = _metadata(conn, ids)
+    clusters = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        clusters.append({
+            "document_ids": [ids[i] for i in members],
+            "size": len(members),
+            "sources": sorted({(meta.get(ids[i]) or {}).get("source") or "unknown"
+                               for i in members}),
+        })
+    clusters.sort(key=lambda c: -c["size"])
+    return {"clusters": clusters, "count": len(clusters), "threshold": threshold,
+            "truncated": truncated,
+            "note": "near-duplicate clusters by embedding cosine; shared vectors "
+                    "can be coincidental (wire copy, quotations)"}

--- a/src/ingestion/embed.py
+++ b/src/ingestion/embed.py
@@ -1,0 +1,73 @@
+"""
+Document embedding pass over the unified corpus.
+
+Reads documents that have no embedding yet (source-type-agnostic, via the
+``corpus_documents`` view), embeds ``title + content`` with a pluggable
+:class:`~services.embeddings.provider.EmbeddingProvider`, and persists one vector
+per document into :class:`~src.ingestion.embedding_store.EmbeddingStore`. This is
+the indexer that makes semantic search / near-duplicate detection / embedding
+topic-modelling possible over the DuckDB corpus.
+
+The provider is injected. In production it defaults to the env-configured
+provider (``local`` sentence-transformers by default); tests and offline runs
+pass the deterministic ``hashing`` provider, so the pass runs (and is
+gate-tested) with no heavy dependencies. Idempotent: an already-embedded
+document is skipped, so re-running only fills the gaps.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from src.database.news_articles_compat import ensure_corpus_documents_view
+from src.ingestion.embedding_store import EmbeddingStore
+
+# Documents longer than this are truncated before embedding (one vector per
+# document; the head carries the lede/topic for a document-level match).
+DEFAULT_TEXT_MAX_CHARS = 4000
+
+
+def _default_provider():
+    from services.embeddings.provider import get_embedding_provider
+
+    return get_embedding_provider()
+
+
+def embed_documents(
+    conn,
+    provider: Optional[Any] = None,
+    limit: Optional[int] = None,
+    text_max_chars: int = DEFAULT_TEXT_MAX_CHARS,
+) -> int:
+    """Embed documents that have no embedding yet; return how many were embedded.
+
+    Reads ``corpus_documents`` LEFT JOIN ``document_embeddings`` for the
+    un-embedded rows, embeds them with ``provider`` (default: the env-configured
+    provider), and upserts the vectors into ``document_embeddings``.
+    """
+    provider = provider or _default_provider()
+    ensure_corpus_documents_view(conn)   # documents + enrichments + the view
+    store = EmbeddingStore(conn)
+
+    query = (
+        "SELECT d.id, d.title, d.content FROM corpus_documents d "
+        "LEFT JOIN document_embeddings e ON e.document_id = d.id "
+        "WHERE e.document_id IS NULL ORDER BY d.publish_date DESC NULLS LAST"
+    )
+    params: List[Any] = []
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+
+    rows = conn.execute(query, params).fetchall()
+    if not rows:
+        return 0
+
+    ids = [r[0] for r in rows]
+    texts = [f"{(r[1] or '')} {(r[2] or '')}".strip()[:text_max_chars] for r in rows]
+    matrix = provider.embed_texts(texts)
+    model, dim = provider.name(), provider.dim()
+
+    for document_id, vec in zip(ids, matrix):
+        store.upsert(document_id, list(vec), model=model, dim=dim)
+    return len(ids)

--- a/src/ingestion/embedding_store.py
+++ b/src/ingestion/embedding_store.py
@@ -1,0 +1,93 @@
+"""
+Persisted embedding sink, keyed by ``document_id``.
+
+The vector infrastructure the repo already has (``services/rag`` pgvector,
+Qdrant, the Snowflake ``article_embeddings`` path) targets other stores; nothing
+embedded the canonical DuckDB ``documents`` corpus. ``EmbeddingStore`` is that
+missing sink: one dense vector per document, so semantic search, near-duplicate
+detection, and embedding-based topic modelling can run over the same corpus the
+rest of the engine reads.
+
+The vector is stored as a JSON array of floats (portable across DuckDB builds,
+no vector extension required); the embedding ``model`` and ``dim`` are recorded
+alongside so a reader can tell which space a vector lives in. The connection is
+injected, so it is offline-testable, and ``upsert`` is idempotent (last write
+wins per document).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS document_embeddings (
+    document_id TEXT PRIMARY KEY,
+    model       TEXT,
+    dim         INTEGER,
+    vector      TEXT,   -- JSON array of floats
+    updated_at  BIGINT
+)
+"""
+
+
+class EmbeddingStore:
+    """Idempotent per-document store for dense embedding vectors."""
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        self.conn.execute(_SCHEMA)
+
+    def upsert(
+        self,
+        document_id: str,
+        vector: Sequence[float],
+        *,
+        model: str,
+        dim: Optional[int] = None,
+        updated_at: Optional[int] = None,
+    ) -> None:
+        """Insert or replace the embedding for ``document_id`` (last write wins)."""
+        vec = [float(x) for x in vector]
+        self.conn.execute(
+            """
+            INSERT INTO document_embeddings (document_id, model, dim, vector, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (document_id) DO UPDATE SET
+                model      = excluded.model,
+                dim        = excluded.dim,
+                vector     = excluded.vector,
+                updated_at = excluded.updated_at
+            """,
+            [document_id, model, int(dim if dim is not None else len(vec)),
+             json.dumps(vec), updated_at],
+        )
+
+    def get(self, document_id: str) -> Optional[Dict[str, Any]]:
+        """Return ``{model, dim, vector}`` for ``document_id``, or None if absent."""
+        row = self.conn.execute(
+            "SELECT model, dim, vector FROM document_embeddings WHERE document_id = ?",
+            [document_id],
+        ).fetchone()
+        if row is None:
+            return None
+        return {"model": row[0], "dim": row[1], "vector": json.loads(row[2]) if row[2] else []}
+
+    def vectors(self, model: Optional[str] = None) -> List[Tuple[str, List[float]]]:
+        """All ``(document_id, vector)`` pairs, optionally filtered to one model."""
+        if model is not None:
+            rows = self.conn.execute(
+                "SELECT document_id, vector FROM document_embeddings WHERE model = ?",
+                [model],
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT document_id, vector FROM document_embeddings"
+            ).fetchall()
+        return [(r[0], json.loads(r[1]) if r[1] else []) for r in rows]
+
+    def count(self) -> int:
+        return self.conn.execute("SELECT COUNT(*) FROM document_embeddings").fetchone()[0]

--- a/tests/unit/analytics/test_semantic_search.py
+++ b/tests/unit/analytics/test_semantic_search.py
@@ -1,0 +1,72 @@
+"""Unit tests for semantic search over the document embedding sink. Offline via
+the deterministic hashing backend (lexical similarity is enough to pin ranking).
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.embeddings.provider import EmbeddingProvider
+from services.ingest.common.document_model import Document
+from src.analytics.semantic_search import near_duplicates, semantic_search, similar_documents
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.embed import embed_documents
+
+
+@pytest.fixture
+def provider():
+    return EmbeddingProvider(provider="hashing")
+
+
+def _doc(doc_id, content, source="Src"):
+    return Document(document_id=doc_id, source_type="news", language="en",
+                    ingested_at=1_700_000_000_000, created_at=1_700_000_000_000,
+                    url=f"https://ex.com/{doc_id}", title=doc_id, content=content,
+                    source_id=source, metadata={"source": source})
+
+
+@pytest.fixture
+def wh(provider):
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn).upsert([
+        _doc("econ1", "the economy grew as inflation cooled and jobs rose"),
+        _doc("econ2", "inflation cooled while the economy grew and hiring rose"),
+        _doc("sport1", "the team won the championship final in overtime"),
+    ])
+    embed_documents(conn, provider=provider)
+    return conn
+
+
+def test_search_ranks_topical_match_first(wh, provider):
+    out = semantic_search(wh, "economy inflation jobs", top_k=3, provider=provider)
+    assert out["count"] >= 1
+    top_ids = [r["document_id"] for r in out["results"][:2]]
+    assert "econ1" in top_ids and "econ2" in top_ids  # economy docs beat the sports doc
+    assert out["results"][0]["source"] == "Src"       # citation metadata joined
+
+
+def test_empty_index_returns_note():
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn)
+    out = semantic_search(conn, "anything", provider=EmbeddingProvider(provider="hashing"))
+    assert out["count"] == 0 and "note" in out
+
+
+def test_similar_documents_excludes_self(wh):
+    out = similar_documents(wh, "econ1", top_k=3)
+    ids = [r["document_id"] for r in out["results"]]
+    assert "econ1" not in ids
+    assert ids[0] == "econ2"  # the paraphrase is the nearest neighbour
+
+
+def test_similar_documents_unindexed_is_flagged(wh):
+    out = similar_documents(wh, "ghost")
+    assert out.get("code") == "not_indexed"
+
+
+def test_near_duplicates_clusters_paraphrases(wh):
+    out = near_duplicates(wh, threshold=0.5)
+    assert out["count"] >= 1
+    members = {d for c in out["clusters"] for d in c["document_ids"]}
+    assert {"econ1", "econ2"} <= members  # the two economy paraphrases cluster

--- a/tests/unit/ingestion/test_embed.py
+++ b/tests/unit/ingestion/test_embed.py
@@ -1,0 +1,76 @@
+"""Unit tests for the document embedding pass. Offline, in-memory DuckDB via the
+deterministic hashing embedding backend (no heavy ML deps)."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.embeddings.provider import EmbeddingProvider
+from services.ingest.common.document_model import Document
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.embed import embed_documents
+from src.ingestion.embedding_store import EmbeddingStore
+
+
+@pytest.fixture
+def provider():
+    return EmbeddingProvider(provider="hashing")
+
+
+def _doc(doc_id, content, source_type="news"):
+    return Document(document_id=doc_id, source_type=source_type, language="en",
+                    ingested_at=1_700_000_000_000, created_at=1_700_000_000_000,
+                    url=f"https://ex.com/{doc_id}", title=f"title {doc_id}",
+                    content=content, source_id="Src", metadata={"source": "Src"})
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    DocumentStore(c).upsert([
+        _doc("d1", "Markets surge as profits gain and growth beats"),
+        _doc("p1", "A study of measured warming trends over the decade", source_type="paper"),
+    ])
+    return c
+
+
+def test_hashing_backend_is_deterministic_and_normalised(provider):
+    import numpy as np
+
+    a = provider.embed_texts(["the economy grew sharply"])
+    b = provider.embed_texts(["the economy grew sharply"])
+    assert a.shape == (1, provider.dim())
+    assert np.allclose(a, b)                       # deterministic
+    assert abs(float(np.linalg.norm(a[0])) - 1.0) < 1e-9  # L2-normalised
+
+
+def test_embeds_documents_and_persists(conn, provider):
+    n = embed_documents(conn, provider=provider)
+    assert n == 2
+    store = EmbeddingStore(conn)
+    assert store.count() == 2
+    rec = store.get("d1")
+    assert rec["model"] == provider.name()  # "hashing:hashing" (provider:backend)
+    assert rec["dim"] == provider.dim()
+    assert len(rec["vector"]) == provider.dim()
+
+
+def test_is_idempotent_only_fills_gaps(conn, provider):
+    assert embed_documents(conn, provider=provider) == 2
+    # Re-running embeds nothing new.
+    assert embed_documents(conn, provider=provider) == 0
+    # A newly-added document is picked up next pass.
+    DocumentStore(conn).upsert([_doc("d3", "new content about elections")])
+    assert embed_documents(conn, provider=provider) == 1
+
+
+def test_limit_caps_the_batch(conn, provider):
+    assert embed_documents(conn, provider=provider, limit=1) == 1
+    assert EmbeddingStore(conn).count() == 1
+
+
+def test_covers_non_news_documents(conn, provider):
+    embed_documents(conn, provider=provider)
+    # The paper document (non-news) is embedded, not just news.
+    assert EmbeddingStore(conn).get("p1") is not None

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1724,6 +1724,106 @@ def speaker_balance(media: Optional[str] = None) -> dict:
         con.close()
 
 
+# --------------------------------------------------------------------------- #
+# Semantic search over the document embedding sink (document_embeddings).
+# The index is built by trigger_embed_documents; queries embed with the
+# env-configured provider (EMBEDDING_PROVIDER; "hashing" for an offline default).
+# --------------------------------------------------------------------------- #
+
+
+@mcp.tool
+def semantic_search(query: str, top_k: int = 10) -> dict:
+    """Documents most semantically similar to a free-text query, by embedding
+    cosine, each cited to its source. Returns a note if the corpus is not yet
+    embedded (run trigger_embed_documents first).
+
+    Args:
+        query: the free-text query to search for.
+        top_k: number of results to return (default 10).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.semantic_search import semantic_search as _search
+
+        return _search(con, query, top_k=top_k)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def similar_documents(document_id: str, top_k: int = 10) -> dict:
+    """Documents most similar to a given document (by embedding cosine),
+    excluding the document itself.
+
+    Args:
+        document_id: the document to find neighbours for.
+        top_k: number of neighbours to return (default 10).
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.semantic_search import similar_documents as _sim
+
+        return _sim(con, document_id, top_k=top_k)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def near_duplicate_documents(threshold: float = 0.9) -> dict:
+    """Clusters of near-identical documents by embedding cosine (>= threshold);
+    flags reuse/echo. Similarity can be coincidental (wire copy, quotations).
+
+    Args:
+        threshold: cosine cutoff for two documents to count as near-duplicates.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.semantic_search import near_duplicates as _nd
+
+        return _nd(con, threshold=threshold)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def trigger_embed_documents(limit: Optional[int] = None) -> dict:
+    """Embed documents that have no embedding yet into ``document_embeddings``
+    (RW), using the env-configured embedding provider. Idempotent; returns the
+    number embedded.
+
+    Args:
+        limit: optional cap on how many documents to embed this pass.
+    """
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.ingestion.embed import embed_documents
+
+        embedded = embed_documents(con, limit=limit)
+        return {"embedded": embedded}
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     from src.mcp_host.transport import run_server
 


### PR DESCRIPTION
## Summary

The repo's vector infrastructure (`services/rag` pgvector, Qdrant, the Snowflake `article_embeddings` path) all targets other stores — nothing embedded the canonical DuckDB `documents` corpus, so there was no semantic search / near-duplicate detection / embedding-based topic modelling over it. This adds that end-to-end, **reusing the existing `EmbeddingProvider`** rather than a new model layer.

## Changes

- **`services/embeddings/backends/hashing.py`** — a deterministic, dependency-light feature-hashing backend added to the pluggable provider (`provider="hashing"`). Reproducible, offline, L2-normalised lexical embeddings — the default for tests and the fallback where sentence-transformers is absent. The existing `local` (sentence-transformers) / `openai` backends remain the production semantic path.
- **`src/ingestion/embedding_store.py`** (`EmbeddingStore`) — a `document_embeddings` sink keyed by `document_id`, vector stored as JSON + model/dim (no vector extension needed).
- **`src/ingestion/embed.py`** (`embed_documents`) — an idempotent indexer embedding un-embedded documents source-agnostically (via `corpus_documents`) with an injected provider; mirrors the `enrich_documents` pass.
- **`src/analytics/semantic_search.py`** — `semantic_search` (free-text → cited documents), `similar_documents`, `near_duplicates` (embedding-cosine clusters). Read-only safe (never creates/writes tables), brute-force numpy cosine, joined to the corpus for citations.
- **`tools/pipeline_mcp/server.py`** — `semantic_search`, `similar_documents`, `near_duplicate_documents` (read-only) + `trigger_embed_documents` (RW index build), in the import-light lazy-import pattern.

## Tests

Run entirely offline via the hashing backend (deterministic ranking): indexing (idempotent, non-news covered), search ranking, self-exclusion, near-duplicate clustering, the empty-index note, and backend determinism/normalisation.

First of four DS/NLP capability PRs; topic modelling (#4) will build on this embedding sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_