### PR TITLE
Wire a pretrained zero-shot NLI backend for the frame classifier

### DIFF
--- a/src/argument_mining/frames.py
+++ b/src/argument_mining/frames.py
@@ -16,7 +16,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from services.ingest.common.document_model import Document
 
@@ -138,10 +138,53 @@ class FrameClassifier:
     keyword heuristic runs.
     """
 
-    def __init__(self, model_dir: Optional[Path] = None) -> None:
+    #: entailment hypothesis per frame for the zero-shot NLI backend (#955)
+    NLI_TEMPLATES = {
+        "economic": "This text frames the issue as an economic issue.",
+        "security": "This text frames the issue as a security issue.",
+        "humanitarian": "This text frames the issue as a humanitarian issue.",
+        "legal": "This text frames the issue as a legal issue.",
+        "political": "This text frames the issue as a political issue.",
+        "scientific": "This text frames the issue as a scientific issue.",
+        "other": "This text frames the issue outside economics, security, humanitarian, legal, political, or scientific terms.",
+    }
+    #: per-label decision thresholds — deliberately permissive for the frames
+    #: the heuristic starved of recall (political 0.16, humanitarian 0.25)
+    NLI_THRESHOLDS = {
+        "political": 0.35,
+        "humanitarian": 0.35,
+    }
+    NLI_DEFAULT_THRESHOLD = 0.45
+
+    def __init__(self, model_dir: Optional[Path] = None, nli: Optional[Any] = None) -> None:
         self._model_dir = model_dir or _FRAME_MODEL_DIR
         self._pipeline = None
+        self._nli = nli
         self._try_load()
+        if self._pipeline is None and self._nli is None:
+            self._try_load_nli()
+
+    def _try_load_nli(self) -> None:
+        """Zero-shot NLI backend, opt-in via NOESIS_FRAMES_BACKEND=nli.
+
+        Opt-in because loading the pinned cross-encoder can trigger a model
+        download; the fetch flow (#959) prepares the cache first.
+        """
+        import os
+
+        if os.environ.get("NOESIS_FRAMES_BACKEND", "").lower() != "nli":
+            return
+        try:
+            from src.kb.nli import TransformersNLI
+
+            self._nli = TransformersNLI()
+            logger.info("FrameClassifier: zero-shot NLI backend active (%s)",
+                        self._nli.model_name)
+        except Exception:
+            logger.warning(
+                "FrameClassifier: NLI backend unavailable — using heuristic fallback",
+                exc_info=True,
+            )
 
     def _try_load(self) -> None:
         if not (self._model_dir / "config.json").exists():
@@ -165,9 +208,11 @@ class FrameClassifier:
 
     @property
     def prediction_mode(self) -> str:
-        """`model:<dir>` when a checkpoint is active, else `heuristic` (#958)."""
+        """`model:<dir>` | `zero-shot:<model>` | `heuristic` (#958, #955)."""
         if self._pipeline is not None:
             return f"model:{self._model_dir.name}"
+        if self._nli is not None:
+            return self._nli.prediction_mode
         return "heuristic"
 
     # ------------------------------------------------------------------
@@ -186,7 +231,35 @@ class FrameClassifier:
             )
         if self._pipeline is not None:
             return self._predict_model(document, text)
+        if self._nli is not None:
+            return self._predict_nli(document, text)
         return _frame_heuristic(text, document.document_id, document.source_type)
+
+    def _predict_nli(self, document: Document, text: str) -> FramePrediction:
+        """Multi-label frames via independent entailment per hypothesis.
+
+        Each frame's score is its entailment confidence (0 when the model
+        answers contradiction/neutral); a frame is *on* when its score
+        clears its per-label threshold. Dominant = highest score, `other`
+        when nothing clears — the same shape the heuristic produces, so
+        downstream consumers are agnostic.
+        """
+        snippet = text[:1500]
+        scores: Dict[str, float] = {}
+        for frame, hypothesis in self.NLI_TEMPLATES.items():
+            outcome = self._nli.classify(snippet, hypothesis)
+            score = outcome.confidence if outcome.label == "entailment" else 0.0
+            threshold = self.NLI_THRESHOLDS.get(frame, self.NLI_DEFAULT_THRESHOLD)
+            scores[frame] = round(score, 4) if score >= threshold else 0.0
+        dominant = max(scores, key=scores.get)
+        if scores[dominant] <= 0.0:
+            dominant = "other"
+        return FramePrediction(
+            document_id=document.document_id,
+            source_type=document.source_type,
+            frames=scores,
+            dominant=dominant,
+        )
 
     def predict_text(self, text: str, source_type: str = "news") -> FramePrediction:
         """Convenience method for raw text."""

--- a/tests/unit/kb/test_nli_frames.py
+++ b/tests/unit/kb/test_nli_frames.py
@@ -1,0 +1,67 @@
+"""Unit tests for the zero-shot NLI frame backend (#955)."""
+
+from src.argument_mining.frames import FrameClassifier
+from src.kb.nli import ENTAILMENT, NEUTRAL, NLIResult
+
+
+class ScriptedNLI:
+    """Entails the hypotheses whose frame word appears in the premise."""
+
+    name = "nli:fake-nli"
+    prediction_mode = "zero-shot:fake-nli"
+    model_version = "fake-nli@r1"
+
+    SIGNALS = {
+        "political": ("parliament", 0.6),
+        "economic": ("tariff", 0.8),
+        "humanitarian": ("refugees", 0.4),
+    }
+
+    def classify(self, premise, hypothesis):
+        p = premise.lower()
+        for frame, (token, score) in self.SIGNALS.items():
+            if token in p and f"{frame} issue" in hypothesis:
+                return NLIResult(ENTAILMENT, score, self.prediction_mode)
+        return NLIResult(NEUTRAL, 0.6, self.prediction_mode)
+
+
+class TestNLIFrames:
+    def test_multi_label_scores_and_dominant(self):
+        classifier = FrameClassifier(nli=ScriptedNLI())
+        assert classifier.prediction_mode == "zero-shot:fake-nli"
+
+        prediction = classifier.predict_text(
+            "Parliament debated the tariff bill as refugees arrived.",
+        )
+        # economic (0.8) and political (0.6) clear their thresholds;
+        # humanitarian (0.4) clears its *permissive* 0.35 threshold.
+        assert prediction.frames["economic"] == 0.8
+        assert prediction.frames["political"] == 0.6
+        assert prediction.frames["humanitarian"] == 0.4
+        assert prediction.frames["scientific"] == 0.0
+        assert prediction.dominant == "economic"
+
+    def test_permissive_thresholds_recover_starved_frames(self):
+        classifier = FrameClassifier(nli=ScriptedNLI())
+        prediction = classifier.predict_text("Refugees crossed the border.")
+        # 0.4 would fail the default 0.45 threshold; the per-label 0.35
+        # threshold for humanitarian keeps it on.
+        assert prediction.frames["humanitarian"] == 0.4
+        assert prediction.dominant == "humanitarian"
+
+    def test_nothing_clears_thresholds_means_other(self):
+        classifier = FrameClassifier(nli=ScriptedNLI())
+        prediction = classifier.predict_text("A quiet afternoon by the lake.")
+        assert prediction.dominant == "other"
+
+    def test_without_nli_or_checkpoint_stays_heuristic(self, monkeypatch):
+        monkeypatch.delenv("NOESIS_FRAMES_BACKEND", raising=False)
+        classifier = FrameClassifier()
+        assert classifier.prediction_mode == "heuristic"
+
+    def test_env_opt_in_survives_missing_stack(self, monkeypatch):
+        monkeypatch.setenv("NOESIS_FRAMES_BACKEND", "nli")
+        monkeypatch.setenv("NOESIS_NLI_MODEL", "definitely/not-a-real-model")
+        classifier = FrameClassifier()
+        assert classifier._nli is None
+        assert classifier.prediction_mode == "heuristic"


### PR DESCRIPTION
## Overview

Implements #955 — multi-label frames via independent entailment, keeping the seven-frame taxonomy exactly, with per-label thresholds targeted at the recall the keyword heuristic starved (political 0.158 → permissive 0.35 threshold, humanitarian 0.25 → 0.35).

## Changes Summary

- **`FrameClassifier`**: third tier between checkpoint and heuristic — the shared pinned NLI cross-encoder (same model as stance #954 and claim links #964: one download, one memory footprint). One hypothesis per frame ("This text frames the issue as an economic issue.", …), score = entailment confidence, per-label decision thresholds, dominant = highest scorer with `other` when nothing clears. Output shape identical to the heuristic's `FramePrediction`, so `document_frames` writers, framing-diversity scores, and every other consumer stay backend-agnostic.
- **Opt-in** via `NOESIS_FRAMES_BACKEND=nli` (no surprise downloads; #959 prepares the cache), graceful heuristic fallback when the stack is absent, `prediction_mode = zero-shot:<model>` per #958, injectable backend for offline tests.
- **Tests**: 5 new — multi-label scoring + dominant selection, the permissive-threshold recovery of starved frames, the `other` default, the heuristic default, and env-opt-in fallback safety.

Benchmark-gate evaluation (macro F1 ≥ 0.70, political/humanitarian recall ≥ 0.60) runs against the held-out split once the pinned model is fetched via #959.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 136 passed

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_