### PR TITLE
Add embedding-based topic modelling (topics + MCP tool)

### DIFF
--- a/src/analytics/topics.py
+++ b/src/analytics/topics.py
@@ -1,0 +1,175 @@
+"""
+Embedding-based topic modelling over the corpus.
+
+The lexical narrative clustering in ``narratives.py`` groups documents by
+bag-of-words cosine; its own docstring names the intended upgrade as clustering
+over *document embeddings*. This is that: cluster the vectors in
+``document_embeddings`` (written by :func:`src.ingestion.embed.embed_documents`)
+into topics, and label each with its salient terms.
+
+Model-optional, as elsewhere. The default clusterer is offline and
+deterministic — connected components over an embedding-cosine threshold (the
+same shape as the lexical narrative graph, but in embedding space). When
+``clusterer="hdbscan"`` and the library is installed, density-based HDBSCAN is
+used instead (better with noise/outliers); it falls back to components if
+unavailable. Read-only: reads the embedding sink and the corpus, writes nothing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from src.analytics.text import tokenize, top_terms
+from src.database.news_articles_compat import corpus_table
+
+# Import json lazily-safe (stdlib) for reading stored vectors.
+import json
+
+
+def _has_embeddings(conn) -> bool:
+    try:
+        return bool(conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'document_embeddings'"
+        ).fetchone())
+    except Exception:
+        return False
+
+
+def _normalise(mat: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return mat / norms
+
+
+def _load_matrix(conn, model: Optional[str]):
+    if model is not None:
+        rows = conn.execute(
+            "SELECT document_id, vector FROM document_embeddings WHERE model = ?", [model]
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT document_id, vector FROM document_embeddings"
+        ).fetchall()
+    ids = [r[0] for r in rows]
+    if not ids:
+        return ids, np.empty((0, 0))
+    return ids, np.asarray([json.loads(r[1]) for r in rows], dtype=np.float64)
+
+
+def _components(sims: np.ndarray, threshold: float) -> List[List[int]]:
+    n = sims.shape[0]
+    parent = list(range(n))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if sims[i, j] >= threshold:
+                parent[find(i)] = find(j)
+    groups: Dict[int, List[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return list(groups.values())
+
+
+def _hdbscan_labels(mat: np.ndarray, min_cluster_size: int) -> Optional[List[int]]:
+    try:
+        import hdbscan
+
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=max(2, min_cluster_size),
+                                    metric="euclidean")
+        # Cosine on L2-normalised vectors is monotonic with euclidean distance.
+        return list(clusterer.fit_predict(_normalise(mat)))
+    except Exception:
+        return None
+
+
+def _label(conn, tbl: str, ids: List[str]) -> Dict[str, Any]:
+    """Salient terms + a representative title for a cluster of documents."""
+    ph = ", ".join("?" for _ in ids)
+    rows = conn.execute(
+        f"SELECT id, title, content FROM {tbl} WHERE id IN ({ph})", ids
+    ).fetchall()
+    counter: Counter = Counter()
+    titles: Dict[str, str] = {}
+    for doc_id, title, content in rows:
+        counter.update(tokenize(f"{title or ''} {content or ''}"))
+        titles[doc_id] = title
+    terms = top_terms(dict(counter), n=6)
+    return {"terms": terms, "label": " / ".join(terms[:3]) if terms else "(untitled)",
+            "representative_title": next((titles.get(i) for i in ids if titles.get(i)), None)}
+
+
+def model_topics(
+    conn, min_similarity: float = 0.35, min_cluster_size: int = 3,
+    model: Optional[str] = None, max_docs: int = 2000, clusterer: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Cluster document embeddings into labelled topics.
+
+    Args:
+        min_similarity: cosine threshold for the default (components) clusterer.
+        min_cluster_size: drop clusters smaller than this.
+        model: restrict to one embedding model/space.
+        clusterer: ``"hdbscan"`` to use density clustering when available, else
+            the default connected-components clusterer.
+    """
+    if not _has_embeddings(conn):
+        return {"topics": [], "count": 0,
+                "note": "no embeddings indexed; run embed_documents first"}
+    ids, mat = _load_matrix(conn, model)
+    if len(ids) < min_cluster_size:
+        return {"topics": [], "count": 0, "note": "too few embedded documents"}
+    truncated = len(ids) > max_docs
+    if truncated:
+        ids, mat = ids[:max_docs], mat[:max_docs]
+
+    method = "connected-components over embedding cosine"
+    clusters: List[List[int]]
+    if clusterer == "hdbscan":
+        labels = _hdbscan_labels(mat, min_cluster_size)
+        if labels is not None:
+            method = "hdbscan over document embeddings"
+            grouped: Dict[int, List[int]] = {}
+            for idx, lab in enumerate(labels):
+                if lab == -1:  # noise
+                    continue
+                grouped.setdefault(lab, []).append(idx)
+            clusters = list(grouped.values())
+        else:
+            clusters = _components(_normalise(mat) @ _normalise(mat).T, min_similarity)
+    else:
+        clusters = _components(_normalise(mat) @ _normalise(mat).T, min_similarity)
+
+    tbl = corpus_table(conn)
+    topics = []
+    for members in clusters:
+        if len(members) < min_cluster_size:
+            continue
+        member_ids = [ids[i] for i in members]
+        info = _label(conn, tbl, member_ids)
+        topics.append({
+            "topic_id": len(topics),
+            "label": info["label"],
+            "terms": info["terms"],
+            "size": len(member_ids),
+            "document_ids": member_ids[:50],
+            "representative_title": info["representative_title"],
+        })
+    topics.sort(key=lambda t: -t["size"])
+    for i, t in enumerate(topics):
+        t["topic_id"] = i
+    return {
+        "topics": topics,
+        "count": len(topics),
+        "method": method,
+        "truncated": truncated,
+        "caveat": "topics are unsupervised clusters over document embeddings; "
+                  "labels are the clusters' salient terms, not curated categories",
+    }

