### PR TITLE
Claim clusters: presentation-time merge, corroboration, contradiction ledger

### DIFF
--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -223,6 +223,28 @@ class CorpusViewBacking(DomainBacking):
             params,
         )
 
+    def claims(
+        self,
+        since: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Clustered, cited claims for this domain (presentation merge).
+
+        Each entry is a cluster: representative + full citation list,
+        corroboration count, cross-cluster contradictions, and supersedence
+        flags. See :func:`src.kb.clusters.cluster_claims`.
+        """
+        from src.kb.clusters import cluster_claims
+
+        since_ms = _since_to_epoch_ms(since) if since else None
+        with self._lock():
+            return cluster_claims(
+                self.conn,
+                domain=self.definition.name,
+                limit=limit,
+                since=since_ms,
+            )
+
     def search(self, query: str, limit: int = 20) -> List[Dict[str, Any]]:
         """Lexical search within the domain (semantic lands with the contract)."""
         view = self._view()

--- a/src/kb/clusters.py
+++ b/src/kb/clusters.py
@@ -1,0 +1,274 @@
+"""
+Claim clusters: the presentation-time merge over the link graph.
+
+Storage never merges (#964 writes links only); this module derives the
+merged reading experience consumers actually want. A **cluster** is a
+connected component over ``duplicate`` links: one representative claim plus
+every citation, with corroboration and contradiction as cluster-level
+properties. This is where information overload actually drops — six copies
+of a story collapse to one entry with a source list.
+
+- **Cluster ids** are ``cl-<min claim_id in component>``: deterministic, and
+  stable as long as the smallest member stays; when two clusters merge, the
+  smaller id wins, so one side keeps its identity.
+- **Representative** = recency blended with source quality, using the
+  existing ``outlet_scores`` transparency scores as the quality input.
+  Superseded claims are never chosen while a live member exists.
+- **Corroboration** = independent sources per cluster (distinct normalized
+  ``source_id``), not raw row count.
+- **Contradictions** = ``contradicts`` links whose endpoints land in
+  different clusters, cited on both sides.
+- **Supersedence** honoured at presentation: superseded members are marked
+  historical, never silently dropped.
+
+Singleton claims (no duplicate links) are clusters of one at read time —
+they get no ``claim_clusters`` row, keeping the table proportional to the
+linked subgraph.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+_CLUSTERS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claim_clusters (
+    claim_id    TEXT PRIMARY KEY,
+    cluster_id  TEXT NOT NULL,
+    run_id      TEXT,
+    assigned_at BIGINT NOT NULL
+)
+"""
+
+
+def ensure_cluster_schema(conn) -> None:
+    from src.kb.claim_links import ensure_claim_link_schema
+
+    ensure_claim_link_schema(conn)
+    conn.execute(_CLUSTERS_SCHEMA)
+
+
+class _UnionFind:
+    def __init__(self) -> None:
+        self.parent: Dict[str, str] = {}
+
+    def find(self, item: str) -> str:
+        self.parent.setdefault(item, item)
+        root = item
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[item] != root:
+            self.parent[item], item = root, self.parent[item]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        root_a, root_b = self.find(a), self.find(b)
+        if root_a != root_b:
+            # Smaller id becomes the root so cluster ids stay deterministic.
+            if root_b < root_a:
+                root_a, root_b = root_b, root_a
+            self.parent[root_b] = root_a
+
+
+def run_clustering_pass(conn, run_id: Optional[str] = None) -> Dict[str, Any]:
+    """(Re)derive clusters from the duplicate-link graph.
+
+    Recomputes components over all duplicate links — the link graph is the
+    source of truth, so this is idempotent and self-healing after
+    :func:`src.kb.claim_links.delete_run`.
+    """
+    ensure_cluster_schema(conn)
+    run_id = run_id or f"kb-clusters-{uuid.uuid4().hex[:12]}"
+
+    links = conn.execute(
+        "SELECT claim_a, claim_b FROM claim_links WHERE relation = 'duplicate'"
+    ).fetchall()
+
+    uf = _UnionFind()
+    for claim_a, claim_b in links:
+        uf.union(claim_a, claim_b)
+
+    members = sorted(uf.parent.keys())
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        conn.execute("DELETE FROM claim_clusters")
+        now = int(time.time() * 1000)
+        for claim_id in members:
+            conn.execute(
+                "INSERT INTO claim_clusters (claim_id, cluster_id, run_id, assigned_at)"
+                " VALUES (?, ?, ?, ?)",
+                [claim_id, f"cl-{uf.find(claim_id)}", run_id, now],
+            )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    clusters = {uf.find(claim_id) for claim_id in members}
+    return {"run_id": run_id, "linked_claims": len(members), "clusters": len(clusters)}
+
+
+def _outlet_quality(conn) -> Dict[str, float]:
+    """Latest composite transparency score per source (normalized name)."""
+    rows = conn.execute(
+        """
+        SELECT source, composite_score FROM outlet_scores
+        WHERE (source, score_date) IN (
+            SELECT source, MAX(score_date) FROM outlet_scores GROUP BY source
+        )
+        """
+    ).fetchall()
+    return {
+        str(source).strip().lower(): float(score)
+        for source, score in rows
+        if score is not None
+    }
+
+
+def _superseded_claims(conn) -> Set[str]:
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT claim_b FROM claim_links WHERE relation = 'supersedes'"
+        ).fetchall()
+    }
+
+
+def cluster_claims(
+    conn,
+    domain: Optional[str] = None,
+    limit: int = 50,
+    since: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Clustered, cited claims — the presentation merge.
+
+    ``domain`` filters members through ``document_domains``; ``since`` is an
+    epoch-ms floor on the member document's ingestion time (a cluster
+    surfaces when *any* member passes). Clusters are ordered by their newest
+    member's arrival, newest first.
+    """
+    ensure_cluster_schema(conn)
+
+    domain_filter = ""
+    params: List[Any] = []
+    if domain:
+        domain_filter = (
+            "AND c.document_id IN"
+            " (SELECT document_id FROM document_domains WHERE domain = ?)"
+        )
+        params.append(domain)
+
+    rows = conn.execute(
+        f"""
+        SELECT c.claim_id, c.claim_text, c.document_id, c.confidence,
+               COALESCE(cl.cluster_id, 'cl-' || c.claim_id) AS cluster_id,
+               COALESCE(d.source_id, '') AS source_id,
+               d.url, d.title, COALESCE(d.ingested_at, 0) AS ingested_at
+        FROM argument_claims c
+        LEFT JOIN claim_clusters cl ON cl.claim_id = c.claim_id
+        LEFT JOIN documents d ON d.document_id = c.document_id
+        WHERE 1 = 1 {domain_filter}
+        """,
+        params,
+    ).fetchall()
+    if not rows:
+        return []
+
+    quality = _outlet_quality(conn)
+    superseded = _superseded_claims(conn)
+
+    grouped: Dict[str, List[Tuple]] = {}
+    for row in rows:
+        grouped.setdefault(row[4], []).append(row)
+
+    newest = {
+        cluster_id: max(member[8] for member in members)
+        for cluster_id, members in grouped.items()
+    }
+    if since is not None:
+        grouped = {
+            cluster_id: members
+            for cluster_id, members in grouped.items()
+            if newest[cluster_id] >= since
+        }
+
+    contradiction_rows = conn.execute(
+        """
+        SELECT l.claim_a, l.claim_b, l.confidence, l.prediction_mode,
+               a.claim_text, b.claim_text
+        FROM claim_links l
+        JOIN argument_claims a ON a.claim_id = l.claim_a
+        JOIN argument_claims b ON b.claim_id = l.claim_b
+        WHERE l.relation = 'contradicts'
+        """
+    ).fetchall()
+
+    clusters: List[Dict[str, Any]] = []
+    for cluster_id, members in grouped.items():
+        citations = []
+        for (claim_id, text, document_id, confidence, _cl, source_id,
+             url, title, ingested_at) in sorted(
+                members, key=lambda member: member[8], reverse=True):
+            citations.append(
+                {
+                    "claim_id": claim_id,
+                    "claim_text": text,
+                    "document_id": document_id,
+                    "source": source_id,
+                    "url": url,
+                    "title": title,
+                    "ingested_at": ingested_at,
+                    "confidence": confidence,
+                    "superseded": claim_id in superseded,
+                }
+            )
+
+        live = [c for c in citations if not c["superseded"]] or citations
+        max_ingested = max(c["ingested_at"] for c in citations) or 1
+
+        def rank(citation: Dict[str, Any]) -> float:
+            recency = (
+                citation["ingested_at"] / max_ingested if max_ingested else 0.0
+            )
+            source_quality = quality.get(
+                str(citation["source"]).strip().lower(), 0.5
+            )
+            return 0.6 * recency + 0.4 * source_quality
+
+        representative = max(live, key=rank)
+        member_ids = {c["claim_id"] for c in citations}
+        contradictions = []
+        for (claim_a, claim_b, confidence, mode, text_a, text_b) in contradiction_rows:
+            if claim_a in member_ids and claim_b not in member_ids:
+                contradictions.append(
+                    {"claim_id": claim_b, "claim_text": text_b,
+                     "confidence": confidence, "prediction_mode": mode}
+                )
+            elif claim_b in member_ids and claim_a not in member_ids:
+                contradictions.append(
+                    {"claim_id": claim_a, "claim_text": text_a,
+                     "confidence": confidence, "prediction_mode": mode}
+                )
+
+        corroboration = len(
+            {
+                str(c["source"]).strip().lower()
+                for c in citations
+                if c["source"]
+            }
+        )
+        clusters.append(
+            {
+                "cluster_id": cluster_id,
+                "representative": representative,
+                "citations": citations,
+                "corroboration": corroboration,
+                "contradictions": contradictions,
+                "size": len(citations),
+                "last_ingested_ms": newest[cluster_id],
+            }
+        )
+
+    clusters.sort(key=lambda cluster: cluster["last_ingested_ms"], reverse=True)
+    return clusters[: int(limit)]

--- a/tests/unit/kb/test_clusters.py
+++ b/tests/unit/kb/test_clusters.py
@@ -1,0 +1,180 @@
+"""Unit tests for claim clustering and the presentation-time merge."""
+
+import duckdb
+import pytest
+
+from src.kb.claim_links import delete_run, run_claim_linking_pass
+from src.kb.clusters import (
+    cluster_claims,
+    ensure_cluster_schema,
+    run_clustering_pass,
+)
+from tests.unit.kb.test_claim_links import (
+    CONTRA,
+    DAY_MS,
+    BASE_MS,
+    DUP_A,
+    DUP_B,
+    FakeNLI,
+    FakeProvider,
+    _seed_claims,
+)
+
+
+@pytest.fixture()
+def conn():
+    return duckdb.connect()
+
+
+def _link_and_cluster(conn):
+    summary = run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+    run_clustering_pass(conn)
+    return summary
+
+
+class TestClustering:
+    def test_duplicates_form_one_cluster(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, "economics"),
+                ("c2", DUP_B, "d2", BASE_MS + DAY_MS, "economics"),
+            ],
+        )
+        result = _link_and_cluster(conn)
+        assert result["links"]["duplicate"] == 1
+        stats = run_clustering_pass(conn)
+        assert stats["clusters"] == 1
+        rows = conn.execute(
+            "SELECT DISTINCT cluster_id FROM claim_clusters"
+        ).fetchall()
+        assert rows == [("cl-c1",)]  # smallest member id wins
+
+    def test_cluster_ids_stable_across_reruns(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("c2", DUP_B, "d2", BASE_MS, None),
+            ],
+        )
+        _link_and_cluster(conn)
+        before = dict(
+            conn.execute("SELECT claim_id, cluster_id FROM claim_clusters").fetchall()
+        )
+        run_clustering_pass(conn)
+        after = dict(
+            conn.execute("SELECT claim_id, cluster_id FROM claim_clusters").fetchall()
+        )
+        assert before == after
+
+    def test_self_heals_after_delete_run(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, None),
+                ("c2", DUP_B, "d2", BASE_MS, None),
+            ],
+        )
+        summary = _link_and_cluster(conn)
+        assert conn.execute("SELECT COUNT(*) FROM claim_clusters").fetchone()[0] == 2
+
+        delete_run(conn, summary["run_id"])
+        stats = run_clustering_pass(conn)
+        assert stats["linked_claims"] == 0
+        assert conn.execute("SELECT COUNT(*) FROM claim_clusters").fetchone()[0] == 0
+
+
+class TestPresentationMerge:
+    def _seed_story(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("c1", DUP_A, "d1", BASE_MS, "economics"),
+                ("c2", DUP_B, "d2", BASE_MS + DAY_MS, "economics"),
+                ("c3", CONTRA, "d3", BASE_MS + DAY_MS, "economics"),
+            ],
+        )
+        conn.execute("UPDATE documents SET source_id = 'reuters' WHERE document_id = 'd1'")
+        conn.execute("UPDATE documents SET source_id = 'bbc' WHERE document_id = 'd2'")
+        conn.execute("UPDATE documents SET source_id = 'ft' WHERE document_id = 'd3'")
+        _link_and_cluster(conn)
+
+    def test_merged_cluster_with_citations_and_corroboration(self, conn):
+        self._seed_story(conn)
+        clusters = cluster_claims(conn, domain="economics")
+        merged = next(c for c in clusters if c["size"] == 2)
+        assert merged["corroboration"] == 2
+        assert {c["source"] for c in merged["citations"]} == {"reuters", "bbc"}
+        assert merged["representative"]["claim_id"] in {"c1", "c2"}
+
+    def test_contradictions_cited_across_clusters(self, conn):
+        self._seed_story(conn)
+        clusters = cluster_claims(conn, domain="economics")
+        merged = next(c for c in clusters if c["size"] == 2)
+        assert any(
+            contradiction["claim_id"] == "c3"
+            for contradiction in merged["contradictions"]
+        )
+        lone = next(c for c in clusters if c["size"] == 1)
+        assert any(
+            contradiction["claim_id"] in {"c1", "c2"}
+            for contradiction in lone["contradictions"]
+        )
+
+    def test_representative_prefers_quality_and_recency(self, conn):
+        self._seed_story(conn)
+        # Give the older source a dominant transparency score.
+        conn.execute(
+            "INSERT INTO outlet_scores (source, source_type, score_date,"
+            " composite_score) VALUES ('reuters', 'news', '2026-07-01', 0.99)"
+        )
+        conn.execute(
+            "INSERT INTO outlet_scores (source, source_type, score_date,"
+            " composite_score) VALUES ('bbc', 'news', '2026-07-01', 0.10)"
+        )
+        clusters = cluster_claims(conn, domain="economics")
+        merged = next(c for c in clusters if c["size"] == 2)
+        # 0.6*recency + 0.4*quality: reuters' 0.99 beats bbc's newer arrival.
+        assert merged["representative"]["source"] == "reuters"
+
+    def test_superseded_marked_and_not_representative(self, conn):
+        _seed_claims(
+            conn,
+            [
+                ("old", DUP_A, "d1", BASE_MS, "economics"),
+                ("new", DUP_B, "d2", BASE_MS + 5 * DAY_MS, "economics"),
+            ],
+        )
+        _link_and_cluster(conn)
+        clusters = cluster_claims(conn, domain="economics")
+        cluster = clusters[0]
+        flags = {c["claim_id"]: c["superseded"] for c in cluster["citations"]}
+        assert flags == {"new": False, "old": True}
+        assert cluster["representative"]["claim_id"] == "new"
+
+    def test_singletons_are_clusters_of_one(self, conn):
+        _seed_claims(conn, [("solo", DUP_A, "d1", BASE_MS, "economics")])
+        run_clustering_pass(conn)
+        clusters = cluster_claims(conn, domain="economics")
+        assert len(clusters) == 1
+        assert clusters[0]["cluster_id"] == "cl-solo"
+        assert clusters[0]["size"] == 1
+
+    def test_since_filter_on_cluster_recency(self, conn):
+        self._seed_story(conn)
+        clusters = cluster_claims(
+            conn, domain="economics", since=BASE_MS + DAY_MS
+        )
+        # Every cluster whose newest member arrived on day 2 qualifies —
+        # including the merged one (its newest member is c2).
+        assert {c["cluster_id"] for c in clusters} == {"cl-c1", "cl-c3"}
+
+    def test_backing_claims_wires_through(self, conn):
+        from src.kb import load_registry
+
+        self._seed_story(conn)
+        registry = load_registry()
+        backing = registry.resolve("economics", conn=conn)
+        clusters = backing.claims()
+        assert any(c["size"] == 2 for c in clusters)

