### PR TITLE
Consolidation v1: claim linking pass (duplicate / supports / contradicts / supersedes)

### DIFF
--- a/src/kb/claim_links.py
+++ b/src/kb/claim_links.py
@@ -1,0 +1,451 @@
+"""
+Consolidation v1: the claim linking pass.
+
+The corpus is enriched per-document, so the same claim arriving from six
+outlets over three days is six ``argument_claims`` rows. This pass turns
+that stream into knowledge by adding **links** between claims — never by
+rewriting them (link-don't-merge; the merged reading experience is computed
+from clusters at presentation time, #966).
+
+Relations: ``duplicate`` (symmetric, canonical id order), ``supports`` /
+``contradicts`` (directed, premise → hypothesis), and ``supersedes``
+(directed, newer → older duplicate across a time gap; cluster-level
+supersedence lands with #966).
+
+Mechanics:
+
+- **Candidates** are generated per new claim against claims whose documents
+  fall inside a time window (default ±14 days) — never O(n²) over the
+  corpus. With an embedding provider, candidate ranking is cosine over
+  claim-text vectors persisted in ``claim_embeddings``; without one, a
+  lexical-overlap fallback ranks the same window.
+- **Classification** uses the shared NLI backend (:mod:`src.kb.nli`):
+  entailment → supports, contradiction → contradicts, high similarity plus
+  bidirectional entailment → duplicate. The heuristic NLI floor keeps the
+  pass fully offline-capable.
+- **Provenance**: every link row carries method, model version,
+  ``prediction_mode``/confidence (#958), and a ``run_id`` — a bad model
+  release is reverted by :func:`delete_run`, which restores the prior state
+  exactly.
+- **Incrementality** is set-based via a scan ledger (``kb_claim_link_scans``),
+  the same discipline as the membership pass.
+
+Link endpoints carry ``(domain, claim_id)`` pairs so cross-backing links
+(#967) need no schema change; ``domain`` is the claim's document's
+highest-score domain, or ``''`` when unassigned.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.kb.nli import CONTRADICTION, ENTAILMENT, HeuristicNLI
+
+_LINKS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claim_links (
+    domain_a        TEXT NOT NULL,
+    claim_a         TEXT NOT NULL,
+    domain_b        TEXT NOT NULL,
+    claim_b         TEXT NOT NULL,
+    relation        TEXT NOT NULL,
+    score           DOUBLE NOT NULL,
+    method          TEXT NOT NULL,
+    prediction_mode TEXT NOT NULL,
+    confidence      DOUBLE,
+    model_version   TEXT,
+    run_id          TEXT NOT NULL,
+    created_at      BIGINT NOT NULL,
+    PRIMARY KEY (claim_a, claim_b, relation)
+)
+"""
+
+_CLAIM_EMBEDDINGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claim_embeddings (
+    claim_id   TEXT PRIMARY KEY,
+    model      TEXT,
+    dim        INTEGER,
+    vector     TEXT,
+    updated_at BIGINT
+)
+"""
+
+_SCANS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kb_claim_link_scans (
+    claim_id   TEXT PRIMARY KEY,
+    run_id     TEXT,
+    scanned_at BIGINT NOT NULL
+)
+"""
+
+_STOP = {
+    "the", "a", "an", "of", "in", "on", "to", "for", "and", "or", "is",
+    "are", "was", "were", "be", "this", "that", "it", "with", "as", "by",
+    "at", "from", "said", "says",
+}
+
+RELATIONS = ("duplicate", "supports", "contradicts", "supersedes")
+
+
+def ensure_claim_link_schema(conn) -> None:
+    from src.database.local_warehouse_seed import ensure_schema
+    from src.kb.membership import ensure_membership_schema
+
+    ensure_schema(conn)  # argument_claims + documents (+ compat views)
+    ensure_membership_schema(conn)  # document_domains, read for endpoints
+    conn.execute(_LINKS_SCHEMA)
+    conn.execute(_CLAIM_EMBEDDINGS_SCHEMA)
+    conn.execute(_SCANS_SCHEMA)
+
+
+def _tokens(text: str) -> set:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9']+", text.lower())
+        if token not in _STOP
+    }
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(y * y for y in b) ** 0.5
+    if not norm_a or not norm_b:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _claim_domain(conn, document_id: str) -> str:
+    row = conn.execute(
+        "SELECT domain FROM document_domains WHERE document_id = ?"
+        " ORDER BY score DESC, domain LIMIT 1",
+        [document_id],
+    ).fetchone()
+    return row[0] if row else ""
+
+
+def _embed_new_claims(conn, claims, provider, model_name: str) -> None:
+    missing = [
+        (claim_id, text)
+        for claim_id, text in claims
+        if conn.execute(
+            "SELECT 1 FROM claim_embeddings WHERE claim_id = ? AND model = ?",
+            [claim_id, model_name],
+        ).fetchone()
+        is None
+    ]
+    if not missing:
+        return
+    vectors = provider.embed_texts([text for _, text in missing])
+    now = int(time.time() * 1000)
+    for (claim_id, _), vector in zip(missing, vectors):
+        values = [float(component) for component in vector]
+        conn.execute(
+            """
+            INSERT INTO claim_embeddings (claim_id, model, dim, vector, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (claim_id) DO UPDATE SET
+                model = excluded.model, dim = excluded.dim,
+                vector = excluded.vector, updated_at = excluded.updated_at
+            """,
+            [claim_id, model_name, len(values), json.dumps(values), now],
+        )
+
+
+def _upsert_link(
+    conn,
+    endpoint_a: Tuple[str, str],
+    endpoint_b: Tuple[str, str],
+    relation: str,
+    score: float,
+    method: str,
+    prediction_mode: str,
+    confidence: float,
+    model_version: str,
+    run_id: str,
+) -> bool:
+    """Insert or strengthen a link; returns True when a row was written."""
+    domain_a, claim_a = endpoint_a
+    domain_b, claim_b = endpoint_b
+    # duplicate and contradicts are symmetric — store one canonical row.
+    if relation in ("duplicate", "contradicts") and claim_b < claim_a:
+        domain_a, claim_a, domain_b, claim_b = domain_b, claim_b, domain_a, claim_a
+    before = conn.execute(
+        "SELECT confidence FROM claim_links"
+        " WHERE claim_a = ? AND claim_b = ? AND relation = ?",
+        [claim_a, claim_b, relation],
+    ).fetchone()
+    conn.execute(
+        """
+        INSERT INTO claim_links
+            (domain_a, claim_a, domain_b, claim_b, relation, score, method,
+             prediction_mode, confidence, model_version, run_id, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (claim_a, claim_b, relation) DO UPDATE SET
+            score = excluded.score,
+            method = excluded.method,
+            prediction_mode = excluded.prediction_mode,
+            confidence = excluded.confidence,
+            model_version = excluded.model_version,
+            run_id = excluded.run_id,
+            created_at = excluded.created_at
+        WHERE excluded.confidence > claim_links.confidence
+        """,
+        [
+            domain_a, claim_a, domain_b, claim_b, relation, round(score, 6),
+            method, prediction_mode, round(confidence, 4), model_version,
+            run_id, int(time.time() * 1000),
+        ],
+    )
+    return before is None
+
+
+def run_claim_linking_pass(
+    conn,
+    provider: Optional[Any] = None,
+    nli: Optional[Any] = None,
+    run_id: Optional[str] = None,
+    embedding_model: str = "all-MiniLM-L6-v2",
+    time_window_days: int = 14,
+    k_neighbors: int = 8,
+    candidate_threshold: float = 0.5,
+    duplicate_threshold: float = 0.88,
+    min_link_confidence: float = 0.55,
+    supersede_gap_days: int = 3,
+) -> Dict[str, Any]:
+    """Link new claims to their neighbours; returns a summary.
+
+    ``provider`` embeds claim texts for candidate ranking (``None`` → lexical
+    fallback). ``nli`` classifies pair relations (``None`` → the shared
+    backend's heuristic floor). Both are injectable for offline tests.
+    """
+    ensure_claim_link_schema(conn)
+    nli = nli or HeuristicNLI()
+    run_id = run_id or f"kb-claim-links-{uuid.uuid4().hex[:12]}"
+    window_ms = time_window_days * 86_400_000
+
+    new_claims = conn.execute(
+        """
+        SELECT c.claim_id, c.claim_text, c.document_id,
+               COALESCE(d.ingested_at, 0)
+        FROM argument_claims c
+        LEFT JOIN documents d ON d.document_id = c.document_id
+        LEFT JOIN kb_claim_link_scans s ON s.claim_id = c.claim_id
+        WHERE s.claim_id IS NULL
+        ORDER BY c.claim_id
+        """
+    ).fetchall()
+
+    summary = {
+        "run_id": run_id,
+        "scanned": len(new_claims),
+        "links": {relation: 0 for relation in RELATIONS},
+        "mode": getattr(nli, "prediction_mode", "heuristic"),
+    }
+    if not new_claims:
+        return summary
+
+    if provider is not None:
+        _embed_new_claims(
+            conn,
+            [(claim_id, text) for claim_id, text, _, _ in new_claims],
+            provider,
+            embedding_model,
+        )
+
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        for claim_id, claim_text, document_id, ingested_at in new_claims:
+            candidates = _candidates_for(
+                conn,
+                claim_id,
+                claim_text,
+                ingested_at,
+                provider is not None,
+                embedding_model,
+                window_ms,
+                k_neighbors,
+                candidate_threshold,
+            )
+            if candidates:
+                domain = _claim_domain(conn, document_id)
+                for other_id, other_text, other_doc, other_ingested, similarity in candidates:
+                    _link_pair(
+                        conn,
+                        nli,
+                        run_id,
+                        summary,
+                        (domain, claim_id, claim_text, ingested_at),
+                        (
+                            _claim_domain(conn, other_doc),
+                            other_id,
+                            other_text,
+                            other_ingested,
+                        ),
+                        similarity,
+                        duplicate_threshold,
+                        min_link_confidence,
+                        supersede_gap_days * 86_400_000,
+                    )
+            conn.execute(
+                """
+                INSERT INTO kb_claim_link_scans (claim_id, run_id, scanned_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT (claim_id) DO UPDATE SET
+                    run_id = excluded.run_id, scanned_at = excluded.scanned_at
+                """,
+                [claim_id, run_id, int(time.time() * 1000)],
+            )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    return summary
+
+
+def _candidates_for(
+    conn,
+    claim_id: str,
+    claim_text: str,
+    ingested_at: int,
+    use_embeddings: bool,
+    embedding_model: str,
+    window_ms: int,
+    k_neighbors: int,
+    candidate_threshold: float,
+) -> List[Tuple[str, str, str, int, float]]:
+    """Top-K similar claims inside the time window (embedding or lexical)."""
+    rows = conn.execute(
+        """
+        SELECT c.claim_id, c.claim_text, c.document_id,
+               COALESCE(d.ingested_at, 0), e.vector
+        FROM argument_claims c
+        LEFT JOIN documents d ON d.document_id = c.document_id
+        LEFT JOIN claim_embeddings e
+          ON e.claim_id = c.claim_id AND e.model = ?
+        WHERE c.claim_id <> ?
+          AND (COALESCE(d.ingested_at, 0) = 0 OR ? = 0
+               OR abs(COALESCE(d.ingested_at, 0) - ?) <= ?)
+        """,
+        [embedding_model, claim_id, ingested_at, ingested_at, window_ms],
+    ).fetchall()
+
+    own_vector = None
+    if use_embeddings:
+        vector_row = conn.execute(
+            "SELECT vector FROM claim_embeddings WHERE claim_id = ? AND model = ?",
+            [claim_id, embedding_model],
+        ).fetchone()
+        if vector_row and vector_row[0]:
+            own_vector = json.loads(vector_row[0])
+    own_tokens = _tokens(claim_text)
+
+    scored = []
+    for other_id, other_text, other_doc, other_ingested, other_vector_json in rows:
+        if own_vector is not None and other_vector_json:
+            similarity = _cosine(own_vector, json.loads(other_vector_json))
+        else:
+            similarity = _jaccard(own_tokens, _tokens(other_text or ""))
+        if similarity >= candidate_threshold:
+            scored.append((other_id, other_text, other_doc, other_ingested, similarity))
+    scored.sort(key=lambda item: item[4], reverse=True)
+    return scored[:k_neighbors]
+
+
+def _link_pair(
+    conn,
+    nli,
+    run_id: str,
+    summary: Dict[str, Any],
+    side_a: Tuple[str, str, str, int],
+    side_b: Tuple[str, str, str, int],
+    similarity: float,
+    duplicate_threshold: float,
+    min_link_confidence: float,
+    supersede_gap_ms: int,
+) -> None:
+    domain_a, claim_a, text_a, ingested_a = side_a
+    domain_b, claim_b, text_b, ingested_b = side_b
+    method = getattr(nli, "name", "heuristic")
+    mode = getattr(nli, "prediction_mode", "heuristic")
+    model_version = getattr(nli, "model_version", "unknown")
+
+    forward = nli.classify(text_a, text_b)
+    backward = nli.classify(text_b, text_a)
+
+    # Duplicate: high similarity + mutual entailment.
+    if (
+        similarity >= duplicate_threshold
+        and forward.label == ENTAILMENT
+        and backward.label == ENTAILMENT
+    ):
+        confidence = min(forward.confidence, backward.confidence)
+        if confidence >= min_link_confidence:
+            wrote = _upsert_link(
+                conn, (domain_a, claim_a), (domain_b, claim_b), "duplicate",
+                similarity, method, mode, confidence, model_version, run_id,
+            )
+            if wrote:
+                summary["links"]["duplicate"] += 1
+            if (
+                ingested_a and ingested_b
+                and abs(ingested_a - ingested_b) >= supersede_gap_ms
+            ):
+                newer, older = (
+                    ((domain_a, claim_a), (domain_b, claim_b))
+                    if ingested_a > ingested_b
+                    else ((domain_b, claim_b), (domain_a, claim_a))
+                )
+                if _upsert_link(
+                    conn, newer, older, "supersedes", similarity,
+                    f"{method}+temporal", mode, confidence, model_version, run_id,
+                ):
+                    summary["links"]["supersedes"] += 1
+            return
+
+    # Directed supports/contradicts: keep the stronger direction.
+    best = None
+    for premise, hypothesis, result in (
+        ((domain_a, claim_a), (domain_b, claim_b), forward),
+        ((domain_b, claim_b), (domain_a, claim_a), backward),
+    ):
+        if result.label in (ENTAILMENT, CONTRADICTION):
+            if best is None or result.confidence > best[2].confidence:
+                best = (premise, hypothesis, result)
+    if best is None:
+        return
+    premise, hypothesis, result = best
+    if result.confidence < min_link_confidence:
+        return
+    relation = "supports" if result.label == ENTAILMENT else "contradicts"
+    if _upsert_link(
+        conn, premise, hypothesis, relation, similarity, method, mode,
+        result.confidence, model_version, run_id,
+    ):
+        summary["links"][relation] += 1
+
+
+def delete_run(conn, run_id: str) -> Dict[str, int]:
+    """Revert one run: its links and scan-ledger rows are removed.
+
+    Claims scanned by the run become unscanned, so the next pass reassesses
+    them — deleting a bad model release's run restores the prior state.
+    """
+    links = conn.execute(
+        "SELECT COUNT(*) FROM claim_links WHERE run_id = ?", [run_id]
+    ).fetchone()[0]
+    scans = conn.execute(
+        "SELECT COUNT(*) FROM kb_claim_link_scans WHERE run_id = ?", [run_id]
+    ).fetchone()[0]
+    conn.execute("DELETE FROM claim_links WHERE run_id = ?", [run_id])
+    conn.execute("DELETE FROM kb_claim_link_scans WHERE run_id = ?", [run_id])
+    return {"links_deleted": int(links), "scans_deleted": int(scans)}

