### PR TITLE
Expose the daily brief on the REST contract

### DIFF
--- a/src/api/routes/kb_routes.py
+++ b/src/api/routes/kb_routes.py
@@ -35,6 +35,24 @@ def list_domains():
     return _run(contract.kb_domains)
 
 
+@router.get("/brief")
+def brief(
+    domains: Optional[str] = None,
+    since: Optional[str] = None,
+    budget: int = 15,
+):
+    """The daily brief (markdown + sections + meta) for external consumers.
+
+    ``domains`` is a comma-separated list; omit for all configured domains.
+    """
+    domain_list = (
+        [name.strip() for name in domains.split(",") if name.strip()]
+        if domains
+        else None
+    )
+    return _run(contract.kb_brief, domain_list, since, budget)
+
+
 @router.get("/{domain}/search")
 def search(domain: str, q: str, limit: int = 20):
     return _run(contract.kb_search, domain, q, limit)

--- a/src/kb/contract.py
+++ b/src/kb/contract.py
@@ -148,6 +148,35 @@ def kb_diff(
         raise KBContractError("bad_since", str(exc)) from exc
 
 
+def kb_brief(
+    domains: Optional[List[str]] = None,
+    since: Optional[str] = None,
+    budget: int = 15,
+    conn=None,
+    config_path=None,
+) -> Dict[str, Any]:
+    """The daily brief as a contract call (markdown + sections + meta).
+
+    External consumers (Modulo, dashboards) fetch this instead of composing
+    diffs themselves; the envelope carries no single domain, so ``domain``
+    is ``None`` and the per-domain breakdown lives in ``data.sections``.
+    """
+    from src.kb.brief import generate_brief
+    from src.kb.registry import DomainConfigError
+
+    try:
+        brief = generate_brief(
+            domains=domains, since=since, budget=int(budget),
+            conn=conn, config_path=config_path,
+        )
+    except DomainConfigError as exc:
+        raise KBContractError("unknown_domain", str(exc)) from exc
+    except ValueError as exc:
+        raise KBContractError("bad_since", str(exc)) from exc
+
+    return _envelope(None, brief)
+
+
 def kb_coverage(domain: str, conn=None, config_path=None) -> Dict[str, Any]:
     backing = _backing(domain, conn, config_path)
     payload = backing.coverage()

--- a/tests/unit/kb/test_brief.py
+++ b/tests/unit/kb/test_brief.py
@@ -121,6 +121,61 @@ class TestBrief:
         assert "nothing new (no arrivals from any feed)" in brief["markdown"]
         assert brief["meta"]["kept"] == 0
 
+    def test_contract_call_wraps_brief_in_envelope(self, conn, config_path):
+        from src.kb import contract
+        from src.kb.contract import KBContractError
+
+        _seed_world(conn, config_path)
+        payload = contract.kb_brief(
+            since=SINCE_DAY2, conn=conn, config_path=config_path
+        )
+        assert payload["contract"] == "noesis-kb-v1"
+        assert payload["domain"] is None
+        assert "markdown" in payload["data"]
+        assert payload["data"]["meta"]["kept"] >= 1
+
+        with pytest.raises(KBContractError) as excinfo:
+            contract.kb_brief(
+                domains=["finance"], conn=conn, config_path=config_path
+            )
+        assert excinfo.value.code == "unknown_domain"
+
+    def test_rest_brief_route(self, conn, config_path, tmp_path, monkeypatch):
+        import importlib.util
+        from pathlib import Path
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        db_path = tmp_path / "wh.duckdb"
+        file_conn = __import__("duckdb").connect(str(db_path))
+        _seed_world(file_conn, config_path)
+        file_conn.close()
+
+        monkeypatch.setenv("NOESIS_DOMAINS_CONFIG", str(config_path))
+        monkeypatch.setenv("NOESIS_DB_PATH", str(db_path))
+        import src.database.local_analytics_connector as lac
+
+        monkeypatch.setattr(lac, "_CONNECTION", None, raising=False)
+
+        spec = importlib.util.spec_from_file_location(
+            "kb_routes_brief_test",
+            Path(__file__).resolve().parents[3] / "src/api/routes/kb_routes.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        app = FastAPI()
+        app.include_router(module.router)
+
+        response = TestClient(app).get(
+            "/api/v1/kb/brief",
+            params={"domains": "papers", "since": SINCE_DAY2},
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert [s["domain"] for s in data["sections"]] == ["papers"]
+        assert "New publications" in data["markdown"]
+
     def test_domain_selection(self, conn, config_path):
         _seed_world(conn, config_path)
         brief = generate_brief(

--- a/tools/kb_mcp/server.py
+++ b/tools/kb_mcp/server.py
@@ -118,12 +118,9 @@ def kb_brief(
     """The daily brief: per-domain changes since T under a hard item budget
     (dropped count reported), with a New-publications section for research
     domains. Returns {markdown, sections, meta}; every line cited."""
-    from src.kb.brief import generate_brief
+    from src.kb import contract
 
-    try:
-        return generate_brief(domains=domains, since=since, budget=budget)
-    except Exception as exc:  # noqa: BLE001 - tool boundary
-        return {"error": {"code": "internal", "message": str(exc)}}
+    return _run(contract.kb_brief, domains, since, budget)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Overview

The consumption seam for external integrations (Modulo first): the daily brief becomes a contract call — one GET returns markdown plus structured sections.

## Changes Summary

- **`src/kb/contract.py`**: `kb_brief(domains?, since?, budget)` wraps the generator in the `noesis-kb-v1` envelope (`domain: null`; per-domain breakdown in `data.sections`) with typed `unknown_domain`/`bad_since` errors.
- **`GET /api/v1/kb/brief`**: REST mirror with a comma-separated `domains` param.
- **`kb_brief` MCP tool** now routes through the same contract function, so the two surfaces cannot drift.
- **Tests**: envelope + unknown-domain error, and a REST round-trip through the actual router asserting the research-publications section renders.

## Testing Status

- [x] `python3 -m pytest tests/unit/kb/ -q` → 160 passed

Refs #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZrRDMXMBZ4ewBXQ3EoFuB)_