### PR TITLE
Add the knowledge-domain registry with a backing abstraction

### DIFF
--- a/config/domains.yml
+++ b/config/domains.yml
@@ -1,0 +1,17 @@
+# Knowledge-domain registry (see src/kb/registry.py for the schema).
+#
+# A domain scopes synthesized knowledge (documents, claims, entities) that
+# applications consume through the KB contract. Each domain declares its
+# backing:
+#   corpus-view — membership rows + views over the shared documents sink
+#   namespace   — a provisioned knowledge graph with its own storage
+#
+# Default policy: start as a corpus-view; promote to a namespace when the
+# domain earns its own lifecycle (retention, re-index cadence, quotas).
+# Every domain must declare embedding_model — cross-domain similarity only
+# means anything inside one shared embedding space.
+#
+# Starter definitions (news, economics, technology, web3, local, papers)
+# arrive with the seeding increment.
+version: 1
+domains: []

--- a/docs/architecture/kb-domains.md
+++ b/docs/architecture/kb-domains.md
@@ -1,0 +1,61 @@
+# Knowledge domains: one abstraction, two backings
+
+Noesis synthesizes the ingested corpus into **knowledge domains** (news,
+economics, technology, web3, papers, …) that applications consume through the
+KB contract. The domain layer lives in `src/kb/` and is deliberately distinct
+from `src/domains/` (domain *packs*, which extend behaviour — enrichers,
+routes, flags). A KB domain scopes *content*.
+
+## The abstraction
+
+`config/domains.yml` is the single source of truth. The
+`KnowledgeDomainRegistry` (`src/kb/registry.py`) validates it and resolves
+each domain name to a `DomainBacking` (`src/kb/backing.py`) — the read
+interface every domain answers:
+
+| Surface | Calls |
+|---|---|
+| retrieve | `documents`, `search`, `claims`, `entities` |
+| diff | `diff(since)` |
+| meta | `coverage()` |
+
+Consumers only ever hold `DomainBacking`. They must never be able to tell
+which backing serves them; `coverage()` *reports* the backing as metadata, but
+answer shapes are identical across backings.
+
+## The two backings
+
+- **`corpus-view`** — membership rows (`document_domains`) + views over the
+  shared `documents` sink. Right for overlapping daily topics: heavy
+  cross-domain overlap, shared enrichments, cheap joins, one consolidation
+  pass covers them all. A document can belong to several domains — that is
+  the point of views.
+- **`namespace`** — a provisioned knowledge graph (the provisioning plane)
+  with its own storage, pipelines, quotas, and teardown. Right for domains
+  with their own lifecycle: a reference corpus of papers/books with different
+  retention and re-index cadence than the daily stream, experimental domains,
+  agent-provisioned domains.
+
+### Default policy: start as a view, promote when a domain earns isolation
+
+Promotion (`corpus-view` → `namespace`, or the reverse) is a registry pointer
+flip plus a data migration through the provisioning plane's ingest tools,
+preserving document ids so links survive. Because consumers only saw the
+contract, nothing downstream changes.
+
+## The shared embedding space
+
+Cross-domain and cross-backing similarity (claim linking, depth linkage
+between daily domains and the reference corpus) only means anything inside a
+single embedding space. Therefore every domain **must** declare
+`embedding_model` in its definition; the registry exposes
+`embedding_models()` for consistency checks, and `coverage()` surfaces each
+domain's model so a stale backing fails loudly instead of returning silently
+bad similarity.
+
+## Roadmap anchors
+
+- Corpus-view data paths (membership pass, per-domain views): #962
+- Starter domains + curated feeds: #963
+- Namespace backing + cross-backing linkage: #967
+- KB contract v1 over both backings: #970

