### PR TITLE
Starter knowledge domains: curated feeds + one-command bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,14 @@ contract.validate:
 	fi
 	@echo "✅ Event validation complete!"
 
+kb-bootstrap:
+	@echo "Bootstrapping knowledge domains (seed feeds + harvest + membership)..."
+	python3 scripts/kb_bootstrap.py
+
+kb-bootstrap-offline:
+	@echo "Bootstrapping knowledge domains (offline: seed + membership only)..."
+	python3 scripts/kb_bootstrap.py --no-harvest
+
 demo:
 	@echo "Running NeuroNews offline demo pipeline..."
 	python3 scripts/demo.py

--- a/config/domains.yml
+++ b/config/domains.yml
@@ -8,10 +8,168 @@
 #
 # Default policy: start as a corpus-view; promote to a namespace when the
 # domain earns its own lifecycle (retention, re-index cadence, quotas).
-# Every domain must declare embedding_model — cross-domain similarity only
-# means anything inside one shared embedding space.
+# Every domain declares embedding_model — cross-domain similarity only means
+# anything inside one shared embedding space.
 #
-# Starter definitions (news, economics, technology, web3, local, papers)
-# arrive with the seeding increment.
+# Feed curation rationale lives in docs/kb/starter-domains.md. Seeding is
+# idempotent: `make kb-bootstrap` (scripts/kb_bootstrap.py) subscribes any
+# missing feeds under the domain's tags, harvests, and runs the membership
+# pass.
 version: 1
