### PR TITLE
Add relation extraction over the corpus (document_relations + MCP tools)

### DIFF
--- a/src/argument_mining/relations.py
+++ b/src/argument_mining/relations.py
@@ -1,0 +1,254 @@
+"""
+Relation extraction over the document corpus.
+
+Entity extraction over the corpus already exists (``metadata.py`` →
+``document_actors``); what was missing is *relations between* entities. This
+extracts subject–relation–object triples from document text and persists them to
+``document_relations``, so the KG / ``relationship_path`` layer has typed,
+cited relations rather than only co-mention edges.
+
+Heuristic-first, model-optional (as elsewhere): entities are found with the
+shared spaCy-or-regex NER from :mod:`src.argument_mining.metadata`; a relation is
+emitted when a known relation verb links two consecutive entities within one
+sentence. spaCy improves entity recall when installed; the regex fallback keeps
+it dependency-light and offline. Stable ``entity_id``\\s are reused from
+``metadata`` so relations join to ``document_actors`` and the KG.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
+
+from src.argument_mining.metadata import _entity_id, _get_nlp, _valid_name
+from src.database.news_articles_compat import corpus_table, ensure_corpus_documents_view
+
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+_WORD_RE = re.compile(r"[a-z']+")
+_TITLECASE_RE = re.compile(
+    r"\b(?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}|[A-Z]{2,}(?:\s+[A-Z]{2,})?)\b"
+)
+
+# Relation-bearing verbs (present + past). A relation is emitted only when one of
+# these links two entities, which keeps precision high and avoids pairing every
+# co-mention. Deliberately curated rather than open-vocabulary.
+_RELATION_VERBS = frozenset({
+    "met", "meets", "joined", "joins", "acquired", "acquires", "bought", "buys",
+    "criticized", "criticised", "praised", "praises", "supported", "supports",
+    "backed", "backs", "opposed", "opposes", "accused", "accuses", "sued", "sues",
+    "led", "leads", "heads", "headed", "founded", "founds", "owns", "owned",
+    "hired", "hires", "fired", "fires", "replaced", "replaces", "succeeded",
+    "succeeds", "defeated", "defeats", "beat", "beats", "partnered", "partners",
+    "attacked", "attacks", "visited", "visits", "endorsed", "endorses", "blamed",
+    "blames", "urged", "urges", "warned", "warns", "thanked", "thanks",
+    "appointed", "appoints", "elected", "elects", "named", "names", "married",
+    "marries", "represents", "represented", "funded", "funds", "invested",
+    "invests", "merged", "merges", "signed", "signs", "testified", "testifies",
+    "questioned", "questions", "interviewed", "interviews", "challenged",
+    "challenges", "met with", "spoke", "quoted", "cited",
+})
+
+
+@dataclass
+class RelationRecord:
+    document_id: str
+    source_type: str
+    subject: str
+    subject_id: str
+    relation: str
+    object: str
+    object_id: str
+    sentence: str
+    confidence: float
+    extracted_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+_RELATION_DDL = """
+CREATE TABLE IF NOT EXISTS document_relations (
+    document_id  TEXT,
+    source_type  TEXT,
+    subject      TEXT,
+    subject_id   TEXT,
+    relation     TEXT,
+    object       TEXT,
+    object_id    TEXT,
+    sentence     TEXT,
+    confidence   DOUBLE,
+    extracted_at TEXT
+)
+"""
+
+# A processed marker keyed by document, so a document that yields *zero*
+# relations is still recorded as done and not re-scanned every pass.
+_STATE_DDL = """
+CREATE TABLE IF NOT EXISTS document_relations_state (
+    document_id  TEXT PRIMARY KEY,
+    extracted_at TEXT
+)
+"""
+
+
+def _sentences(text: str) -> List[str]:
+    return [s.strip() for s in _SENTENCE_RE.split((text or "").strip()) if s.strip()]
+
+
+def _entity_spans(sentence: str) -> List[Tuple[str, int, int]]:
+    """(name, start, end) entity spans in a sentence — spaCy when available,
+    else a title-case regex fallback."""
+    nlp = _get_nlp()
+    if nlp is not None:
+        try:
+            doc = nlp(sentence[:20_000])
+            spans = [
+                (e.text.strip(), e.start_char, e.end_char)
+                for e in doc.ents
+                if e.label_ in ("PERSON", "ORG", "GPE", "FAC", "NORP")
+                and len(e.text.strip()) >= 2
+            ]
+            if spans:
+                return sorted(spans, key=lambda s: s[1])
+        except Exception:
+            pass
+    return sorted(
+        [(m.group(0), m.start(), m.end()) for m in _TITLECASE_RE.finditer(sentence)
+         if _valid_name(m.group(0))],
+        key=lambda s: s[1],
+    )
+
+
+def extract_relations(document_id: str, source_type: str, text: str) -> List[RelationRecord]:
+    """Subject–relation–object triples: a known relation verb linking two
+    consecutive entities within a sentence."""
+    out: List[RelationRecord] = []
+    seen = set()
+    for sentence in _sentences(text):
+        spans = _entity_spans(sentence)
+        for (n1, _s1, e1), (n2, s2, _e2) in zip(spans, spans[1:]):
+            sid, oid = _entity_id(n1), _entity_id(n2)
+            if sid == oid:
+                continue
+            between = sentence[e1:s2].lower()
+            tokens = _WORD_RE.findall(between)
+            verb = next((t for t in tokens if t in _RELATION_VERBS), None)
+            if verb is None:
+                continue
+            key = (sid, verb, oid)
+            if key in seen:
+                continue
+            seen.add(key)
+            confidence = round(max(0.3, 0.8 - 0.05 * len(tokens)), 3)
+            out.append(RelationRecord(
+                document_id=document_id, source_type=source_type,
+                subject=n1, subject_id=sid, relation=verb, object=n2, object_id=oid,
+                sentence=sentence[:240], confidence=confidence,
+            ))
+    return out
+
+
+def store_relations(conn, records: List[RelationRecord]) -> None:
+    conn.execute(_RELATION_DDL)
+    for r in records:
+        conn.execute(
+            "INSERT INTO document_relations (document_id, source_type, subject, "
+            "subject_id, relation, object, object_id, sentence, confidence, extracted_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [r.document_id, r.source_type, r.subject, r.subject_id, r.relation,
+             r.object, r.object_id, r.sentence, r.confidence, r.extracted_at],
+        )
+
+
+def extract_document_relations(conn, limit: Optional[int] = None) -> dict:
+    """Extract relations for corpus documents not yet processed; persist them.
+
+    Sweeps ``corpus_documents`` for documents whose id is absent from
+    ``document_relations``, extracts relations, and stores them. Returns the
+    number of documents processed and relations found.
+    """
+    ensure_corpus_documents_view(conn)
+    conn.execute(_RELATION_DDL)
+    conn.execute(_STATE_DDL)
+
+    query = (
+        "SELECT d.id, d.source_type, d.title, d.content FROM corpus_documents d "
+        "WHERE d.id NOT IN (SELECT document_id FROM document_relations_state) "
+        "ORDER BY d.publish_date DESC NULLS LAST"
+    )
+    params: List[Any] = []
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+
+    now = datetime.now(timezone.utc).isoformat()
+    rows = conn.execute(query, params).fetchall()
+    processed = relations = 0
+    for document_id, source_type, title, content in rows:
+        text = f"{title or ''}. {content or ''}".strip()
+        records = extract_relations(document_id, source_type or "news", text)
+        store_relations(conn, records)
+        conn.execute(
+            "INSERT INTO document_relations_state (document_id, extracted_at) VALUES (?, ?) "
+            "ON CONFLICT (document_id) DO NOTHING",
+            [document_id, now],
+        )
+        processed += 1
+        relations += len(records)
+    return {"documents_processed": processed, "relations_found": relations}
+
+
+# --------------------------------------------------------------------------- #
+# Read-only accessors (safe against a read-only warehouse connection)
+# --------------------------------------------------------------------------- #
+
+def _has_relations(conn) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'document_relations'"
+        ).fetchone())
+    except Exception:
+        return False
+
+
+def document_relations(conn, document_id: str) -> dict:
+    """Relations extracted from one document, each cited to its source sentence."""
+    if not _has_relations(conn):
+        return {"document_id": document_id, "relations": [], "count": 0,
+                "note": "no relations extracted yet"}
+    rows = conn.execute(
+        "SELECT subject, relation, object, confidence, sentence FROM document_relations "
+        "WHERE document_id = ? ORDER BY confidence DESC",
+        [document_id],
+    ).fetchall()
+    return {
+        "document_id": document_id,
+        "relations": [
+            {"subject": r[0], "relation": r[1], "object": r[2],
+             "confidence": r[3], "sentence": r[4]} for r in rows
+        ],
+        "count": len(rows),
+    }
+
+
+def entity_relations(conn, entity: str, limit: int = 100) -> dict:
+    """Relations involving an entity (as subject or object), by name or entity_id."""
+    if not _has_relations(conn):
+        return {"entity": entity, "relations": [], "count": 0,
+                "note": "no relations extracted yet"}
+    eid = _entity_id(entity) if not entity.startswith("ent-") else entity
+    rows = conn.execute(
+        "SELECT subject, relation, object, document_id, confidence FROM document_relations "
+        "WHERE subject_id = ? OR object_id = ? OR subject = ? OR object = ? "
+        "ORDER BY confidence DESC LIMIT ?",
+        [eid, eid, entity, entity, limit],
+    ).fetchall()
+    return {
+        "entity": entity,
+        "relations": [
+            {"subject": r[0], "relation": r[1], "object": r[2],
+             "document_id": r[3], "confidence": r[4]} for r in rows
+        ],
+        "count": len(rows),
+    }

--- a/tests/unit/argument_mining/test_relations.py
+++ b/tests/unit/argument_mining/test_relations.py
@@ -1,0 +1,93 @@
+"""Unit tests for relation extraction. Offline; the regex NER fallback needs no
+ML stack (spaCy improves recall when installed but is not required)."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.ingest.common.document_model import Document
+from src.argument_mining.relations import (
+    document_relations,
+    entity_relations,
+    extract_document_relations,
+    extract_relations,
+)
+from src.database.news_articles_compat import ensure_corpus_documents_view
+from src.ingestion.document_store import DocumentStore
+
+
+def _doc(doc_id, content, source_type="news"):
+    return Document(document_id=doc_id, source_type=source_type, language="en",
+                    ingested_at=1_700_000_000_000, created_at=1_700_000_000_000,
+                    url=f"https://ex.com/{doc_id}", title="Politics", content=content,
+                    source_id="Wire", metadata={"source": "Wire", "category": "Politics"})
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    DocumentStore(c).upsert([
+        _doc("d1", "Angela Merkel met Emmanuel Macron in Berlin on Tuesday. "
+                   "Later, Joe Biden praised Angela Merkel for the agreement."),
+        _doc("d2", "The weather was mild and nothing of note occurred today."),
+    ])
+    ensure_corpus_documents_view(c)
+    return c
+
+
+# --- extractor -------------------------------------------------------------- #
+
+
+def test_extracts_subject_verb_object():
+    rels = extract_relations("d0", "news", "Angela Merkel met Emmanuel Macron in Paris.")
+    assert any(r.subject == "Angela Merkel" and r.relation == "met"
+               and r.object == "Emmanuel Macron" for r in rels)
+
+
+def test_no_relation_without_a_relation_verb():
+    rels = extract_relations("d0", "news", "Angela Merkel and Emmanuel Macron were present.")
+    assert rels == []
+
+
+def test_relation_ids_are_stable_entity_ids():
+    from src.argument_mining.metadata import _entity_id
+
+    rels = extract_relations("d0", "news", "Joe Biden praised Angela Merkel.")
+    assert rels
+    r = rels[0]
+    assert r.subject_id == _entity_id(r.subject)
+    assert r.object_id == _entity_id(r.object)
+
+
+# --- batch + persistence ---------------------------------------------------- #
+
+
+def test_batch_extracts_and_persists(conn):
+    result = extract_document_relations(conn)
+    assert result["documents_processed"] == 2
+    assert result["relations_found"] >= 2       # d1 has met + praised
+    got = document_relations(conn, "d1")
+    verbs = {r["relation"] for r in got["relations"]}
+    assert {"met", "praised"} <= verbs
+
+
+def test_batch_is_idempotent(conn):
+    assert extract_document_relations(conn)["documents_processed"] == 2
+    # Re-running processes nothing (both documents already in the table).
+    assert extract_document_relations(conn)["documents_processed"] == 0
+
+
+def test_entity_relations_by_name(conn):
+    extract_document_relations(conn)
+    out = entity_relations(conn, "Angela Merkel")
+    assert out["count"] >= 2   # subject of "met", object of "praised"
+    assert all("Angela Merkel" in (r["subject"], r["object"]) for r in out["relations"])
+
+
+def test_read_only_accessors_before_extraction(conn):
+    # No batch run yet -> document_relations table may be absent -> graceful note.
+    out = document_relations(conn, "d1")
+    assert out["count"] == 0 and "note" in out
+    out2 = entity_relations(conn, "Angela Merkel")
+    assert out2["count"] == 0 and "note" in out2