--- a/src/kb/__init__.py
+++ b/src/kb/__init__.py
@@ -1,0 +1,50 @@
+"""
+Knowledge-base domain layer.
+
+A *knowledge domain* (economics, technology, web3, papers, …) is a named scope
+of synthesized knowledge that applications consume through the KB contract.
+Every domain is served through the :class:`~src.kb.backing.DomainBacking`
+interface and can be realized by one of two backings, invisible to consumers:
+
+- ``corpus-view`` — membership rows + views over the shared ``documents`` sink
+  (right for overlapping daily topics that share enrichments), and
+- ``namespace`` — a provisioned knowledge graph with its own storage and
+  pipelines (right for domains with their own lifecycle: retention, re-index
+  cadence, quotas, teardown).
+
+This package is distinct from :mod:`src.domains`, which registers domain
+*packs* (enrichers, routes, and feature flags — capabilities). A KB domain
+scopes *content*; a pack extends *behaviour*.
+
+Usage::
+
+    from src.kb import load_registry
+
+    registry = load_registry()            # reads config/domains.yml
+    backing = registry.resolve("web3")    # -> DomainBacking, whatever the type
+    backing.coverage()
+"""
+
+from src.kb.backing import (
+    CorpusViewBacking,
+    DomainBacking,
+    NamespaceBacking,
+)
+from src.kb.registry import (
+    DomainConfigError,
+    DomainDefinition,
+    FeedSpec,
+    KnowledgeDomainRegistry,
+    load_registry,
+)
+
+__all__ = [
+    "CorpusViewBacking",
+    "DomainBacking",
+    "DomainConfigError",
+    "DomainDefinition",
+    "FeedSpec",
+    "KnowledgeDomainRegistry",
+    "NamespaceBacking",
+    "load_registry",
+]

