### PR TITLE
Namespace backing + cross-backing linkage (one brain, many stores)

### DIFF
--- a/src/kb/backing.py
+++ b/src/kb/backing.py
@@ -295,14 +295,222 @@ class CorpusViewBacking(DomainBacking):
 class NamespaceBacking(DomainBacking):
     """Domain served by a provisioned namespace with its own storage.
 
-    Wired against the provisioning plane in a later increment; until then
-    only :meth:`coverage` answers. ``namespace`` defaults to the domain name
-    at validation time, so the field is always present here.
+    Reads go against the provisioning plane's namespaced tables
+    (``kg_<name>_documents/entities/claims``), either table-prefixed in the
+    shared warehouse or alias-qualified in the namespace's own attached
+    DuckDB file (``namespace_backend: attached`` — one engine, so
+    cross-backing SQL joins stay possible). The base namespaced schema is
+    thin; promotion (:mod:`src.kb.promotion`) extends it with ``content``
+    and ``ingested_at`` columns, and every read here tolerates their
+    absence. ``diff`` arrives with the change-feed increment.
     """
 
     backing_type = "namespace"
 
+    def _tables(self) -> Dict[str, str]:
+        from src.provisioning.namespaces import (
+            BACKEND_ATTACHED,
+            BACKEND_TABLE_PREFIX,
+            create_namespace,
+        )
+
+        backend = (
+            BACKEND_ATTACHED
+            if self.definition.namespace_backend == "attached"
+            else BACKEND_TABLE_PREFIX
+        )
+        with self._lock():
+            return create_namespace(self.conn, self.definition.namespace, backend)
+
+    def _has_column(self, table: str, column: str) -> bool:
+        from src.provisioning.namespaces import _has_column
+
+        return _has_column(self.conn, table, column)
+
+    def documents(
+        self,
+        limit: int = 50,
+        since: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        tables = self._tables()
+        docs = tables["documents"]
+        has_content = self._has_column(docs, "content")
+        has_ingested = self._has_column(docs, "ingested_at")
+        content_expr = "content" if has_content else "NULL AS content"
+        arrival = "ingested_at" if has_ingested else "epoch_ms(routed_at)"
+        params: List[Any] = []
+        where = ""
+        if since:
+            where = f"WHERE COALESCE({arrival}, 0) >= ?"
+            params.append(_since_to_epoch_ms(since))
+        params.append(int(limit))
+        with self._lock():
+            rows = self.conn.execute(
+                f"SELECT id, title, source, source_type, url,"
+                f" epoch_ms(published_at), COALESCE({arrival}, 0), {content_expr}"
+                f" FROM {docs} {where}"
+                f" ORDER BY COALESCE({arrival}, 0) DESC LIMIT ?",
+                params,
+            ).fetchall()
+        return [
+            {
+                "document_id": row[0],
+                "title": row[1],
+                "source_id": row[2],
+                "source_type": row[3],
+                "url": row[4],
+                "created_at": row[5],
+                "ingested_at": row[6],
+                "content": row[7],
+            }
+            for row in rows
+        ]
+
+    def search(self, query: str, limit: int = 20) -> List[Dict[str, Any]]:
+        tables = self._tables()
+        docs = tables["documents"]
+        has_content = self._has_column(docs, "content")
+        pattern = CorpusViewBacking._like_pattern(query)
+        content_clause = (
+            " OR lower(COALESCE(content, '')) LIKE ? ESCAPE '\\'"
+            if has_content
+            else ""
+        )
+        params: List[Any] = [pattern] + ([pattern] if has_content else [])
+        params.append(int(limit))
+        with self._lock():
+            rows = self.conn.execute(
+                f"SELECT id, title, source, url FROM {docs}"
+                f" WHERE lower(COALESCE(title, '')) LIKE ? ESCAPE '\\'{content_clause}"
+                f" ORDER BY routed_at DESC NULLS LAST LIMIT ?",
+                params,
+            ).fetchall()
+        return [
+            {"document_id": row[0], "title": row[1], "source_id": row[2], "url": row[3]}
+            for row in rows
+        ]
+
+    def claims(
+        self,
+        since: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Namespace claims in the same cluster shape corpus domains serve.
+
+        Namespace-native claims are clusters of one until the cross-backing
+        link pass connects them; links they participate in live in the
+        shared ``claim_links`` table and are cited here.
+        """
+        tables = self._tables()
+        with self._lock():
+            rows = self.conn.execute(
+                f"SELECT claim_id, claim_text, verdict, document_id"
+                f" FROM {tables['claims']} ORDER BY claim_id LIMIT ?",
+                [int(limit)],
+            ).fetchall()
+            links = self.conn.execute(
+                "SELECT claim_a, claim_b, relation, confidence, prediction_mode"
+                " FROM claim_links WHERE relation IN ('supports', 'contradicts')"
+            ).fetchall() if self._link_table_exists() else []
+        by_claim: Dict[str, List[Dict[str, Any]]] = {}
+        for claim_a, claim_b, relation, confidence, mode in links:
+            by_claim.setdefault(claim_a, []).append(
+                {"claim_id": claim_b, "relation": relation,
+                 "confidence": confidence, "prediction_mode": mode}
+            )
+            by_claim.setdefault(claim_b, []).append(
+                {"claim_id": claim_a, "relation": relation,
+                 "confidence": confidence, "prediction_mode": mode}
+            )
+        clusters = []
+        for claim_id, text, verdict, document_id in rows:
+            related = by_claim.get(claim_id, [])
+            clusters.append(
+                {
+                    "cluster_id": f"cl-{claim_id}",
+                    "representative": {
+                        "claim_id": claim_id,
+                        "claim_text": text,
+                        "document_id": document_id,
+                        "verdict": verdict,
+                        "superseded": False,
+                    },
+                    "citations": [
+                        {"claim_id": claim_id, "claim_text": text,
+                         "document_id": document_id, "verdict": verdict,
+                         "superseded": False}
+                    ],
+                    "corroboration": 1,
+                    "contradictions": [
+                        link for link in related if link["relation"] == "contradicts"
+                    ],
+                    "supports": [
+                        link for link in related if link["relation"] == "supports"
+                    ],
+                    "size": 1,
+                }
+            )
+        return clusters
+
+    def entities(self, name: Optional[str] = None) -> List[Dict[str, Any]]:
+        tables = self._tables()
+        params: List[Any] = []
+        where = ""
+        if name:
+            where = "WHERE lower(entity) LIKE ? ESCAPE '\\'"
+            params.append(CorpusViewBacking._like_pattern(name))
+        with self._lock():
+            rows = self.conn.execute(
+                f"SELECT entity, mentions FROM {tables['entities']} {where}"
+                " ORDER BY mentions DESC NULLS LAST",
+                params,
+            ).fetchall()
+        return [{"entity": row[0], "mentions": row[1]} for row in rows]
+
+    def _link_table_exists(self) -> bool:
+        return (
+            self.conn.execute(
+                "SELECT 1 FROM information_schema.tables"
+                " WHERE table_name = 'claim_links'"
+            ).fetchone()
+            is not None
+        )
+
     def coverage(self) -> Dict[str, Any]:
         payload = super().coverage()
         payload["namespace"] = self.definition.namespace
+        payload["namespace_backend"] = self.definition.namespace_backend
+        tables = self._tables()
+        with self._lock():
+            documents = self.conn.execute(
+                f"SELECT COUNT(*) FROM {tables['documents']}"
+            ).fetchone()[0]
+            claims = self.conn.execute(
+                f"SELECT COUNT(*) FROM {tables['claims']}"
+            ).fetchone()[0]
+            # Shared-embedding-space guard: vectors for this namespace's
+            # documents embedded under a *different* model are a loud
+            # mismatch, not silently bad similarity.
+            mismatches = 0
+            if (
+                self.conn.execute(
+                    "SELECT 1 FROM information_schema.tables"
+                    " WHERE table_name = 'document_embeddings'"
+                ).fetchone()
+                is not None
+            ):
+                mismatches = self.conn.execute(
+                    f"SELECT COUNT(*) FROM document_embeddings e"
+                    f" JOIN {tables['documents']} n ON n.id = e.document_id"
+                    f" WHERE e.model <> ?",
+                    [self.definition.embedding_model],
+                ).fetchone()[0]
+        payload.update(
+            {
+                "ready": True,
+                "documents": int(documents or 0),
+                "claims": int(claims or 0),
+                "embedding_model_mismatches": int(mismatches or 0),
+            }
+        )
         return payload

--- a/src/kb/claim_links.py
+++ b/src/kb/claim_links.py
@@ -434,6 +434,137 @@ def _link_pair(
         summary["links"][relation] += 1
 
 
+def run_cross_backing_link_pass(
+    conn,
+    registry: Any,
+    provider: Optional[Any] = None,
+    nli: Optional[Any] = None,
+    run_id: Optional[str] = None,
+    embedding_model: str = "all-MiniLM-L6-v2",
+    time_window_days: int = 3650,
+    k_neighbors: int = 8,
+    candidate_threshold: float = 0.5,
+    duplicate_threshold: float = 0.88,
+    min_link_confidence: float = 0.55,
+) -> Dict[str, Any]:
+    """Link namespace-native claims to the shared corpus (depth linkage).
+
+    A lighter pass than intra-corpus linking: only claims that live *solely*
+    in a namespace (never seen by ``argument_claims``) are candidates, and
+    they bridge into the corpus along embedding similarity. The default time
+    window is effectively unbounded — a 2019 paper contradicting today's
+    claim is exactly the point.
+
+    Enforces the shared embedding space: a namespace domain declaring a
+    different ``embedding_model`` than the corpus domains fails loudly.
+    """
+    from src.kb.registry import DomainConfigError
+    from src.provisioning.namespaces import (
+        BACKEND_ATTACHED,
+        BACKEND_TABLE_PREFIX,
+        ensure_attached,
+        namespace_tables,
+    )
+
+    ensure_claim_link_schema(conn)
+    nli = nli or HeuristicNLI()
+    run_id = run_id or f"kb-cross-links-{uuid.uuid4().hex[:12]}"
+    window_ms = time_window_days * 86_400_000
+
+    models = registry.embedding_models()
+    summary: Dict[str, Any] = {
+        "run_id": run_id,
+        "domains": {},
+        "mode": getattr(nli, "prediction_mode", "heuristic"),
+    }
+
+    for definition in registry.domains():
+        if definition.backing != "namespace":
+            continue
+        corpus_models = {
+            model
+            for name, model in models.items()
+            if registry.get(name).backing == "corpus-view"
+        }
+        if corpus_models and definition.embedding_model not in corpus_models:
+            raise DomainConfigError(
+                f"domain {definition.name!r} embeds with "
+                f"{definition.embedding_model!r} but the corpus uses "
+                f"{sorted(corpus_models)}; cross-backing similarity needs one "
+                "shared embedding space"
+            )
+
+        backend = (
+            BACKEND_ATTACHED
+            if definition.namespace_backend == "attached"
+            else BACKEND_TABLE_PREFIX
+        )
+        if backend == BACKEND_ATTACHED:
+            ensure_attached(conn, definition.namespace)
+        tables = namespace_tables(definition.namespace, backend)
+
+        native = conn.execute(
+            f"""
+            SELECT n.claim_id, n.claim_text
+            FROM {tables['claims']} n
+            LEFT JOIN argument_claims shared ON shared.claim_id = n.claim_id
+            LEFT JOIN kb_claim_link_scans s ON s.claim_id = n.claim_id
+            WHERE shared.claim_id IS NULL AND s.claim_id IS NULL
+            ORDER BY n.claim_id
+            """
+        ).fetchall()
+
+        counts = {"scanned": len(native), "links": 0}
+        if native and provider is not None:
+            _embed_new_claims(conn, native, provider, embedding_model)
+
+        conn.execute("BEGIN TRANSACTION")
+        try:
+            for claim_id, claim_text in native:
+                candidates = _candidates_for(
+                    conn, claim_id, claim_text, 0,
+                    provider is not None, embedding_model,
+                    window_ms, k_neighbors, candidate_threshold,
+                )
+                for other_id, other_text, other_doc, other_ingested, similarity in candidates:
+                    before = conn.execute(
+                        "SELECT COUNT(*) FROM claim_links WHERE run_id = ?",
+                        [run_id],
+                    ).fetchone()[0]
+                    _link_pair(
+                        conn, nli, run_id,
+                        {"links": {r: 0 for r in RELATIONS}},
+                        (definition.name, claim_id, claim_text, 0),
+                        (
+                            _claim_domain(conn, other_doc),
+                            other_id, other_text, other_ingested,
+                        ),
+                        similarity, duplicate_threshold,
+                        min_link_confidence, 10**15,
+                    )
+                    after = conn.execute(
+                        "SELECT COUNT(*) FROM claim_links WHERE run_id = ?",
+                        [run_id],
+                    ).fetchone()[0]
+                    counts["links"] += max(0, after - before)
+                conn.execute(
+                    """
+                    INSERT INTO kb_claim_link_scans (claim_id, run_id, scanned_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT (claim_id) DO UPDATE SET
+                        run_id = excluded.run_id, scanned_at = excluded.scanned_at
+                    """,
+                    [claim_id, run_id, int(time.time() * 1000)],
+                )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        summary["domains"][definition.name] = counts
+
+    return summary
+
+
 def delete_run(conn, run_id: str) -> Dict[str, int]:
     """Revert one run: its links and scan-ledger rows are removed.
 

--- a/src/kb/promotion.py
+++ b/src/kb/promotion.py
@@ -1,0 +1,226 @@
+"""
+Backing promotion: a registry pointer flip plus a data migration.
+
+``corpus-view → namespace`` copies the domain's member documents and claims
+into the provisioning plane's namespaced tables **preserving ids**, so every
+inbound link (``claim_links`` endpoints, ``document_domains`` provenance)
+survives; then the domain's entry in ``config/domains.yml`` flips to
+``backing: namespace``. The shared corpus is never mutated — the rows stay
+where they were (link-don't-merge), the domain simply stops being *served*
+from them. The reverse (``namespace → corpus-view``) upserts any
+namespace-native rows back into the shared sink and flips the pointer back.
+
+Because consumers only ever hold the ``DomainBacking`` interface, nothing
+downstream changes on either flip.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+from src.kb.registry import (
+    DomainConfigError,
+    KnowledgeDomainRegistry,
+    load_registry,
+)
+
+_EXTENDED_COLUMNS = (
+    ("content", "VARCHAR"),
+    ("ingested_at", "BIGINT"),
+)
+
+
+def _flip_config(config_path: Path, domain: str, updates: Dict[str, Any]) -> None:
+    raw = yaml.safe_load(config_path.read_text())
+    for entry in raw.get("domains", []):
+        if entry.get("name") == domain:
+            for key, value in updates.items():
+                if value is None:
+                    entry.pop(key, None)
+                else:
+                    entry[key] = value
+            break
+    else:
+        raise DomainConfigError(f"domain {domain!r} not in {config_path}")
+    config_path.write_text(yaml.safe_dump(raw, sort_keys=False, allow_unicode=True))
+
+
+def _extend_documents_table(conn, table: str) -> None:
+    from src.provisioning.namespaces import _has_column
+
+    for column, column_type in _EXTENDED_COLUMNS:
+        if not _has_column(conn, table, column):
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_type}")
+
+
+def promote_to_namespace(
+    conn,
+    domain: str,
+    config_path: Path,
+    backend: str = "table-prefix",
+    db_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Promote a corpus-view domain to a provisioned namespace."""
+    from src.provisioning.namespaces import (
+        create_namespace,
+        require_valid_name,
+    )
+    from src.kb.membership import view_name
+
+    registry = load_registry(config_path)
+    definition = registry.get(domain)
+    if definition.backing != "corpus-view":
+        raise DomainConfigError(f"domain {domain!r} is not corpus-view backed")
+
+    from src.database.local_warehouse_seed import ensure_schema
+
+    ensure_schema(conn)  # argument_claims and friends on a fresh warehouse
+    namespace = require_valid_name(domain.replace("-", "_"))
+    tables = create_namespace(conn, namespace, backend, db_path)
+    _extend_documents_table(conn, tables["documents"])
+
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        copied_docs = conn.execute(
+            f"""
+            INSERT INTO {tables['documents']}
+                (id, title, source, source_type, url, published_at, routed_at,
+                 content, ingested_at)
+            SELECT d.document_id, d.title, d.source_id, d.source_type, d.url,
+                   CASE WHEN d.created_at IS NULL THEN NULL
+                        ELSE to_timestamp(d.created_at / 1000.0) END,
+                   now(), d.content, d.ingested_at
+            FROM documents d
+            JOIN document_domains m
+              ON m.document_id = d.document_id AND m.domain = ?
+            WHERE d.document_id NOT IN (SELECT id FROM {tables['documents']})
+            """,
+            [domain],
+        ).fetchone()
+        copied_claims = conn.execute(
+            f"""
+            INSERT INTO {tables['claims']}
+                (claim_id, claim_text, verdict, document_id, routed_at)
+            SELECT c.claim_id, c.claim_text, c.factcheck_verdict, c.document_id, now()
+            FROM argument_claims c
+            JOIN document_domains m
+              ON m.document_id = c.document_id AND m.domain = ?
+            WHERE c.claim_id NOT IN (SELECT claim_id FROM {tables['claims']})
+            """,
+            [domain],
+        ).fetchone()
+        # The stale per-domain view must not keep serving corpus reads.
+        conn.execute(f"DROP VIEW IF EXISTS {view_name(domain)}")
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    _flip_config(
+        Path(config_path),
+        domain,
+        {
+            "backing": "namespace",
+            "namespace": namespace,
+            "namespace_backend": backend,
+        },
+    )
+    return {
+        "domain": domain,
+        "namespace": namespace,
+        "backend": backend,
+        "documents_copied": int(copied_docs[0]) if copied_docs else 0,
+        "claims_copied": int(copied_claims[0]) if copied_claims else 0,
+    }
+
+
+def demote_to_corpus_view(
+    conn,
+    domain: str,
+    config_path: Path,
+) -> Dict[str, Any]:
+    """Reverse flip: serve the domain from the shared corpus again.
+
+    Namespace-native documents (ids the shared sink has never seen) are
+    upserted into ``documents`` and given membership rows, so nothing is
+    lost; ids are preserved so links survive. The namespace tables are left
+    in place (teardown stays a provisioning-plane decision).
+    """
+    from src.provisioning.namespaces import (
+        BACKEND_ATTACHED,
+        BACKEND_TABLE_PREFIX,
+        namespace_tables,
+        ensure_attached,
+    )
+    from src.kb.membership import ensure_membership_schema
+
+    registry = load_registry(config_path)
+    definition = registry.get(domain)
+    if definition.backing != "namespace":
+        raise DomainConfigError(f"domain {domain!r} is not namespace backed")
+
+    backend = (
+        BACKEND_ATTACHED
+        if definition.namespace_backend == "attached"
+        else BACKEND_TABLE_PREFIX
+    )
+    if backend == BACKEND_ATTACHED:
+        ensure_attached(conn, definition.namespace)
+    tables = namespace_tables(definition.namespace, backend)
+    ensure_membership_schema(conn)
+
+    from src.provisioning.namespaces import _has_column
+
+    has_content = _has_column(conn, tables["documents"], "content")
+    has_ingested = _has_column(conn, tables["documents"], "ingested_at")
+    content_expr = "n.content" if has_content else "NULL"
+    ingested_expr = (
+        "COALESCE(n.ingested_at, epoch_ms(n.routed_at))"
+        if has_ingested
+        else "epoch_ms(n.routed_at)"
+    )
+
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        restored = conn.execute(
+            f"""
+            INSERT INTO documents
+                (document_id, source_type, ingested_at, created_at,
+                 source_id, url, title, content)
+            SELECT n.id, COALESCE(n.source_type, 'news'), {ingested_expr},
+                   epoch_ms(n.published_at), n.source, n.url, n.title,
+                   {content_expr}
+            FROM {tables['documents']} n
+            WHERE n.id NOT IN (SELECT document_id FROM documents)
+            """
+        ).fetchone()
+        now = int(time.time() * 1000)
+        conn.execute(
+            f"""
+            INSERT INTO document_domains (document_id, domain, score, method, run_id, assigned_at)
+            SELECT n.id, ?, 1.0, 'source', 'demotion', ?
+            FROM {tables['documents']} n
+            WHERE (n.id, ?) NOT IN (
+                SELECT document_id, domain FROM document_domains
+            )
+            """,
+            [domain, now, domain],
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    _flip_config(
+        Path(config_path),
+        domain,
+        {"backing": "corpus-view", "namespace": None, "namespace_backend": None},
+    )
+    return {
+        "domain": domain,
+        "documents_restored": int(restored[0]) if restored else 0,
+    }

--- a/src/kb/registry.py
+++ b/src/kb/registry.py
@@ -84,6 +84,7 @@ class DomainDefinition:
     embedding_anchors: List[str] = field(default_factory=list)
     membership_threshold: float = 0.35
     namespace: Optional[str] = None
+    namespace_backend: Optional[str] = None
 
 
 def _require_str_list(raw: Any, domain: str, key: str) -> List[str]:
@@ -151,10 +152,26 @@ def _parse_domain(raw: Any) -> DomainDefinition:
     if namespace is not None and not isinstance(namespace, str):
         raise DomainConfigError(f"domain {name!r}: namespace must be a string")
     if backing == "namespace" and not namespace:
-        namespace = name
+        # Provisioning namespace names use [a-z][a-z0-9_]; slugs use dashes.
+        namespace = name.replace("-", "_")
     if backing == "corpus-view" and namespace:
         raise DomainConfigError(
             f"domain {name!r}: namespace is only valid for namespace backing"
+        )
+
+    namespace_backend = raw.get("namespace_backend")
+    if namespace_backend is not None and namespace_backend not in (
+        "table-prefix",
+        "attached",
+    ):
+        raise DomainConfigError(
+            f"domain {name!r}: namespace_backend must be table-prefix or attached"
+        )
+    if backing == "namespace" and namespace_backend is None:
+        namespace_backend = "table-prefix"
+    if backing == "corpus-view" and namespace_backend:
+        raise DomainConfigError(
+            f"domain {name!r}: namespace_backend is only valid for namespace backing"
         )
 
     return DomainDefinition(
@@ -170,6 +187,7 @@ def _parse_domain(raw: Any) -> DomainDefinition:
         ),
         membership_threshold=float(threshold),
         namespace=namespace,
+        namespace_backend=namespace_backend,
     )
 
 

--- a/tests/unit/kb/test_namespace_backing.py
+++ b/tests/unit/kb/test_namespace_backing.py
@@ -1,0 +1,244 @@
+"""Unit tests for the namespace backing, promotion round-trip, and cross-backing links."""
+
+import duckdb
+import pytest
+import yaml
+
+from src.kb import load_registry
+from src.kb.claim_links import run_cross_backing_link_pass
+from src.kb.membership import run_membership_pass
+from src.kb.promotion import demote_to_corpus_view, promote_to_namespace
+from src.kb.registry import DomainConfigError
+from tests.unit.kb.test_claim_links import (
+    BASE_MS,
+    DAY_MS,
+    DUP_A,
+    DUP_B,
+    CONTRA,
+    FakeNLI,
+    FakeProvider,
+    _seed_claims,
+)
+
+CONFIG = """
+version: 1
+domains:
+  - name: web3
+    backing: corpus-view
+    embedding_model: fake-embed
+    tags: [web3]
+    keywords: [defi, staking, stablecoin]
+  - name: reference
+    backing: namespace
+    embedding_model: fake-embed
+"""
+
+
+@pytest.fixture()
+def conn():
+    return duckdb.connect()
+
+
+@pytest.fixture()
+def config_path(tmp_path):
+    path = tmp_path / "domains.yml"
+    path.write_text(CONFIG)
+    return path
+
+
+def _seed_corpus_domain(conn, config_path):
+    from src.ingestion.document_store import DocumentStore
+    from src.kb.claim_links import ensure_claim_link_schema
+
+    ensure_claim_link_schema(conn)  # documents + membership + argument_claims
+    DocumentStore(conn).upsert(
+        [
+            {
+                "document_id": "d1",
+                "source_type": "news",
+                "language": "en",
+                "ingested_at": BASE_MS,
+                "source_id": "wire",
+                "url": "https://example.com/d1",
+                "title": "Defi staking news",
+                "content": "defi staking coverage continues.",
+                "metadata": {"tags": ["web3"]},
+            }
+        ]
+    )
+    run_membership_pass(conn, load_registry(config_path))
+    conn.execute(
+        "INSERT INTO argument_claims (claim_id, claim_text, document_id,"
+        " source_type, confidence) VALUES ('c1', ?, 'd1', 'news', 0.8)",
+        [DUP_A],
+    )
+
+
+class TestRegistryFields:
+    def test_namespace_backend_defaults_and_validation(self, config_path):
+        registry = load_registry(config_path)
+        reference = registry.get("reference")
+        assert reference.namespace == "reference"
+        assert reference.namespace_backend == "table-prefix"
+
+    def test_namespace_backend_invalid_value_rejected(self, tmp_path):
+        path = tmp_path / "bad.yml"
+        path.write_text(
+            "version: 1\ndomains:\n"
+            "  - {name: x, backing: namespace, embedding_model: m,"
+            " namespace_backend: sqlite}\n"
+        )
+        with pytest.raises(DomainConfigError, match="namespace_backend"):
+            load_registry(path)
+
+
+class TestPromotionRoundTrip:
+    def test_promote_flips_config_and_copies_rows(self, conn, config_path):
+        _seed_corpus_domain(conn, config_path)
+        result = promote_to_namespace(conn, "web3", config_path)
+        assert result["documents_copied"] == 1
+        assert result["claims_copied"] == 1
+
+        flipped = yaml.safe_load(config_path.read_text())
+        entry = next(d for d in flipped["domains"] if d["name"] == "web3")
+        assert entry["backing"] == "namespace"
+        assert entry["namespace"] == "web3"
+
+        registry = load_registry(config_path)
+        backing = registry.resolve("web3", conn=conn)
+        assert backing.backing_type == "namespace"
+        docs = backing.documents()
+        assert [d["document_id"] for d in docs] == ["d1"]
+        assert docs[0]["content"] == "defi staking coverage continues."
+
+        clusters = backing.claims()
+        assert clusters[0]["representative"]["claim_id"] == "c1"
+
+    def test_same_consumer_calls_work_on_both_backings(self, conn, config_path):
+        _seed_corpus_domain(conn, config_path)
+        registry = load_registry(config_path)
+        corpus_backing = registry.resolve("web3", conn=conn)
+        corpus_docs = corpus_backing.documents()
+        corpus_cov = corpus_backing.coverage()
+
+        promote_to_namespace(conn, "web3", config_path)
+        ns_backing = load_registry(config_path).resolve("web3", conn=conn)
+        ns_docs = ns_backing.documents()
+        ns_cov = ns_backing.coverage()
+
+        # Same ids served, same core coverage keys answered.
+        assert [d["document_id"] for d in ns_docs] == [
+            d["document_id"] for d in corpus_docs
+        ]
+        for key in ("domain", "backing", "embedding_model", "ready", "documents"):
+            assert key in corpus_cov and key in ns_cov
+        assert corpus_cov["documents"] == ns_cov["documents"] == 1
+        assert ns_backing.search("staking")[0]["document_id"] == "d1"
+
+    def test_demote_restores_corpus_serving(self, conn, config_path):
+        _seed_corpus_domain(conn, config_path)
+        promote_to_namespace(conn, "web3", config_path)
+        # Simulate a namespace-native document (never in the shared sink).
+        conn.execute(
+            "INSERT INTO kg_web3_documents (id, title, source, source_type, url,"
+            " published_at, routed_at, content, ingested_at)"
+            " VALUES ('native-1', 'Native doc', 'ns', 'paper', 'https://x/n1',"
+            " NULL, now(), 'native content', ?)",
+            [BASE_MS + DAY_MS],
+        )
+        result = demote_to_corpus_view(conn, "web3", config_path)
+        assert result["documents_restored"] == 1
+
+        registry = load_registry(config_path)
+        backing = registry.resolve("web3", conn=conn)
+        assert backing.backing_type == "corpus-view"
+        ids = {d["document_id"] for d in backing.documents()}
+        assert ids == {"d1", "native-1"}
+
+
+class TestAttachedBackend:
+    def test_attached_namespace_serves_and_joins(self, conn, config_path, tmp_path, monkeypatch):
+        monkeypatch.setenv("NOESIS_KG_DB_DIR", str(tmp_path))
+        _seed_corpus_domain(conn, config_path)
+        promote_to_namespace(
+            conn, "web3", config_path, backend="attached",
+            db_path=str(tmp_path / "web3.duckdb"),
+        )
+        registry = load_registry(config_path)
+        backing = registry.resolve("web3", conn=conn)
+        assert backing.definition.namespace_backend == "attached"
+        assert [d["document_id"] for d in backing.documents()] == ["d1"]
+        # One engine: cross-database join between the attached namespace and
+        # the shared corpus works in a single SQL statement.
+        joined = conn.execute(
+            "SELECT COUNT(*) FROM kg_web3.documents n"
+            " JOIN argument_claims c ON c.document_id = n.id"
+        ).fetchone()[0]
+        assert joined == 1
+
+
+class TestCrossBackingLinks:
+    def _promote_and_add_native_claim(self, conn, config_path, text):
+        _seed_corpus_domain(conn, config_path)
+        # reference is already namespace-backed; create its tables + claim.
+        from src.provisioning.namespaces import create_namespace
+
+        tables = create_namespace(conn, "reference")
+        conn.execute(
+            f"INSERT INTO {tables['claims']} (claim_id, claim_text, verdict,"
+            " document_id, routed_at) VALUES ('ref-c1', ?, NULL, 'ref-d1', now())",
+            [text],
+        )
+
+    def test_native_claim_links_into_corpus(self, conn, config_path):
+        self._promote_and_add_native_claim(conn, config_path, CONTRA)
+        registry = load_registry(config_path)
+        summary = run_cross_backing_link_pass(
+            conn, registry, provider=FakeProvider(), nli=FakeNLI(),
+            embedding_model="fake-embed",
+        )
+        assert summary["domains"]["reference"]["scanned"] == 1
+        row = conn.execute(
+            "SELECT domain_a, claim_a, domain_b, claim_b, relation"
+            " FROM claim_links WHERE relation = 'contradicts'"
+        ).fetchone()
+        assert row is not None
+        endpoints = {(row[0], row[1]), (row[2], row[3])}
+        assert ("reference", "ref-c1") in endpoints
+        assert ("web3", "c1") in endpoints
+
+        # Visible from the namespace side's cluster shape too.
+        backing = registry.resolve("reference", conn=conn)
+        clusters = backing.claims()
+        ref = next(c for c in clusters if c["representative"]["claim_id"] == "ref-c1")
+        assert any(l["claim_id"] == "c1" for l in ref["contradictions"])
+
+    def test_second_pass_scans_nothing(self, conn, config_path):
+        self._promote_and_add_native_claim(conn, config_path, DUP_B)
+        registry = load_registry(config_path)
+        run_cross_backing_link_pass(
+            conn, registry, provider=FakeProvider(), nli=FakeNLI(),
+            embedding_model="fake-embed",
+        )
+        second = run_cross_backing_link_pass(
+            conn, registry, provider=FakeProvider(), nli=FakeNLI(),
+            embedding_model="fake-embed",
+        )
+        assert second["domains"]["reference"]["scanned"] == 0
+
+    def test_embedding_space_mismatch_fails_loudly(self, conn, tmp_path):
+        path = tmp_path / "mismatch.yml"
+        path.write_text(
+            CONFIG.replace(
+                "  - name: reference\n    backing: namespace\n"
+                "    embedding_model: fake-embed",
+                "  - name: reference\n    backing: namespace\n"
+                "    embedding_model: other-space",
+            )
+        )
+        registry = load_registry(path)
+        from src.kb.claim_links import ensure_claim_link_schema
+
+        ensure_claim_link_schema(conn)
+        with pytest.raises(DomainConfigError, match="shared embedding space"):
+            run_cross_backing_link_pass(conn, registry, provider=FakeProvider())

--- a/tests/unit/kb/test_registry.py
+++ b/tests/unit/kb/test_registry.py
@@ -155,10 +155,13 @@ class TestResolution:
         assert coverage["ready"] is True
         assert coverage["documents"] == 0
 
-        namespace_coverage = registry.resolve("reference").coverage()
+        namespace_coverage = registry.resolve(
+            "reference", conn=duckdb.connect()
+        ).coverage()
         assert namespace_coverage["backing"] == "namespace"
         assert namespace_coverage["namespace"] == "reference"
-        assert namespace_coverage["ready"] is False
+        assert namespace_coverage["ready"] is True
+        assert namespace_coverage["documents"] == 0
 
     def test_unimplemented_reads_fail_loudly(self, registry):
         import duckdb


### PR DESCRIPTION
## Overview

Implements #967 — the second half of the backing abstraction: domains served from provisioned namespaces through the same `DomainBacking` interface as corpus views, a promotion/demotion migration that is a registry pointer flip plus an id-preserving copy, and the cross-backing pass that links namespace-native knowledge into the daily corpus.

## Changes Summary

- **`src/kb/backing.py`**: full `NamespaceBacking` over `kg_<name>_documents/entities/claims` — table-prefixed or alias-qualified in the namespace's attached DuckDB (`namespace_backend: attached`; one engine, so cross-database joins work in single SQL statements). Reads tolerate the thin base schema and use the extended `content`/`ingested_at` columns when promotion added them. `coverage()` enforces the shared embedding space by loudly counting vectors embedded under a foreign model.
- **`src/kb/promotion.py`**: `promote_to_namespace` (transactional copy preserving document/claim ids, stale corpus view dropped, YAML pointer flipped) and `demote_to_corpus_view` (namespace-native rows upserted back into the shared sink with membership provenance; namespace tables left in place — teardown stays a provisioning decision).
- **`src/kb/claim_links.py`**: `run_cross_backing_link_pass` — namespace-native claims (absent from `argument_claims`) bridge into the corpus along embedding similarity with an effectively unbounded time window, writing ordinary `claim_links` rows whose `(domain, claim_id)` endpoints were designed for this in #964. Embedding-space mismatch between a namespace domain and the corpus fails loudly with `DomainConfigError`.
- **`src/kb/registry.py`**: `namespace_backend` field (validated, defaulted, slug→identifier mapping for namespace names).
- **Tests**: 9 new — config fields, promotion round-trip with id preservation, the same consumer calls running unchanged against both backings, demotion restoring namespace-native docs, attached-backend serving + cross-database join, cross-backing contradiction linking visible from both sides, ledger idempotency, and the loud embedding-space guard.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 91 passed

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_