--- a/tools/argument_mcp/server.py
+++ b/tools/argument_mcp/server.py
@@ -1185,6 +1185,80 @@ def stance_significance(a: str, b: str, topic: str) -> dict:
         return {"error": str(e)}
 
 
+# --------------------------------------------------------------------------- #
+# Relation extraction (document_relations): subject-relation-object triples
+# between entities. Entities come from the same NER as the actor batch; the
+# batch is built by trigger_relation_extraction.
+# --------------------------------------------------------------------------- #
+
+
+@mcp.tool
+def document_relations(document_id: str) -> dict:
+    """Relations extracted from one document (subject-relation-object), each
+    cited to its source sentence.
+
+    Args:
+        document_id: the document to list relations for.
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+    try:
+        from src.argument_mining.relations import document_relations as _dr
+
+        return _dr(conn, document_id)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool
+def entity_relations(entity: str) -> dict:
+    """Relations involving an entity, as subject or object (by name or entity_id).
+
+    Args:
+        entity: the entity name or ``ent-...`` id.
+    """
+    conn, err = _warehouse_ro()
+    if err or conn is None:
+        return {"error": err or "no connection"}
+    try:
+        from src.argument_mining.relations import entity_relations as _er
+
+        return _er(conn, entity)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool
+def trigger_relation_extraction(limit: int = 200) -> dict:
+    """Extract relations for corpus documents not yet processed into
+    ``document_relations`` (RW). Safe to call repeatedly.
+
+    Args:
+        limit: max documents per call (default 200).
+
+    Returns {"documents_processed": int, "relations_found": int}.
+    """
+    import os
+    import duckdb
+
+    try:
+        from src.argument_mining.relations import extract_document_relations
+    except ImportError as e:
+        return {"error": f"relations module unavailable: {e}"}
+
+    db_path = os.environ.get(
+        "NEURONEWS_DB_PATH", str(REPO_ROOT / "data" / "local_warehouse.duckdb")
+    )
+    try:
+        rw_conn = duckdb.connect(db_path, read_only=False)
+        result = extract_document_relations(rw_conn, limit=limit)
+        rw_conn.close()
+        return result
+    except Exception as e:
+        return {"error": f"write connection failed — warehouse may be locked: {e}"}
+
+
 if __name__ == "__main__":
     from src.mcp_host.transport import run_server
 


### PR DESCRIPTION
## Summary

Entity extraction over the corpus already exists (`metadata.py` → `document_actors`), but nothing extracted **relations between** entities — the KG / `relationship_path` layer had only co-mention edges, not typed, cited triples.

## Changes

- **`src/argument_mining/relations.py`** — subject–relation–object extraction from document text. Heuristic-first / model-optional (like `frames.py`): entities come from the **shared spaCy-or-regex NER in `metadata.py`**, and a relation is emitted when a curated relation verb links two consecutive entities within a sentence. Stable `entity_id`s are reused from `metadata` so relations join to `document_actors` and the KG.
  - `extract_document_relations` — idempotent batch; a processed-marker table (`document_relations_state`) records zero-relation documents so they aren't re-scanned every pass.
  - `document_relations` / `entity_relations` — read-only accessors, each triple cited to its source sentence.
- **`tools/argument_mcp/server.py`** — `document_relations`, `entity_relations` (read-only) + `trigger_relation_extraction` (RW batch), alongside the existing actor/entity tools.

## Tests

Run offline via the regex NER fallback: SVO extraction, no-relation without a relation verb, stable entity ids, idempotent batch (zero-relation docs not reprocessed), entity lookup, graceful read-only accessors before extraction. The full `argument_mining` suite (376) stays green.

Third of four DS/NLP capability PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_