### PR TITLE
Add corpus summarization (extractive default + lazy abstractive, sink + MCP tools)

### DIFF
--- a/src/ingestion/summarize.py
+++ b/src/ingestion/summarize.py
@@ -1,0 +1,188 @@
+"""
+Document summarization over the unified corpus.
+
+Two summarizers behind one ``summarizer(text) -> str`` interface, following the
+repo's heuristic-first / model-optional discipline (cf. ``frames.py``):
+
+* :func:`extractive_summary` - the default. Dependency-light, deterministic,
+  offline: score sentences by normalized term frequency with a lead bias, keep
+  the top-N in reading order. Runs (and is gate-tested) with no ML stack.
+* :func:`abstractive_summary` - optional. Lazily loads a transformers
+  summarization pipeline (BART/DistilBART) for a fluent abstractive summary;
+  falls back to the extractive summary if the model stack is unavailable.
+
+:func:`summarize_documents` is the idempotent batch pass (writes
+``document_summaries``); :func:`summarize_topic` composes a short brief for a
+topic from its most recent documents. The heavy summarizer already in the repo
+(``src/nlp/ai_summarizer.py``) is async, article-bound and eager-imports torch;
+this is the corpus-oriented, import-light replacement.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, List, Optional
+
+from src.database.news_articles_compat import corpus_table, ensure_corpus_documents_view
+from src.ingestion.summary_store import SummaryStore
+
+Summarizer = Callable[[str], str]
+
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+_WORD_RE = re.compile(r"[a-z']+")
+_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with",
+    "at", "by", "from", "as", "is", "are", "was", "were", "be", "been", "it",
+    "its", "this", "that", "these", "those", "has", "have", "had", "will", "would",
+    "could", "should", "after", "over", "into", "about", "than", "then", "he",
+    "she", "they", "we", "you", "his", "her", "their", "our", "said",
+})
+
+DEFAULT_MAX_SENTENCES = 3
+
+
+def _sentences(text: str) -> List[str]:
+    return [s.strip() for s in _SENTENCE_RE.split((text or "").strip()) if s.strip()]
+
+
+def extractive_summary(text: str, max_sentences: int = DEFAULT_MAX_SENTENCES) -> str:
+    """Top-``max_sentences`` sentences by normalized term frequency + lead bias,
+    returned in original reading order. Deterministic and dependency-free."""
+    sentences = _sentences(text)
+    if len(sentences) <= max_sentences:
+        return " ".join(sentences)
+
+    freq: dict = {}
+    for w in _WORD_RE.findall(text.lower()):
+        if len(w) > 2 and w not in _STOPWORDS:
+            freq[w] = freq.get(w, 0) + 1
+    if not freq:
+        return " ".join(sentences[:max_sentences])
+    top = max(freq.values())
+
+    scored = []
+    for i, sent in enumerate(sentences):
+        words = [w for w in _WORD_RE.findall(sent.lower()) if w in freq]
+        if not words:
+            score = 0.0
+        else:
+            score = sum(freq[w] / top for w in words) / len(words)
+        score += 0.15 if i == 0 else (0.05 if i == 1 else 0.0)  # lead bias
+        scored.append((score, i, sent))
+
+    keep = sorted((i for _, i, _ in sorted(scored, reverse=True)[:max_sentences]))
+    return " ".join(sentences[i] for i in keep)
+
+
+def abstractive_summary(
+    text: str, max_length: int = 130, min_length: int = 30,
+    model_name: str = "sshleifer/distilbart-cnn-12-6",
+) -> str:
+    """A fluent abstractive summary via a lazily-loaded transformers pipeline.
+
+    Falls back to :func:`extractive_summary` if transformers/torch are
+    unavailable or the model errors, so callers get a summary either way."""
+    try:
+        from transformers import pipeline
+
+        summarizer = pipeline("summarization", model=model_name)
+        out = summarizer(text[:3000], max_length=max_length, min_length=min_length,
+                         do_sample=False)
+        return out[0]["summary_text"].strip()
+    except Exception:
+        return extractive_summary(text)
+
+
+def default_summarizer(text: str) -> str:
+    """The offline default (extractive)."""
+    return extractive_summary(text)
+
+
+def summarize_documents(
+    conn,
+    summarizer: Optional[Summarizer] = None,
+    limit: Optional[int] = None,
+    method: str = "extractive",
+) -> int:
+    """Summarize documents that have no summary yet; return how many were done.
+
+    Reads ``corpus_documents`` LEFT JOIN ``document_summaries`` for the
+    un-summarized rows, runs ``summarizer`` (default: extractive) over
+    ``title + content``, and upserts into ``document_summaries``. Idempotent.
+    """
+    summarizer = summarizer or default_summarizer
+    ensure_corpus_documents_view(conn)
+    store = SummaryStore(conn)
+
+    query = (
+        "SELECT d.id, d.title, d.content FROM corpus_documents d "
+        "LEFT JOIN document_summaries s ON s.document_id = d.id "
+        "WHERE s.document_id IS NULL ORDER BY d.publish_date DESC NULLS LAST"
+    )
+    params: List[Any] = []
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+
+    rows = conn.execute(query, params).fetchall()
+    done = 0
+    for document_id, title, content in rows:
+        text = f"{title or ''}. {content or ''}".strip()
+        store.upsert(document_id, summarizer(text), method=method)
+        done += 1
+    return done
+
+
+def document_summary(conn, document_id: str, max_sentences: int = DEFAULT_MAX_SENTENCES) -> dict:
+    """A single document's summary — the stored one if present, else computed
+    extractively from its corpus content on the fly. Read-only (never writes)."""
+    try:
+        has_store = bool(conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'document_summaries'"
+        ).fetchone())
+    except Exception:
+        has_store = False
+    if has_store:
+        row = conn.execute(
+            "SELECT summary, method FROM document_summaries WHERE document_id = ?",
+            [document_id],
+        ).fetchone()
+        if row is not None:
+            return {"document_id": document_id, "summary": row[0], "method": row[1],
+                    "stored": True}
+
+    tbl = corpus_table(conn)
+    row = conn.execute(
+        f"SELECT title, content FROM {tbl} WHERE id = ?", [document_id]
+    ).fetchone()
+    if row is None:
+        return {"error": f"document {document_id!r} not found", "code": "not_found",
+                "document_id": document_id}
+    text = f"{row[0] or ''}. {row[1] or ''}".strip()
+    return {"document_id": document_id, "method": "extractive", "stored": False,
+            "summary": extractive_summary(text, max_sentences=max_sentences)}
+
+
+def summarize_topic(
+    conn, topic: str, summarizer: Optional[Summarizer] = None, max_docs: int = 20,
+    max_sentences: int = 5,
+) -> dict:
+    """A short brief for a topic (category), summarizing its most recent
+    documents. Read-only; returns the summary and the documents it drew on."""
+    summarizer = summarizer or (lambda t: extractive_summary(t, max_sentences=max_sentences))
+    tbl = corpus_table(conn)
+    rows = conn.execute(
+        f"SELECT id, title, content FROM {tbl} WHERE category = ? "
+        f"ORDER BY publish_date DESC NULLS LAST LIMIT ?",
+        [topic, max_docs],
+    ).fetchall()
+    if not rows:
+        return {"topic": topic, "summary": "", "document_count": 0,
+                "note": "no documents for this topic"}
+    corpus = " ".join(f"{r[1] or ''}. {r[2] or ''}" for r in rows)
+    return {
+        "topic": topic,
+        "summary": summarizer(corpus),
+        "document_count": len(rows),
+        "document_ids": [r[0] for r in rows],
+    }

--- a/src/ingestion/summary_store.py
+++ b/src/ingestion/summary_store.py
@@ -1,0 +1,68 @@
+"""
+Persisted summary sink, keyed by ``document_id``.
+
+A document-level summary is a distinct enrichment (variable-length text, its own
+method), so it gets its own table rather than a column on ``document_enrichments``.
+Written by :func:`src.ingestion.summarize.summarize_documents`; read by the
+summarization MCP tools and any consumer that wants a short-form of a document
+without re-running a model. The connection is injected (offline-testable) and
+``upsert`` is idempotent (last write wins per document).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS document_summaries (
+    document_id TEXT PRIMARY KEY,
+    summary     TEXT,
+    method      TEXT,
+    updated_at  BIGINT
+)
+"""
+
+
+class SummaryStore:
+    """Idempotent per-document store for short-form summaries."""
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        self.conn.execute(_SCHEMA)
+
+    def upsert(
+        self,
+        document_id: str,
+        summary: str,
+        *,
+        method: str,
+        updated_at: Optional[int] = None,
+    ) -> None:
+        """Insert or replace the summary for ``document_id`` (last write wins)."""
+        self.conn.execute(
+            """
+            INSERT INTO document_summaries (document_id, summary, method, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (document_id) DO UPDATE SET
+                summary    = excluded.summary,
+                method     = excluded.method,
+                updated_at = excluded.updated_at
+            """,
+            [document_id, summary, method, updated_at],
+        )
+
+    def get(self, document_id: str) -> Optional[Dict[str, Any]]:
+        """Return ``{summary, method}`` for ``document_id``, or None if absent."""
+        row = self.conn.execute(
+            "SELECT summary, method FROM document_summaries WHERE document_id = ?",
+            [document_id],
+        ).fetchone()
+        if row is None:
+            return None
+        return {"summary": row[0], "method": row[1]}
+
+    def count(self) -> int:
+        return self.conn.execute("SELECT COUNT(*) FROM document_summaries").fetchone()[0]

--- a/tests/unit/ingestion/test_summarize.py
+++ b/tests/unit/ingestion/test_summarize.py
@@ -1,0 +1,120 @@
+"""Unit tests for the document summarization pass. Offline, in-memory DuckDB;
+the extractive default needs no ML stack."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.database.news_articles_compat import ensure_corpus_documents_view
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.summarize import (
+    document_summary,
+    extractive_summary,
+    summarize_documents,
+    summarize_topic,
+)
+from src.ingestion.summary_store import SummaryStore
+
+_LEDE = "The central bank raised interest rates by half a point on Wednesday."
+_BODY = (
+    "Officials cited persistent inflation as the main driver of the decision. "
+    "Markets had largely expected the move after recent economic data. "
+    "The bank signalled further tightening could follow if prices stay high. "
+    "Analysts debated whether the economy could avoid a recession."
+)
+
+
+def _doc(doc_id, content, category="Economy", source_type="news"):
+    return Document(document_id=doc_id, source_type=source_type, language="en",
+                    ingested_at=1_700_000_000_000, created_at=1_700_000_000_000,
+                    url=f"https://ex.com/{doc_id}", title=f"Rates decision {doc_id}",
+                    content=content, source_id="Wire",
+                    metadata={"source": "Wire", "category": category})
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    DocumentStore(c).upsert([
+        _doc("d1", f"{_LEDE} {_BODY}"),
+        _doc("p1", "A paper on measured warming trends over the last decade. "
+                   "It reports steady increases across all monitored regions.",
+             category="Science", source_type="paper"),
+    ])
+    ensure_corpus_documents_view(c)   # the corpus view is part of the warehouse
+    return c
+
+
+# --- extractive summarizer -------------------------------------------------- #
+
+
+def test_extractive_is_deterministic_and_bounded():
+    a = extractive_summary(f"{_LEDE} {_BODY}", max_sentences=2)
+    b = extractive_summary(f"{_LEDE} {_BODY}", max_sentences=2)
+    assert a == b                                   # deterministic
+    assert a.count(".") <= 2                         # at most 2 sentences
+    assert _LEDE in a                                # lead sentence retained
+
+
+def test_extractive_short_text_returned_whole():
+    assert extractive_summary("One short sentence.") == "One short sentence."
+
+
+# --- batch pass ------------------------------------------------------------- #
+
+
+def test_summarizes_documents_and_persists(conn):
+    n = summarize_documents(conn)
+    assert n == 2
+    store = SummaryStore(conn)
+    assert store.count() == 2
+    rec = store.get("d1")
+    assert rec["method"] == "extractive"
+    assert rec["summary"]
+
+
+def test_is_idempotent_only_fills_gaps(conn):
+    assert summarize_documents(conn) == 2
+    assert summarize_documents(conn) == 0
+    DocumentStore(conn).upsert([_doc("d3", "New coverage about the budget vote.")])
+    assert summarize_documents(conn) == 1
+
+
+def test_covers_non_news(conn):
+    summarize_documents(conn)
+    assert SummaryStore(conn).get("p1") is not None
+
+
+# --- read-only accessors ---------------------------------------------------- #
+
+
+def test_document_summary_prefers_stored(conn):
+    summarize_documents(conn)
+    out = document_summary(conn, "d1")
+    assert out["stored"] is True and out["summary"]
+
+
+def test_document_summary_computes_on_the_fly_when_absent(conn):
+    # No batch run: document_summaries table does not exist yet.
+    out = document_summary(conn, "d1")
+    assert out["stored"] is False and out["method"] == "extractive"
+    assert out["summary"]
+
+
+def test_document_summary_unknown_is_flagged(conn):
+    out = document_summary(conn, "ghost")
+    assert out.get("code") == "not_found"
+
+
+def test_summarize_topic_draws_on_topic_docs(conn):
+    out = summarize_topic(conn, "Economy")
+    assert out["document_count"] == 1
+    assert "d1" in out["document_ids"]
+    assert out["summary"]
+
+
+def test_summarize_topic_empty(conn):
+    out = summarize_topic(conn, "Sports")
+    assert out["document_count"] == 0 and "note" in out

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1824,6 +1824,79 @@ def trigger_embed_documents(limit: Optional[int] = None) -> dict:
         con.close()
 
 
+# --------------------------------------------------------------------------- #
+# Summarization over the corpus (document_summaries sink).
+# The batch index is built by trigger_summarize_documents; single-document and
+# per-topic summaries are computed read-only (extractive) when not pre-stored.
+# --------------------------------------------------------------------------- #
+
+
+@mcp.tool
+def summarize_document(document_id: str) -> dict:
+    """A short summary of one document — the stored summary if the batch has run,
+    else an extractive summary computed on the fly from its content.
+
+    Args:
+        document_id: the document to summarize.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.ingestion.summarize import document_summary
+
+        return document_summary(con, document_id)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def summarize_topic(topic: str) -> dict:
+    """A short brief for a topic (category), summarizing its most recent
+    documents extractively, with the documents it drew on.
+
+    Args:
+        topic: the topic (category) to summarize.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.ingestion.summarize import summarize_topic as _st
+
+        return _st(con, topic)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
+@mcp.tool
+def trigger_summarize_documents(limit: Optional[int] = None) -> dict:
+    """Summarize documents that have no summary yet into ``document_summaries``
+    (RW), using the extractive summarizer. Idempotent; returns the count.
+
+    Args:
+        limit: optional cap on how many documents to summarize this pass.
+    """
+    try:
+        con = _warehouse_rw()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.ingestion.summarize import summarize_documents
+
+        return {"summarized": summarize_documents(con, limit=limit)}
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     from src.mcp_host.transport import run_server
 


### PR DESCRIPTION
## Summary

The repo's summarizer (`src/nlp/ai_summarizer.py`) is async, article-bound, and eager-imports torch, with its own `article_id`-keyed store and no MCP surface — not usable over the DuckDB `documents` corpus. This adds a corpus-oriented summarization capability following the heuristic-first / model-optional pattern (like `frames.py`).

## Changes

- **`src/ingestion/summarize.py`**:
  - `extractive_summary` — the **default**: dependency-light, deterministic, offline (term-frequency sentence scoring + lead bias, top-N in reading order);
  - `abstractive_summary` — **optional**: lazily loads a transformers summarization pipeline (DistilBART), falling back to extractive if the ML stack is absent;
  - `summarize_documents` — idempotent batch over `corpus_documents` → the sink;
  - `summarize_topic` / `document_summary` — read-only per-topic and per-document summaries (computed on the fly when not pre-stored).
- **`src/ingestion/summary_store.py`** (`SummaryStore`) — the `document_summaries` sink keyed by `document_id`.
- **`tools/pipeline_mcp/server.py`** — `summarize_document`, `summarize_topic` (read-only) + `trigger_summarize_documents` (RW batch), lazy-imported.

## Tests

Run entirely offline via the extractive default: determinism, sentence bounding, lead retention, idempotent batch (non-news covered), stored-vs-on-the-fly accessors, and per-topic briefs.

Second of four DS/NLP capability PRs (after semantic search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_