### PR TITLE
Corpus-view backing: document→domain membership pass + per-domain views

### DIFF
--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -35,8 +35,18 @@ class DomainBacking:
     #: machine-readable backing discriminator, overridden per subclass
     backing_type: str = "abstract"
 
-    def __init__(self, definition: "DomainDefinition") -> None:
+    def __init__(self, definition: "DomainDefinition", conn: Any = None) -> None:
         self.definition = definition
+        self._conn = conn
+
+    @property
+    def conn(self) -> Any:
+        """Warehouse connection, defaulting to the shared read connection."""
+        if self._conn is None:
+            from src.database.local_analytics_connector import get_shared_connection
+
+            self._conn = get_shared_connection()
+        return self._conn
 
     # -- retrieve -----------------------------------------------------------
 
@@ -100,12 +110,107 @@ class DomainBacking:
 class CorpusViewBacking(DomainBacking):
     """Domain served by membership rows + views over the shared corpus.
 
-    The data paths (membership pass, per-domain views) are wired by the
-    corpus-view implementation issue; until then only :meth:`coverage`
-    answers.
+    Reads go through the per-domain view (``kb_domain_<name>``) built from
+    ``document_domains`` — membership is data written by the membership pass,
+    never a per-query classification. ``claims``/``entities``/``diff`` arrive
+    with the consolidation increments.
     """
 
     backing_type = "corpus-view"