--- a/tests/unit/analytics/test_topics.py
+++ b/tests/unit/analytics/test_topics.py
@@ -1,0 +1,72 @@
+"""Unit tests for embedding-based topic modelling. Offline via the hashing
+embedding backend (lexical vectors cluster same-vocabulary documents)."""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from services.embeddings.provider import EmbeddingProvider
+from services.ingest.common.document_model import Document
+from src.analytics.topics import model_topics
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.embed import embed_documents
+
+
+@pytest.fixture
+def provider():
+    return EmbeddingProvider(provider="hashing")
+
+
+def _doc(doc_id, content):
+    return Document(document_id=doc_id, source_type="news", language="en",
+                    ingested_at=1_700_000_000_000, created_at=1_700_000_000_000,
+                    url=f"https://ex.com/{doc_id}", title=doc_id, content=content,
+                    source_id="Wire", metadata={"source": "Wire"})
+
+
+@pytest.fixture
+def wh(provider):
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn).upsert([
+        _doc("e1", "inflation cooled as the economy grew and interest rates held steady"),
+        _doc("e2", "the economy grew while inflation cooled and interest rates held"),
+        _doc("e3", "interest rates and inflation shaped the economy this quarter"),
+        _doc("s1", "the football team won the championship final in overtime"),
+        _doc("s2", "the championship final was won by the football team in overtime"),
+    ])
+    embed_documents(conn, provider=provider)
+    return conn
+
+
+def test_clusters_documents_into_topics(wh):
+    out = model_topics(wh, min_similarity=0.25, min_cluster_size=2)
+    assert out["count"] >= 2
+    clusters = [set(t["document_ids"]) for t in out["topics"]]
+    econ = next((c for c in clusters if "e1" in c), set())
+    sport = next((c for c in clusters if "s1" in c), set())
+    assert {"e1", "e2", "e3"} <= econ      # economy documents cluster together
+    assert {"s1", "s2"} <= sport            # sports documents cluster together
+    assert econ.isdisjoint(sport)           # and are separate topics
+
+
+def test_topics_are_labelled_with_salient_terms(wh):
+    out = model_topics(wh, min_similarity=0.25, min_cluster_size=2)
+    econ = next(t for t in out["topics"] if "e1" in t["document_ids"])
+    # The economy cluster's salient terms include its shared vocabulary.
+    assert any(term in {"inflation", "economy", "rates", "interest"} for term in econ["terms"])
+    assert econ["label"]
+
+
+def test_empty_without_embeddings():
+    conn = duckdb.connect(":memory:")
+    DocumentStore(conn)
+    out = model_topics(conn)
+    assert out["count"] == 0 and "note" in out
+
+
+def test_min_cluster_size_filters_singletons(wh):
+    # A very high threshold makes every document its own singleton -> no topics
+    # survive min_cluster_size=2.
+    out = model_topics(wh, min_similarity=0.999, min_cluster_size=2)
+    assert out["count"] == 0

--- a/tools/pipeline_mcp/server.py
+++ b/tools/pipeline_mcp/server.py
@@ -1897,6 +1897,37 @@ def trigger_summarize_documents(limit: Optional[int] = None) -> dict:
         con.close()
 
 
+# --------------------------------------------------------------------------- #
+# Embedding-based topic modelling over document_embeddings. Read-only; the
+# lexical cluster_narratives tool is the bag-of-words counterpart.
+# --------------------------------------------------------------------------- #
+
+
+@mcp.tool
+def topic_model(min_similarity: float = 0.35, min_cluster_size: int = 3) -> dict:
+    """Unsupervised topics over the document embeddings — clusters of similar
+    documents, each labelled with its salient terms. Requires the corpus to be
+    embedded (run trigger_embed_documents first).
+
+    Args:
+        min_similarity: cosine threshold for grouping documents into a topic.
+        min_cluster_size: drop topics smaller than this many documents.
+    """
+    try:
+        con = _warehouse_ro()
+    except Exception as exc:
+        return {"error": str(exc)}
+    try:
+        from src.analytics.topics import model_topics
+
+        return model_topics(con, min_similarity=min_similarity,
+                            min_cluster_size=min_cluster_size)
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        con.close()
+
+
 if __name__ == "__main__":
     from src.mcp_host.transport import run_server
 


### PR DESCRIPTION
## Summary

`narratives.py` clusters documents by bag-of-words cosine; its own docstring names the intended upgrade as clustering over **document embeddings**. This adds that, on top of the embedding sink from the semantic-search work.

## Changes

- **`src/analytics/topics.py`** (`model_topics`) — clusters the vectors in `document_embeddings` into labelled topics. Model-optional:
  - default clusterer is offline and deterministic (connected components over an embedding-cosine threshold — the embedding-space analogue of the lexical narrative graph);
  - `clusterer="hdbscan"` uses density-based HDBSCAN when the library is installed, falling back to components otherwise.
  - Each topic is labelled with its salient terms (reusing `analytics.text`). Read-only (reads the sink + corpus, writes nothing).
- **`tools/pipeline_mcp/server.py`** — a read-only `topic_model` tool, the embedding-based counterpart to the lexical `cluster_narratives`.

## Tests

Run offline via the hashing backend: same-vocabulary documents cluster into separate topics, topics carry salient-term labels, min-cluster-size filters singletons, and the empty-index case returns a note.

**Fourth and final** of the four DS/NLP capability PRs (semantic search → summarization → relation extraction → topic modelling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TxWaBiXAPP1ZsBzd8mgxq)_