### PR TITLE
Wire the cross-dataset benchmarks: FEVER/LIAR/AVeriTeC fetch + default pickup

### DIFF
--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -641,6 +641,17 @@ def main() -> int:
     if args.quiet:
         logging.getLogger().setLevel(logging.WARNING)
 
+    # Prepared external benchmarks are picked up by default when present
+    # (scripts/prepare_external_benchmarks.py puts them here); an explicit
+    # --fever/--liar/--averitec path always wins. (#957)
+    external_root = REPO / "data" / "external_benchmarks"
+    for attr in ("fever", "liar", "averitec"):
+        if getattr(args, attr) is None:
+            candidate = external_root / attr
+            if candidate.exists():
+                setattr(args, attr, candidate)
+                log.info("Using prepared %s benchmark at %s", attr.upper(), candidate)
+
     out_dir = args.out
     out_dir.mkdir(parents=True, exist_ok=True)
     # JSON stays at docs/benchmark_results.json (read by the get_benchmark_results

--- a/scripts/prepare_external_benchmarks.py
+++ b/scripts/prepare_external_benchmarks.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Fetch and prepare the external claim-detection benchmarks (#957).
+
+Downloads FEVER, LIAR, and AVeriTeC into ``data/external_benchmarks/`` in
+exactly the layout ``scripts/benchmark_models.py`` consumes (and now picks up
+by default when present):
+
+    data/external_benchmarks/fever/paper_dev.jsonl
+    data/external_benchmarks/liar/test.tsv
+    data/external_benchmarks/averitec/dev.json
+
+Every fetch is recorded in ``manifest.json`` (url, sha256, size, fetched-at)
+so results are reproducible and provenance is auditable. Idempotent: existing
+files are kept unless ``--force``.
+
+Label-mapping decisions (documented per the issue):
+
+- **FEVER** (CC BY-SA 3.0, Wikipedia-derived): ``SUPPORTS``/``REFUTES``
+  rows are verifiable claims (positive); ``NOT ENOUGH INFO`` maps to
+  non-claim. This is a *proxy* mapping — NEI claims are claims a verifier
+  could not resolve, so the negative class is soft; treat FEVER primarily
+  as a recall check.
+- **LIAR** (research use; Politifact-derived): every statement is a
+  political claim regardless of its 6-way truthfulness label
+  (pants-fire … true), so the 6-way scale is deliberately **not** mapped to
+  claim/no-claim — truthfulness is a fact-check property, not
+  claim-worthiness. LIAR measures recall/precision balance on all-positive
+  data.
+- **AVeriTeC** (CC BY-NC 4.0): all items are real-world verifiable claims —
+  all-positive, recall check.
+
+CI mode: ``--sample N`` truncates each prepared file to its first N records
+after download (deterministic head-sampling), keeping the suite runnable in
+CI without multi-hundred-MB artifacts.
+
+Usage:
+    python3 scripts/prepare_external_benchmarks.py            # fetch all
+    python3 scripts/prepare_external_benchmarks.py --sample 200
+    python3 scripts/prepare_external_benchmarks.py --only liar --force
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import sys
+import time
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ROOT = REPO / "data" / "external_benchmarks"
+
+DATASETS = {
+    "fever": {
+        "url": "https://fever.ai/download/fever/paper_dev.jsonl",
+        "target": "fever/paper_dev.jsonl",
+        "license": "CC BY-SA 3.0 (Wikipedia-derived); https://fever.ai/dataset/fever.html",
+        "kind": "file",
+    },
+    "liar": {
+        "url": "https://www.cs.ucsb.edu/~william/data/liar_dataset.zip",
+        "target": "liar/test.tsv",
+        "license": "Research use; Wang (2017), Politifact-derived",
+        "kind": "zip",
+        "member": "test.tsv",
+    },
+    "averitec": {
+        "url": "https://huggingface.co/datasets/chenxwh/AVeriTeC/resolve/main/data/dev.json",
+        "target": "averitec/dev.json",
+        "license": "CC BY-NC 4.0; Schlichtkrull et al. (2023)",
+        "kind": "file",
+    },
+}
+
+
+def _download(url: str, timeout: int = 120) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": "noesis-benchmarks/1.0"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def _sample_file(path: Path, n: int) -> None:
+    if path.suffix == ".json":
+        data = json.loads(path.read_text())
+        if isinstance(data, list):
+            path.write_text(json.dumps(data[:n]))
+    else:
+        lines = path.read_text().splitlines()
+        path.write_text("\n".join(lines[:n]) + "\n")
+
+
+def prepare(only=None, force: bool = False, sample: int = 0) -> int:
+    manifest_path = ROOT / "manifest.json"
+    manifest = {}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except ValueError:
+            manifest = {}
+
+    failures = 0
+    for name, spec in DATASETS.items():
+        if only and name != only:
+            continue
+        target = ROOT / spec["target"]
+        if target.exists() and not force:
+            print(f"[skip] {name}: {target} present (use --force to refetch)")
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        print(f"[fetch] {name}: {spec['url']}")
+        try:
+            payload = _download(spec["url"])
+            if spec["kind"] == "zip":
+                with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+                    payload = archive.read(spec["member"])
+            target.write_bytes(payload)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            print(f"[fail] {name}: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+
+        if sample:
+            _sample_file(target, sample)
+            print(f"[sample] {name}: truncated to first {sample} records")
+
+        manifest[name] = {
+            "url": spec["url"],
+            "license": spec["license"],
+            "sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+            "bytes": target.stat().st_size,
+            "sampled_to": sample or None,
+            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        print(f"[ok] {name}: {target} ({target.stat().st_size} bytes)")
+
+    ROOT.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"[manifest] {manifest_path}")
+    print("\nRun the benchmarks (prepared sets are picked up automatically):")
+    print("  python3 scripts/benchmark_models.py")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", choices=sorted(DATASETS), default=None)
+    parser.add_argument("--force", action="store_true", help="Refetch even if present")
+    parser.add_argument("--sample", type=int, default=0,
+                        help="Truncate each prepared file to its first N records (CI mode)")
+    args = parser.parse_args()
+    return prepare(only=args.only, force=args.force, sample=args.sample)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/kb/test_external_benchmarks.py
+++ b/tests/unit/kb/test_external_benchmarks.py
@@ -1,0 +1,101 @@
+"""Unit tests for external-benchmark preparation and harness pickup (#957)."""
+
+import json
+
+import pytest
+
+import scripts.prepare_external_benchmarks as prep
+
+
+class TestPrepare:
+    @pytest.fixture()
+    def sandbox(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(prep, "ROOT", tmp_path / "external_benchmarks")
+
+        def fake_download(url, timeout=120):
+            if "fever" in url:
+                rows = [
+                    {"label": "SUPPORTS", "claim": f"Claim {i}."} for i in range(5)
+                ]
+                return "\n".join(json.dumps(r) for r in rows).encode()
+            if "liar" in url:
+                import io
+                import zipfile
+
+                buffer = io.BytesIO()
+                with zipfile.ZipFile(buffer, "w") as archive:
+                    tsv = "\n".join(
+                        f"id{i}\tfalse\tStatement {i}.\tmeta" for i in range(5)
+                    )
+                    archive.writestr("test.tsv", tsv)
+                return buffer.getvalue()
+            return json.dumps([{"claim": f"AV claim {i}."} for i in range(5)]).encode()
+
+        monkeypatch.setattr(prep, "_download", fake_download)
+        return tmp_path / "external_benchmarks"
+
+    def test_prepares_expected_layout_and_manifest(self, sandbox):
+        assert prep.prepare() == 0
+        assert (sandbox / "fever/paper_dev.jsonl").exists()
+        assert (sandbox / "liar/test.tsv").exists()
+        assert (sandbox / "averitec/dev.json").exists()
+
+        manifest = json.loads((sandbox / "manifest.json").read_text())
+        assert set(manifest) == {"fever", "liar", "averitec"}
+        for entry in manifest.values():
+            assert entry["sha256"] and entry["bytes"] > 0 and entry["license"]
+
+    def test_idempotent_without_force(self, sandbox, capsys):
+        prep.prepare()
+        prep.prepare()
+        assert "[skip]" in capsys.readouterr().out
+
+    def test_sample_mode_truncates(self, sandbox):
+        prep.prepare(sample=2)
+        fever_lines = (sandbox / "fever/paper_dev.jsonl").read_text().strip().splitlines()
+        assert len(fever_lines) == 2
+        averitec = json.loads((sandbox / "averitec/dev.json").read_text())
+        assert len(averitec) == 2
+        manifest = json.loads((sandbox / "manifest.json").read_text())
+        assert manifest["fever"]["sampled_to"] == 2
+
+    def test_failure_reported_not_fatal(self, sandbox, monkeypatch):
+        def broken(url, timeout=120):
+            raise OSError("network down")
+
+        monkeypatch.setattr(prep, "_download", broken)
+        assert prep.prepare(force=True) == 1
+
+
+class TestHarnessEvaluators:
+    """The existing _try_* evaluators run against prepared fixture files."""
+
+    def test_fever_evaluator_reads_prepared_file(self, tmp_path):
+        import scripts.benchmark_models as bench
+
+        fever = tmp_path / "fever"
+        fever.mkdir()
+        rows = [
+            {"label": "SUPPORTS", "claim": "GDP rose 3 percent in 2024."},
+            {"label": "NOT ENOUGH INFO", "claim": "Something unverifiable happened."},
+        ]
+        (fever / "paper_dev.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows)
+        )
+        metrics = bench._try_fever(fever)
+        assert metrics is not None
+        assert metrics["n"] == 2
+        assert 0.0 <= metrics["f1"] <= 1.0
+
+    def test_liar_evaluator_reads_prepared_file(self, tmp_path):
+        import scripts.benchmark_models as bench
+
+        liar = tmp_path / "liar"
+        liar.mkdir()
+        (liar / "test.tsv").write_text(
+            "id1\tfalse\tThe deficit doubled last year.\tmeta\n"
+            "id2\ttrue\tUnemployment fell to 4 percent.\tmeta\n"
+        )
+        metrics = bench._try_liar(liar)
+        assert metrics is not None
+        assert metrics["n"] == 2


### PR DESCRIPTION
## Overview

Implements #957 — the Cross-Dataset Generalisation section stops saying "not available". One command fetches the three external sets with provenance, and the harness picks them up by default.

## Changes Summary

- **`scripts/prepare_external_benchmarks.py`**: downloads FEVER (`paper_dev.jsonl`), LIAR (`test.tsv` out of the upstream zip), and AVeriTeC (`dev.json`) into `data/external_benchmarks/` — exactly the layout the existing `_try_*` evaluators consume. A `manifest.json` records url, sha256, size, license, and fetch time per set. Idempotent (`--force` to refetch), per-set `--only`, and **`--sample N`** head-truncation for CI runs without large artifacts. Fetch failures report and continue.
- **Label mappings documented** as the issue demanded: FEVER `SUPPORTS`/`REFUTES` → claim with `NOT ENOUGH INFO` as a soft negative (a recall-leaning proxy, stated as such); LIAR's 6-way truthfulness scale deliberately **not** mapped — truthfulness is a fact-check property, not claim-worthiness, so LIAR is an all-positive recall/precision-balance check; AVeriTeC all-positive.
- **`scripts/benchmark_models.py`**: prepared sets are used by default when present (explicit paths still win), so `python3 scripts/benchmark_models.py` populates the external rows and records them in `docs/benchmark_results.json` for the regression gate — baseline heuristic numbers land on the first full run.
- **Tests**: 6 new — prepared layout + manifest with checksums, idempotency, sample truncation, non-fatal failures, and the existing FEVER/LIAR evaluators reading prepared fixture files end-to-end.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 148 passed

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_