--- a/src/kb/nli.py
+++ b/src/kb/nli.py
@@ -1,0 +1,172 @@
+"""
+Shared NLI (natural-language inference) backend.
+
+One pinned pretrained NLI model serves three surfaces: stance classification,
+frame classification, and claim-pair relation linking. This module provides
+the common interface plus two implementations:
+
+- :class:`TransformersNLI` — the pinned pretrained cross-encoder (lazy
+  import; requires ``transformers``/``torch`` and a fetched model). Model
+  name comes from ``NOESIS_NLI_MODEL``.
+- :class:`HeuristicNLI` — the fully-offline floor: lexical overlap plus
+  negation/antonym cues. Degraded quality, still valid output, consistent
+  with the repo-wide fallback discipline.
+
+Every result carries ``prediction_mode`` so downstream honesty reporting
+(#958) can distinguish model-grade from heuristic-grade output.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Set, Tuple
+
+ENTAILMENT = "entailment"
+CONTRADICTION = "contradiction"
+NEUTRAL = "neutral"
+
+#: default pinned model; #959 wires revision pinning + fetch
+DEFAULT_NLI_MODEL = "cross-encoder/nli-deberta-v3-base"
+NLI_MODEL_ENV = "NOESIS_NLI_MODEL"
+
+_STOPWORDS = {
+    "the", "a", "an", "of", "in", "on", "to", "for", "and", "or", "is", "are",
+    "was", "were", "be", "been", "this", "that", "these", "those", "it", "its",
+    "with", "as", "by", "at", "from", "their", "our", "we", "has", "have",
+    "had", "will", "would", "said", "says", "say",
+}
+
+_NEGATIONS = {
+    "not", "no", "never", "n't", "denies", "denied", "deny", "refutes",
+    "refuted", "rejects", "rejected", "disputes", "disputed", "without",
+}
+
+#: cheap directional antonyms common in news/economics claims
+_ANTONYM_PAIRS = [
+    ("rise", "fall"), ("rises", "falls"), ("rose", "fell"),
+    ("increase", "decrease"), ("increased", "decreased"),
+    ("up", "down"), ("gain", "loss"), ("gains", "losses"),
+    ("higher", "lower"), ("approve", "reject"), ("approved", "rejected"),
+    ("growth", "contraction"), ("surge", "plunge"), ("won", "lost"),
+    ("confirmed", "denied"), ("supports", "opposes"), ("more", "fewer"),
+]
+
+
+@dataclass
+class NLIResult:
+    label: str          # entailment | contradiction | neutral
+    confidence: float   # calibrated-ish [0, 1]
+    prediction_mode: str
+
+
+def _content_tokens(text: str) -> Set[str]:
+    tokens = re.findall(r"[a-z0-9']+", text.lower())
+    return {token for token in tokens if token not in _STOPWORDS}
+
+
+def _negation_count(text: str) -> int:
+    tokens = re.findall(r"[a-z']+", text.lower())
+    return sum(1 for token in tokens if token in _NEGATIONS)
+
+
+class HeuristicNLI:
+    """Offline floor: overlap + negation parity + directional antonyms."""
+
+    name = "heuristic"
+    prediction_mode = "heuristic"
+    model_version = "heuristic-v1"
+
+    def classify(self, premise: str, hypothesis: str) -> NLIResult:
+        premise_tokens = _content_tokens(premise)
+        hypothesis_tokens = _content_tokens(hypothesis)
+        if not premise_tokens or not hypothesis_tokens:
+            return NLIResult(NEUTRAL, 0.3, self.prediction_mode)
+
+        overlap = len(premise_tokens & hypothesis_tokens) / len(
+            premise_tokens | hypothesis_tokens
+        )
+        negation_flip = (_negation_count(premise) % 2) != (
+            _negation_count(hypothesis) % 2
+        )
+        antonym = any(
+            (a in premise_tokens and b in hypothesis_tokens)
+            or (b in premise_tokens and a in hypothesis_tokens)
+            for a, b in _ANTONYM_PAIRS
+        )
+
+        if overlap >= 0.4 and (negation_flip or antonym):
+            return NLIResult(
+                CONTRADICTION,
+                round(min(0.85, 0.5 + overlap / 2), 3),
+                self.prediction_mode,
+            )
+        if overlap >= 0.6 and not negation_flip and not antonym:
+            return NLIResult(
+                ENTAILMENT,
+                round(min(0.85, 0.4 + overlap / 2), 3),
+                self.prediction_mode,
+            )
+        return NLIResult(NEUTRAL, round(0.4 + (1 - overlap) / 4, 3), self.prediction_mode)
+
+
+class TransformersNLI:
+    """Pinned pretrained NLI cross-encoder, lazily loaded.
+
+    Raises ``RuntimeError`` from the constructor when the stack is not
+    available — callers should use :func:`get_nli_backend`, which falls back
+    to :class:`HeuristicNLI`.
+    """
+
+    def __init__(self, model_name: Optional[str] = None) -> None:
+        self.model_name = model_name or os.environ.get(
+            NLI_MODEL_ENV, DEFAULT_NLI_MODEL
+        )
+        try:
+            from transformers import (  # noqa: F401
+                AutoModelForSequenceClassification,
+                AutoTokenizer,
+            )
+            import torch  # noqa: F401
+        except Exception as exc:  # pragma: no cover - env-dependent
+            raise RuntimeError(f"transformers/torch unavailable: {exc}") from exc
+
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self._model = AutoModelForSequenceClassification.from_pretrained(
+            self.model_name
+        )
+        self._model.eval()
+        # id2label varies across NLI checkpoints; normalize to our labels.
+        self._id2label = {
+            index: label.lower()
+            for index, label in self._model.config.id2label.items()
+        }
+        self.name = f"nli:{self.model_name}"
+        self.prediction_mode = f"zero-shot:{self.model_name}"
+        self.model_version = self.model_name
+
+    def classify(self, premise: str, hypothesis: str) -> NLIResult:  # pragma: no cover - needs model
+        import torch
+
+        inputs = self._tokenizer(
+            premise, hypothesis, return_tensors="pt", truncation=True, max_length=512
+        )
+        with torch.no_grad():
+            logits = self._model(**inputs).logits[0]
+        probs = torch.softmax(logits, dim=-1).tolist()
+        best = max(range(len(probs)), key=lambda index: probs[index])
+        label = self._id2label.get(best, NEUTRAL)
+        if label not in (ENTAILMENT, CONTRADICTION, NEUTRAL):
+            label = NEUTRAL
+        return NLIResult(label, round(float(probs[best]), 4), self.prediction_mode)
+
+
+def get_nli_backend(model_name: Optional[str] = None):
+    """The pinned pretrained backend when available, else the heuristic floor."""
+    try:
+        return TransformersNLI(model_name)
+    except Exception:
+        return HeuristicNLI()

--- a/tests/unit/kb/test_claim_links.py
+++ b/tests/unit/kb/test_claim_links.py
@@ -1,0 +1,257 @@
+"""Unit tests for the claim linking pass and the shared NLI heuristic floor."""
+
+import duckdb
+import pytest
+
+from src.kb.claim_links import (
+    delete_run,
+    ensure_claim_link_schema,
+    run_claim_linking_pass,
+)
+from src.kb.nli import CONTRADICTION, ENTAILMENT, NEUTRAL, HeuristicNLI
+
+DAY_MS = 86_400_000
+BASE_MS = 1_750_000_000_000
+
+
+class FakeNLI:
+    """Deterministic NLI double driven by marker tokens."""
+
+    name = "nli:fake-model"
+    prediction_mode = "zero-shot:fake-model"
+    model_version = "fake-model@r1"
+
+    def classify(self, premise, hypothesis):
+        from src.kb.nli import NLIResult
+
+        p, h = premise.lower(), hypothesis.lower()
+        same_topic = ("rates" in p and "rates" in h) or ("mpox" in p and "mpox" in h)
+        if same_topic:
+            flip = ("not" in p) != ("not" in h) or ("over" in p) != ("over" in h)
+            if flip:
+                return NLIResult(CONTRADICTION, 0.9, self.prediction_mode)
+            return NLIResult(ENTAILMENT, 0.85, self.prediction_mode)
+        return NLIResult(NEUTRAL, 0.6, self.prediction_mode)
+
+
+class FakeProvider:
+    VOCAB = [
+        "central", "bank", "raise", "rates", "september", "mpox",
+        "outbreak", "over", "continues", "gardening", "tomatoes",
+    ]
+
+    def embed_texts(self, texts):
+        out = []
+        for text in texts:
+            tokens = set(text.lower().replace(".", " ").split())
+            out.append([1.0 if word in tokens else 0.0 for word in self.VOCAB])
+        return out
+
+
+def _seed_claims(conn, rows):
+    """rows: (claim_id, text, document_id, ingested_at, domain or None)"""
+    ensure_claim_link_schema(conn)
+    for claim_id, text, doc_id, ingested_at, domain in rows:
+        conn.execute(
+            "INSERT OR IGNORE INTO documents (document_id, source_type, ingested_at)"
+            " VALUES (?, 'news', ?)",
+            [doc_id, ingested_at],
+        )
+        conn.execute(
+            "INSERT INTO argument_claims (claim_id, claim_text, document_id,"
+            " source_type, confidence) VALUES (?, ?, ?, 'news', 0.8)",
+            [claim_id, text, doc_id],
+        )
+        if domain:
+            conn.execute(
+                "INSERT INTO document_domains VALUES (?, ?, 1.0, 'source', 'r0', 0)",
+                [doc_id, domain],
+            )
+
+
+@pytest.fixture()
+def conn():
+    return duckdb.connect()
+
+
+DUP_A = "The central bank will raise rates in September."
+DUP_B = "Central bank set to raise rates September."
+CONTRA = "The central bank will not raise rates in September."
+UNRELATED = "Gardening tomatoes continues."
+
+
+class TestLinking:
+    def test_duplicate_link_with_provenance(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, "economics"),
+                ("c2", DUP_B, "d2", BASE_MS + DAY_MS, "economics"),
+            ],
+        )
+        summary = run_claim_linking_pass(
+            conn, provider=FakeProvider(), nli=FakeNLI()
+        )
+        assert summary["links"]["duplicate"] == 1
+        row = conn.execute(
+            "SELECT domain_a, claim_a, claim_b, method, prediction_mode,"
+            " model_version, run_id FROM claim_links WHERE relation = 'duplicate'"
+        ).fetchone()
+        assert row[1] == "c1" and row[2] == "c2"  # canonical order
+        assert row[0] == "economics"
+        assert row[3] == "nli:fake-model"
+        assert row[4] == "zero-shot:fake-model"
+        assert row[5] == "fake-model@r1"
+        assert row[6] == summary["run_id"]
+
+    def test_contradiction_link(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, "economics"),
+                ("c3", CONTRA, "d3", BASE_MS + DAY_MS, None),
+            ],
+        )
+        summary = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert summary["links"]["contradicts"] == 1
+
+    def test_supersedes_written_for_gapped_duplicates(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("old", DUP_A, "d1", BASE_MS, None),
+                ("new", DUP_B, "d2", BASE_MS + 5 * DAY_MS, None),
+            ],
+        )
+        run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        row = conn.execute(
+            "SELECT claim_a, claim_b, method FROM claim_links"
+            " WHERE relation = 'supersedes'"
+        ).fetchone()
+        assert row is not None
+        assert (row[0], row[1]) == ("new", "old")  # newer supersedes older
+        assert row[2].endswith("+temporal")
+
+    def test_time_window_blocks_far_candidates(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("far", DUP_B, "d2", BASE_MS + 60 * DAY_MS, None),
+            ],
+        )
+        summary = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert summary["links"]["duplicate"] == 0
+
+    def test_unrelated_claims_stay_unlinked(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("u1", UNRELATED, "d2", BASE_MS, None),
+            ],
+        )
+        run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert conn.execute("SELECT COUNT(*) FROM claim_links").fetchone()[0] == 0
+
+    def test_offline_heuristic_mode_links_duplicates(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("c2", DUP_A, "d2", BASE_MS + DAY_MS, None),
+                ("c3", CONTRA, "d3", BASE_MS + DAY_MS, None),
+            ],
+        )
+        summary = run_claim_linking_pass(conn)  # no provider, no NLI
+        assert summary["mode"] == "heuristic"
+        relations = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT relation, prediction_mode FROM claim_links"
+            ).fetchall()
+        }
+        assert "duplicate" in relations
+        assert relations["duplicate"] == "heuristic"
+        assert "contradicts" in relations
+
+
+class TestIncrementality:
+    def test_second_run_scans_nothing(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("c2", DUP_B, "d2", BASE_MS, None),
+            ],
+        )
+        run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        links_before = conn.execute("SELECT * FROM claim_links ORDER BY claim_a").fetchall()
+
+        second = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert second["scanned"] == 0
+        assert (
+            conn.execute("SELECT * FROM claim_links ORDER BY claim_a").fetchall()
+            == links_before
+        )
+
+    def test_new_claim_links_against_old_corpus(self, conn):
+        _seed_claims(conn, [("c1", DUP_A, "d1", BASE_MS, None)])
+        run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+
+        _seed_claims_more = [("c2", DUP_B, "d2", BASE_MS + DAY_MS, None)]
+        for claim_id, text, doc_id, ingested_at, _ in _seed_claims_more:
+            conn.execute(
+                "INSERT INTO documents (document_id, source_type, ingested_at)"
+                " VALUES (?, 'news', ?)",
+                [doc_id, ingested_at],
+            )
+            conn.execute(
+                "INSERT INTO argument_claims (claim_id, claim_text, document_id,"
+                " source_type, confidence) VALUES (?, ?, ?, 'news', 0.8)",
+                [claim_id, text, doc_id],
+            )
+        summary = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert summary["scanned"] == 1
+        assert summary["links"]["duplicate"] == 1
+
+    def test_delete_run_reverts_links_and_ledger(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("c2", DUP_B, "d2", BASE_MS, None),
+            ],
+        )
+        summary = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert conn.execute("SELECT COUNT(*) FROM claim_links").fetchone()[0] > 0
+
+        result = delete_run(conn, summary["run_id"])
+        assert result["links_deleted"] > 0
+        assert conn.execute("SELECT COUNT(*) FROM claim_links").fetchone()[0] == 0
+        # Claims are unscanned again: the next pass reassesses them.
+        rerun = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+        assert rerun["scanned"] == 2
+        assert conn.execute("SELECT COUNT(*) FROM claim_links").fetchone()[0] > 0
+
+
+class TestHeuristicNLI:
+    def test_entailment_on_high_overlap(self):
+        result = HeuristicNLI().classify(DUP_A, DUP_B)
+        assert result.label == ENTAILMENT
+        assert result.prediction_mode == "heuristic"
+
+    def test_contradiction_on_negation_flip(self):
+        result = HeuristicNLI().classify(DUP_A, CONTRA)
+        assert result.label == CONTRADICTION
+
+    def test_contradiction_on_antonyms(self):
+        result = HeuristicNLI().classify(
+            "Inflation rose sharply last quarter in Europe.",
+            "Inflation fell sharply last quarter in Europe.",
+        )
+        assert result.label == CONTRADICTION
+
+    def test_neutral_on_disjoint_topics(self):
+        result = HeuristicNLI().classify(DUP_A, UNRELATED)
+        assert result.label == NEUTRAL


### PR DESCRIPTION
## Overview

Implements #964 — the heart of consolidation: link rows between claims, never rewrites. Six copies of a story become one claim with links; the merged reading experience is computed at presentation time (#966).

## Changes Summary

- **`src/kb/claim_links.py`**: incremental linking pass. Candidates per new claim inside a ±14-day window (never O(n²)), ranked by claim-text embeddings persisted in `claim_embeddings` (lexical-overlap fallback offline). Relations via the shared NLI backend: high similarity + mutual entailment → `duplicate` (symmetric, canonical order), entailment/contradiction → directed `supports` / symmetric-canonical `contradicts`, and `supersedes` (newer→older duplicate across a ≥3-day gap; cluster-level supersedence lands in #966). Every row carries `(domain, claim_id)` endpoints (cross-backing ready for #967), method, `model_version`, `prediction_mode`, confidence (#958), and `run_id`. `delete_run()` reverts a bad model release and un-scans its claims. Set-based scan ledger + transaction, same discipline the #962 review forced on membership.
- **`src/kb/nli.py`**: the shared NLI interface for this pass and the stance/frame backends (#954/#955) — pinned pretrained cross-encoder (`NOESIS_NLI_MODEL`, lazy import, label normalization) with a fully-offline heuristic floor (lexical overlap + negation parity + directional antonyms).
- **Tests**: 13 new — duplicate/contradiction/supersedes fixtures with provenance assertions, time-window blocking, offline heuristic mode, incremental re-runs, new-vs-old linking, `delete_run` revert, and heuristic-NLI unit cases.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 56 passed

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_