--- a/tests/unit/kb/test_registry.py
+++ b/tests/unit/kb/test_registry.py
@@ -164,8 +164,8 @@ class TestResolution:
         import duckdb
 
         backing = registry.resolve("web3", conn=duckdb.connect())
-        with pytest.raises(NotImplementedError, match="claims"):
-            backing.claims()
+        with pytest.raises(NotImplementedError, match="entities"):
+            backing.entities()
         with pytest.raises(NotImplementedError, match="diff"):
             backing.diff(since="2026-07-01")
 


### PR DESCRIPTION
## Overview

Implements #966 — the merged reading experience computed from the link graph at query time. Six copies of a story collapse to one cluster entry with a source list; storage never merges.

## Changes Summary

- **`src/kb/clusters.py`**: `claim_clusters` via union-find over `duplicate` links with deterministic `cl-<min member>` ids (smaller id wins on merges, so identities stay mostly stable); recomputed from the link graph each pass — idempotent and self-healing after `delete_run`. `cluster_claims()` performs the presentation merge: representative chosen by 0.6·recency + 0.4·`outlet_scores` composite (superseded members never chosen while a live one exists), full citation list with supersedence flags, **corroboration** as distinct-normalized-source count, and **contradictions** as cross-cluster `contradicts` links cited on both sides. Singletons are clusters of one at read time, keeping the table proportional to the linked subgraph.
- **`src/kb/backing.py`**: `CorpusViewBacking.claims(since, limit)` now serves clusters (domain-scoped through `document_domains`, since on newest-member arrival), under the shared-connection lock.
- **Tests**: 10 new — component formation, id stability, self-heal after link revert, citations/corroboration, cross-cluster contradiction citations, quality-vs-recency representative selection, supersedence flags, singletons, since-filtering, and the backing wire-through.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 82 passed

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_