+
+    _DOCUMENT_COLUMNS = (
+        "document_id", "source_type", "source_id", "url", "title",
+        "language", "ingested_at", "created_at",
+        "domain_score", "domain_method", "sentiment_score", "sentiment_label",
+    )
+
+    def _view(self) -> str:
+        from src.kb.membership import ensure_domain_views, view_name
+
+        name = view_name(self.definition.name)
+        exists = self.conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
+            [name],
+        ).fetchone()
+        if exists is None:
+            from src.kb.registry import KnowledgeDomainRegistry
+
+            ensure_domain_views(
+                self.conn, KnowledgeDomainRegistry([self.definition])
+            )
+        return name
+
+    def _rows(self, sql: str, params: List[Any]) -> List[Dict[str, Any]]:
+        rows = self.conn.execute(sql, params).fetchall()
+        return [dict(zip(self._DOCUMENT_COLUMNS, row)) for row in rows]
+
+    def documents(
+        self,
+        limit: int = 50,
+        since: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        view = self._view()
+        columns = ", ".join(self._DOCUMENT_COLUMNS)
+        params: List[Any] = []
+        where = ""
+        if since:
+            where = (
+                "WHERE COALESCE(created_at, ingested_at, 0)"
+                " >= epoch_ms(CAST(? AS TIMESTAMP))"
+            )
+            params.append(since)
+        params.append(int(limit))
+        return self._rows(
+            f"SELECT {columns} FROM {view} {where}"
+            " ORDER BY COALESCE(created_at, ingested_at, 0) DESC LIMIT ?",
+            params,
+        )
+
+    def search(self, query: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """Lexical search within the domain (semantic lands with the contract)."""
+        view = self._view()
+        columns = ", ".join(self._DOCUMENT_COLUMNS)
+        pattern = f"%{query.lower()}%"
+        return self._rows(
+            f"SELECT {columns} FROM {view}"
+            " WHERE lower(COALESCE(title, '')) LIKE ?"
+            "    OR lower(COALESCE(content, '')) LIKE ?"
+            " ORDER BY COALESCE(created_at, ingested_at, 0) DESC LIMIT ?",
+            [pattern, pattern, int(limit)],
+        )
+
+    def coverage(self) -> Dict[str, Any]:
+        payload = super().coverage()
+        view = self._view()
+        total, first_seen, last_seen = self.conn.execute(
+            f"SELECT COUNT(*), MIN(COALESCE(created_at, ingested_at)),"
+            f" MAX(COALESCE(created_at, ingested_at)) FROM {view}"
+        ).fetchone()
+        methods = dict(
+            self.conn.execute(
+                "SELECT method, COUNT(*) FROM document_domains"
+                " WHERE domain = ? GROUP BY method",
+                [self.definition.name],
+            ).fetchall()
+        )
+        sources = [
+            row[0]
+            for row in self.conn.execute(
+                f"SELECT source_id FROM {view} WHERE source_id IS NOT NULL"
+                " GROUP BY source_id ORDER BY COUNT(*) DESC LIMIT 25"
+            ).fetchall()
+        ]
+        payload.update(
+            {
+                "ready": True,
+                "documents": int(total or 0),
+                "first_seen_ms": first_seen,
+                "last_seen_ms": last_seen,
+                "assignment_methods": methods,
+                "sources": sources,
+            }
+        )
+        return payload
 
 
 class NamespaceBacking(DomainBacking):

--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -18,10 +18,23 @@ The read surface mirrors the planned ``noesis-kb-v1`` contract:
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
     from src.kb.registry import DomainDefinition
+
+
+def _since_to_epoch_ms(since: str) -> int:
+    """Parse an ISO-8601 ``since`` into epoch ms, honouring UTC offsets.
+
+    Naive timestamps are interpreted as UTC (casting in SQL would silently
+    drop non-zero offsets); malformed input raises ``ValueError`` loudly.
+    """
+    parsed = datetime.fromisoformat(since.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)
 
 
 class DomainBacking:
@@ -201,8 +214,8 @@ class CorpusViewBacking(DomainBacking):
         params: List[Any] = []
         where = ""
         if since:
-            where = "WHERE COALESCE(ingested_at, 0) >= epoch_ms(CAST(? AS TIMESTAMP))"
-            params.append(since)
+            where = "WHERE COALESCE(ingested_at, 0) >= ?"
+            params.append(_since_to_epoch_ms(since))
         params.append(int(limit))
         return self._rows(
             f"SELECT {columns} FROM {view} {where}"

--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -38,15 +38,42 @@ class DomainBacking:
     def __init__(self, definition: "DomainDefinition", conn: Any = None) -> None:
         self.definition = definition
         self._conn = conn
+        # True when we lazily adopted the process-wide shared connection —
+        # every execute must then hold the module's lock (the shared handle
+        # is not safe for concurrent use).
+        self._on_shared_conn = False
 
     @property
     def conn(self) -> Any:
-        """Warehouse connection, defaulting to the shared read connection."""
+        """Warehouse connection, defaulting to the shared connection.
+
+        The default is **in-process only**: it adopts the warehouse-owning
+        process's shared DuckDB handle (creating and seeding the warehouse
+        file if this process is the first opener — a write side effect).
+        DuckDB allows a single read-write process per file, so a second
+        process taking this default while the API holds the file will fail
+        to connect. Out-of-process callers (jobs, CLIs, tests) must inject
+        their own connection instead.
+        """
         if self._conn is None:
             from src.database.local_analytics_connector import get_shared_connection
 
             self._conn = get_shared_connection()
+            self._on_shared_conn = True
         return self._conn
+
+    def _lock(self):
+        """Serialize shared-connection access; no-op for injected conns."""
+        if self._on_shared_conn or self._conn is None:
+            # Touch .conn first so adoption happens before locking.
+            _ = self.conn
+        if self._on_shared_conn:
+            from src.database.local_analytics_connector import _LOCK
+
+            return _LOCK
+        from contextlib import nullcontext
+
+        return nullcontext()
 
     # -- retrieve -----------------------------------------------------------
 
@@ -128,41 +155,58 @@ class CorpusViewBacking(DomainBacking):
         from src.kb.membership import ensure_domain_views, view_name
 
         name = view_name(self.definition.name)
-        exists = self.conn.execute(
-            "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
-            [name],
-        ).fetchone()
-        if exists is None:
-            from src.kb.registry import KnowledgeDomainRegistry
+        with self._lock():
+            exists = self.conn.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = ?",
+                [name],
+            ).fetchone()
+            if exists is None:
+                from src.kb.registry import KnowledgeDomainRegistry
 
-            ensure_domain_views(
-                self.conn, KnowledgeDomainRegistry([self.definition])
-            )
+                ensure_domain_views(
+                    self.conn, KnowledgeDomainRegistry([self.definition])
+                )
         return name
 
     def _rows(self, sql: str, params: List[Any]) -> List[Dict[str, Any]]:
-        rows = self.conn.execute(sql, params).fetchall()
+        with self._lock():
+            rows = self.conn.execute(sql, params).fetchall()
         return [dict(zip(self._DOCUMENT_COLUMNS, row)) for row in rows]
+
+    @staticmethod
+    def _like_pattern(query: str) -> str:
+        """Contains-pattern with LIKE wildcards escaped (used with ESCAPE '\\')."""
+        escaped = (
+            query.lower()
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+        return f"%{escaped}%"
 
     def documents(
         self,
         limit: int = 50,
         since: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
+        """Member documents, newest *arrival* first.
+
+        ``since`` filters on ingestion time — "what entered the domain since
+        T" — not on publication date; a backfilled 2020 paper ingested today
+        is new domain content today. Publication time (``created_at``) is
+        returned on each row for display.
+        """
         view = self._view()
         columns = ", ".join(self._DOCUMENT_COLUMNS)
         params: List[Any] = []
         where = ""
         if since:
-            where = (
-                "WHERE COALESCE(created_at, ingested_at, 0)"
-                " >= epoch_ms(CAST(? AS TIMESTAMP))"
-            )
+            where = "WHERE COALESCE(ingested_at, 0) >= epoch_ms(CAST(? AS TIMESTAMP))"
             params.append(since)
         params.append(int(limit))
         return self._rows(
             f"SELECT {columns} FROM {view} {where}"
-            " ORDER BY COALESCE(created_at, ingested_at, 0) DESC LIMIT ?",
+            " ORDER BY COALESCE(ingested_at, 0) DESC LIMIT ?",
             params,
         )
 
@@ -170,42 +214,42 @@ class CorpusViewBacking(DomainBacking):
         """Lexical search within the domain (semantic lands with the contract)."""
         view = self._view()
         columns = ", ".join(self._DOCUMENT_COLUMNS)
-        pattern = f"%{query.lower()}%"
+        pattern = self._like_pattern(query)
         return self._rows(
             f"SELECT {columns} FROM {view}"
-            " WHERE lower(COALESCE(title, '')) LIKE ?"
-            "    OR lower(COALESCE(content, '')) LIKE ?"
-            " ORDER BY COALESCE(created_at, ingested_at, 0) DESC LIMIT ?",
+            " WHERE lower(COALESCE(title, '')) LIKE ? ESCAPE '\\'"
+            "    OR lower(COALESCE(content, '')) LIKE ? ESCAPE '\\'"
+            " ORDER BY COALESCE(ingested_at, 0) DESC LIMIT ?",
             [pattern, pattern, int(limit)],
         )
 
     def coverage(self) -> Dict[str, Any]:
         payload = super().coverage()
         view = self._view()
-        total, first_seen, last_seen = self.conn.execute(
-            f"SELECT COUNT(*), MIN(COALESCE(created_at, ingested_at)),"
-            f" MAX(COALESCE(created_at, ingested_at)) FROM {view}"
-        ).fetchone()
-        methods = dict(
-            self.conn.execute(
-                "SELECT method, COUNT(*) FROM document_domains"
-                " WHERE domain = ? GROUP BY method",
-                [self.definition.name],
-            ).fetchall()
-        )
-        sources = [
-            row[0]
-            for row in self.conn.execute(
-                f"SELECT source_id FROM {view} WHERE source_id IS NOT NULL"
-                " GROUP BY source_id ORDER BY COUNT(*) DESC LIMIT 25"
-            ).fetchall()
-        ]
+        with self._lock():
+            total, first_ingested, last_ingested = self.conn.execute(
+                f"SELECT COUNT(*), MIN(ingested_at), MAX(ingested_at) FROM {view}"
+            ).fetchone()
+            methods = dict(
+                self.conn.execute(
+                    "SELECT method, COUNT(*) FROM document_domains"
+                    " WHERE domain = ? GROUP BY method",
+                    [self.definition.name],
+                ).fetchall()
+            )
+            sources = [
+                row[0]
+                for row in self.conn.execute(
+                    f"SELECT source_id FROM {view} WHERE source_id IS NOT NULL"
+                    " GROUP BY source_id ORDER BY COUNT(*) DESC LIMIT 25"
+                ).fetchall()
+            ]
         payload.update(
             {
                 "ready": True,
                 "documents": int(total or 0),
-                "first_seen_ms": first_seen,
-                "last_seen_ms": last_seen,
+                "first_ingested_ms": first_ingested,
+                "last_ingested_ms": last_ingested,
                 "assignment_methods": methods,
                 "sources": sources,
             }

--- a/src/kb/membership.py
+++ b/src/kb/membership.py
@@ -20,9 +20,17 @@ Three assignment methods, strongest kept per (document, domain):
   declared embedding space. Skipped (never guessed) when the stored vector's
   model does not match the domain's ``embedding_model``.
 
-The pass is incremental per domain: a watermark on ``ingested_at`` skips
-already-scanned documents, and a config fingerprint triggers a full rebuild
-of that domain's rows when its definition changes.
+Incrementality is set-based, not timestamp-based: a scan ledger
+(``kb_membership_scans``) records which (document, domain) pairs have been
+assessed, so out-of-order ingestion, payload-supplied timestamps, and
+``ingested_at = 0`` legacy rows can never be silently skipped. A document
+assessed before its embedding vector existed stays ``embedding_pending`` and
+is re-assessed once the vector (and an anchor provider) is available.
+
+A config fingerprint triggers a full rebuild of a domain's rows when its
+definition changes; the rebuild computes anchors *before* any destructive
+work and runs delete + reassign inside one transaction, so a failed rebuild
+leaves the previous assignments intact.
 """
 
 from __future__ import annotations
@@ -48,13 +56,23 @@ CREATE TABLE IF NOT EXISTS document_domains (
 )
 """
 
+_SCANS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kb_membership_scans (
+    document_id       TEXT NOT NULL,
+    domain            TEXT NOT NULL,
+    embedding_pending BOOLEAN NOT NULL,
+    run_id            TEXT,
+    scanned_at        BIGINT NOT NULL,
+    PRIMARY KEY (document_id, domain)
+)
+"""
+
 _STATE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS kb_membership_state (
-    domain                TEXT PRIMARY KEY,
-    config_fingerprint    TEXT NOT NULL,
-    watermark_ingested_at BIGINT NOT NULL,
-    last_run_id           TEXT,
-    updated_at            BIGINT NOT NULL
+    domain             TEXT PRIMARY KEY,
+    config_fingerprint TEXT NOT NULL,
+    last_run_id        TEXT,
+    updated_at         BIGINT NOT NULL
 )
 """
 
@@ -63,7 +81,19 @@ _KEYWORD_HIT_SCORE = 0.34
 
 
 def ensure_membership_schema(conn) -> None:
+    """Create the membership tables plus every table the pass reads.
+
+    The pass joins ``documents`` and ``document_embeddings``, so their
+    schemas are ensured here too — a warehouse that has never run the
+    embedding pass must not crash the membership pass.
+    """
+    from src.database.news_articles_compat import ensure_documents_schema
+    from src.ingestion.embedding_store import EmbeddingStore
+
+    ensure_documents_schema(conn)
+    EmbeddingStore(conn)
     conn.execute(_MEMBERSHIP_SCHEMA)
+    conn.execute(_SCANS_SCHEMA)
     conn.execute(_STATE_SCHEMA)
 
 
@@ -83,8 +113,7 @@ def _fingerprint(definition: DomainDefinition) -> str:
 
 def _domain_state(conn, domain: str):
     return conn.execute(
-        "SELECT config_fingerprint, watermark_ingested_at FROM kb_membership_state"
-        " WHERE domain = ?",
+        "SELECT config_fingerprint FROM kb_membership_state WHERE domain = ?",
         [domain],
     ).fetchone()
 
@@ -104,6 +133,23 @@ def _upsert_assignment(
         WHERE excluded.score > document_domains.score
         """,
         [document_id, domain, score, method, run_id, int(time.time() * 1000)],
+    )
+
+
+def _upsert_scan(
+    conn, document_id: str, domain: str, embedding_pending: bool, run_id: str
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO kb_membership_scans
+            (document_id, domain, embedding_pending, run_id, scanned_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (document_id, domain) DO UPDATE SET
+            embedding_pending = excluded.embedding_pending,
+            run_id = excluded.run_id,
+            scanned_at = excluded.scanned_at
+        """,
+        [document_id, domain, embedding_pending, run_id, int(time.time() * 1000)],
     )
 
 
@@ -156,12 +202,16 @@ def run_membership_pass(
     provider: Optional[Any] = None,
     run_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Assign new documents to every corpus-view domain; return a summary.
+    """Assess unscanned documents for every corpus-view domain.
 
     ``provider`` is the embedding provider used for domain *anchor* texts
     only (document vectors come from the embeddings sink). Passing ``None``
-    disables the embedding method; tests inject the deterministic ``hashing``
-    provider.
+    disables the embedding method for this run; affected documents stay
+    ``embedding_pending`` and are re-assessed on a later run.
+
+    Intended to run inside the warehouse-owning process (the same rule as
+    every shared-connection consumer); callers running it as a separate job
+    must inject their own connection.
     """
     from src.kb.registry import load_registry
 
@@ -184,59 +234,67 @@ def _run_domain(
 ) -> Dict[str, Any]:
     fingerprint = _fingerprint(definition)
     state = _domain_state(conn, definition.name)
-    watermark = 0
-    if state is not None:
-        if state[0] == fingerprint:
-            watermark = int(state[1])
-        else:
-            # Definition changed: this domain's assignments are stale as a set.
+    rebuild = state is not None and state[0] != fingerprint
+
+    # Anchor embedding is the only fallible external call — do it before any
+    # destructive work so a provider failure cannot leave the domain empty.
+    anchor = _anchor_vector(definition, provider)
+    domain_tags = {tag.lower() for tag in definition.tags}
+    keywords = [keyword for keyword in definition.keywords if keyword.strip()]
+    has_anchors = bool(definition.embedding_anchors)
+
+    counts = {"source": 0, "keyword": 0, "embedding": 0, "scanned": 0}
+
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        if rebuild:
             conn.execute(
                 "DELETE FROM document_domains WHERE domain = ?", [definition.name]
             )
+            conn.execute(
+                "DELETE FROM kb_membership_scans WHERE domain = ?", [definition.name]
+            )
 
-    rows = conn.execute(
-        """
-        SELECT document_id, COALESCE(title, ''), COALESCE(content, ''),
-               metadata, COALESCE(ingested_at, 0)
-        FROM documents
-        WHERE COALESCE(ingested_at, 0) > ?
-        ORDER BY COALESCE(ingested_at, 0)
-        """,
-        [watermark],
-    ).fetchall()
+        # Set-based candidates: never-scanned documents, plus previously
+        # scanned ones whose embedding assessment is still pending.
+        rows = conn.execute(
+            """
+            SELECT d.document_id, COALESCE(d.title, ''), COALESCE(d.content, ''),
+                   d.metadata, e.vector
+            FROM documents d
+            LEFT JOIN kb_membership_scans s
+              ON s.document_id = d.document_id AND s.domain = ?
+            LEFT JOIN document_embeddings e
+              ON e.document_id = d.document_id AND e.model = ?
+            WHERE s.document_id IS NULL OR s.embedding_pending
+            """,
+            [definition.name, definition.embedding_model],
+        ).fetchall()
 
-    counts = {"source": 0, "keyword": 0, "embedding": 0}
-    domain_tags = {tag.lower() for tag in definition.tags}
-    keywords = [keyword for keyword in definition.keywords if keyword.strip()]
-    anchor = _anchor_vector(definition, provider)
-    max_ingested = watermark
+        for document_id, title, content, metadata_json, vector_json in rows:
+            assigned = False
 
-    for document_id, title, content, metadata_json, ingested_at in rows:
-        max_ingested = max(max_ingested, int(ingested_at))
-
-        if domain_tags and domain_tags & set(_document_tags(metadata_json)):
-            _upsert_assignment(conn, document_id, definition.name, 1.0, "source", run_id)
-            counts["source"] += 1
-            continue
-
-        if keywords:
-            hits = _keyword_hits(f"{title}\n{content}".lower(), keywords)
-            score = min(1.0, hits * _KEYWORD_HIT_SCORE)
-            if hits and score >= definition.membership_threshold:
+            if domain_tags and domain_tags & set(_document_tags(metadata_json)):
                 _upsert_assignment(
-                    conn, document_id, definition.name, score, "keyword", run_id
+                    conn, document_id, definition.name, 1.0, "source", run_id
                 )
-                counts["keyword"] += 1
-                continue
+                counts["source"] += 1
+                assigned = True
 
-        if anchor is not None:
-            vector_row = conn.execute(
-                "SELECT vector FROM document_embeddings"
-                " WHERE document_id = ? AND model = ?",
-                [document_id, definition.embedding_model],
-            ).fetchone()
-            if vector_row and vector_row[0]:
-                similarity = _cosine(anchor, json.loads(vector_row[0]))
+            if not assigned and keywords:
+                hits = _keyword_hits(f"{title}\n{content}".lower(), keywords)
+                score = min(1.0, hits * _KEYWORD_HIT_SCORE)
+                if hits and score >= definition.membership_threshold:
+                    _upsert_assignment(
+                        conn, document_id, definition.name, score, "keyword", run_id
+                    )
+                    counts["keyword"] += 1
+                    assigned = True
+
+            embedding_assessed = False
+            if not assigned and anchor is not None and vector_json:
+                embedding_assessed = True
+                similarity = _cosine(anchor, json.loads(vector_json))
                 if similarity >= definition.membership_threshold:
                     _upsert_assignment(
                         conn,
@@ -247,20 +305,33 @@ def _run_domain(
                         run_id,
                     )
                     counts["embedding"] += 1
+                    assigned = True
 
-    conn.execute(
-        """
-        INSERT INTO kb_membership_state
-            (domain, config_fingerprint, watermark_ingested_at, last_run_id, updated_at)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT (domain) DO UPDATE SET
-            config_fingerprint = excluded.config_fingerprint,
-            watermark_ingested_at = excluded.watermark_ingested_at,
-            last_run_id = excluded.last_run_id,
-            updated_at = excluded.updated_at
-        """,
-        [definition.name, fingerprint, max_ingested, run_id, int(time.time() * 1000)],
-    )
+            # Pending: the embedding method could still change the outcome —
+            # the domain has anchors but this run lacked a vector or provider.
+            embedding_pending = (
+                has_anchors and not assigned and not embedding_assessed
+            )
+            _upsert_scan(
+                conn, document_id, definition.name, embedding_pending, run_id
+            )
+
+        conn.execute(
+            """
+            INSERT INTO kb_membership_state
+                (domain, config_fingerprint, last_run_id, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (domain) DO UPDATE SET
+                config_fingerprint = excluded.config_fingerprint,
+                last_run_id = excluded.last_run_id,
+                updated_at = excluded.updated_at
+            """,
+            [definition.name, fingerprint, run_id, int(time.time() * 1000)],
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
 
     counts["scanned"] = len(rows)
     return counts
@@ -272,12 +343,14 @@ def view_name(domain: str) -> str:
 
 
 def ensure_domain_views(conn, registry: Optional[KnowledgeDomainRegistry] = None) -> List[str]:
-    """Create/refresh one view per corpus-view domain; return view names."""
-    from src.database.news_articles_compat import ensure_documents_schema
+    """Create/refresh one view per corpus-view domain; return view names.
+
+    Domain names are registry-validated slugs (``[a-z0-9-]``), which is what
+    makes the f-string interpolation below safe.
+    """
     from src.kb.registry import load_registry
 
     registry = registry or load_registry()
-    ensure_documents_schema(conn)
     ensure_membership_schema(conn)
 
     created: List[str] = []

--- a/src/kb/membership.py
+++ b/src/kb/membership.py
@@ -1,0 +1,315 @@
+"""
+Document → domain membership: the corpus-view backing's data spine.
+
+Membership is **data, not a per-query filter**: a consolidation pass assigns
+documents to domains and stores the assignment in ``document_domains``, so
+per-domain views stay cheap and every assignment is auditable (method, score,
+run id). A document can belong to several domains — that is the point of
+views over namespaces.
+
+Three assignment methods, strongest kept per (document, domain):
+
+- ``source``    — the document arrived through a feed/connector tagged with
+  the domain's tags (score 1.0; provenance is the subscription itself).
+- ``keyword``   — the domain's seed vocabulary matches the title/content
+  (score scales with distinct keyword hits; 2+ hits clear the default
+  threshold, a single hit does not — precision over recall, the embedding
+  path supplies recall).
+- ``embedding`` — cosine similarity between the document's stored vector and
+  the mean of the domain's anchor embeddings, computed in the domain's
+  declared embedding space. Skipped (never guessed) when the stored vector's
+  model does not match the domain's ``embedding_model``.
+
+The pass is incremental per domain: a watermark on ``ingested_at`` skips
+already-scanned documents, and a config fingerprint triggers a full rebuild
+of that domain's rows when its definition changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+from src.kb.registry import DomainDefinition, KnowledgeDomainRegistry
+
+_MEMBERSHIP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS document_domains (
+    document_id TEXT NOT NULL,
+    domain      TEXT NOT NULL,
+    score       DOUBLE NOT NULL,
+    method      TEXT NOT NULL,
+    run_id      TEXT NOT NULL,
+    assigned_at BIGINT NOT NULL,
+    PRIMARY KEY (document_id, domain)
+)
+"""
+
+_STATE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kb_membership_state (
+    domain                TEXT PRIMARY KEY,
+    config_fingerprint    TEXT NOT NULL,
+    watermark_ingested_at BIGINT NOT NULL,
+    last_run_id           TEXT,
+    updated_at            BIGINT NOT NULL
+)
+"""
+
+#: single keyword hit ≈ 0.34: below the default 0.35 threshold by design.
+_KEYWORD_HIT_SCORE = 0.34
+
+
+def ensure_membership_schema(conn) -> None:
+    conn.execute(_MEMBERSHIP_SCHEMA)
+    conn.execute(_STATE_SCHEMA)
+
+
+def _fingerprint(definition: DomainDefinition) -> str:
+    payload = json.dumps(
+        {
+            "tags": sorted(definition.tags),
+            "keywords": sorted(definition.keywords),
+            "anchors": list(definition.embedding_anchors),
+            "threshold": definition.membership_threshold,
+            "embedding_model": definition.embedding_model,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _domain_state(conn, domain: str):
+    return conn.execute(
+        "SELECT config_fingerprint, watermark_ingested_at FROM kb_membership_state"
+        " WHERE domain = ?",
+        [domain],
+    ).fetchone()
+
+
+def _upsert_assignment(
+    conn, document_id: str, domain: str, score: float, method: str, run_id: str
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO document_domains (document_id, domain, score, method, run_id, assigned_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT (document_id, domain) DO UPDATE SET
+            score = excluded.score,
+            method = excluded.method,
+            run_id = excluded.run_id,
+            assigned_at = excluded.assigned_at
+        WHERE excluded.score > document_domains.score
+        """,
+        [document_id, domain, score, method, run_id, int(time.time() * 1000)],
+    )
+
+
+def _document_tags(metadata_json: Optional[str]) -> List[str]:
+    if not metadata_json:
+        return []
+    try:
+        metadata = json.loads(metadata_json)
+    except (TypeError, ValueError):
+        return []
+    tags = metadata.get("tags") if isinstance(metadata, dict) else None
+    if isinstance(tags, list):
+        return [str(tag).lower() for tag in tags]
+    return []
+
+
+def _keyword_hits(text: str, keywords: List[str]) -> int:
+    hits = 0
+    for keyword in keywords:
+        if re.search(rf"(?<!\w){re.escape(keyword.lower())}(?!\w)", text):
+            hits += 1
+    return hits
+
+
+def _cosine(a: List[float], b: List[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(y * y for y in b) ** 0.5
+    if not norm_a or not norm_b:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _anchor_vector(
+    definition: DomainDefinition, provider: Any
+) -> Optional[List[float]]:
+    if not definition.embedding_anchors or provider is None:
+        return None
+    vectors = provider.embed_texts(list(definition.embedding_anchors))
+    rows = [list(map(float, row)) for row in vectors]
+    if not rows:
+        return None
+    dim = len(rows[0])
+    return [sum(row[i] for row in rows) / len(rows) for i in range(dim)]
+
+
+def run_membership_pass(
+    conn,
+    registry: Optional[KnowledgeDomainRegistry] = None,
+    provider: Optional[Any] = None,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Assign new documents to every corpus-view domain; return a summary.
+
+    ``provider`` is the embedding provider used for domain *anchor* texts
+    only (document vectors come from the embeddings sink). Passing ``None``
+    disables the embedding method; tests inject the deterministic ``hashing``
+    provider.
+    """
+    from src.kb.registry import load_registry
+
+    registry = registry or load_registry()
+    run_id = run_id or f"kb-membership-{uuid.uuid4().hex[:12]}"
+    ensure_membership_schema(conn)
+
+    summary: Dict[str, Any] = {"run_id": run_id, "domains": {}}
+    for definition in registry.domains():
+        if definition.backing != "corpus-view":
+            continue
+        summary["domains"][definition.name] = _run_domain(
+            conn, definition, provider, run_id
+        )
+    return summary
+
+
+def _run_domain(
+    conn, definition: DomainDefinition, provider: Any, run_id: str
+) -> Dict[str, Any]:
+    fingerprint = _fingerprint(definition)
+    state = _domain_state(conn, definition.name)
+    watermark = 0
+    if state is not None:
+        if state[0] == fingerprint:
+            watermark = int(state[1])
+        else:
+            # Definition changed: this domain's assignments are stale as a set.
+            conn.execute(
+                "DELETE FROM document_domains WHERE domain = ?", [definition.name]
+            )
+
+    rows = conn.execute(
+        """
+        SELECT document_id, COALESCE(title, ''), COALESCE(content, ''),
+               metadata, COALESCE(ingested_at, 0)
+        FROM documents
+        WHERE COALESCE(ingested_at, 0) > ?
+        ORDER BY COALESCE(ingested_at, 0)
+        """,
+        [watermark],
+    ).fetchall()
+
+    counts = {"source": 0, "keyword": 0, "embedding": 0}
+    domain_tags = {tag.lower() for tag in definition.tags}
+    keywords = [keyword for keyword in definition.keywords if keyword.strip()]
+    anchor = _anchor_vector(definition, provider)
+    max_ingested = watermark
+
+    for document_id, title, content, metadata_json, ingested_at in rows:
+        max_ingested = max(max_ingested, int(ingested_at))
+
+        if domain_tags and domain_tags & set(_document_tags(metadata_json)):
+            _upsert_assignment(conn, document_id, definition.name, 1.0, "source", run_id)
+            counts["source"] += 1
+            continue
+
+        if keywords:
+            hits = _keyword_hits(f"{title}\n{content}".lower(), keywords)
+            score = min(1.0, hits * _KEYWORD_HIT_SCORE)
+            if hits and score >= definition.membership_threshold:
+                _upsert_assignment(
+                    conn, document_id, definition.name, score, "keyword", run_id
+                )
+                counts["keyword"] += 1
+                continue
+
+        if anchor is not None:
+            vector_row = conn.execute(
+                "SELECT vector FROM document_embeddings"
+                " WHERE document_id = ? AND model = ?",
+                [document_id, definition.embedding_model],
+            ).fetchone()
+            if vector_row and vector_row[0]:
+                similarity = _cosine(anchor, json.loads(vector_row[0]))
+                if similarity >= definition.membership_threshold:
+                    _upsert_assignment(
+                        conn,
+                        document_id,
+                        definition.name,
+                        round(similarity, 6),
+                        "embedding",
+                        run_id,
+                    )
+                    counts["embedding"] += 1
+
+    conn.execute(
+        """
+        INSERT INTO kb_membership_state
+            (domain, config_fingerprint, watermark_ingested_at, last_run_id, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (domain) DO UPDATE SET
+            config_fingerprint = excluded.config_fingerprint,
+            watermark_ingested_at = excluded.watermark_ingested_at,
+            last_run_id = excluded.last_run_id,
+            updated_at = excluded.updated_at
+        """,
+        [definition.name, fingerprint, max_ingested, run_id, int(time.time() * 1000)],
+    )
+
+    counts["scanned"] = len(rows)
+    return counts
+
+
+def view_name(domain: str) -> str:
+    """Stable per-domain view name (slug dashes become underscores)."""
+    return f"kb_domain_{domain.replace('-', '_')}"
+
+
+def ensure_domain_views(conn, registry: Optional[KnowledgeDomainRegistry] = None) -> List[str]:
+    """Create/refresh one view per corpus-view domain; return view names."""
+    from src.database.news_articles_compat import ensure_documents_schema
+    from src.kb.registry import load_registry
+
+    registry = registry or load_registry()
+    ensure_documents_schema(conn)
+    ensure_membership_schema(conn)
+
+    created: List[str] = []
+    for definition in registry.domains():
+        if definition.backing != "corpus-view":
+            continue
+        name = view_name(definition.name)
+        conn.execute(
+            f"""
+            CREATE OR REPLACE VIEW {name} AS
+            SELECT
+                d.document_id,
+                d.source_type,
+                d.source_id,
+                d.url,
+                d.title,
+                d.content,
+                d.language,
+                d.authors,
+                d.metadata,
+                d.ingested_at,
+                d.created_at,
+                m.score  AS domain_score,
+                m.method AS domain_method,
+                e.sentiment_score,
+                e.sentiment_label
+            FROM documents d
+            JOIN document_domains m
+              ON m.document_id = d.document_id AND m.domain = '{definition.name}'
+            LEFT JOIN document_enrichments e
+              ON e.document_id = d.document_id
+            """
+        )
+        created.append(name)
+    return created

--- a/src/kb/membership.py
+++ b/src/kb/membership.py
@@ -293,8 +293,24 @@ def _run_domain(
 
             embedding_assessed = False
             if not assigned and anchor is not None and vector_json:
-                embedding_assessed = True
-                similarity = _cosine(anchor, json.loads(vector_json))
+                try:
+                    vector = json.loads(vector_json)
+                except (TypeError, ValueError):
+                    # One corrupt vector row must not wedge the whole pass;
+                    # the document stays embedding_pending until repaired.
+                    import logging
+
+                    logging.getLogger(__name__).warning(
+                        "kb-membership: malformed embedding vector for %s; "
+                        "leaving embedding assessment pending",
+                        document_id,
+                    )
+                    vector = None
+                if vector is not None:
+                    embedding_assessed = True
+                    similarity = _cosine(anchor, vector)
+                else:
+                    similarity = -1.0
                 if similarity >= definition.membership_threshold:
                     _upsert_assignment(
                         conn,

--- a/src/kb/registry.py
+++ b/src/kb/registry.py
@@ -230,10 +230,14 @@ class KnowledgeDomainRegistry:
                 f"unknown domain {name!r}; configured: {self.names()}"
             ) from None
 
-    def resolve(self, name: str) -> DomainBacking:
-        """Resolve a domain name to its backing implementation."""
+    def resolve(self, name: str, conn: Any = None) -> DomainBacking:
+        """Resolve a domain name to its backing implementation.
+
+        ``conn`` optionally injects a warehouse connection (tests, attached
+        databases); by default the backing lazily uses the shared connection.
+        """
         definition = self.get(name)
-        return _BACKING_CLASSES[definition.backing](definition)
+        return _BACKING_CLASSES[definition.backing](definition, conn=conn)
 
     def embedding_models(self) -> Dict[str, str]:
         """Domain -> embedding model, for shared-space consistency checks."""

--- a/tests/unit/kb/test_membership.py
+++ b/tests/unit/kb/test_membership.py
@@ -169,7 +169,7 @@ class TestAssignment:
 
 
 class TestIncrementalRuns:
-    def test_idempotent_and_watermarked(self, conn, registry):
+    def test_idempotent_and_incremental(self, conn, registry):
         _seed(conn, [_doc("d1", "Defi staking", "defi staking news.", ingested_at=1000)])
         first = run_membership_pass(conn, registry)
         assert first["domains"]["web3"]["scanned"] == 1
@@ -183,6 +183,38 @@ class TestIncrementalRuns:
         assert third["domains"]["web3"]["scanned"] == 1
         assert set(_assignments(conn, "web3")) == {"d1", "d2"}
 
+    def test_out_of_order_arrival_is_not_skipped(self, conn, registry):
+        # A document committed later with an *older* payload timestamp must
+        # still be assessed — incrementality is set-based, not clock-based.
+        _seed(conn, [_doc("late-clock", "Defi staking", "defi staking now.", ingested_at=5000)])
+        run_membership_pass(conn, registry)
+        _seed(conn, [_doc("early-clock", "Old defi staking", "defi staking then.", ingested_at=100)])
+        run_membership_pass(conn, registry)
+        assert set(_assignments(conn, "web3")) == {"late-clock", "early-clock"}
+
+    def test_zero_ingested_at_documents_are_scanned(self, conn, registry):
+        # Legacy compat writers (seed, migration) store ingested_at = 0.
+        _seed(conn, [_doc("legacy", "Defi staking", "defi staking legacy.", ingested_at=None)])
+        conn.execute("UPDATE documents SET ingested_at = 0 WHERE document_id = 'legacy'")
+        run_membership_pass(conn, registry)
+        assert "legacy" in _assignments(conn, "web3")
+
+    def test_late_arriving_embedding_is_reassessed(self, conn, registry):
+        _seed(conn, [_doc("late-vec", "Chain analysis", "on chain data only.")])
+        run_membership_pass(conn, registry, provider=FakeProvider())
+        assert "late-vec" not in _assignments(conn, "web3")
+
+        EmbeddingStore(conn).upsert(
+            "late-vec",
+            model="hashing-model",
+            vector=FakeProvider().embed_texts(
+                ["decentralized finance staking chain"]
+            )[0],
+        )
+        summary = run_membership_pass(conn, registry, provider=FakeProvider())
+        assert summary["domains"]["web3"]["scanned"] >= 1
+        assert _assignments(conn, "web3")["late-vec"][0] == "embedding"
+
     def test_config_change_rebuilds_domain(self, conn, registry, tmp_path):
         _seed(conn, [_doc("d1", "Defi staking", "defi staking news.")])
         run_membership_pass(conn, registry)
@@ -193,6 +225,27 @@ class TestIncrementalRuns:
         path.write_text(changed)
         run_membership_pass(conn, load_registry(path))
         assert "d1" not in _assignments(conn, "web3")
+
+    def test_failed_rebuild_keeps_previous_assignments(self, conn, registry, tmp_path):
+        class ExplodingProvider:
+            def embed_texts(self, texts):
+                raise RuntimeError("provider outage")
+
+        _seed(conn, [_doc("d1", "Defi staking", "defi staking news.")])
+        run_membership_pass(conn, registry)
+        assert "d1" in _assignments(conn, "web3")
+
+        changed = CONFIG.replace("[defi, staking, stablecoin]", "[defi, staking]")
+        path = tmp_path / "changed.yml"
+        path.write_text(changed)
+        with pytest.raises(RuntimeError, match="outage"):
+            run_membership_pass(conn, load_registry(path), provider=ExplodingProvider())
+        # The failed rebuild must not have emptied the domain.
+        assert "d1" in _assignments(conn, "web3")
+
+        # A later healthy pass self-heals onto the new definition.
+        run_membership_pass(conn, load_registry(path))
+        assert "d1" in _assignments(conn, "web3")
 
 
 class TestViewsAndBacking:
@@ -235,7 +288,7 @@ class TestViewsAndBacking:
         assert coverage["assignment_methods"] == {"source": 2}
         assert coverage["sources"] == ["feed"]
 
-    def test_backing_since_filter(self, conn, registry):
+    def test_backing_since_filters_on_ingestion_time(self, conn, registry):
         old_ms = 1_600_000_000_000
         new_ms = 1_900_000_000_000
         _seed(
@@ -245,8 +298,31 @@ class TestViewsAndBacking:
                 _doc("new", "New defi staking", "defi staking, the sequel.", tags=["web3"], ingested_at=new_ms),
             ],
         )
-        conn.execute("UPDATE documents SET created_at = ingested_at")
+        # A backfilled document published long ago but ingested *now* is new
+        # domain content — publication date must not hide it from `since`.
+        conn.execute(
+            "UPDATE documents SET created_at = 1_000_000_000_000"
+            " WHERE document_id = 'new'"
+        )
         run_membership_pass(conn, registry)
         backing = registry.resolve("web3", conn=conn)
         recent = backing.documents(since="2025-01-01")
         assert [doc["document_id"] for doc in recent] == ["new"]
+
+    def test_search_escapes_like_wildcards(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc("pct", "Markets", "stocks saw a 50% gain today, defi staking up.", tags=["web3"]),
+                _doc("nopct", "Markets again", "a 50 point gain today, defi staking up.", tags=["web3"]),
+            ],
+        )
+        run_membership_pass(conn, registry)
+        backing = registry.resolve("web3", conn=conn)
+
+        hits = backing.search("50% gain")
+        assert [hit["document_id"] for hit in hits] == ["pct"]
+        # Wildcards are literals now: "%" finds the doc containing a literal
+        # percent sign; "_" (present nowhere) must not match everything.
+        assert [hit["document_id"] for hit in backing.search("%")] == ["pct"]
+        assert backing.search("_") == []

--- a/tests/unit/kb/test_membership.py
+++ b/tests/unit/kb/test_membership.py
@@ -1,0 +1,252 @@
+"""Unit tests for the document→domain membership pass and corpus-view backing."""
+
+import json
+import time
+
+import duckdb
+import pytest
+
+from src.ingestion.document_store import DocumentStore
+from src.ingestion.embedding_store import EmbeddingStore
+from src.kb import load_registry
+from src.kb.membership import (
+    ensure_domain_views,
+    run_membership_pass,
+    view_name,
+)
+
+CONFIG = """
+version: 1
+domains:
+  - name: web3
+    backing: corpus-view
+    embedding_model: hashing-model
+    tags: [web3]
+    keywords: [defi, staking, stablecoin]
+    embedding_anchors:
+      - decentralized finance protocols and staking on chain
+  - name: economics
+    backing: corpus-view
+    embedding_model: hashing-model
+    tags: [economics]
+    keywords: [inflation, "interest rates"]
+  - name: reference
+    backing: namespace
+    embedding_model: hashing-model
+"""
+
+
+class FakeProvider:
+    """Deterministic embedding provider keyed on token overlap."""
+
+    VOCAB = [
+        "decentralized", "finance", "protocols", "staking", "chain",
+        "inflation", "rates", "cats", "gardening", "weather",
+    ]
+
+    def embed_texts(self, texts):
+        vectors = []
+        for text in texts:
+            tokens = set(text.lower().replace(",", " ").split())
+            vectors.append(
+                [1.0 if word in tokens else 0.0 for word in self.VOCAB]
+            )
+        return vectors
+
+
+def _doc(document_id, title, content, tags=None, source_id="feed", ingested_at=None):
+    return {
+        "document_id": document_id,
+        "source_type": "blog",
+        "language": "en",
+        "ingested_at": ingested_at or int(time.time() * 1000),
+        "source_id": source_id,
+        "url": f"https://example.com/{document_id}",
+        "title": title,
+        "content": content,
+        "metadata": {"tags": tags or []},
+    }
+
+
+@pytest.fixture()
+def conn():
+    connection = duckdb.connect()
+    DocumentStore(connection)
+    EmbeddingStore(connection)
+    return connection
+
+
+@pytest.fixture()
+def registry(tmp_path):
+    path = tmp_path / "domains.yml"
+    path.write_text(CONFIG)
+    return load_registry(path)
+
+
+def _seed(conn, docs):
+    DocumentStore(conn).upsert(docs)
+
+
+def _assignments(conn, domain):
+    return {
+        row[0]: (row[1], row[2])
+        for row in conn.execute(
+            "SELECT document_id, method, score FROM document_domains WHERE domain = ?",
+            [domain],
+        ).fetchall()
+    }
+
+
+class TestAssignment:
+    def test_by_source_tag(self, conn, registry):
+        _seed(conn, [_doc("d1", "Governance vote", "A protocol vote.", tags=["web3"])])
+        run_membership_pass(conn, registry)
+        assignments = _assignments(conn, "web3")
+        assert assignments["d1"][0] == "source"
+        assert assignments["d1"][1] == 1.0
+
+    def test_by_keywords_needs_two_hits_at_default_threshold(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc("one-hit", "Note", "Only defi is mentioned here."),
+                _doc("two-hits", "Defi report", "Both defi and staking feature."),
+            ],
+        )
+        run_membership_pass(conn, registry)
+        assignments = _assignments(conn, "web3")
+        assert "one-hit" not in assignments
+        assert assignments["two-hits"][0] == "keyword"
+
+    def test_keyword_matching_respects_word_boundaries(self, conn, registry):
+        _seed(
+            conn,
+            [_doc("bound", "Ratesx inflationary", "ratesx and inflationary only.")],
+        )
+        run_membership_pass(conn, registry)
+        assert "bound" not in _assignments(conn, "economics")
+
+    def test_by_embedding_similarity(self, conn, registry):
+        _seed(conn, [_doc("emb", "Chain analysis", "On chain staking data.")])
+        EmbeddingStore(conn).upsert(
+            "emb",
+            model="hashing-model",
+            vector=FakeProvider().embed_texts(
+                ["decentralized finance staking chain"]
+            )[0],
+        )
+        run_membership_pass(conn, registry, provider=FakeProvider())
+        assignments = _assignments(conn, "web3")
+        assert assignments["emb"][0] == "embedding"
+        assert assignments["emb"][1] >= 0.35
+
+    def test_embedding_skipped_on_model_mismatch(self, conn, registry):
+        _seed(conn, [_doc("mismatch", "Chain analysis", "On chain staking data.")])
+        EmbeddingStore(conn).upsert(
+            "mismatch",
+            model="other-model",
+            vector=FakeProvider().embed_texts(["decentralized finance staking"])[0],
+        )
+        run_membership_pass(conn, registry, provider=FakeProvider())
+        assert "mismatch" not in _assignments(conn, "web3")
+
+    def test_overlapping_membership(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc(
+                    "both",
+                    "Stablecoin rules",
+                    "Regulators weigh stablecoin rules as inflation and"
+                    " interest rates shift.",
+                    tags=["web3"],
+                )
+            ],
+        )
+        run_membership_pass(conn, registry)
+        assert "both" in _assignments(conn, "web3")
+        assert "both" in _assignments(conn, "economics")
+
+
+class TestIncrementalRuns:
+    def test_idempotent_and_watermarked(self, conn, registry):
+        _seed(conn, [_doc("d1", "Defi staking", "defi staking news.", ingested_at=1000)])
+        first = run_membership_pass(conn, registry)
+        assert first["domains"]["web3"]["scanned"] == 1
+
+        second = run_membership_pass(conn, registry)
+        assert second["domains"]["web3"]["scanned"] == 0
+        assert len(_assignments(conn, "web3")) == 1
+
+        _seed(conn, [_doc("d2", "More defi staking", "defi staking again.", ingested_at=2000)])
+        third = run_membership_pass(conn, registry)
+        assert third["domains"]["web3"]["scanned"] == 1
+        assert set(_assignments(conn, "web3")) == {"d1", "d2"}
+
+    def test_config_change_rebuilds_domain(self, conn, registry, tmp_path):
+        _seed(conn, [_doc("d1", "Defi staking", "defi staking news.")])
+        run_membership_pass(conn, registry)
+        assert "d1" in _assignments(conn, "web3")
+
+        changed = CONFIG.replace("[defi, staking, stablecoin]", "[gardening, weather]")
+        path = tmp_path / "changed.yml"
+        path.write_text(changed)
+        run_membership_pass(conn, load_registry(path))
+        assert "d1" not in _assignments(conn, "web3")
+
+
+class TestViewsAndBacking:
+    def test_views_contain_members_only(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc("member", "Defi staking", "defi staking news.", tags=["web3"]),
+                _doc("outsider", "Gardening", "tomatoes and weather."),
+            ],
+        )
+        run_membership_pass(conn, registry)
+        ensure_domain_views(conn, registry)
+        rows = conn.execute(
+            f"SELECT document_id FROM {view_name('web3')}"
+        ).fetchall()
+        assert [row[0] for row in rows] == ["member"]
+
+    def test_backing_documents_search_coverage(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc("a", "Stablecoin rules", "stablecoin and defi.", tags=["web3"]),
+                _doc("b", "Staking yield", "defi staking yields.", tags=["web3"]),
+            ],
+        )
+        run_membership_pass(conn, registry)
+        backing = registry.resolve("web3", conn=conn)
+
+        documents = backing.documents(limit=10)
+        assert {doc["document_id"] for doc in documents} == {"a", "b"}
+        assert documents[0]["domain_method"] == "source"
+
+        hits = backing.search("stablecoin")
+        assert [hit["document_id"] for hit in hits] == ["a"]
+
+        coverage = backing.coverage()
+        assert coverage["ready"] is True
+        assert coverage["documents"] == 2
+        assert coverage["assignment_methods"] == {"source": 2}
+        assert coverage["sources"] == ["feed"]
+
+    def test_backing_since_filter(self, conn, registry):
+        old_ms = 1_600_000_000_000
+        new_ms = 1_900_000_000_000
+        _seed(
+            conn,
+            [
+                _doc("old", "Old defi staking", "defi staking, the early days.", tags=["web3"], ingested_at=old_ms),
+                _doc("new", "New defi staking", "defi staking, the sequel.", tags=["web3"], ingested_at=new_ms),
+            ],
+        )
+        conn.execute("UPDATE documents SET created_at = ingested_at")
+        run_membership_pass(conn, registry)
+        backing = registry.resolve("web3", conn=conn)
+        recent = backing.documents(since="2025-01-01")
+        assert [doc["document_id"] for doc in recent] == ["new"]

--- a/tests/unit/kb/test_membership.py
+++ b/tests/unit/kb/test_membership.py
@@ -215,6 +215,29 @@ class TestIncrementalRuns:
         assert summary["domains"]["web3"]["scanned"] >= 1
         assert _assignments(conn, "web3")["late-vec"][0] == "embedding"
 
+    def test_malformed_vector_row_does_not_wedge_the_pass(self, conn, registry):
+        _seed(
+            conn,
+            [
+                _doc("corrupt", "Chain analysis", "on chain data only."),
+                _doc("healthy", "Defi staking", "defi staking news."),
+            ],
+        )
+        EmbeddingStore(conn).upsert("corrupt", model="hashing-model", vector=[0.1])
+        conn.execute(
+            "UPDATE document_embeddings SET vector = 'not-json'"
+            " WHERE document_id = 'corrupt'"
+        )
+        summary = run_membership_pass(conn, registry, provider=FakeProvider())
+        assert summary["domains"]["web3"]["scanned"] == 2
+        assert "healthy" in _assignments(conn, "web3")
+        # The corrupt row stays pending, ready for reassessment once repaired.
+        pending = conn.execute(
+            "SELECT embedding_pending FROM kb_membership_scans"
+            " WHERE document_id = 'corrupt' AND domain = 'web3'"
+        ).fetchone()[0]
+        assert pending is True
+
     def test_config_change_rebuilds_domain(self, conn, registry, tmp_path):
         _seed(conn, [_doc("d1", "Defi staking", "defi staking news.")])
         run_membership_pass(conn, registry)
@@ -308,6 +331,12 @@ class TestViewsAndBacking:
         backing = registry.resolve("web3", conn=conn)
         recent = backing.documents(since="2025-01-01")
         assert [doc["document_id"] for doc in recent] == ["new"]
+
+        # UTC offsets are honoured, not silently dropped: new_ms is
+        # 2030-03-17T17:46:40Z; a since 1s later in a +05:00 offset that is
+        # still earlier in UTC must include the doc, 1s after in UTC must not.
+        assert backing.documents(since="2030-03-17T22:46:39+05:00") != []
+        assert backing.documents(since="2030-03-17T17:46:41+00:00") == []
 
     def test_search_escapes_like_wildcards(self, conn, registry):
         _seed(

--- a/tests/unit/kb/test_registry.py
+++ b/tests/unit/kb/test_registry.py
@@ -145,21 +145,27 @@ class TestResolution:
         with pytest.raises(DomainConfigError, match="unknown domain"):
             registry.resolve("finance")
 
-    def test_coverage_answers_before_data_paths_exist(self, registry):
-        coverage = registry.resolve("web3").coverage()
+    def test_coverage_answers_on_an_empty_warehouse(self, registry):
+        import duckdb
+
+        coverage = registry.resolve("web3", conn=duckdb.connect()).coverage()
         assert coverage["domain"] == "web3"
         assert coverage["backing"] == "corpus-view"
         assert coverage["embedding_model"] == "all-MiniLM-L6-v2"
-        assert coverage["ready"] is False
+        assert coverage["ready"] is True
+        assert coverage["documents"] == 0
 
         namespace_coverage = registry.resolve("reference").coverage()
         assert namespace_coverage["backing"] == "namespace"
         assert namespace_coverage["namespace"] == "reference"
+        assert namespace_coverage["ready"] is False
 
     def test_unimplemented_reads_fail_loudly(self, registry):
-        backing = registry.resolve("web3")
-        with pytest.raises(NotImplementedError, match="search"):
-            backing.search("stablecoin regulation")
+        import duckdb
+
+        backing = registry.resolve("web3", conn=duckdb.connect())
+        with pytest.raises(NotImplementedError, match="claims"):
+            backing.claims()
         with pytest.raises(NotImplementedError, match="diff"):
             backing.diff(since="2026-07-01")
 


### PR DESCRIPTION
## Overview

Implements #962 — the corpus-view backing's data spine. Membership is data, not a per-query filter: an incremental pass writes auditable `(score, method, run_id)` assignments into `document_domains`, per-domain views join documents + enrichments through it, and `CorpusViewBacking` now serves `documents`/`search`/`coverage`.

## Changes Summary

- **`src/kb/membership.py`**: three assignment methods — feed-tag `source` match (score 1.0), seed-`keyword` match (word-boundary; 2+ hits clear the default threshold), and `embedding` cosine similarity between stored document vectors and domain anchor embeddings (skipped, never guessed, on embedding-model mismatch). Incrementality is **set-based** via a `kb_membership_scans` ledger — out-of-order commits, payload-supplied timestamps, and legacy `ingested_at=0` rows cannot be silently skipped, and documents assessed before their vector existed stay `embedding_pending` for automatic reassessment. Config-fingerprint changes rebuild a domain inside one transaction with anchors computed before any destructive work.
- **`src/kb/backing.py`**: reads go through the per-domain view; every shared-connection execute holds the analytics `_LOCK`; `since` filters on ingestion time with UTC-offset-aware parsing; LIKE wildcards escaped with an `ESCAPE` clause; coverage reports counts, freshness, method breakdown, and top sources.
- **Tests**: 34 unit tests including regressions for out-of-order arrival, zero-`ingested_at` legacy rows, late-arriving embeddings, failed-rebuild safety, wildcard escaping, and malformed vector rows.

## Review

Adversarially reviewed by a 12-agent workflow (3 review dimensions → per-finding refutation attempts with live DuckDB repros); all 9 confirmed findings fixed, and a second verification pass confirmed each closed. The one accepted residual: the lazy shared-connection default is documented as in-process-only (out-of-process callers must inject a connection).

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 34 passed

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_