-domains: []
+domains:
+  - name: news
+    backing: corpus-view
+    description: General world news — the broad daily stream.
+    embedding_model: all-MiniLM-L6-v2
+    tags: [news]
+    keywords: []
+    embedding_anchors:
+      - breaking world news, politics, and current events reporting
+    feeds:
+      - url: http://feeds.bbci.co.uk/news/world/rss.xml
+        name: BBC World
+        tags: [news]
+      - url: https://www.theguardian.com/world/rss
+        name: The Guardian World
+        tags: [news]
+      - url: https://feeds.npr.org/1001/rss.xml
+        name: NPR News
+        tags: [news]
+      - url: https://www.aljazeera.com/xml/rss/all.xml
+        name: Al Jazeera
+        tags: [news]
+
+  - name: economics
+    backing: corpus-view
+    description: Macro, markets, and economic policy.
+    embedding_model: all-MiniLM-L6-v2
+    tags: [economics]
+    keywords:
+      - inflation
+      - interest rates
+      - gdp
+      - central bank
+      - recession
+      - monetary policy
+      - fiscal policy
+      - unemployment
+      - tariffs
+    embedding_anchors:
+      - macroeconomic indicators, inflation, central bank policy, and markets
+    feeds:
+      - url: https://www.economist.com/finance-and-economics/rss.xml
+        name: The Economist — Finance & economics
+        tags: [economics]
+      - url: https://fredblog.stlouisfed.org/feed/
+        name: FRED Blog (St. Louis Fed)
+        tags: [economics]
+      - url: https://marginalrevolution.com/feed
+        name: Marginal Revolution
+        tags: [economics]
+      - url: https://www.calculatedriskblog.com/feeds/posts/default
+        name: Calculated Risk
+        tags: [economics]
+      - url: https://www.cnbc.com/id/20910258/device/rss/rss.html
+        name: CNBC Economy
+        tags: [economics]
+
+  - name: technology
+    backing: corpus-view
+    description: Technology industry, research, and engineering.
+    embedding_model: all-MiniLM-L6-v2
+    tags: [technology, tech]
+    keywords:
+      - artificial intelligence
+      - machine learning
+      - semiconductor
+      - cybersecurity
+      - open source
+      - robotics
+      - software
+      - startup
+    embedding_anchors:
+      - technology industry news, software engineering, AI research, and startups
+    feeds:
+      - url: https://feeds.arstechnica.com/arstechnica/index
+        name: Ars Technica
+        tags: [technology]
+      - url: https://www.theverge.com/rss/index.xml
+        name: The Verge
+        tags: [technology]
+      - url: https://www.technologyreview.com/feed/
+        name: MIT Technology Review
+        tags: [technology]
+      - url: https://hnrss.org/frontpage
+        name: Hacker News frontpage
+        tags: [technology]
+
+  - name: web3
+    backing: corpus-view
+    description: Crypto ecosystems, protocols, and on-chain governance.
+    embedding_model: all-MiniLM-L6-v2
+    tags: [web3, crypto]
+    keywords:
+      - defi
+      - stablecoin
+      - ethereum
+      - bitcoin
+      - blockchain
+      - smart contract
+      - staking
+      - tokenization
+      - crypto
+      - dao
+    embedding_anchors:
+      - decentralized finance protocols, blockchains, and on-chain governance
+    feeds:
+      - url: https://www.coindesk.com/arc/outboundfeeds/rss/
+        name: CoinDesk
+        tags: [web3]
+      - url: https://cointelegraph.com/rss
+        name: Cointelegraph
+        tags: [web3]
+      - url: https://blog.ethereum.org/en/feed.xml
+        name: Ethereum Foundation Blog
+        tags: [web3]
+      - url: https://vitalik.eth.limo/feed.xml
+        name: Vitalik Buterin
+        tags: [web3]
+
+  - name: local
+    backing: corpus-view
+    description: >
+      Local events — a documented stub: there is no good generic source for
+      local news/events, so add your city's feeds here (any RSS/Atom URL)
+      under the `local` tag. A proper ICS/calendar connector is a tracked
+      expansion.
+    embedding_model: all-MiniLM-L6-v2
+    tags: [local]
+    keywords: []
+    embedding_anchors:
+      - local city news, community events, and municipal announcements
+    feeds: []
+
+  - name: papers
+    backing: corpus-view
+    description: >
+      Research papers via arXiv category RSS — papers are just another feed
+      domain on day one. Promoted to the namespace-backed reference corpus
+      later (full-text ingestion, books, different retention).
+    embedding_model: all-MiniLM-L6-v2
+    tags: [papers, research]
+    keywords: []
+    embedding_anchors:
+      - peer-reviewed research papers, preprints, methods, and experiments
+    feeds:
+      - url: https://rss.arxiv.org/rss/cs.AI
+        name: arXiv cs.AI
+        tags: [papers]
+      - url: https://rss.arxiv.org/rss/cs.CL
+        name: arXiv cs.CL
+        tags: [papers]
+      - url: https://rss.arxiv.org/rss/cs.CR
+        name: arXiv cs.CR
+        tags: [papers]
+      - url: https://rss.arxiv.org/rss/econ.GN
+        name: arXiv econ.GN
+        tags: [papers]