--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -1,0 +1,124 @@
+"""
+The backing abstraction: one read interface, two storage realizations.
+
+Consumers of a knowledge domain must never be able to tell whether it is
+served from the shared corpus (``corpus-view``) or from a provisioned
+namespace (``namespace``). Every read the KB contract will expose is declared
+here; a backing that has not yet implemented a call raises
+:class:`NotImplementedError` so the gap is loud, not silent.
+
+The read surface mirrors the planned ``noesis-kb-v1`` contract:
+
+- retrieve: :meth:`DomainBacking.documents`, :meth:`DomainBacking.search`,
+  :meth:`DomainBacking.claims`, :meth:`DomainBacking.entities`
+- diff:     :meth:`DomainBacking.diff`
+- meta:     :meth:`DomainBacking.coverage` (always implemented — it reports
+  the backing type and readiness even before the data paths land)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from src.kb.registry import DomainDefinition
+
+
+class DomainBacking:
+    """Read interface every knowledge domain answers, whatever its storage.
+
+    Subclasses implement the data paths incrementally; until then each call
+    raises :class:`NotImplementedError` naming the backing, so a consumer
+    hitting an unfinished path gets a diagnosable error instead of silence.
+    """
+
+    #: machine-readable backing discriminator, overridden per subclass
+    backing_type: str = "abstract"
+
+    def __init__(self, definition: "DomainDefinition") -> None:
+        self.definition = definition
+
+    # -- retrieve -----------------------------------------------------------
+
+    def documents(
+        self,
+        limit: int = 50,
+        since: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Member documents, newest first, each row citing its source."""
+        raise self._not_implemented("documents")
+
+    def search(self, query: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """Semantic + lexical search scoped to this domain."""
+        raise self._not_implemented("search")
+
+    def claims(
+        self,
+        since: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Clustered, cited claims for this domain."""
+        raise self._not_implemented("claims")
+
+    def entities(self, name: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Canonical entities (with aliases) mentioned in this domain."""
+        raise self._not_implemented("entities")
+
+    # -- diff ---------------------------------------------------------------
+
+    def diff(self, since: str) -> Dict[str, Any]:
+        """What changed since ``since`` — the primitive consumers reduce to."""
+        raise self._not_implemented("diff")
+
+    # -- meta ---------------------------------------------------------------
+
+    def coverage(self) -> Dict[str, Any]:
+        """Domain metadata: backing, sources, freshness, embedding model.
+
+        Always answerable. Subclasses extend the payload with real corpus
+        stats once their data paths exist; ``ready`` flips to True when the
+        retrieve surface is implemented.
+        """
+        return {
+            "domain": self.definition.name,
+            "backing": self.backing_type,
+            "embedding_model": self.definition.embedding_model,
+            "feeds": [feed.url for feed in self.definition.feeds],
+            "tags": list(self.definition.tags),
+            "ready": False,
+        }
+
+    # -- helpers ------------------------------------------------------------
+
+    def _not_implemented(self, call: str) -> NotImplementedError:
+        return NotImplementedError(
+            f"{call}() is not implemented yet for domain "
+            f"{self.definition.name!r} (backing {self.backing_type!r})"
+        )
+
+
+class CorpusViewBacking(DomainBacking):
+    """Domain served by membership rows + views over the shared corpus.
+
+    The data paths (membership pass, per-domain views) are wired by the
+    corpus-view implementation issue; until then only :meth:`coverage`
+    answers.
+    """
+
+    backing_type = "corpus-view"
+
+
+class NamespaceBacking(DomainBacking):
+    """Domain served by a provisioned namespace with its own storage.
+
+    Wired against the provisioning plane in a later increment; until then
+    only :meth:`coverage` answers. ``namespace`` defaults to the domain name
+    at validation time, so the field is always present here.
+    """
+
+    backing_type = "namespace"
+
+    def coverage(self) -> Dict[str, Any]:
+        payload = super().coverage()
+        payload["namespace"] = self.definition.namespace
+        return payload

--- a/src/kb/registry.py
+++ b/src/kb/registry.py
@@ -1,0 +1,248 @@
+"""
+Knowledge-domain registry: the single source of truth for what domains exist
+and how each one is realized.
+
+Definitions live in a declarative config (``config/domains.yml`` by default,
+overridable via ``NOESIS_DOMAINS_CONFIG``). The registry validates the config
+against the schema below and resolves each domain name to its
+:class:`~src.kb.backing.DomainBacking` implementation. Consumers only ever
+hold the backing interface — switching a domain between backings is a config
+change, not a consumer change.
+
+Config schema (YAML)::
+
+    version: 1
+    domains:
+      - name: web3                  # required, unique slug [a-z0-9-]
+        backing: corpus-view        # required: corpus-view | namespace
+        description: ...            # optional
+        embedding_model: all-MiniLM-L6-v2   # required (shared space guard)
+        feeds:                      # optional feed subscriptions
+          - url: https://example.com/rss
+            name: Example
+            tags: [web3]
+        tags: [web3]                # feed-tag scope for by-source membership
+        keywords: [defi, staking]   # seed vocabulary for by-content membership
+        embedding_anchors:          # anchor sentences for by-content membership
+          - "decentralized finance protocols and on-chain governance"
+        membership_threshold: 0.35  # optional, by-content assignment cutoff
+        namespace: reference        # namespace backing only; defaults to name
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from src.kb.backing import CorpusViewBacking, DomainBacking, NamespaceBacking
+
+#: repo-root-relative default config location
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "domains.yml"
+
+#: environment variable overriding the config path
+CONFIG_PATH_ENV = "NOESIS_DOMAINS_CONFIG"
+
+VALID_BACKINGS = ("corpus-view", "namespace")
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+_BACKING_CLASSES = {
+    "corpus-view": CorpusViewBacking,
+    "namespace": NamespaceBacking,
+}
+
+
+class DomainConfigError(ValueError):
+    """Raised when the domain config is missing, malformed, or inconsistent."""
+
+
+@dataclass
+class FeedSpec:
+    """One feed subscription a domain wants harvested under its tags."""
+
+    url: str
+    name: str = ""
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DomainDefinition:
+    """A validated knowledge-domain definition."""
+
+    name: str
+    backing: str
+    embedding_model: str
+    description: str = ""
+    feeds: List[FeedSpec] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
+    embedding_anchors: List[str] = field(default_factory=list)
+    membership_threshold: float = 0.35
+    namespace: Optional[str] = None
+
+
+def _require_str_list(raw: Any, domain: str, key: str) -> List[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise DomainConfigError(
+            f"domain {domain!r}: {key} must be a list of strings"
+        )
+    return list(raw)
+
+
+def _parse_feeds(raw: Any, domain: str) -> List[FeedSpec]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise DomainConfigError(f"domain {domain!r}: feeds must be a list")
+    feeds: List[FeedSpec] = []
+    for entry in raw:
+        if not isinstance(entry, dict) or not entry.get("url"):
+            raise DomainConfigError(
+                f"domain {domain!r}: every feed needs at least a url"
+            )
+        feeds.append(
+            FeedSpec(
+                url=str(entry["url"]),
+                name=str(entry.get("name", "")),
+                tags=_require_str_list(entry.get("tags"), domain, "feed tags"),
+            )
+        )
+    return feeds
+
+
+def _parse_domain(raw: Any) -> DomainDefinition:
+    if not isinstance(raw, dict):
+        raise DomainConfigError("every domain entry must be a mapping")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not _NAME_RE.match(name):
+        raise DomainConfigError(
+            f"domain name {name!r} must be a lowercase slug ([a-z0-9-])"
+        )
+
+    backing = raw.get("backing")
+    if backing not in VALID_BACKINGS:
+        raise DomainConfigError(
+            f"domain {name!r}: backing {backing!r} is not one of {VALID_BACKINGS}"
+        )
+
+    embedding_model = raw.get("embedding_model")
+    if not isinstance(embedding_model, str) or not embedding_model.strip():
+        raise DomainConfigError(
+            f"domain {name!r}: embedding_model is required — cross-backing "
+            "similarity needs one shared embedding space, so every domain "
+            "declares (and is checked against) its model"
+        )
+
+    threshold = raw.get("membership_threshold", 0.35)
+    if not isinstance(threshold, (int, float)) or not 0.0 <= float(threshold) <= 1.0:
+        raise DomainConfigError(
+            f"domain {name!r}: membership_threshold must be in [0, 1]"
+        )
+
+    namespace = raw.get("namespace")
+    if namespace is not None and not isinstance(namespace, str):
+        raise DomainConfigError(f"domain {name!r}: namespace must be a string")
+    if backing == "namespace" and not namespace:
+        namespace = name
+    if backing == "corpus-view" and namespace:
+        raise DomainConfigError(
+            f"domain {name!r}: namespace is only valid for namespace backing"
+        )
+
+    return DomainDefinition(
+        name=name,
+        backing=backing,
+        embedding_model=embedding_model.strip(),
+        description=str(raw.get("description", "")),
+        feeds=_parse_feeds(raw.get("feeds"), name),
+        tags=_require_str_list(raw.get("tags"), name, "tags"),
+        keywords=_require_str_list(raw.get("keywords"), name, "keywords"),
+        embedding_anchors=_require_str_list(
+            raw.get("embedding_anchors"), name, "embedding_anchors"
+        ),
+        membership_threshold=float(threshold),
+        namespace=namespace,
+    )
+
+
+class KnowledgeDomainRegistry:
+    """Validated domain definitions + resolution to backings."""
+
+    def __init__(self, definitions: List[DomainDefinition]):
+        names = [definition.name for definition in definitions]
+        duplicates = {name for name in names if names.count(name) > 1}
+        if duplicates:
+            raise DomainConfigError(
+                f"duplicate domain names: {sorted(duplicates)}"
+            )
+        self._definitions = {
+            definition.name: definition for definition in definitions
+        }
+
+    @classmethod
+    def from_config(
+        cls, path: Optional[os.PathLike] = None
+    ) -> "KnowledgeDomainRegistry":
+        """Load and validate the registry from a YAML config file."""
+        config_path = Path(
+            path or os.environ.get(CONFIG_PATH_ENV) or DEFAULT_CONFIG_PATH
+        )
+        if not config_path.exists():
+            raise DomainConfigError(f"domain config not found: {config_path}")
+        try:
+            raw = yaml.safe_load(config_path.read_text()) or {}
+        except yaml.YAMLError as exc:
+            raise DomainConfigError(
+                f"domain config is not valid YAML: {config_path}: {exc}"
+            ) from exc
+        if not isinstance(raw, dict):
+            raise DomainConfigError("domain config must be a mapping")
+        if raw.get("version") != 1:
+            raise DomainConfigError(
+                f"unsupported domain config version {raw.get('version')!r}; "
+                "expected 1"
+            )
+        domains_raw = raw.get("domains") or []
+        if not isinstance(domains_raw, list):
+            raise DomainConfigError("domains must be a list")
+        return cls([_parse_domain(entry) for entry in domains_raw])
+
+    def domains(self) -> List[DomainDefinition]:
+        """All definitions, in config order."""
+        return list(self._definitions.values())
+
+    def names(self) -> List[str]:
+        return list(self._definitions.keys())
+
+    def get(self, name: str) -> DomainDefinition:
+        try:
+            return self._definitions[name]
+        except KeyError:
+            raise DomainConfigError(
+                f"unknown domain {name!r}; configured: {self.names()}"
+            ) from None
+
+    def resolve(self, name: str) -> DomainBacking:
+        """Resolve a domain name to its backing implementation."""
+        definition = self.get(name)
+        return _BACKING_CLASSES[definition.backing](definition)
+
+    def embedding_models(self) -> Dict[str, str]:
+        """Domain -> embedding model, for shared-space consistency checks."""
+        return {
+            definition.name: definition.embedding_model
+            for definition in self.domains()
+        }
+
+
+def load_registry(path: Optional[os.PathLike] = None) -> KnowledgeDomainRegistry:
+    """Convenience wrapper: load the registry from the configured path."""
+    return KnowledgeDomainRegistry.from_config(path)

--- a/tests/unit/kb/test_registry.py
+++ b/tests/unit/kb/test_registry.py
@@ -1,0 +1,170 @@
+"""Unit tests for the knowledge-domain registry and backing abstraction."""
+
+import pytest
+
+from src.kb import (
+    CorpusViewBacking,
+    DomainConfigError,
+    KnowledgeDomainRegistry,
+    NamespaceBacking,
+    load_registry,
+)
+from src.kb.registry import CONFIG_PATH_ENV
+
+VALID_CONFIG = """
+version: 1
+domains:
+  - name: web3
+    backing: corpus-view
+    description: On-chain ecosystems and governance
+    embedding_model: all-MiniLM-L6-v2
+    feeds:
+      - url: https://example.com/web3.xml
+        name: Example Web3
+        tags: [web3]
+    tags: [web3]
+    keywords: [defi, staking]
+    embedding_anchors:
+      - decentralized finance protocols and on-chain governance
+  - name: reference
+    backing: namespace
+    embedding_model: all-MiniLM-L6-v2
+"""
+
+
+def _write(tmp_path, text):
+    path = tmp_path / "domains.yml"
+    path.write_text(text)
+    return path
+
+
+class TestLoading:
+    def test_valid_config_loads_both_backings(self, tmp_path):
+        registry = load_registry(_write(tmp_path, VALID_CONFIG))
+        assert registry.names() == ["web3", "reference"]
+
+        web3 = registry.get("web3")
+        assert web3.backing == "corpus-view"
+        assert web3.feeds[0].url == "https://example.com/web3.xml"
+        assert web3.keywords == ["defi", "staking"]
+        assert web3.membership_threshold == pytest.approx(0.35)
+
+    def test_namespace_defaults_to_domain_name(self, tmp_path):
+        registry = load_registry(_write(tmp_path, VALID_CONFIG))
+        assert registry.get("reference").namespace == "reference"
+
+    def test_env_var_overrides_default_path(self, tmp_path, monkeypatch):
+        path = _write(tmp_path, VALID_CONFIG)
+        monkeypatch.setenv(CONFIG_PATH_ENV, str(path))
+        assert load_registry().names() == ["web3", "reference"]
+
+    def test_missing_file_is_a_config_error(self, tmp_path):
+        with pytest.raises(DomainConfigError, match="not found"):
+            load_registry(tmp_path / "absent.yml")
+
+    def test_unsupported_version_rejected(self, tmp_path):
+        with pytest.raises(DomainConfigError, match="version"):
+            load_registry(_write(tmp_path, "version: 2\ndomains: []\n"))
+
+    def test_repo_default_config_is_valid(self):
+        # config/domains.yml ships empty until the seeding increment, but it
+        # must always parse.
+        assert load_registry().domains() == []
+
+
+class TestValidation:
+    def test_duplicate_names_rejected(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - {name: web3, backing: corpus-view, embedding_model: m}
+  - {name: web3, backing: corpus-view, embedding_model: m}
+"""
+        with pytest.raises(DomainConfigError, match="duplicate"):
+            load_registry(_write(tmp_path, config))
+
+    def test_unknown_backing_rejected(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - {name: web3, backing: warehouse, embedding_model: m}
+"""
+        with pytest.raises(DomainConfigError, match="backing"):
+            load_registry(_write(tmp_path, config))
+
+    def test_missing_embedding_model_rejected(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - {name: web3, backing: corpus-view}
+"""
+        with pytest.raises(DomainConfigError, match="embedding_model"):
+            load_registry(_write(tmp_path, config))
+
+    def test_bad_slug_rejected(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - {name: Web 3, backing: corpus-view, embedding_model: m}
+"""
+        with pytest.raises(DomainConfigError, match="slug"):
+            load_registry(_write(tmp_path, config))
+
+    def test_namespace_field_invalid_for_corpus_view(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - {name: web3, backing: corpus-view, embedding_model: m, namespace: x}
+"""
+        with pytest.raises(DomainConfigError, match="namespace"):
+            load_registry(_write(tmp_path, config))
+
+    def test_threshold_out_of_range_rejected(self, tmp_path):
+        config = """
+version: 1
+domains:
+  - name: web3
+    backing: corpus-view
+    embedding_model: m
+    membership_threshold: 1.5
+"""
+        with pytest.raises(DomainConfigError, match="membership_threshold"):
+            load_registry(_write(tmp_path, config))
+
+
+class TestResolution:
+    @pytest.fixture()
+    def registry(self, tmp_path) -> KnowledgeDomainRegistry:
+        return load_registry(_write(tmp_path, VALID_CONFIG))
+
+    def test_resolve_returns_backing_per_type(self, registry):
+        assert isinstance(registry.resolve("web3"), CorpusViewBacking)
+        assert isinstance(registry.resolve("reference"), NamespaceBacking)
+
+    def test_unknown_domain_is_a_config_error(self, registry):
+        with pytest.raises(DomainConfigError, match="unknown domain"):
+            registry.resolve("finance")
+
+    def test_coverage_answers_before_data_paths_exist(self, registry):
+        coverage = registry.resolve("web3").coverage()
+        assert coverage["domain"] == "web3"
+        assert coverage["backing"] == "corpus-view"
+        assert coverage["embedding_model"] == "all-MiniLM-L6-v2"
+        assert coverage["ready"] is False
+
+        namespace_coverage = registry.resolve("reference").coverage()
+        assert namespace_coverage["backing"] == "namespace"
+        assert namespace_coverage["namespace"] == "reference"
+
+    def test_unimplemented_reads_fail_loudly(self, registry):
+        backing = registry.resolve("web3")
+        with pytest.raises(NotImplementedError, match="search"):
+            backing.search("stablecoin regulation")
+        with pytest.raises(NotImplementedError, match="diff"):
+            backing.diff(since="2026-07-01")
+
+    def test_embedding_models_map(self, registry):
+        assert registry.embedding_models() == {
+            "web3": "all-MiniLM-L6-v2",
+            "reference": "all-MiniLM-L6-v2",
+        }


### PR DESCRIPTION
## Overview

Implements #961 — the foundation of the knowledge-base synthesis layer: a declarative registry of knowledge domains, each resolved to a `DomainBacking` (corpus-view or namespace) behind one read interface, so consumers never depend on how a domain is stored.

## Changes Summary

- **`src/kb/`** (new package, distinct from the `src/domains/` pack registry): `registry.py` loads and validates `config/domains.yml` (unique slugs, valid backing, required `embedding_model`, threshold bounds, namespace-only fields) and resolves names to backings; `backing.py` declares the future KB-contract read surface (`documents`/`search`/`claims`/`entities`/`diff`/`coverage`) with loud `NotImplementedError`s for unwired paths and an always-answerable `coverage()`.
- **`config/domains.yml`**: ships empty with schema docs; starter domains land with #963.
- **`docs/architecture/kb-domains.md`**: the two backings, the start-as-view/promote-when-earned policy, and the shared-embedding-space rule.
- **`tests/unit/kb/test_registry.py`**: 17 tests covering loading, validation failures, resolution, and the coverage/fail-loud behaviour.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 17 passed

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_