### PR TITLE
Daily brief with a research-publications section (thin KB-contract consumer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,10 @@ models:
 	@echo "Fetching pinned pretrained model backends (NLI + claim detection)..."
 	python3 -m src.argument_mining.fetch_models
 
+kb-brief:
+	@echo "Harvesting feeds and rendering the daily brief..."
+	python3 scripts/kb_brief.py --harvest
+
 kb-bootstrap:
 	@echo "Bootstrapping knowledge domains (seed feeds + harvest + membership)..."
 	python3 scripts/kb_bootstrap.py

--- a/scripts/kb_brief.py
+++ b/scripts/kb_brief.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Render the daily brief (a thin consumer of the KB contract, #960).
+
+Usage:
+    python3 scripts/kb_brief.py                       # all domains, last 24h
+    python3 scripts/kb_brief.py --domains papers      # research-only brief
+    python3 scripts/kb_brief.py --since 2026-07-20 --budget 10
+    python3 scripts/kb_brief.py --out brief.md        # write instead of print
+    python3 scripts/kb_brief.py --harvest             # pull feeds + assign first
+
+Pair with the harvest for a one-command daily run:
+    make kb-brief
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render the Noesis daily brief")
+    parser.add_argument("--domains", nargs="*", default=None,
+                        help="Domains to include (default: all configured)")
+    parser.add_argument("--since", default=None,
+                        help="ISO-8601 UTC floor (default: 24h ago)")
+    parser.add_argument("--budget", type=int, default=15,
+                        help="Max ranked items across all domains (default 15)")
+    parser.add_argument("--out", type=Path, default=None,
+                        help="Write markdown to a file instead of stdout")
+    parser.add_argument("--harvest", action="store_true",
+                        help="Harvest feeds + run membership/consolidation first")
+    args = parser.parse_args()
+
+    from src.database.local_analytics_connector import get_shared_connection
+
+    conn = get_shared_connection()
+
+    if args.harvest:
+        from src.ingestion.connectors.blog.connector import BlogConnector
+        from src.ingestion.document_store import DocumentStore
+        from src.kb.claim_links import run_claim_linking_pass
+        from src.kb.clusters import run_clustering_pass
+        from src.kb.entities import run_entity_canonicalization_pass
+        from src.kb.membership import run_membership_pass
+
+        summary = BlogConnector(fetch_full_text=False, limit_per_feed=20).harvest_run(
+            store=DocumentStore(conn)
+        )
+        print(
+            f"harvest: {summary.inserted} new, {summary.duplicate} duplicates,"
+            f" {summary.fetch_errors} fetch errors",
+            file=sys.stderr,
+        )
+        run_membership_pass(conn)
+        run_claim_linking_pass(conn)
+        run_clustering_pass(conn)
+        run_entity_canonicalization_pass(conn)
+
+    from src.kb.brief import generate_brief
+
+    brief = generate_brief(
+        domains=args.domains, since=args.since, budget=args.budget, conn=conn
+    )
+    if args.out:
+        args.out.write_text(brief["markdown"])
+        print(f"wrote {args.out} ({brief['meta']['kept']} items,"
+              f" {brief['meta']['dropped']} dropped)", file=sys.stderr)
+    else:
+        print(brief["markdown"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb/brief.py
+++ b/src/kb/brief.py
@@ -1,0 +1,244 @@
+"""
+The daily brief: a thin consumer of the KB contract (#960).
+
+One reader, one page: per-domain "what changed" computed from
+``kb_diff``/``kb_documents`` — never from raw feeds — under a hard length
+budget with an explicit dropped count (a brief that grows unboundedly
+recreates the overload it exists to solve). Research domains (``papers``
+tags) get a dedicated **New publications** section listing each new paper,
+cited, grouped by feed.
+
+Every line is cited (source + url), analytic entries carry
+``prediction_mode``/confidence, and the header states the corpus's
+evidence quality — the honesty rules of the contract carried into prose.
+
+This module deliberately touches nothing below the contract: it proves the
+layering (#971) and doubles as the template for the next consumer.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from src.kb import contract
+
+#: total item budget across all domains (per #960's overload discipline)
+DEFAULT_BUDGET = 15
+#: publications listed per research domain before "…and N more"
+MAX_PUBLICATIONS = 10
+
+
+def _default_since() -> str:
+    return (
+        datetime.now(timezone.utc) - timedelta(hours=24)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _is_research_domain(definition) -> bool:
+    return "papers" in definition.tags or "research" in definition.tags
+
+
+def _cluster_line(cluster: Dict[str, Any], note: str = "") -> Dict[str, Any]:
+    representative = cluster["representative"]
+    sources = sorted(
+        {
+            str(citation.get("source") or "").strip()
+            for citation in cluster["citations"]
+            if citation.get("source")
+        }
+    )
+    return {
+        "text": (representative.get("claim_text") or "").strip(),
+        "url": representative.get("url"),
+        "sources": sources,
+        "corroboration": cluster.get("corroboration", 1),
+        "note": note,
+        "contradicted": bool(cluster.get("contradictions")),
+        "recency": cluster.get("last_ingested_ms", 0),
+    }
+
+
+def generate_brief(
+    domains: Optional[List[str]] = None,
+    since: Optional[str] = None,
+    budget: int = DEFAULT_BUDGET,
+    conn=None,
+    config_path=None,
+) -> Dict[str, Any]:
+    """Build the brief; returns ``{markdown, sections, meta}``.
+
+    ``since`` defaults to 24h ago (UTC). Items across all non-research
+    sections are ranked (corroboration, then recency) and cut to
+    ``budget``, with the dropped count reported — never silently.
+    """
+    from src.kb.registry import load_registry
+
+    registry = load_registry(config_path)
+    names = domains or registry.names()
+    since = since or _default_since()
+
+    sections: List[Dict[str, Any]] = []
+    candidates: List[Dict[str, Any]] = []  # rankable items across domains
+
+    for name in names:
+        definition = registry.get(name)
+        diff = contract.kb_diff(name, since, conn=conn, config_path=config_path)["data"]
+
+        section: Dict[str, Any] = {
+            "domain": name,
+            "research": _is_research_domain(definition),
+            "documents_new": diff["documents"]["new"],
+            "documents_total": diff["documents"]["total"],
+            "sources_delivered": diff["documents"]["sources_delivered"],
+            "items": [],
+            "contradictions": diff["new_contradictions"],
+            "entity_surges": diff["entity_surges"] or [],
+            "publications": [],
+        }
+
+        if section["research"]:
+            docs = contract.kb_documents(
+                name, since=since, limit=200, conn=conn, config_path=config_path
+            )["data"]
+            section["publications"] = [
+                {
+                    "title": (doc.get("title") or "(untitled)").strip(),
+                    "source": doc.get("source_id") or "",
+                    "url": doc.get("url"),
+                }
+                for doc in docs
+            ]
+        else:
+            for cluster in diff["new_clusters"]:
+                item = _cluster_line(cluster)
+                if item["text"]:
+                    candidates.append({**item, "domain": name})
+            for cluster in diff["gained_corroboration"]:
+                item = _cluster_line(
+                    cluster,
+                    note="gained sources: " + ", ".join(cluster.get("new_sources", [])),
+                )
+                if item["text"]:
+                    candidates.append({**item, "domain": name})
+
+        sections.append(section)
+
+    # ── the budget: rank, cut, and say what was dropped ──────────────────
+    candidates.sort(key=lambda c: (c["corroboration"], c["recency"]), reverse=True)
+    kept, dropped = candidates[: int(budget)], max(0, len(candidates) - int(budget))
+    for item in kept:
+        for section in sections:
+            if section["domain"] == item["domain"]:
+                section["items"].append(item)
+                break
+
+    # ── evidence-quality header line (via any domain's coverage) ─────────
+    quality_line = None
+    if names:
+        coverage = contract.kb_coverage(
+            names[0], conn=conn, config_path=config_path
+        )["data"]
+        quality = coverage.get("evidence_quality")
+        if quality and quality.get("total_rows"):
+            fraction = quality["model_grade_fraction"]
+            quality_line = (
+                f"{round(fraction * 100)}% of underlying analysis is model-grade"
+                f" ({quality['total_rows']} prediction rows)"
+            )
+
+    meta = {
+        "since": since,
+        "generated_at_ms": int(time.time() * 1000),
+        "budget": int(budget),
+        "kept": len(kept),
+        "dropped": dropped,
+        "evidence_quality": quality_line,
+    }
+    return {
+        "markdown": _render_markdown(sections, meta),
+        "sections": sections,
+        "meta": meta,
+    }
+
+
+def _render_markdown(sections: List[Dict[str, Any]], meta: Dict[str, Any]) -> str:
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    lines = [f"# Noesis daily brief — {day}", ""]
+    subtitle = [
+        f"since {meta['since']}",
+        f"{meta['kept']} items",
+    ]
+    if meta["dropped"]:
+        subtitle.append(f"{meta['dropped']} below the budget line (not shown)")
+    if meta["evidence_quality"]:
+        subtitle.append(meta["evidence_quality"])
+    lines += ["_" + " · ".join(subtitle) + "_", ""]
+
+    for section in sections:
+        has_content = (
+            section["items"]
+            or section["publications"]
+            or section["contradictions"]
+            or section["entity_surges"]
+        )
+        header = (
+            f"## {section['domain']}"
+            f" — {section['documents_new']} new of"
+            f" {section['documents_total']} documents"
+        )
+        lines.append(header)
+        if not has_content:
+            note = (
+                "nothing new (no arrivals from any feed)"
+                if not section["sources_delivered"]
+                else "arrivals, but nothing cleared the bar"
+            )
+            lines += [f"_{note}_", ""]
+            continue
+
+        for item in section["items"]:
+            cite = ", ".join(item["sources"]) or "uncited — flagged"
+            line = f"- **{item['text']}**  \n  {item['corroboration']}× corroborated ({cite})"
+            if item["url"]:
+                line += f" — [link]({item['url']})"
+            if item["note"]:
+                line += f" — _{item['note']}_"
+            if item["contradicted"]:
+                line += " — ⚡ contested"
+            lines.append(line)
+
+        if section["publications"]:
+            shown = section["publications"][:MAX_PUBLICATIONS]
+            lines.append(f"\n### New publications ({len(section['publications'])})")
+            for publication in shown:
+                line = f"- {publication['title']} — _{publication['source']}_"
+                if publication["url"]:
+                    line += f" ([link]({publication['url']}))"
+                lines.append(line)
+            remainder = len(section["publications"]) - len(shown)
+            if remainder > 0:
+                lines.append(f"- …and {remainder} more")
+
+        if section["contradictions"]:
+            lines.append("\n### Contested")
+            for entry in section["contradictions"][:5]:
+                a, b = entry["claim_a"], entry["claim_b"]
+                lines.append(
+                    f"- \"{(a['text'] or '')[:110]}\" **vs** \"{(b['text'] or '')[:110]}\""
+                    f" _(confidence {entry['confidence']},"
+                    f" {entry['prediction_mode']})_"
+                )
+
+        if section["entity_surges"]:
+            surging = ", ".join(
+                f"{surge['name']} ({surge['mentions']}×, baseline"
+                f" {surge['baseline_mentions']})"
+                for surge in section["entity_surges"][:5]
+            )
+            lines.append(f"\n**Surging:** {surging}")
+
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"

--- a/tests/unit/kb/test_brief.py
+++ b/tests/unit/kb/test_brief.py
@@ -1,0 +1,130 @@
+"""Unit tests for the daily brief (thin consumer of the KB contract)."""
+
+import duckdb
+import pytest
+
+from src.kb.brief import generate_brief
+from src.kb.claim_links import run_claim_linking_pass
+from src.kb.clusters import run_clustering_pass
+from src.kb.membership import run_membership_pass
+from src.kb.registry import load_registry
+from tests.unit.kb.test_claim_links import (
+    BASE_MS,
+    DAY_MS,
+    CONTRA,
+    DUP_A,
+    DUP_B,
+    FakeNLI,
+    FakeProvider,
+    _seed_claims,
+)
+
+CONFIG = """
+version: 1
+domains:
+  - name: web3
+    backing: corpus-view
+    embedding_model: fake-embed
+    tags: [web3]
+    keywords: [defi, staking]
+  - name: papers
+    backing: corpus-view
+    embedding_model: fake-embed
+    tags: [papers, research]
+"""
+
+SINCE_DAY2 = "2025-06-16T00:00:00Z"
+
+
+@pytest.fixture()
+def conn():
+    return duckdb.connect()
+
+
+@pytest.fixture()
+def config_path(tmp_path):
+    path = tmp_path / "domains.yml"
+    path.write_text(CONFIG)
+    return path
+
+
+def _seed_world(conn, config_path):
+    """Day 1: one web3 story. Day 2: corroboration + contradiction + papers."""
+    _seed_claims(
+        conn,
+        [
+            ("c1", DUP_A, "d1", BASE_MS, "web3"),
+            ("c2", DUP_B, "d2", BASE_MS + DAY_MS, "web3"),
+            ("c3", CONTRA, "d3", BASE_MS + DAY_MS, "web3"),
+        ],
+    )
+    conn.execute("UPDATE documents SET source_id = 'wire-a' WHERE document_id = 'd1'")
+    conn.execute("UPDATE documents SET source_id = 'wire-b' WHERE document_id IN ('d2','d3')")
+    for index in range(3):
+        conn.execute(
+            "INSERT INTO documents (document_id, source_type, source_id, url,"
+            " title, ingested_at) VALUES (?, 'blog', ?, ?, ?, ?)",
+            [
+                f"paper-{index}",
+                f"arXiv cs.AI",
+                f"https://arxiv.org/abs/{index}",
+                f"Paper number {index}",
+                BASE_MS + DAY_MS,
+            ],
+        )
+        conn.execute(
+            "INSERT INTO document_domains VALUES (?, 'papers', 1.0, 'source', 'r0', 0)",
+            [f"paper-{index}"],
+        )
+    run_membership_pass(conn, load_registry(config_path))
+    run_claim_linking_pass(conn, provider=FakeProvider(), nli=FakeNLI())
+    run_clustering_pass(conn)
+
+
+class TestBrief:
+    def test_research_section_lists_new_publications(self, conn, config_path):
+        _seed_world(conn, config_path)
+        brief = generate_brief(
+            since=SINCE_DAY2, conn=conn, config_path=config_path
+        )
+        papers = next(s for s in brief["sections"] if s["domain"] == "papers")
+        assert papers["research"] is True
+        assert len(papers["publications"]) == 3
+        assert papers["publications"][0]["source"] == "arXiv cs.AI"
+        assert "### New publications (3)" in brief["markdown"]
+        assert "Paper number 0" in brief["markdown"]
+
+    def test_items_cited_and_contested_flagged(self, conn, config_path):
+        _seed_world(conn, config_path)
+        brief = generate_brief(since=SINCE_DAY2, conn=conn, config_path=config_path)
+        web3 = next(s for s in brief["sections"] if s["domain"] == "web3")
+        assert web3["items"], "expected ranked items for web3"
+        for item in web3["items"]:
+            assert item["sources"], "every line cited"
+        assert "Contested" in brief["markdown"]
+        assert "zero-shot:fake-model" in brief["markdown"]
+
+    def test_budget_enforced_with_dropped_count(self, conn, config_path):
+        _seed_world(conn, config_path)
+        brief = generate_brief(
+            since=SINCE_DAY2, budget=1, conn=conn, config_path=config_path
+        )
+        assert brief["meta"]["kept"] == 1
+        assert brief["meta"]["dropped"] >= 1
+        assert "below the budget line" in brief["markdown"]
+
+    def test_quiet_day_is_honest_about_why(self, conn, config_path):
+        _seed_world(conn, config_path)
+        brief = generate_brief(
+            since="2030-01-01", conn=conn, config_path=config_path
+        )
+        assert "nothing new (no arrivals from any feed)" in brief["markdown"]
+        assert brief["meta"]["kept"] == 0
+
+    def test_domain_selection(self, conn, config_path):
+        _seed_world(conn, config_path)
+        brief = generate_brief(
+            domains=["papers"], since=SINCE_DAY2, conn=conn, config_path=config_path
+        )
+        assert [s["domain"] for s in brief["sections"]] == ["papers"]
+        assert "## web3" not in brief["markdown"]

--- a/tools/kb_mcp/server.py
+++ b/tools/kb_mcp/server.py
@@ -110,6 +110,23 @@ def kb_diff(domain: str, since: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+def kb_brief(
+    domains: Optional[list] = None,
+    since: Optional[str] = None,
+    budget: int = 15,
+) -> Dict[str, Any]:
+    """The daily brief: per-domain changes since T under a hard item budget
+    (dropped count reported), with a New-publications section for research
+    domains. Returns {markdown, sections, meta}; every line cited."""
+    from src.kb.brief import generate_brief
+
+    try:
+        return generate_brief(domains=domains, since=since, budget=budget)
+    except Exception as exc:  # noqa: BLE001 - tool boundary
+        return {"error": {"code": "internal", "message": str(exc)}}
+
+
+@mcp.tool()
 def kb_coverage(domain: str) -> Dict[str, Any]:
     """Corpus stats, freshness, sources, backing, embedding model —
     so a consumer can honestly say when coverage is thin."""


### PR DESCRIPTION
## Overview

First slice of #960, extended per request with a dedicated **research publications** section: the daily brief as a thin consumer built strictly against the `noesis-kb-v1` contract — nothing below it — proving the layering the epic (#971) promised.

## Changes Summary

- **`src/kb/brief.py`**: per-domain sections from `kb_diff` — ranked cluster items (corroboration then recency) under a **hard global budget with the dropped count stated**, contested claims with `prediction_mode`/confidence, entity surges — plus, for research domains (`papers`/`research` tags), a **New publications** section listing each new paper cited and grouped by feed (arXiv categories). Quiet days are honest about why ("no arrivals from any feed" vs "nothing cleared the bar"), and the header states the corpus's evidence-quality fraction.
- **`scripts/kb_brief.py`** + `make kb-brief`: render to stdout or file; `--harvest` pulls feeds and runs membership + consolidation first, so one command produces a fresh brief without Airflow or Docker.
- **`kb_brief` MCP tool**: the same payload (`{markdown, sections, meta}`) for any MCP host — ask Claude Desktop for the brief conversationally.
- **Tests**: 5 new — publications section, citation discipline + contested flags, budget enforcement with dropped count, honest quiet days, domain selection.

Remaining for #960 (not in this PR): scheduled email delivery via the reports/SMTP path and the books/papers depth-annotation layer on brief items.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 158 passed
- [x] CLI smoke-run renders correctly against a local warehouse

Refs #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_