--- a/docs/kb/starter-domains.md
+++ b/docs/kb/starter-domains.md
@@ -1,0 +1,59 @@
+# Starter knowledge domains
+
+`config/domains.yml` ships six domains. One command stands them up:
+
+```bash
+make kb-bootstrap            # seed feeds + harvest + assign membership
+# or, offline:
+python3 scripts/kb_bootstrap.py --no-harvest
+```
+
+Seeding is idempotent and non-destructive: missing feeds are subscribed into
+`config/blog_subscriptions.json` under the domain's tags; existing
+subscriptions only ever gain tags, and user-added feeds are never touched.
+Any feed you subscribe yourself with a domain's tag (e.g. `local`) feeds that
+domain via by-source membership — no config change needed.
+
+## Curated feeds and why
+
+| Domain | Feed | Rationale |
+|---|---|---|
+| news | BBC World | broad, fast wire-style coverage |
+| news | The Guardian World | second general outlet, different editorial line |
+| news | NPR News | US-centric complement |
+| news | Al Jazeera | non-Western vantage for contradiction analysis |
+| economics | The Economist — Finance & economics | macro analysis |
+| economics | FRED Blog | data-first, primary-source charts |
+| economics | Marginal Revolution | academic-economics commentary |
+| economics | Calculated Risk | housing/markets nowcasting |
+| economics | CNBC Economy | daily markets newsflow |
+| technology | Ars Technica | depth-first tech reporting |
+| technology | The Verge | consumer/industry breadth |
+| technology | MIT Technology Review | research-adjacent analysis |
+| technology | Hacker News frontpage | community signal for what matters today |
+| web3 | CoinDesk | industry newswire |
+| web3 | Cointelegraph | second wire, corroboration/contradiction pair |
+| web3 | Ethereum Foundation Blog | primary-source protocol announcements |
+| web3 | Vitalik Buterin | primary-source design arguments |
+| papers | arXiv cs.AI / cs.CL / cs.CR / econ.GN | preprints as ordinary feeds; category set mirrors the other domains' subjects |
+| local | *(none — add your city's feeds)* | no good generic source exists; ICS/calendar connector is a tracked expansion |
+
+Prune or extend freely — the list is config, not code. Keyword lists are the
+*seed vocabulary* for by-content membership (word-boundary matching; two
+distinct hits clear the default threshold), and `embedding_anchors` describe
+the domain for the similarity method once document embeddings exist
+(`kb_bootstrap.py --embeddings`).
+
+## Cross-domain overlap is a feature
+
+A stablecoin-regulation story is legitimately both `web3` and `economics`;
+an AI-chip export-control story is both `technology` and `news`. Membership
+is many-to-many by design — the shared corpus with domain views exists
+precisely so one document can serve several domains without duplication.
+
+## Where papers go next
+
+`papers` starts as a corpus-view over arXiv RSS (abstracts). The reference
+increment promotes it to a namespace-backed domain with full-text ingestion,
+books, and its own retention — consumers notice nothing because they only
+ever see the `DomainBacking` interface.

--- a/scripts/kb_bootstrap.py
+++ b/scripts/kb_bootstrap.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+One-command knowledge-domain bootstrap.
+
+Seeds the feed subscriptions from ``config/domains.yml``, harvests the
+subscribed feeds into the unified documents sink, runs the membership pass,
+builds the per-domain views, and prints a coverage summary per domain.
+
+Usage:
+    python3 scripts/kb_bootstrap.py                 # seed + harvest + assign
+    python3 scripts/kb_bootstrap.py --no-harvest    # offline: seed + assign only
+    python3 scripts/kb_bootstrap.py --limit 10      # cap entries per feed
+    python3 scripts/kb_bootstrap.py --embeddings    # also use the embedding
+                                                    # method (env-configured
+                                                    # provider; downloads a
+                                                    # model on first use)
+
+Harvest requires network access; failures per feed are reported and skipped,
+never fatal — the command is safe to re-run any time (seeding, harvest, and
+membership are all idempotent).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap the knowledge domains")
+    parser.add_argument("--no-harvest", action="store_true",
+                        help="Skip feed harvesting (offline mode)")
+    parser.add_argument("--limit", type=int, default=20,
+                        help="Max entries per feed (default 20)")
+    parser.add_argument("--full-text", action="store_true",
+                        help="Fetch full article bodies (slower)")
+    parser.add_argument("--embeddings", action="store_true",
+                        help="Enable the embedding membership method via the "
+                             "env-configured provider")
+    args = parser.parse_args()
+
+    from src.database.local_analytics_connector import get_shared_connection
+    from src.ingestion.document_store import DocumentStore
+    from src.kb import load_registry
+    from src.kb.membership import ensure_domain_views, run_membership_pass
+    from src.kb.seeding import seed_domain_feeds
+
+    registry = load_registry()
+    print(f"Domains: {', '.join(registry.names())}")
+
+    seeded = seed_domain_feeds(registry)
+    print(
+        f"Feeds: {len(seeded['added'])} added, {len(seeded['retagged'])} retagged,"
+        f" {len(seeded['unchanged'])} unchanged"
+    )
+
+    conn = get_shared_connection()
+
+    if not args.no_harvest:
+        from src.ingestion.connectors.blog.connector import BlogConnector
+
+        connector = BlogConnector(
+            fetch_full_text=args.full_text, limit_per_feed=args.limit
+        )
+        summary = connector.harvest_run(store=DocumentStore(conn))
+        print(
+            f"Harvest: {summary.discovered} feeds discovered,"
+            f" {summary.documents} entries parsed, {summary.inserted} stored,"
+            f" {summary.duplicate} duplicates, {summary.fetch_errors} fetch errors"
+        )
+        for source_id, per_source in sorted(summary.per_source.items()):
+            if per_source.get("fetch_errors") or per_source.get("parse_errors"):
+                print(
+                    f"  [!] {source_id}: fetch_errors="
+                    f"{per_source.get('fetch_errors', 0)} parse_errors="
+                    f"{per_source.get('parse_errors', 0)}"
+                )
+
+    provider = None
+    if args.embeddings:
+        from services.embeddings.provider import get_embedding_provider
+
+        provider = get_embedding_provider()
+        # Fill missing document vectors first so membership can use them.
+        from src.ingestion.embed import embed_documents
+
+        embedded = embed_documents(conn, provider=provider)
+        print(f"Embeddings: {embedded} documents embedded")
+
+    membership = run_membership_pass(conn, registry, provider=provider)
+    ensure_domain_views(conn, registry)
+
+    print("\nCoverage:")
+    for name in registry.names():
+        definition = registry.get(name)
+        if definition.backing != "corpus-view":
+            continue
+        coverage = registry.resolve(name, conn=conn).coverage()
+        counts = membership["domains"].get(name, {})
+        methods = coverage.get("assignment_methods") or {}
+        method_text = (
+            ", ".join(f"{key}={value}" for key, value in sorted(methods.items()))
+            or "none"
+        )
+        print(
+            f"  {name:<12} documents={coverage['documents']:<5}"
+            f" scanned_now={counts.get('scanned', 0):<5} methods: {method_text}"
+        )
+
+    print("\nDone. Re-run any time; every step is idempotent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb/membership.py
+++ b/src/kb/membership.py
@@ -94,6 +94,16 @@ def ensure_membership_schema(conn) -> None:
     EmbeddingStore(conn)
     conn.execute(_MEMBERSHIP_SCHEMA)
     conn.execute(_SCANS_SCHEMA)
+    # kb_membership_state is derived metadata (fingerprints + run markers):
+    # a legacy pre-ledger shape is dropped, not migrated — the scan ledger
+    # and assignments survive, and the next pass repopulates the state rows.
+    legacy = conn.execute(
+        "SELECT 1 FROM information_schema.columns"
+        " WHERE table_name = 'kb_membership_state'"
+        "   AND column_name = 'watermark_ingested_at'"
+    ).fetchone()
+    if legacy is not None:
+        conn.execute("DROP TABLE kb_membership_state")
     conn.execute(_STATE_SCHEMA)
 
 

--- a/src/kb/seeding.py
+++ b/src/kb/seeding.py
@@ -1,0 +1,51 @@
+"""
+Idempotent feed seeding: make the subscription store match the domain config.
+
+``config/domains.yml`` declares which feeds each domain wants harvested;
+``config/blog_subscriptions.json`` (the SubscriptionStore) is what the blog
+connector actually reads. Seeding reconciles the two without clobbering user
+edits: missing feeds are subscribed under the union of the feed's and the
+domain's tags, and existing subscriptions only ever *gain* tags — names,
+extra user tags, and user-added feeds are preserved.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.kb.registry import KnowledgeDomainRegistry
+
+
+def seed_domain_feeds(
+    registry: Optional[KnowledgeDomainRegistry] = None,
+    store: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Subscribe every domain feed that is not already subscribed.
+
+    Returns a summary: feeds added, feeds whose tags were extended, and
+    feeds already up to date.
+    """
+    from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+    from src.kb.registry import load_registry
+
+    registry = registry or load_registry()
+    store = store or SubscriptionStore()
+
+    summary: Dict[str, Any] = {"added": [], "retagged": [], "unchanged": []}
+    for definition in registry.domains():
+        for feed in definition.feeds:
+            wanted_tags = sorted({*feed.tags, *definition.tags})
+            existing = store.get(feed.url)
+            if existing is None:
+                store.subscribe(feed.url, name=feed.name, tags=wanted_tags)
+                summary["added"].append(feed.url)
+                continue
+            merged = sorted({*existing.tags, *wanted_tags})
+            if merged != sorted(existing.tags):
+                store.subscribe(
+                    feed.url, name=existing.name or feed.name, tags=merged
+                )
+                summary["retagged"].append(feed.url)
+            else:
+                summary["unchanged"].append(feed.url)
+    return summary

--- a/tests/unit/kb/test_registry.py
+++ b/tests/unit/kb/test_registry.py
@@ -67,9 +67,9 @@ class TestLoading:
             load_registry(_write(tmp_path, "version: 2\ndomains: []\n"))
 
     def test_repo_default_config_is_valid(self):
-        # config/domains.yml ships empty until the seeding increment, but it
-        # must always parse.
-        assert load_registry().domains() == []
+        # The shipped config must always load; starter-domain specifics are
+        # covered in test_seeding.py.
+        assert len(load_registry().domains()) >= 1
 
 
 class TestValidation:

--- a/tests/unit/kb/test_seeding.py
+++ b/tests/unit/kb/test_seeding.py
@@ -1,0 +1,107 @@
+"""Unit tests for the shipped starter domains and idempotent feed seeding."""
+
+import time
+
+import duckdb
+
+from src.ingestion.connectors.blog.subscriptions import SubscriptionStore
+from src.ingestion.document_store import DocumentStore
+from src.kb import load_registry
+from src.kb.membership import run_membership_pass
+from src.kb.seeding import seed_domain_feeds
+
+EXPECTED_DOMAINS = ["news", "economics", "technology", "web3", "local", "papers"]
+
+
+class TestShippedConfig:
+    def test_starter_domains_load_and_validate(self):
+        registry = load_registry()
+        assert registry.names() == EXPECTED_DOMAINS
+
+    def test_all_domains_share_one_embedding_space(self):
+        models = set(load_registry().embedding_models().values())
+        assert models == {"all-MiniLM-L6-v2"}
+
+    def test_papers_rides_arxiv_rss(self):
+        papers = load_registry().get("papers")
+        assert papers.backing == "corpus-view"
+        assert any("rss.arxiv.org" in feed.url for feed in papers.feeds)
+
+    def test_local_is_a_documented_stub(self):
+        local = load_registry().get("local")
+        assert local.feeds == []
+        assert local.tags == ["local"]
+
+    def test_every_feed_carries_its_domain_tags(self):
+        registry = load_registry()
+        for definition in registry.domains():
+            for feed in definition.feeds:
+                assert set(feed.tags) & set(definition.tags), (
+                    f"{definition.name}: {feed.url} lacks a domain tag"
+                )
+
+
+class TestSeeding:
+    def test_seed_subscribes_missing_feeds(self, tmp_path):
+        store = SubscriptionStore(path=tmp_path / "subs.json")
+        summary = seed_domain_feeds(load_registry(), store=store)
+        subscribed = {sub.url for sub in store.list()}
+        assert len(summary["added"]) == len(subscribed)
+        assert "https://www.coindesk.com/arc/outboundfeeds/rss/" in subscribed
+
+    def test_seed_is_idempotent(self, tmp_path):
+        store = SubscriptionStore(path=tmp_path / "subs.json")
+        seed_domain_feeds(load_registry(), store=store)
+        second = seed_domain_feeds(load_registry(), store=store)
+        assert second["added"] == []
+        assert second["retagged"] == []
+        assert len(second["unchanged"]) == len(store.list())
+
+    def test_seed_preserves_user_edits_and_merges_tags(self, tmp_path):
+        store = SubscriptionStore(path=tmp_path / "subs.json")
+        # User subscribed CoinDesk earlier under their own name and tag.
+        store.subscribe(
+            "https://www.coindesk.com/arc/outboundfeeds/rss/",
+            name="My CoinDesk",
+            tags=["favourites"],
+        )
+        # And their own feed the config knows nothing about.
+        store.subscribe("https://example.com/mine.xml", name="Mine", tags=["local"])
+
+        seed_domain_feeds(load_registry(), store=store)
+
+        coindesk = store.get("https://www.coindesk.com/arc/outboundfeeds/rss/")
+        assert coindesk.name == "My CoinDesk"
+        assert {"favourites", "web3", "crypto"} <= set(coindesk.tags)
+        assert store.get("https://example.com/mine.xml") is not None
+
+
+class TestShippedDefinitionsAssign:
+    def test_cross_domain_overlap_with_real_config(self):
+        conn = duckdb.connect()
+        DocumentStore(conn).upsert(
+            [
+                {
+                    "document_id": "overlap-1",
+                    "source_type": "news",
+                    "language": "en",
+                    "ingested_at": int(time.time() * 1000),
+                    "source_id": "wire",
+                    "url": "https://example.com/stablecoin",
+                    "title": "Central bank weighs stablecoin rules",
+                    "content": (
+                        "The central bank said inflation and interest rates "
+                        "shape its view of stablecoin and defi regulation."
+                    ),
+                    "metadata": {},
+                }
+            ]
+        )
+        run_membership_pass(conn, load_registry())
+        domains = {
+            row[0]
+            for row in conn.execute(
+                "SELECT domain FROM document_domains WHERE document_id = 'overlap-1'"
+            ).fetchall()
+        }
+        assert {"economics", "web3"} <= domains


### PR DESCRIPTION
## Overview

Implements #963 — the six starter domains (news, economics, technology, web3, local, papers) with curated feeds, non-destructive feed seeding, and a one-command bootstrap so a fresh clone gets organized, queryable domains.

## Changes Summary

- **`config/domains.yml`**: 21 curated feeds across five active domains (papers rides arXiv category RSS as ordinary feeds; `local` ships as a documented stub since no generic source exists), all in one embedding space (`all-MiniLM-L6-v2`), each with seed keywords and embedding anchors.
- **`src/kb/seeding.py`**: reconciles the domain config into `config/blog_subscriptions.json` idempotently — missing feeds are subscribed under domain tags, existing subscriptions only ever *gain* tags, user names and user-added feeds are untouched.
- **`scripts/kb_bootstrap.py`** + `make kb-bootstrap`(`-offline`): seed → harvest (`harvest_run` into the documents sink; per-feed failures reported, never fatal) → optional embedding backfill (`--embeddings`) → membership pass → views → per-domain coverage table. Every step idempotent.
- **`src/kb/membership.py`**: drop-and-recreate a legacy pre-ledger `kb_membership_state` table (derived metadata only; assignments and scan ledger survive).
- **`docs/kb/starter-domains.md`**: per-feed rationale and pruning guidance.
- **Tests**: shipped-config validation, seeding idempotency and user-edit preservation, and a cross-domain overlap test against the real config (a stablecoin/inflation doc lands in both `web3` and `economics`).

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 43 passed
- [x] `python3 scripts/kb_bootstrap.py --no-harvest` runs clean end-to-end offline

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_